### PR TITLE
fix: Correct fresh connection creation in pool cleanup

### DIFF
--- a/api/duckdb_pool_simple.py
+++ b/api/duckdb_pool_simple.py
@@ -171,7 +171,17 @@ class SimpleDuckDBPool:
                         pass
 
                     # Create and return a fresh connection to the pool
-                    fresh_conn = duckdb.connect(self.db_path)
+                    fresh_conn = duckdb.connect()
+
+                    # Apply configuration if provided
+                    if self.configure_fn:
+                        try:
+                            self.configure_fn(fresh_conn)
+                        except Exception as config_error:
+                            logger.error(f"Failed to configure fresh connection: {config_error}")
+                            fresh_conn.close()
+                            raise
+
                     self.pool.put(fresh_conn)
 
     def get_metrics(self) -> Dict[str, Any]:


### PR DESCRIPTION
Fixed AttributeError where cleanup tried to access self.db_path which doesn't exist in SimpleDuckDBPool. Fresh connections now created using the same pattern as _initialize_pool():
1. duckdb.connect() (no path)
2. Apply configure_fn if provided

This matches how the pool creates connections initially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)