### PR TITLE
fix: Add bounds checking for integer conversions to prevent overflow

### DIFF
--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -1283,11 +1284,20 @@ func (b *ArrowBuffer) convertColumnsToTyped(columns map[string][]interface{}) (m
 					case uint32:
 						arr[i] = int64(val)
 					case uint64:
+						if val > math.MaxInt64 {
+							return nil, 0, fmt.Errorf("uint64 value %d exceeds int64 max in column '%s'", val, name)
+						}
 						arr[i] = int64(val)
 					// Handle float types (stream may send float when schema inferred int)
 					case float32:
+						if val > math.MaxInt64 || val < math.MinInt64 {
+							return nil, 0, fmt.Errorf("float32 value %f exceeds int64 range in column '%s'", val, name)
+						}
 						arr[i] = int64(val)
 					case float64:
+						if val > math.MaxInt64 || val < math.MinInt64 {
+							return nil, 0, fmt.Errorf("float64 value %f exceeds int64 range in column '%s'", val, name)
+						}
 						arr[i] = int64(val)
 					default:
 						return nil, 0, fmt.Errorf("unexpected type in int column '%s': %T", name, val)


### PR DESCRIPTION
Add validation before converting uint64 and float32/float64 to int64 to prevent silent overflow that could cause data corruption:

- uint64 > math.MaxInt64 now returns an error
- float32/float64 outside int64 range now returns an error

Fixes CodeQL alerts for incorrect integer conversions.