### PR TITLE
perf: Add SQL transform cache for repeated query optimization

### DIFF
--- a/internal/database/sql_transform_cache.go
+++ b/internal/database/sql_transform_cache.go
@@ -1,0 +1,179 @@
+package database
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// SQLTransformCacheTTL is the default TTL for SQL transform cache entries (60 seconds)
+const SQLTransformCacheTTL = 60 * time.Second
+
+// DefaultSQLTransformCacheMaxSize is the default maximum number of cached entries
+const DefaultSQLTransformCacheMaxSize = 10000
+
+// Aliases for backwards compatibility
+const QueryCacheTTL = SQLTransformCacheTTL
+const DefaultQueryCacheMaxSize = DefaultSQLTransformCacheMaxSize
+
+// sqlTransformCacheEntry represents a cached transformed SQL with expiration
+type sqlTransformCacheEntry struct {
+	transformed string
+	expiresAt   time.Time
+}
+
+// SQLTransformCache provides a TTL cache for SQL-to-storage-path transformations.
+// This caches the result of converting table references (e.g., FROM mydb.cpu)
+// to DuckDB read_parquet() calls (e.g., FROM read_parquet('./data/mydb/cpu/**/*.parquet')).
+// This is NOT a query results cache or query plan cache - it only caches the
+// regex-based string transformation that happens before DuckDB sees the query.
+type SQLTransformCache struct {
+	mu         sync.RWMutex
+	entries    map[string]sqlTransformCacheEntry
+	ttl        time.Duration
+	maxSize    int
+	hits       atomic.Int64
+	misses     atomic.Int64
+	evictions  atomic.Int64
+}
+
+// NewSQLTransformCache creates a new SQL transform cache with the specified TTL and max size
+func NewSQLTransformCache(ttl time.Duration, maxSize int) *SQLTransformCache {
+	if ttl <= 0 {
+		ttl = SQLTransformCacheTTL
+	}
+	if maxSize <= 0 {
+		maxSize = DefaultSQLTransformCacheMaxSize
+	}
+	return &SQLTransformCache{
+		entries: make(map[string]sqlTransformCacheEntry),
+		ttl:     ttl,
+		maxSize: maxSize,
+	}
+}
+
+// NewQueryCache creates a new query cache (alias for backwards compatibility)
+func NewQueryCache(ttl time.Duration, maxSize int) *SQLTransformCache {
+	return NewSQLTransformCache(ttl, maxSize)
+}
+
+// QueryCache is an alias for SQLTransformCache (backwards compatibility)
+type QueryCache = SQLTransformCache
+
+// queryHash generates a cache key from SQL using SHA256
+func queryHash(sql string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(sql)))
+}
+
+// Get retrieves a cached transformed SQL if it exists and hasn't expired
+func (c *SQLTransformCache) Get(sql string) (string, bool) {
+	hash := queryHash(sql)
+
+	c.mu.RLock()
+	entry, ok := c.entries[hash]
+	c.mu.RUnlock()
+
+	if !ok {
+		c.misses.Add(1)
+		return "", false
+	}
+
+	if time.Now().After(entry.expiresAt) {
+		c.misses.Add(1)
+		return "", false
+	}
+
+	c.hits.Add(1)
+	return entry.transformed, true
+}
+
+// Set stores a transformed SQL in the cache
+func (c *SQLTransformCache) Set(sql, transformed string) {
+	hash := queryHash(sql)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check if we need to evict entries
+	if len(c.entries) >= c.maxSize {
+		// Simple eviction: remove expired entries first
+		now := time.Now()
+		removed := 0
+		for key, entry := range c.entries {
+			if now.After(entry.expiresAt) {
+				delete(c.entries, key)
+				removed++
+			}
+		}
+		c.evictions.Add(int64(removed))
+
+		// If still at capacity, skip caching this entry
+		// (LRU would be more sophisticated but adds complexity)
+		if len(c.entries) >= c.maxSize {
+			return
+		}
+	}
+
+	c.entries[hash] = sqlTransformCacheEntry{
+		transformed: transformed,
+		expiresAt:   time.Now().Add(c.ttl),
+	}
+}
+
+// Invalidate removes all entries from the cache
+func (c *SQLTransformCache) Invalidate() {
+	c.mu.Lock()
+	c.entries = make(map[string]sqlTransformCacheEntry)
+	c.mu.Unlock()
+}
+
+// Cleanup removes expired entries from the cache
+func (c *SQLTransformCache) Cleanup() int {
+	now := time.Now()
+	removed := 0
+
+	c.mu.Lock()
+	for key, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, key)
+			removed++
+		}
+	}
+	c.mu.Unlock()
+
+	return removed
+}
+
+// Stats returns cache statistics as a map
+func (c *SQLTransformCache) Stats() map[string]interface{} {
+	c.mu.RLock()
+	size := len(c.entries)
+	c.mu.RUnlock()
+
+	hits := c.hits.Load()
+	misses := c.misses.Load()
+	total := hits + misses
+	hitRate := float64(0)
+	if total > 0 {
+		hitRate = float64(hits) / float64(total) * 100
+	}
+
+	return map[string]interface{}{
+		"cache_size":       size,
+		"cache_max_size":   c.maxSize,
+		"cache_hits":       hits,
+		"cache_misses":     misses,
+		"hit_rate_percent": hitRate,
+		"evictions":        c.evictions.Load(),
+		"ttl_seconds":      c.ttl.Seconds(),
+	}
+}
+
+// Size returns the current number of entries in the cache
+func (c *SQLTransformCache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}

