### PR TITLE
fix: Volume permissions for non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 # Create app user (non-root for security)
 RUN useradd -m -u 1000 arc && \
-    mkdir -p /app /data && \
-    chown -R arc:arc /app /data
+    mkdir -p /app/data && \
+    chown -R arc:arc /app
 
 # Set working directory
 WORKDIR /app
@@ -55,6 +55,9 @@ RUN chmod +x entrypoint.sh
 
 # Switch to non-root user
 USER arc
+
+# Declare volume for data persistence
+VOLUME ["/app/data"]
 
 # Expose API port
 EXPOSE 8000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,9 +25,8 @@ PORT=${PORT:-8000}
 TIMEOUT=${TIMEOUT:-300}
 LOG_LEVEL=${LOG_LEVEL:-info}
 
-# Ensure data directories exist with correct permissions
+# Ensure data directories exist
 mkdir -p /app/data/arc
-chmod 755 /app/data
 
 # Wait for dependencies (optional)
 if [ ! -z "$WAIT_FOR_DB" ]; then


### PR DESCRIPTION
- Create /app/data in Dockerfile with correct ownership
- Add VOLUME directive to preserve permissions
- Simplify entrypoint directory creation

Fixes permission denied error when arc user tries to create /app/data/arc subdirectory in mounted volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)