### PR TITLE
feat: Add adaptive flush strategy for low-volume measurements

### DIFF
--- a/api/msgpack_routes.py
+++ b/api/msgpack_routes.py
@@ -58,7 +58,8 @@ def init_arrow_buffer(storage_backend, config: dict = None):
         max_buffer_age_seconds=config.get('max_buffer_age_seconds', 60),
         compression=config.get('compression', 'snappy'),
         wal_enabled=wal_enabled,
-        wal_config=wal_init_config
+        wal_config=wal_init_config,
+        low_volume_threshold=config.get('low_volume_threshold', 60)
     )
 
     logger.info(


### PR DESCRIPTION
Problem:
In multi-worker deployments, low-volume measurements (< 60 rec/min) like mem and processes experienced 30% data loss because records scattered across workers, each buffering independently. Workers that never received certain measurements had nothing to flush during periodic cycles.

Solution:
Implement adaptive flush strategy that automatically detects low-volume measurements and flushes them immediately instead of buffering. This ensures every record is persisted regardless of which worker receives it.

Changes:
- Added measurement volume tracking with 5-minute rolling windows
- Auto-detect low-volume measurements (< 60 records/minute threshold)
- Flush low-volume measurements immediately on write
- High-volume measurements continue to buffer normally for efficiency
- Configurable threshold via low_volume_threshold parameter (default: 60)

Benefits:
- 100% data completeness for all measurements in multi-worker setups
- Works with any number of workers (1 to 100+)
- Zero configuration required - adapts automatically
- Maintains high performance for high-volume data

Testing:
- Verified 100% completeness for simulated low-volume (mem, processes)
- Verified normal buffering for high-volume (cpu)
- Works correctly with concurrent writes across measurements