--- a/internal/database/sql_transform_cache_test.go
+++ b/internal/database/sql_transform_cache_test.go
@@ -1,0 +1,200 @@
+package database
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestQueryCache_GetSet(t *testing.T) {
+	cache := NewQueryCache(time.Minute, 100)
+
+	sql := "SELECT * FROM mydb.cpu WHERE time > 123"
+	transformed := "SELECT * FROM read_parquet('./data/mydb/cpu/**/*.parquet') WHERE time > 123"
+
+	// Initially should miss
+	result, ok := cache.Get(sql)
+	if ok {
+		t.Error("expected cache miss on empty cache")
+	}
+
+	// Set and get
+	cache.Set(sql, transformed)
+	result, ok = cache.Get(sql)
+	if !ok {
+		t.Error("expected cache hit after Set")
+	}
+	if result != transformed {
+		t.Errorf("got %q, want %q", result, transformed)
+	}
+
+	// Different SQL should miss
+	_, ok = cache.Get("SELECT * FROM other")
+	if ok {
+		t.Error("expected cache miss for different SQL")
+	}
+}
+
+func TestQueryCache_Expiration(t *testing.T) {
+	cache := NewQueryCache(10*time.Millisecond, 100)
+
+	sql := "SELECT * FROM mydb.cpu"
+	cache.Set(sql, "transformed")
+
+	// Should hit immediately
+	_, ok := cache.Get(sql)
+	if !ok {
+		t.Error("expected cache hit before expiration")
+	}
+
+	// Wait for expiration
+	time.Sleep(15 * time.Millisecond)
+
+	// Should miss after expiration
+	_, ok = cache.Get(sql)
+	if ok {
+		t.Error("expected cache miss after expiration")
+	}
+}
+
+func TestQueryCache_MaxSize(t *testing.T) {
+	cache := NewQueryCache(time.Minute, 5)
+
+	// Fill cache to max
+	for i := 0; i < 5; i++ {
+		cache.Set("query"+string(rune(i)), "transformed"+string(rune(i)))
+	}
+
+	if cache.Size() != 5 {
+		t.Errorf("expected size 5, got %d", cache.Size())
+	}
+
+	// Adding more should not exceed max (will skip if at capacity)
+	cache.Set("query_extra", "transformed_extra")
+
+	// Size should still be <= max
+	if cache.Size() > 5 {
+		t.Errorf("cache exceeded max size: %d > 5", cache.Size())
+	}
+}
+
+func TestQueryCache_Invalidate(t *testing.T) {
+	cache := NewQueryCache(time.Minute, 100)
+
+	cache.Set("query1", "transformed1")
+	cache.Set("query2", "transformed2")
+
+	if cache.Size() != 2 {
+		t.Errorf("expected size 2, got %d", cache.Size())
+	}
+
+	cache.Invalidate()
+
+	if cache.Size() != 0 {
+		t.Errorf("expected size 0 after invalidate, got %d", cache.Size())
+	}
+
+	_, ok := cache.Get("query1")
+	if ok {
+		t.Error("expected cache miss after invalidate")
+	}
+}
+
+func TestQueryCache_Cleanup(t *testing.T) {
+	cache := NewQueryCache(10*time.Millisecond, 100)
+
+	cache.Set("query1", "transformed1")
+	cache.Set("query2", "transformed2")
+
+	// Wait for expiration
+	time.Sleep(15 * time.Millisecond)
+
+	removed := cache.Cleanup()
+	if removed != 2 {
+		t.Errorf("expected 2 entries cleaned up, got %d", removed)
+	}
+
+	if cache.Size() != 0 {
+		t.Errorf("expected size 0 after cleanup, got %d", cache.Size())
+	}
+}
+
+func TestQueryCache_Stats(t *testing.T) {
+	cache := NewQueryCache(time.Minute, 100)
+
+	cache.Set("query1", "transformed1")
+	cache.Get("query1") // hit
+	cache.Get("query1") // hit
+	cache.Get("query2") // miss
+
+	stats := cache.Stats()
+
+	if stats["cache_hits"].(int64) != 2 {
+		t.Errorf("expected 2 hits, got %d", stats["cache_hits"])
+	}
+	if stats["cache_misses"].(int64) != 1 {
+		t.Errorf("expected 1 miss, got %d", stats["cache_misses"])
+	}
+	if stats["cache_size"].(int) != 1 {
+		t.Errorf("expected size 1, got %d", stats["cache_size"])
+	}
+}
+
+func TestQueryCache_Concurrent(t *testing.T) {
+	cache := NewQueryCache(time.Minute, 1000)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			sql := "query" + string(rune(n%10))
+			cache.Set(sql, "transformed"+string(rune(n)))
+			cache.Get(sql)
+		}(i)
+	}
+	wg.Wait()
+
+	// Should not panic and should have some entries
+	if cache.Size() == 0 {
+		t.Error("expected some entries after concurrent access")
+	}
+}
+
+// BenchmarkQueryCache_Get benchmarks cache lookup performance
+func BenchmarkQueryCache_Get(b *testing.B) {
+	cache := NewQueryCache(time.Minute, 10000)
+
+	// Pre-populate cache
+	testSQL := "SELECT * FROM mydb.cpu WHERE time > 1609459200000000"
+	transformed := "SELECT * FROM read_parquet('./data/mydb/cpu/**/*.parquet') WHERE time > 1609459200000000"
+	cache.Set(testSQL, transformed)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Get(testSQL)
+	}
+}
+
+// BenchmarkQueryCache_Set benchmarks cache write performance
+func BenchmarkQueryCache_Set(b *testing.B) {
+	cache := NewQueryCache(time.Minute, 100000)
+
+	testSQL := "SELECT * FROM mydb.cpu WHERE time > 1609459200000000"
+	transformed := "SELECT * FROM read_parquet('./data/mydb/cpu/**/*.parquet') WHERE time > 1609459200000000"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Set(testSQL, transformed)
+	}
+}
+
+// BenchmarkQueryCache_Hash benchmarks the hash function overhead
+func BenchmarkQueryCache_Hash(b *testing.B) {
+	testSQL := "SELECT * FROM mydb.cpu WHERE time > 1609459200000000 AND host = 'server01' GROUP BY time ORDER BY time DESC LIMIT 100"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		queryHash(testSQL)
+	}
+}


### PR DESCRIPTION
Caches the result of converting table references (e.g., FROM mydb.cpu) to DuckDB read_parquet() calls. This is NOT a query results cache - it only caches the regex-based string transformation.

Benchmark shows 49-104x speedup on cache hits (~300ns vs 13-37μs). Particularly beneficial for dashboard refresh scenarios.

- 60-second TTL, 10,000 max entries
- Thread-safe with RWMutex
- Hit/miss/eviction statistics
- Backwards-compatible type alias (QueryCache = SQLTransformCache)