### PR TITLE
feat: Add configurable max payload size for API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,8 @@ temp/
 *.sha256
 
 docs/progress/2025-11-28-6month-product-roadmap.md
+docs/progress/2024-12-04-arc-cloud-design.md
+docs/progress/2024-12-04-edge-replication-design.md
+docs/progress/2024-12-05-configurable-payload-size.md
 RELEASE_NOTES_2026.01.1.md
 arc.toml

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -387,6 +387,7 @@ func main() {
 		WriteTimeout:    30 * time.Second,
 		IdleTimeout:     120 * time.Second,
 		ShutdownTimeout: 30 * time.Second,
+		MaxPayloadSize:  cfg.Server.MaxPayloadSize,
 		TLSEnabled:      cfg.Server.TLSEnabled,
 		TLSCertFile:     cfg.Server.TLSCertFile,
 		TLSKeyFile:      cfg.Server.TLSKeyFile,
@@ -412,7 +413,7 @@ func main() {
 	}
 
 	// Register MessagePack handler with Arrow buffer
-	msgpackHandler := api.NewMsgPackHandler(logger.Get("msgpack"), arrowBuffer)
+	msgpackHandler := api.NewMsgPackHandler(logger.Get("msgpack"), arrowBuffer, server.GetMaxPayloadSize())
 	msgpackHandler.RegisterRoutes(server.GetApp())
 
 	// Register Line Protocol handler


### PR DESCRIPTION
- Add server.max_payload_size config option (default: 1GB, up from 100MB)
- Support human-readable size formats (1GB, 500MB, 100KB)
- Configurable via arc.toml or ARC_SERVER_MAX_PAYLOAD_SIZE env var
- Applies to both compressed and decompressed payloads
- Improve error messages to suggest batching on 413 errors
- Add comprehensive tests for ParseSize function

Resolves customer issue with 413 errors when importing 300,000 chunks.