### PR TITLE
feat: Add anonymous telemetry system

### DIFF
--- a/arc.conf
+++ b/arc.conf
@@ -386,6 +386,30 @@ timeout = 3600
 temp_dir = "./data/cq_temp"
 
 # ======================
+# Telemetry
+# ======================
+[telemetry]
+# Enable anonymous usage telemetry (default: true)
+# Telemetry helps us understand usage patterns and improve Arc.
+# All data collected is transparent and sent in readable JSON format.
+#
+# Data collected:
+# - Instance ID (random UUID, not tied to hardware)
+# - OS name, version, and architecture
+# - CPU core count
+# - Total RAM
+# - Arc version
+#
+# To disable telemetry, set this to false:
+enabled = true
+
+# Telemetry server endpoint
+endpoint = "https://telemetry.basekick.net/api/v1/telemetry"
+
+# Hours between telemetry reports (default: 24)
+interval_hours = 24
+
+# ======================
 # Monitoring & Metrics
 # ======================
 [monitoring]

--- a/config_loader.py
+++ b/config_loader.py
@@ -315,6 +315,10 @@ class ArcConfig:
         """Get data ingestion configuration"""
         return self.config.get("ingestion", {})
 
+    def get_telemetry_config(self) -> Dict[str, Any]:
+        """Get telemetry configuration"""
+        return self.config.get("telemetry", {})
+
     def dump(self) -> Dict[str, Any]:
         """Get complete configuration (for debugging)"""
         return self.config.copy()

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,161 @@
+# Arc Telemetry
+
+Arc collects anonymous usage telemetry to help us understand how the database is being used and to improve the product. We believe in transparency, so this document explains exactly what data we collect, why we collect it, and how to disable it if you prefer.
+
+## What Data Do We Collect?
+
+Arc sends the following anonymous information to `telemetry.basekick.net` every 24 hours:
+
+```json
+{
+  "instance_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "timestamp": "2025-10-24T15:30:00Z",
+  "arc_version": "25.11",
+  "os": {
+    "name": "Darwin",
+    "version": "23.6.0",
+    "architecture": "arm64",
+    "platform": "macOS-14.5-arm64-arm-64bit"
+  },
+  "cpu": {
+    "physical_cores": 8,
+    "logical_cores": 8,
+    "frequency_mhz": 3200.0
+  },
+  "memory": {
+    "total_gb": 16.0
+  }
+}
+```
+
+### Data Points Explained
+
+- **instance_id**: A random UUID generated on first run and stored in `./data/.instance_id`. This is NOT tied to your hardware, IP address, or any personally identifiable information. It simply helps us count unique installations and track version upgrades.
+
+- **timestamp**: When the telemetry report was generated (UTC)
+
+- **arc_version**: The version of Arc you're running (e.g., "25.11")
+
+- **os**: Operating system information
+  - `name`: OS name (e.g., "Linux", "Darwin", "Windows")
+  - `version`: OS version/kernel version
+  - `architecture`: CPU architecture (e.g., "x86_64", "arm64")
+  - `platform`: Detailed platform string
+
+- **cpu**: CPU information
+  - `physical_cores`: Number of physical CPU cores
+  - `logical_cores`: Number of logical CPU cores (with hyperthreading)
+  - `frequency_mhz`: Maximum CPU frequency in MHz (if available)
+
+- **memory**: Memory information
+  - `total_gb`: Total system RAM in gigabytes
+
+## What We DON'T Collect
+
+Arc telemetry does **NOT** collect:
+
+- ❌ Your data or database contents
+- ❌ Database names, measurement names, or field names
+- ❌ Query contents or query patterns
+- ❌ IP addresses or network information
+- ❌ Hostnames or machine names
+- ❌ User information or credentials
+- ❌ File paths or directory structures
+- ❌ Performance metrics or usage statistics
+- ❌ Any personally identifiable information (PII)
+
+## Why Do We Collect This?
+
+Understanding the environments where Arc runs helps us:
+
+1. **Prioritize platform support**: Know which operating systems and architectures to focus on
+2. **Test on real hardware**: Ensure Arc performs well on the hardware our users actually have
+3. **Track adoption**: Understand how many active installations exist
+4. **Plan features**: Make informed decisions about which features to build next
+5. **Verify upgrades**: Confirm that users are upgrading to new versions
+
+## How to Disable Telemetry
+
+If you prefer to opt out of telemetry, you can disable it in two ways:
+
+### Option 1: Configuration File
+
+Edit `arc.conf` and set `telemetry.enabled` to `false`:
+
+```toml
+[telemetry]
+enabled = false
+```
+
+Then restart Arc:
+
+```bash
+# Kill any running Arc instances
+pkill -f "python -m api.main"
+
+# Start Arc
+./venv/bin/python -m api.main
+```
+
+### Option 2: Environment Variable
+
+Set the `ARC_TELEMETRY_ENABLED` environment variable to `false`:
+
+```bash
+export ARC_TELEMETRY_ENABLED=false
+./venv/bin/python -m api.main
+```
+
+## Telemetry Schedule
+
+- **First Send**: 1 minute after Arc starts (to ensure Arc is fully initialized)
+- **Subsequent Sends**: Every 24 hours after the first send
+- **On Startup**: Telemetry is only sent from the primary worker process (not all workers)
+
+## Verifying Telemetry Status
+
+When Arc starts, you'll see a log message indicating whether telemetry is enabled:
+
+```
+Telemetry enabled: sending to https://telemetry.basekick.net/api/v1/telemetry every 24h
+Instance ID: a1b2c3d4... (to disable: set telemetry.enabled=false in arc.conf)
+```
+
+Or if disabled:
+
+```
+Telemetry disabled by configuration
+```
+
+## Network Requirements
+
+If telemetry is enabled, Arc will make HTTPS POST requests to:
+
+```
+https://telemetry.basekick.net/api/v1/telemetry
+```
+
+If this endpoint is unreachable (due to firewall, no internet, etc.), Arc will:
+- Log a warning message
+- Continue operating normally (telemetry failures do not affect Arc's functionality)
+- Retry on the next scheduled send (24 hours later)
+
+## Privacy & Transparency
+
+We take privacy seriously:
+
+- All telemetry data is sent over HTTPS
+- The telemetry payload is human-readable JSON (not obfuscated or encrypted beyond HTTPS)
+- You can inspect exactly what's being sent by checking the Arc startup logs
+- The telemetry server is operated by Basekick Labs
+- We do not share, sell, or distribute telemetry data to third parties
+
+## Questions?
+
+If you have questions about telemetry, please:
+
+1. Open an issue: https://github.com/Basekick-Labs/arc/issues
+2. Email us: support@basekick.net
+3. Review the source code: `telemetry/collector.py` and `telemetry/sender.py`
+
+We're committed to transparency and happy to answer any questions about our data collection practices.

--- a/telemetry/__init__.py
+++ b/telemetry/__init__.py
@@ -1,0 +1,11 @@
+"""
+Arc Telemetry Module
+
+Collects and sends anonymous usage telemetry to help improve Arc.
+All data collected is transparent and can be disabled in arc.conf.
+"""
+
+from telemetry.collector import TelemetryCollector
+from telemetry.sender import TelemetrySender
+
+__all__ = ['TelemetryCollector', 'TelemetrySender']

--- a/telemetry/collector.py
+++ b/telemetry/collector.py
@@ -1,0 +1,217 @@
+"""
+Telemetry Collector for Arc Time-Series Database
+
+Collects anonymous system information for telemetry purposes.
+This helps the Arc team understand usage patterns and improve the database.
+
+Data collected:
+- Instance ID: Random, persistent identifier (not tied to hardware)
+- OS: Operating system name and version
+- CPU Count: Number of CPU cores
+- RAM: Total system memory in GB
+- Arc Version: Current version of Arc
+
+All data is sent in readable JSON format for transparency.
+Telemetry can be disabled in arc.conf by setting telemetry.enabled = false
+"""
+
+import json
+import logging
+import os
+import platform
+import psutil
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryCollector:
+    """Collects system information for telemetry"""
+
+    def __init__(self, data_dir: str = "./data"):
+        """
+        Initialize telemetry collector
+
+        Args:
+            data_dir: Directory to store instance ID file
+        """
+        self.data_dir = Path(data_dir)
+        self.instance_id_file = self.data_dir / ".instance_id"
+        self.instance_id = self._get_or_create_instance_id()
+
+    def _get_or_create_instance_id(self) -> str:
+        """
+        Get or create a persistent instance ID
+
+        Returns:
+            Unique instance identifier (UUID)
+        """
+        try:
+            # Ensure data directory exists
+            self.data_dir.mkdir(parents=True, exist_ok=True)
+
+            # Try to read existing instance ID
+            if self.instance_id_file.exists():
+                instance_id = self.instance_id_file.read_text().strip()
+                if instance_id:
+                    logger.info(f"Loaded existing instance ID: {instance_id[:8]}...")
+                    return instance_id
+
+            # Generate new instance ID
+            instance_id = str(uuid.uuid4())
+            self.instance_id_file.write_text(instance_id)
+            logger.info(f"Generated new instance ID: {instance_id[:8]}...")
+            return instance_id
+
+        except Exception as e:
+            logger.error(f"Failed to get/create instance ID: {e}")
+            # Return a temporary ID if file operations fail
+            return str(uuid.uuid4())
+
+    def _get_os_info(self) -> Dict[str, str]:
+        """
+        Get operating system information
+
+        Returns:
+            Dictionary with OS name, version, and architecture
+        """
+        try:
+            return {
+                "name": platform.system(),
+                "version": platform.release(),
+                "architecture": platform.machine(),
+                "platform": platform.platform()
+            }
+        except Exception as e:
+            logger.error(f"Failed to collect OS info: {e}")
+            return {
+                "name": "unknown",
+                "version": "unknown",
+                "architecture": "unknown",
+                "platform": "unknown"
+            }
+
+    def _get_cpu_info(self) -> Dict[str, Any]:
+        """
+        Get CPU information
+
+        Returns:
+            Dictionary with CPU count and details
+        """
+        try:
+            return {
+                "physical_cores": psutil.cpu_count(logical=False),
+                "logical_cores": psutil.cpu_count(logical=True),
+                "frequency_mhz": psutil.cpu_freq().max if psutil.cpu_freq() else None
+            }
+        except Exception as e:
+            logger.error(f"Failed to collect CPU info: {e}")
+            return {
+                "physical_cores": None,
+                "logical_cores": None,
+                "frequency_mhz": None
+            }
+
+    def _get_memory_info(self) -> Dict[str, float]:
+        """
+        Get memory information
+
+        Returns:
+            Dictionary with total RAM in GB
+        """
+        try:
+            mem = psutil.virtual_memory()
+            return {
+                "total_gb": round(mem.total / (1024 ** 3), 2)
+            }
+        except Exception as e:
+            logger.error(f"Failed to collect memory info: {e}")
+            return {
+                "total_gb": None
+            }
+
+    def _get_arc_version(self) -> str:
+        """
+        Get Arc version from version file or default
+
+        Returns:
+            Arc version string
+        """
+        try:
+            version_file = Path(__file__).parent.parent / "VERSION"
+            if version_file.exists():
+                return version_file.read_text().strip()
+            return "dev"
+        except Exception as e:
+            logger.error(f"Failed to read version: {e}")
+            return "unknown"
+
+    def collect(self) -> Dict[str, Any]:
+        """
+        Collect all telemetry data
+
+        Returns:
+            Dictionary containing all telemetry information
+        """
+        telemetry_data = {
+            "instance_id": self.instance_id,
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "arc_version": self._get_arc_version(),
+            "os": self._get_os_info(),
+            "cpu": self._get_cpu_info(),
+            "memory": self._get_memory_info()
+        }
+
+        logger.info(f"Collected telemetry data for instance {self.instance_id[:8]}...")
+        return telemetry_data
+
+    def to_json(self) -> str:
+        """
+        Get telemetry data as JSON string
+
+        Returns:
+            JSON string of telemetry data
+        """
+        return json.dumps(self.collect(), indent=2)
+
+    def to_readable_string(self) -> str:
+        """
+        Get telemetry data as human-readable string
+
+        Returns:
+            Formatted string with telemetry information
+        """
+        data = self.collect()
+        lines = [
+            "=== Arc Telemetry Data ===",
+            f"Instance ID: {data['instance_id']}",
+            f"Timestamp: {data['timestamp']}",
+            f"Arc Version: {data['arc_version']}",
+            "",
+            "Operating System:",
+            f"  Name: {data['os']['name']}",
+            f"  Version: {data['os']['version']}",
+            f"  Architecture: {data['os']['architecture']}",
+            f"  Platform: {data['os']['platform']}",
+            "",
+            "CPU:",
+            f"  Physical Cores: {data['cpu']['physical_cores']}",
+            f"  Logical Cores: {data['cpu']['logical_cores']}",
+            f"  Max Frequency: {data['cpu']['frequency_mhz']} MHz" if data['cpu']['frequency_mhz'] else "  Max Frequency: N/A",
+            "",
+            "Memory:",
+            f"  Total RAM: {data['memory']['total_gb']} GB",
+            "=========================="
+        ]
+        return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    # Test the collector
+    collector = TelemetryCollector()
+    print(collector.to_readable_string())
+    print("\nJSON Format:")
+    print(collector.to_json())

--- a/telemetry/sender.py
+++ b/telemetry/sender.py
@@ -1,0 +1,173 @@
+"""
+Telemetry Sender for Arc Time-Series Database
+
+Sends telemetry data to telemetry.basekick.net every 24 hours.
+Handles retries, network failures gracefully, and respects user opt-out.
+"""
+
+import asyncio
+import logging
+import aiohttp
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any
+
+from telemetry.collector import TelemetryCollector
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetrySender:
+    """Sends telemetry data periodically"""
+
+    def __init__(
+        self,
+        collector: TelemetryCollector,
+        endpoint: str = "https://telemetry.basekick.net/api/v1/telemetry",
+        interval_hours: int = 24,
+        enabled: bool = True
+    ):
+        """
+        Initialize telemetry sender
+
+        Args:
+            collector: TelemetryCollector instance
+            endpoint: URL to send telemetry data to
+            interval_hours: Hours between telemetry sends (default: 24)
+            enabled: Whether telemetry is enabled
+        """
+        self.collector = collector
+        self.endpoint = endpoint
+        self.interval_hours = interval_hours
+        self.enabled = enabled
+        self._task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
+
+    async def send_telemetry(self) -> bool:
+        """
+        Send telemetry data to the telemetry server
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.enabled:
+            logger.info("Telemetry is disabled, skipping send")
+            return False
+
+        try:
+            telemetry_data = self.collector.collect()
+
+            logger.info(f"Sending telemetry data for instance {telemetry_data['instance_id'][:8]}...")
+            logger.debug(f"Telemetry endpoint: {self.endpoint}")
+            logger.debug(f"Telemetry data: {telemetry_data}")
+
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    self.endpoint,
+                    json=telemetry_data,
+                    headers={
+                        "Content-Type": "application/json",
+                        "User-Agent": f"Arc/{telemetry_data['arc_version']}"
+                    }
+                ) as response:
+                    if response.status == 200:
+                        logger.info(f"Successfully sent telemetry data to {self.endpoint}")
+                        return True
+                    else:
+                        response_text = await response.text()
+                        logger.warning(
+                            f"Failed to send telemetry: HTTP {response.status} - {response_text}"
+                        )
+                        return False
+
+        except aiohttp.ClientError as e:
+            logger.warning(f"Network error sending telemetry: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Unexpected error sending telemetry: {e}", exc_info=True)
+            return False
+
+    async def _periodic_sender(self):
+        """Background task that sends telemetry periodically"""
+        logger.info(
+            f"Telemetry sender started (interval: {self.interval_hours}h, endpoint: {self.endpoint})"
+        )
+
+        # Send initial telemetry on startup (with a small delay to ensure Arc is fully started)
+        await asyncio.sleep(60)  # Wait 1 minute after startup
+        await self.send_telemetry()
+
+        # Then send periodically
+        interval_seconds = self.interval_hours * 3600
+        while not self._stop_event.is_set():
+            try:
+                # Wait for the interval or until stop is requested
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=interval_seconds
+                )
+                # If we get here, stop was requested
+                break
+            except asyncio.TimeoutError:
+                # Timeout means it's time to send telemetry
+                await self.send_telemetry()
+
+        logger.info("Telemetry sender stopped")
+
+    def start(self):
+        """Start the periodic telemetry sender"""
+        if not self.enabled:
+            logger.info("Telemetry is disabled, not starting sender")
+            return
+
+        if self._task is not None and not self._task.done():
+            logger.warning("Telemetry sender is already running")
+            return
+
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._periodic_sender())
+        logger.info("Telemetry sender task created")
+
+    async def stop(self):
+        """Stop the periodic telemetry sender"""
+        if self._task is None or self._task.done():
+            logger.info("Telemetry sender is not running")
+            return
+
+        logger.info("Stopping telemetry sender...")
+        self._stop_event.set()
+
+        try:
+            await asyncio.wait_for(self._task, timeout=5.0)
+        except asyncio.TimeoutError:
+            logger.warning("Telemetry sender did not stop gracefully, cancelling")
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+        logger.info("Telemetry sender stopped")
+
+
+async def test_telemetry():
+    """Test function to send telemetry immediately"""
+    collector = TelemetryCollector()
+    sender = TelemetrySender(collector, enabled=True)
+
+    print("Collecting telemetry data...")
+    print(collector.to_readable_string())
+
+    print("\nSending telemetry data...")
+    success = await sender.send_telemetry()
+
+    if success:
+        print("✓ Telemetry sent successfully!")
+    else:
+        print("✗ Failed to send telemetry")
+
+
+if __name__ == "__main__":
+    # Test the sender
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(test_telemetry())


### PR DESCRIPTION
- Collect system info (instance ID, OS, CPU, RAM) for usage insights
- Send telemetry to telemetry.basekick.net every 24 hours
- Transparent: all data sent in readable JSON format
- Easy opt-out: set telemetry.enabled=false in arc.conf
- Comprehensive documentation in docs/TELEMETRY.md
- Only primary worker sends telemetry (no duplicates)

Data collected:
- Random instance ID (not tied to hardware)
- OS name, version, and architecture
- CPU core count and frequency
- Total system RAM
- Arc version

All telemetry is anonymous and helps us improve Arc.