### PR TITLE
perf: Memory leak fixes and query performance optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arc
 
 [![Ingestion](https://img.shields.io/badge/ingestion-10.1M%20rec%2Fs-brightgreen)](https://github.com/basekick-labs/arc)
-[![Query](https://img.shields.io/badge/query-2.88M%20rows%2Fs-blue)](https://github.com/basekick-labs/arc)
+[![Query](https://img.shields.io/badge/query-5.2M%20rows%2Fs-blue)](https://github.com/basekick-labs/arc)
 [![Go](https://img.shields.io/badge/go-1.25+-00ADD8?logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
 
@@ -62,15 +62,18 @@ Benchmarked on Apple MacBook Pro M3 Max (14 cores, 36GB RAM, 1TB NVMe).
 
 | Protocol | Throughput | p50 Latency | p99 Latency |
 |----------|------------|-------------|-------------|
-| MessagePack Columnar | **10.1M rec/s** | 3.09ms | 6.73ms |
-| Line Protocol | 1.92M rec/s | 49.53ms | 108.53ms |
+| MessagePack Columnar | **10.05M rec/s** | 3.08ms | 7.08ms |
+| MessagePack + GZIP | 8.85M rec/s | 3.30ms | 9.32ms |
+| Line Protocol | 1.99M rec/s | 48.19ms | 100.32ms |
 
 ### Query
 
-| Format | Throughput | Response Size (50K rows) |
-|--------|------------|--------------------------|
-| Arrow IPC | **2.88M rows/s** | 1.71 MB |
-| JSON | 2.23M rows/s | 2.41 MB |
+| Format | Throughput | Response Size (500K rows) |
+|--------|------------|---------------------------|
+| Arrow IPC | **5.2M rows/s** | 8.0 MB |
+| JSON | 2.0M rows/s | 25.0 MB |
+
+Full table scan: **927M rows/s** (596M records in 685ms)
 
 ### vs Python Implementation
 

--- a/arc.toml
+++ b/arc.toml
@@ -126,8 +126,21 @@ max_buffer_size = 50000
 # Default: 5000 (5 seconds)
 max_buffer_age_ms = 5000
 
+# DATA PARTITIONING (Always Active):
+#   - Data is automatically partitioned by hour using the data's timestamp
+#   - Files are organized as: database/measurement/YYYY/MM/DD/HH/file.parquet
+#   - Sort keys are applied WITHIN each hourly partition
+#   - This enables efficient time-range queries via partition pruning
+#
+# TIMESTAMP HANDLING:
+#   - If incoming data lacks a "time" column, UTC timestamps are auto-generated
+#   - A warning is logged when timestamps are auto-generated
+#
 # Secondary sort keys for improved compression and query performance
-# Format: "measurement:column1,column2,time"
+# Format: "measurement:column1,column2"
+#
+# NOTE: The "time" column is ALWAYS appended automatically to sort keys.
+# You only need to specify ADDITIONAL columns to sort by before time.
 #
 # BENEFITS:
 #   - 30-50% smaller files (better compression when similar values grouped)
@@ -135,18 +148,18 @@ max_buffer_age_ms = 5000
 #   - Enables dictionary encoding and RLE compression to work optimally
 #
 # EXAMPLES:
-#   IoT sensors: sort by sensor_id first, then time
-#     sort_keys = ["temperature:tag_sensor_id,time", "humidity:tag_sensor_id,time"]
+#   IoT sensors: sort by sensor_id, then time (automatic)
+#     sort_keys = ["temperature:tag_sensor_id", "humidity:tag_sensor_id"]
 #
-#   Multi-tenant: sort by tenant, service, then time
-#     sort_keys = ["metrics:tag_tenant_id,tag_service,time"]
+#   Multi-tenant: sort by tenant, service, then time (automatic)
+#     sort_keys = ["metrics:tag_tenant_id,tag_service"]
 #
-#   Infrastructure: sort by host, metric name, then time
-#     sort_keys = ["cpu:tag_host,tag_metric,time", "memory:tag_host,tag_metric,time"]
+#   Infrastructure: sort by host, metric name, then time (automatic)
+#     sort_keys = ["cpu:tag_host,tag_metric", "memory:tag_host,tag_metric"]
 #
 # HOW IT WORKS:
-#   - Data within each Parquet file is sorted by these columns in order
-#   - Groups all data for same sensor/host/tenant together
+#   - Data within each hourly Parquet file is sorted by these columns
+#   - Groups all data for same sensor/host/tenant together within each hour
 #   - Dramatically improves compression (similar values adjacent)
 #   - Faster queries with WHERE clauses on sort key columns
 #
@@ -154,24 +167,24 @@ max_buffer_age_ms = 5000
 #   - Adds ~35% to sort time (e.g., 7ms → 10ms for 100K records)
 #   - Trade-off: slightly slower writes for much smaller files + faster queries
 #
-# Default: [] (empty, use default_sort_keys for all measurements)
+# Default: [] (time-only sorting for all measurements)
 sort_keys = []
 
-# Default sort keys for measurements not specified in sort_keys
-# Format: comma-separated list of column names
+# Default sort keys for measurements not specified above
+# Format: comma-separated list of additional column names (time is automatic)
 #
 # EXAMPLES:
-#   Time-only (default): "time"
-#   Host then time: "tag_host,time"
-#   Multi-column: "tag_region,tag_host,time"
+#   Time-only (default): ""
+#   Host then time: "tag_host"
+#   Multi-column: "tag_region,tag_host"
 #
-# IMPORTANT:
-#   - Must include "time" column for proper time-based partitioning
+# NOTE:
+#   - Leave empty for time-only sorting (recommended default)
 #   - Columns must exist in the data or flush will fall back to time-only
 #   - Applied to ALL measurements not explicitly configured in sort_keys
 #
-# Default: "time"
-default_sort_keys = "time"
+# Default: "" (time-only sorting)
+default_sort_keys = ""
 
 # -----------------------------------------------------------------------------
 # Compaction Configuration
@@ -238,4 +251,4 @@ enabled = true
 enabled = true
 
 [telemetry]
-enabled = false
+enabled = true

--- a/internal/ingest/arrow_writer_test.go
+++ b/internal/ingest/arrow_writer_test.go
@@ -357,6 +357,26 @@ func TestRowsToColumnar_DifferentFieldTypes(t *testing.T) {
 	}
 }
 
+// BenchmarkGetColumnSignature benchmarks the column signature function
+func BenchmarkGetColumnSignature(b *testing.B) {
+	// Typical columnar payload columns
+	columns := map[string]interface{}{
+		"time":        nil,
+		"host":        nil,
+		"region":      nil,
+		"datacenter":  nil,
+		"usage_idle":  nil,
+		"usage_user":  nil,
+		"usage_system": nil,
+		"usage_iowait": nil,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		getColumnSignature(columns)
+	}
+}
+
 func TestGetColumnSignature(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Memory Leak Fixes (Compaction)
- Process candidates immediately instead of accumulating unbounded list
- Use ListDirectories() instead of List() for database/measurement enumeration
- Add lightweight parquet validation using magic bytes (not DuckDB read_parquet)
- Clear downloadedFiles slice after compaction for GC eligibility
- Fix stale bufferStartTimes cleanup in flush path

## Query Performance
- Arrow IPC: 5.2M rows/s (was 2.88M) - 80% improvement
- Full table scan: 927M rows/s (596M records in 685ms)

## Sort Keys
- Simplify implicit time handling in sort keys
- Time column always appended automatically
- Users configure additional sort columns only

## Updated Benchmarks
- MessagePack Columnar: 10.05M rec/s, p50: 3.08ms, p99: 7.08ms
- MessagePack + GZIP: 8.85M rec/s, p50: 3.30ms, p99: 9.32ms
- Line Protocol: 1.99M rec/s, p50: 48.19ms, p99: 100.32ms