### PR TITLE
feat: Add database management REST API endpoints

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -442,6 +442,10 @@ func main() {
 		log.Info().Msg("Delete operations DISABLED (set delete.enabled=true in arc.toml to enable)")
 	}
 
+	// Register Databases handler
+	databasesHandler := api.NewDatabasesHandler(storageBackend, &cfg.Delete, logger.Get("databases"))
+	databasesHandler.RegisterRoutes(server.GetApp())
+
 	// Register Retention handler
 	if cfg.Retention.Enabled {
 		retentionHandler, err := api.NewRetentionHandler(storageBackend, db, &cfg.Retention, logger.Get("retention"))

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -1,0 +1,519 @@
+package api
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// DatabasesHandler handles database management API endpoints
+type DatabasesHandler struct {
+	storage      storage.Backend
+	deleteConfig *config.DeleteConfig
+	logger       zerolog.Logger
+}
+
+// CreateDatabaseRequest represents a request to create a new database
+type CreateDatabaseRequest struct {
+	Name string `json:"name"`
+}
+
+// DatabaseInfo represents information about a database
+type DatabaseInfo struct {
+	Name             string `json:"name"`
+	MeasurementCount int    `json:"measurement_count"`
+	CreatedAt        string `json:"created_at,omitempty"`
+}
+
+// DatabaseListResponse represents the response for listing databases
+type DatabaseListResponse struct {
+	Databases []DatabaseInfo `json:"databases"`
+	Count     int            `json:"count"`
+}
+
+// DatabaseMeasurement represents a measurement within a database
+type DatabaseMeasurement struct {
+	Name      string `json:"name"`
+	FileCount int    `json:"file_count,omitempty"`
+}
+
+// MeasurementListResponse represents the response for listing measurements
+type MeasurementListResponse struct {
+	Database     string                `json:"database"`
+	Measurements []DatabaseMeasurement `json:"measurements"`
+	Count        int                   `json:"count"`
+}
+
+// Database name validation
+var validDatabaseName = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
+// Reserved database names that cannot be created
+var reservedDatabaseNames = map[string]bool{
+	"system":    true,
+	"internal":  true,
+	"_internal": true,
+}
+
+// NewDatabasesHandler creates a new databases handler
+func NewDatabasesHandler(storage storage.Backend, deleteConfig *config.DeleteConfig, logger zerolog.Logger) *DatabasesHandler {
+	return &DatabasesHandler{
+		storage:      storage,
+		deleteConfig: deleteConfig,
+		logger:       logger.With().Str("component", "databases-handler").Logger(),
+	}
+}
+
+// RegisterRoutes registers the database management routes
+func (h *DatabasesHandler) RegisterRoutes(app *fiber.App) {
+	app.Get("/api/v1/databases", h.handleList)
+	app.Post("/api/v1/databases", h.handleCreate)
+	app.Get("/api/v1/databases/:name", h.handleGet)
+	app.Get("/api/v1/databases/:name/measurements", h.handleListMeasurements)
+	app.Delete("/api/v1/databases/:name", h.handleDelete)
+}
+
+// handleList handles GET /api/v1/databases
+func (h *DatabasesHandler) handleList(c *fiber.Ctx) error {
+	ctx := context.Background()
+
+	databases, err := h.listDatabases(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to list databases")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to list databases: " + err.Error(),
+		})
+	}
+
+	// Get measurement counts for each database
+	databaseInfos := make([]DatabaseInfo, 0, len(databases))
+	for _, db := range databases {
+		measurementCount := 0
+		measurements, err := h.listMeasurements(ctx, db)
+		if err == nil {
+			measurementCount = len(measurements)
+		}
+
+		databaseInfos = append(databaseInfos, DatabaseInfo{
+			Name:             db,
+			MeasurementCount: measurementCount,
+		})
+	}
+
+	h.logger.Info().Int("count", len(databaseInfos)).Msg("Listed databases")
+
+	return c.JSON(DatabaseListResponse{
+		Databases: databaseInfos,
+		Count:     len(databaseInfos),
+	})
+}
+
+// handleCreate handles POST /api/v1/databases
+func (h *DatabasesHandler) handleCreate(c *fiber.Ctx) error {
+	var req CreateDatabaseRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body: " + err.Error(),
+		})
+	}
+
+	// Validate database name
+	if req.Name == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name is required",
+		})
+	}
+
+	if !isValidDatabaseName(req.Name) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid database name: must start with a letter and contain only alphanumeric characters, underscores, or hyphens (max 64 characters)",
+		})
+	}
+
+	if reservedDatabaseNames[strings.ToLower(req.Name)] {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name '" + req.Name + "' is reserved",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if database already exists
+	exists, err := h.databaseExists(ctx, req.Name)
+	if err != nil {
+		h.logger.Error().Err(err).Str("database", req.Name).Msg("Failed to check if database exists")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to check if database exists",
+		})
+	}
+
+	if exists {
+		return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+			"error": "Database '" + req.Name + "' already exists",
+		})
+	}
+
+	// Create database by writing a marker file
+	// This works for all storage backends (local, S3, Azure)
+	markerPath := req.Name + "/.arc-database"
+	markerContent := []byte(`{"created_at":"` + time.Now().UTC().Format(time.RFC3339) + `"}`)
+
+	if err := h.storage.Write(ctx, markerPath, markerContent); err != nil {
+		h.logger.Error().Err(err).Str("database", req.Name).Msg("Failed to create database")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to create database: " + err.Error(),
+		})
+	}
+
+	h.logger.Info().Str("database", req.Name).Msg("Created database")
+
+	return c.Status(fiber.StatusCreated).JSON(DatabaseInfo{
+		Name:             req.Name,
+		MeasurementCount: 0,
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// handleGet handles GET /api/v1/databases/:name
+func (h *DatabasesHandler) handleGet(c *fiber.Ctx) error {
+	name := c.Params("name")
+	if name == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name is required",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if database exists
+	exists, err := h.databaseExists(ctx, name)
+	if err != nil {
+		h.logger.Error().Err(err).Str("database", name).Msg("Failed to check if database exists")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to check database",
+		})
+	}
+
+	if !exists {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Database '" + name + "' not found",
+		})
+	}
+
+	// Get measurement count
+	measurements, err := h.listMeasurements(ctx, name)
+	measurementCount := 0
+	if err == nil {
+		measurementCount = len(measurements)
+	}
+
+	return c.JSON(DatabaseInfo{
+		Name:             name,
+		MeasurementCount: measurementCount,
+	})
+}
+
+// handleListMeasurements handles GET /api/v1/databases/:name/measurements
+func (h *DatabasesHandler) handleListMeasurements(c *fiber.Ctx) error {
+	name := c.Params("name")
+	if name == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name is required",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if database exists
+	exists, err := h.databaseExists(ctx, name)
+	if err != nil {
+		h.logger.Error().Err(err).Str("database", name).Msg("Failed to check if database exists")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to check database",
+		})
+	}
+
+	if !exists {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Database '" + name + "' not found",
+		})
+	}
+
+	// List measurements
+	measurements, err := h.listMeasurements(ctx, name)
+	if err != nil {
+		h.logger.Error().Err(err).Str("database", name).Msg("Failed to list measurements")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to list measurements: " + err.Error(),
+		})
+	}
+
+	// Build response
+	measurementInfos := make([]DatabaseMeasurement, 0, len(measurements))
+	for _, m := range measurements {
+		measurementInfos = append(measurementInfos, DatabaseMeasurement{
+			Name: m,
+		})
+	}
+
+	h.logger.Info().
+		Str("database", name).
+		Int("count", len(measurementInfos)).
+		Msg("Listed measurements")
+
+	return c.JSON(MeasurementListResponse{
+		Database:     name,
+		Measurements: measurementInfos,
+		Count:        len(measurementInfos),
+	})
+}
+
+// handleDelete handles DELETE /api/v1/databases/:name
+func (h *DatabasesHandler) handleDelete(c *fiber.Ctx) error {
+	// Check if delete is enabled
+	if h.deleteConfig == nil || !h.deleteConfig.Enabled {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+			"error": "Delete operations are disabled. Set delete.enabled=true in arc.toml to enable.",
+		})
+	}
+
+	name := c.Params("name")
+	if name == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name is required",
+		})
+	}
+
+	// Require confirmation
+	confirm := c.Query("confirm")
+	if confirm != "true" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Confirmation required. Add ?confirm=true to delete the database.",
+		})
+	}
+
+	// Prevent deletion of reserved names
+	if reservedDatabaseNames[strings.ToLower(name)] {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+			"error": "Cannot delete reserved database '" + name + "'",
+		})
+	}
+
+	ctx := context.Background()
+
+	// Check if database exists
+	exists, err := h.databaseExists(ctx, name)
+	if err != nil {
+		h.logger.Error().Err(err).Str("database", name).Msg("Failed to check if database exists")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to check database",
+		})
+	}
+
+	if !exists {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Database '" + name + "' not found",
+		})
+	}
+
+	// List all files in the database
+	files, err := h.storage.List(ctx, name+"/")
+	if err != nil {
+		h.logger.Error().Err(err).Str("database", name).Msg("Failed to list database files")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to list database files",
+		})
+	}
+
+	// Delete all files
+	deletedCount := 0
+	var deleteErrors []string
+
+	// Try batch delete if available
+	if batchDeleter, ok := h.storage.(storage.BatchDeleter); ok && len(files) > 0 {
+		if err := batchDeleter.DeleteBatch(ctx, files); err != nil {
+			h.logger.Error().Err(err).Str("database", name).Msg("Batch delete failed")
+			deleteErrors = append(deleteErrors, err.Error())
+		} else {
+			deletedCount = len(files)
+		}
+	} else {
+		// Fall back to individual deletes
+		for _, file := range files {
+			if err := h.storage.Delete(ctx, file); err != nil {
+				h.logger.Warn().Err(err).Str("file", file).Msg("Failed to delete file")
+				deleteErrors = append(deleteErrors, file+": "+err.Error())
+			} else {
+				deletedCount++
+			}
+		}
+	}
+
+	// Also delete the .arc-database marker file (not included in List due to hidden file filter)
+	markerPath := name + "/.arc-database"
+	if err := h.storage.Delete(ctx, markerPath); err == nil {
+		deletedCount++
+		h.logger.Debug().Str("path", markerPath).Msg("Deleted database marker file")
+	}
+
+	// Try to remove the empty database directory
+	// This is a best-effort operation - for local storage, we try to remove the directory
+	// For S3/Azure, directories don't exist as actual objects, so this is a no-op
+	if dirRemover, ok := h.storage.(storage.DirectoryRemover); ok {
+		if err := dirRemover.RemoveDirectory(ctx, name); err != nil {
+			h.logger.Debug().Err(err).Str("database", name).Msg("Could not remove database directory (may not be empty)")
+		}
+	}
+
+	if len(deleteErrors) > 0 {
+		h.logger.Error().
+			Str("database", name).
+			Int("deleted", deletedCount).
+			Int("errors", len(deleteErrors)).
+			Msg("Partial database deletion")
+
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error":         "Partial deletion - some files could not be deleted",
+			"deleted_count": deletedCount,
+			"errors":        deleteErrors,
+		})
+	}
+
+	h.logger.Info().
+		Str("database", name).
+		Int("files_deleted", deletedCount).
+		Msg("Deleted database")
+
+	return c.JSON(fiber.Map{
+		"message":       "Database '" + name + "' deleted successfully",
+		"files_deleted": deletedCount,
+	})
+}
+
+// Helper functions
+
+func isValidDatabaseName(name string) bool {
+	if len(name) == 0 || len(name) > 64 {
+		return false
+	}
+	return validDatabaseName.MatchString(name)
+}
+
+func (h *DatabasesHandler) listDatabases(ctx context.Context) ([]string, error) {
+	var databases []string
+
+	// Use DirectoryLister if available
+	if lister, ok := h.storage.(storage.DirectoryLister); ok {
+		dirs, err := lister.ListDirectories(ctx, "")
+		if err != nil {
+			return nil, err
+		}
+		databases = dirs
+	} else {
+		// Fall back to List and extract unique top-level directories
+		files, err := h.storage.List(ctx, "")
+		if err != nil {
+			return nil, err
+		}
+		databases = extractTopLevelDirs(files)
+	}
+
+	// Filter out hidden directories and sort
+	filtered := make([]string, 0, len(databases))
+	for _, db := range databases {
+		if !strings.HasPrefix(db, ".") && !strings.HasPrefix(db, "_") {
+			filtered = append(filtered, db)
+		}
+	}
+	sort.Strings(filtered)
+
+	return filtered, nil
+}
+
+func (h *DatabasesHandler) listMeasurements(ctx context.Context, database string) ([]string, error) {
+	var measurements []string
+
+	// Use DirectoryLister if available
+	if lister, ok := h.storage.(storage.DirectoryLister); ok {
+		dirs, err := lister.ListDirectories(ctx, database+"/")
+		if err != nil {
+			return nil, err
+		}
+		measurements = dirs
+	} else {
+		// Fall back to List and extract unique subdirectories
+		files, err := h.storage.List(ctx, database+"/")
+		if err != nil {
+			return nil, err
+		}
+		measurements = extractSubdirectories(files, database)
+	}
+
+	// Filter out hidden directories and sort
+	filtered := make([]string, 0, len(measurements))
+	for _, m := range measurements {
+		if !strings.HasPrefix(m, ".") && !strings.HasPrefix(m, "_") {
+			filtered = append(filtered, m)
+		}
+	}
+	sort.Strings(filtered)
+
+	return filtered, nil
+}
+
+func (h *DatabasesHandler) databaseExists(ctx context.Context, name string) (bool, error) {
+	databases, err := h.listDatabases(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	for _, db := range databases {
+		if db == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func extractTopLevelDirs(files []string) []string {
+	dirSet := make(map[string]bool)
+	for _, file := range files {
+		parts := strings.SplitN(file, "/", 2)
+		if len(parts) > 0 && parts[0] != "" {
+			dirSet[parts[0]] = true
+		}
+	}
+
+	dirs := make([]string, 0, len(dirSet))
+	for dir := range dirSet {
+		dirs = append(dirs, dir)
+	}
+	return dirs
+}
+
+func extractSubdirectories(files []string, prefix string) []string {
+	dirSet := make(map[string]bool)
+	prefixWithSlash := prefix + "/"
+
+	for _, file := range files {
+		if strings.HasPrefix(file, prefixWithSlash) {
+			remainder := strings.TrimPrefix(file, prefixWithSlash)
+			parts := strings.SplitN(remainder, "/", 2)
+			if len(parts) > 0 && parts[0] != "" {
+				dirSet[parts[0]] = true
+			}
+		}
+	}
+
+	dirs := make([]string, 0, len(dirSet))
+	for dir := range dirSet {
+		dirs = append(dirs, dir)
+	}
+	return dirs
+}

--- a/internal/api/databases_test.go
+++ b/internal/api/databases_test.go
@@ -1,0 +1,591 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// setupTestDatabasesHandler creates a test handler with a local storage backend
+func setupTestDatabasesHandler(t *testing.T, deleteEnabled bool) (*DatabasesHandler, *fiber.App, string) {
+	t.Helper()
+
+	// Create temporary directory for tests
+	tmpDir, err := os.MkdirTemp("", "arc-databases-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	backend, err := storage.NewLocalBackend(tmpDir, logger)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatalf("failed to create LocalBackend: %v", err)
+	}
+
+	deleteConfig := &config.DeleteConfig{
+		Enabled: deleteEnabled,
+	}
+
+	handler := NewDatabasesHandler(backend, deleteConfig, logger)
+
+	app := fiber.New()
+	handler.RegisterRoutes(app)
+
+	return handler, app, tmpDir
+}
+
+// TestDatabasesHandler_List tests listing databases
+func TestDatabasesHandler_List(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	// Create some databases by creating directories with files
+	ctx := context.Background()
+	backend, _ := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	defer backend.Close()
+
+	// Create database1 with 2 measurements
+	backend.Write(ctx, "database1/measurement1/data.parquet", []byte("data"))
+	backend.Write(ctx, "database1/measurement2/data.parquet", []byte("data"))
+
+	// Create database2 with 1 measurement
+	backend.Write(ctx, "database2/measurement1/data.parquet", []byte("data"))
+
+	t.Run("List databases", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/databases", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result DatabaseListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		if result.Count != 2 {
+			t.Errorf("Expected 2 databases, got %d", result.Count)
+		}
+
+		// Check that databases have correct measurement counts
+		dbMap := make(map[string]int)
+		for _, db := range result.Databases {
+			dbMap[db.Name] = db.MeasurementCount
+		}
+
+		if dbMap["database1"] != 2 {
+			t.Errorf("Expected database1 to have 2 measurements, got %d", dbMap["database1"])
+		}
+		if dbMap["database2"] != 1 {
+			t.Errorf("Expected database2 to have 1 measurement, got %d", dbMap["database2"])
+		}
+	})
+}
+
+// TestDatabasesHandler_ListEmpty tests listing when no databases exist
+func TestDatabasesHandler_ListEmpty(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	req := httptest.NewRequest("GET", "/api/v1/databases", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	var result DatabaseListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if result.Count != 0 {
+		t.Errorf("Expected 0 databases, got %d", result.Count)
+	}
+}
+
+// TestDatabasesHandler_Create tests creating a database
+func TestDatabasesHandler_Create(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	t.Run("Create database", func(t *testing.T) {
+		body := `{"name": "mydb"}`
+		req := httptest.NewRequest("POST", "/api/v1/databases", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+
+		if resp.StatusCode != fiber.StatusCreated {
+			respBody, _ := io.ReadAll(resp.Body)
+			t.Fatalf("Expected status 201, got %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		var result DatabaseInfo
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		if result.Name != "mydb" {
+			t.Errorf("Expected name 'mydb', got %q", result.Name)
+		}
+		if result.MeasurementCount != 0 {
+			t.Errorf("Expected 0 measurements, got %d", result.MeasurementCount)
+		}
+		if result.CreatedAt == "" {
+			t.Error("Expected CreatedAt to be set")
+		}
+	})
+}
+
+// TestDatabasesHandler_CreateInvalidName tests creating a database with invalid name
+func TestDatabasesHandler_CreateInvalidName(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	tests := []struct {
+		name        string
+		dbName      string
+		expectError bool
+	}{
+		{"empty name", "", true},
+		{"starts with number", "123db", true},
+		{"contains spaces", "my db", true},
+		{"contains special chars", "my@db", true},
+		{"valid name", "my_db", false},
+		{"valid with hyphen", "my-db", false},
+		{"valid alphanumeric", "myDb123", false},
+		{"reserved name system", "system", true},
+		{"reserved name internal", "internal", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"name": "` + tt.dbName + `"}`
+			req := httptest.NewRequest("POST", "/api/v1/databases", bytes.NewBufferString(body))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("Request failed: %v", err)
+			}
+
+			if tt.expectError {
+				if resp.StatusCode == fiber.StatusCreated {
+					t.Errorf("Expected error for name %q, but got success", tt.dbName)
+				}
+			} else {
+				if resp.StatusCode != fiber.StatusCreated {
+					respBody, _ := io.ReadAll(resp.Body)
+					t.Errorf("Expected success for name %q, got status %d: %s", tt.dbName, resp.StatusCode, string(respBody))
+				}
+			}
+		})
+	}
+}
+
+// TestDatabasesHandler_CreateAlreadyExists tests creating a database that already exists
+func TestDatabasesHandler_CreateAlreadyExists(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	// Create database first
+	body := `{"name": "existingdb"}`
+	req := httptest.NewRequest("POST", "/api/v1/databases", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("Failed to create initial database")
+	}
+
+	// Try to create again
+	req = httptest.NewRequest("POST", "/api/v1/databases", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ = app.Test(req)
+
+	if resp.StatusCode != fiber.StatusConflict {
+		t.Errorf("Expected status 409 Conflict, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["error"] == "" {
+		t.Error("Expected error message in response")
+	}
+}
+
+// TestDatabasesHandler_Get tests getting a database
+func TestDatabasesHandler_Get(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a database with measurements
+	ctx := context.Background()
+	backend, _ := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	defer backend.Close()
+	backend.Write(ctx, "testdb/measurement1/data.parquet", []byte("data"))
+	backend.Write(ctx, "testdb/measurement2/data.parquet", []byte("data"))
+
+	t.Run("Get existing database", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/databases/testdb", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result DatabaseInfo
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		if result.Name != "testdb" {
+			t.Errorf("Expected name 'testdb', got %q", result.Name)
+		}
+		if result.MeasurementCount != 2 {
+			t.Errorf("Expected 2 measurements, got %d", result.MeasurementCount)
+		}
+	})
+}
+
+// TestDatabasesHandler_GetNotFound tests getting a non-existent database
+func TestDatabasesHandler_GetNotFound(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	req := httptest.NewRequest("GET", "/api/v1/databases/nonexistent", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestDatabasesHandler_ListMeasurements tests listing measurements in a database
+func TestDatabasesHandler_ListMeasurements(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a database with measurements
+	ctx := context.Background()
+	backend, _ := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	defer backend.Close()
+	backend.Write(ctx, "testdb/cpu/data.parquet", []byte("data"))
+	backend.Write(ctx, "testdb/memory/data.parquet", []byte("data"))
+	backend.Write(ctx, "testdb/disk/data.parquet", []byte("data"))
+
+	t.Run("List measurements", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/databases/testdb/measurements", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result MeasurementListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		if result.Database != "testdb" {
+			t.Errorf("Expected database 'testdb', got %q", result.Database)
+		}
+		if result.Count != 3 {
+			t.Errorf("Expected 3 measurements, got %d", result.Count)
+		}
+	})
+}
+
+// TestDatabasesHandler_ListMeasurementsEmpty tests listing measurements in an empty database
+func TestDatabasesHandler_ListMeasurementsEmpty(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false)
+	defer os.RemoveAll(tmpDir)
+
+	// Create empty database (just the marker file)
+	ctx := context.Background()
+	backend, _ := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	defer backend.Close()
+	backend.Write(ctx, "emptydb/.arc-database", []byte(`{"created_at":"2025-01-01T00:00:00Z"}`))
+
+	req := httptest.NewRequest("GET", "/api/v1/databases/emptydb/measurements", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result MeasurementListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if result.Count != 0 {
+		t.Errorf("Expected 0 measurements, got %d", result.Count)
+	}
+}
+
+// TestDatabasesHandler_Delete tests deleting a database
+func TestDatabasesHandler_Delete(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, true) // delete enabled
+	defer os.RemoveAll(tmpDir)
+
+	// Create a database with data
+	ctx := context.Background()
+	backend, _ := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	defer backend.Close()
+	backend.Write(ctx, "deletedb/measurement1/data1.parquet", []byte("data"))
+	backend.Write(ctx, "deletedb/measurement1/data2.parquet", []byte("data"))
+	backend.Write(ctx, "deletedb/measurement2/data1.parquet", []byte("data"))
+
+	t.Run("Delete database with confirmation", func(t *testing.T) {
+		req := httptest.NewRequest("DELETE", "/api/v1/databases/deletedb?confirm=true", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		filesDeleted, ok := result["files_deleted"].(float64)
+		if !ok || filesDeleted < 3 {
+			t.Errorf("Expected at least 3 files deleted, got %v", result["files_deleted"])
+		}
+
+		// Verify database no longer exists
+		exists, _ := backend.Exists(ctx, "deletedb/measurement1/data1.parquet")
+		if exists {
+			t.Error("Expected database files to be deleted")
+		}
+	})
+}
+
+// TestDatabasesHandler_DeleteDisabled tests deleting when delete is disabled
+func TestDatabasesHandler_DeleteDisabled(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, false) // delete disabled
+	defer os.RemoveAll(tmpDir)
+
+	// Create a database
+	ctx := context.Background()
+	backend, _ := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	defer backend.Close()
+	backend.Write(ctx, "testdb/measurement1/data.parquet", []byte("data"))
+
+	req := httptest.NewRequest("DELETE", "/api/v1/databases/testdb?confirm=true", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		t.Errorf("Expected status 403, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["error"] == "" {
+		t.Error("Expected error message in response")
+	}
+}
+
+// TestDatabasesHandler_DeleteRequiresConfirm tests that delete requires confirmation
+func TestDatabasesHandler_DeleteRequiresConfirm(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, true) // delete enabled
+	defer os.RemoveAll(tmpDir)
+
+	// Create a database
+	ctx := context.Background()
+	backend, _ := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	defer backend.Close()
+	backend.Write(ctx, "testdb/measurement1/data.parquet", []byte("data"))
+
+	t.Run("Without confirm param", func(t *testing.T) {
+		req := httptest.NewRequest("DELETE", "/api/v1/databases/testdb", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+
+		if resp.StatusCode != fiber.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("With confirm=false", func(t *testing.T) {
+		req := httptest.NewRequest("DELETE", "/api/v1/databases/testdb?confirm=false", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+
+		if resp.StatusCode != fiber.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestDatabasesHandler_DeleteNotFound tests deleting a non-existent database
+func TestDatabasesHandler_DeleteNotFound(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, true) // delete enabled
+	defer os.RemoveAll(tmpDir)
+
+	req := httptest.NewRequest("DELETE", "/api/v1/databases/nonexistent?confirm=true", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestDatabasesHandler_DeleteEmptyDatabase tests deleting a database that only has the marker file
+func TestDatabasesHandler_DeleteEmptyDatabase(t *testing.T) {
+	_, app, tmpDir := setupTestDatabasesHandler(t, true) // delete enabled
+	defer os.RemoveAll(tmpDir)
+
+	// Create a database with only the marker file (as created by POST /api/v1/databases)
+	ctx := context.Background()
+	backend, _ := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	defer backend.Close()
+	backend.Write(ctx, "emptydb/.arc-database", []byte(`{"created_at":"2025-01-01T00:00:00Z"}`))
+
+	// Verify database appears in list before deletion
+	listReq := httptest.NewRequest("GET", "/api/v1/databases", nil)
+	listResp, _ := app.Test(listReq)
+	var listResult DatabaseListResponse
+	json.NewDecoder(listResp.Body).Decode(&listResult)
+	found := false
+	for _, db := range listResult.Databases {
+		if db.Name == "emptydb" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("Expected emptydb to appear in database list before deletion")
+	}
+
+	// Delete the database
+	req := httptest.NewRequest("DELETE", "/api/v1/databases/emptydb?confirm=true", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("Expected status 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	// Should have deleted at least the marker file
+	filesDeleted, ok := result["files_deleted"].(float64)
+	if !ok || filesDeleted < 1 {
+		t.Errorf("Expected at least 1 file deleted (marker file), got %v", result["files_deleted"])
+	}
+
+	// Verify database no longer appears in list
+	listReq2 := httptest.NewRequest("GET", "/api/v1/databases", nil)
+	listResp2, _ := app.Test(listReq2)
+	var listResult2 DatabaseListResponse
+	json.NewDecoder(listResp2.Body).Decode(&listResult2)
+	for _, db := range listResult2.Databases {
+		if db.Name == "emptydb" {
+			t.Error("Expected emptydb to NOT appear in database list after deletion")
+		}
+	}
+}
+
+// TestIsValidDatabaseName tests the database name validation function
+func TestIsValidDatabaseName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"valid lowercase", "mydb", true},
+		{"valid with underscore", "my_db", true},
+		{"valid with hyphen", "my-db", true},
+		{"valid mixed case", "MyDb", true},
+		{"valid with numbers", "db123", true},
+		{"empty", "", false},
+		{"starts with number", "123db", false},
+		{"starts with underscore", "_db", false},
+		{"starts with hyphen", "-db", false},
+		{"contains space", "my db", false},
+		{"contains special char", "my@db", false},
+		{"contains dot", "my.db", false},
+		{"too long", string(make([]byte, 65)), false},
+		{"max length", string(make([]byte, 64)), false}, // all same char doesn't match pattern
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidDatabaseName(tt.input)
+			// Special case for max length - needs to be valid chars
+			if tt.name == "max length" {
+				validMaxLength := "a" + string(make([]byte, 63))
+				for i := range validMaxLength {
+					if i > 0 {
+						validMaxLength = validMaxLength[:i] + "a" + validMaxLength[i+1:]
+					}
+				}
+				// Just test length constraint
+				if len(tt.input) > 64 && result {
+					t.Errorf("isValidDatabaseName(%q) = %v, want %v", tt.input, result, tt.expected)
+				}
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("isValidDatabaseName(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -65,3 +65,10 @@ type ObjectInfo struct {
 type ObjectLister interface {
 	ListObjects(ctx context.Context, prefix string) ([]ObjectInfo, error)
 }
+
+// DirectoryRemover removes an empty directory.
+// This is used to clean up database directories after all files are deleted.
+// For object storage (S3, Azure), this is typically a no-op since directories don't exist as objects.
+type DirectoryRemover interface {
+	RemoveDirectory(ctx context.Context, path string) error
+}


### PR DESCRIPTION
Add new REST API endpoints for managing databases programmatically:
- GET /api/v1/databases - List all databases with measurement counts
- POST /api/v1/databases - Create a new database
- GET /api/v1/databases/:name - Get database info
- GET /api/v1/databases/:name/measurements - List measurements
- DELETE /api/v1/databases/:name - Delete a database (requires delete.enabled)

Key features:
- Database name validation (alphanumeric, underscore, hyphen; max 64 chars)
- Reserved names protected (system, internal, _internal)
- DELETE requires ?confirm=true query parameter
- Works with all storage backends (local, S3, Azure)

Also adds DirectoryRemover interface for proper cleanup of empty directories after database deletion.