### PR TITLE
fix: Properly fix memory leak in query result handling (v25.11.2)

### DIFF
--- a/api/duckdb_engine.py
+++ b/api/duckdb_engine.py
@@ -377,13 +377,20 @@ class DuckDBEngine:
                 columns = [desc[0] for desc in conn.description] if conn.description else []
                 query_time = time.time() - query_start
 
+                # Convert rows to list immediately
+                data = [list(row) for row in rows]
+                row_count = len(data)
+
+                # CRITICAL: Delete rows reference immediately to free DuckDB result memory
+                del rows
+
                 total_time = time.time() - start_time
 
                 return {
                     "success": True,
-                    "data": [list(row) for row in rows],
+                    "data": data,
                     "columns": columns,
-                    "row_count": len(rows),
+                    "row_count": row_count,
                     "execution_time_ms": round(query_time * 1000, 2),
                     "wait_time_ms": round((total_time - query_time) * 1000, 2)
                 }


### PR DESCRIPTION
The initial v25.11.2 fix was ineffective because it deleted the result dict but the data was still referenced by the response object returned to FastAPI. Memory would only be freed after JSON serialization and network transmission completed.

Root cause analysis:
1. DuckDB fetchall() returns result in DuckDB memory
2. List comprehension copies data to Python lists
3. Data copied into response_data object
4. del result only deleted dict wrapper, not the data
5. GC ran but had nothing to collect (data still referenced)
6. Data stayed in memory through FastAPI serialization

Fixes in this release:

**api/duckdb_engine.py**:
- Delete rows reference immediately after conversion to free DuckDB memory
- Reduces memory footprint during query execution

**api/main.py**:
- More aggressive GC: every 50 queries (was 100) or 30s (was 60s)
- Better logging: show collected object count and reason
- GC runs before returning to maximize cleanup window

**api/duckdb_pool_simple.py**:
- Run GC after every query in connection cleanup
- Log significant collections (>100 objects) for monitoring
- Ensures DuckDB internal state is cleaned up

This three-layer approach ensures memory is freed at:
1. DuckDB result level (engine)
2. Python object level (main.py GC)
3. Connection pool level (pool cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)