### PR TITLE
fix: Add CTE support and JOIN clause table resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,6 @@ docs/progress/2025-11-28-6month-product-roadmap.md
 docs/progress/2024-12-04-arc-cloud-design.md
 docs/progress/2024-12-04-edge-replication-design.md
 docs/progress/2024-12-05-configurable-payload-size.md
+docs/progress/
 RELEASE_NOTES_2026.01.1.md
 arc.toml


### PR DESCRIPTION
- Add extractCTENames() to identify CTE names from WITH clauses
- Modify convertSQLToStoragePaths() to skip CTE names during path conversion
- Add JOIN clause patterns for database.table syntax
- Update continuous query handler with CTE awareness
- Add comprehensive unit tests and benchmarks

Fixes issue where CTE names like `WITH campaign AS (...)` were incorrectly converted to physical storage paths, causing "No files found" errors.