### PR TITLE
fix: Azure Blob Storage backend support for queries and compaction

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -80,6 +80,10 @@ func main() {
 		S3Endpoint:  cfg.Storage.S3Endpoint,
 		S3UseSSL:    cfg.Storage.S3UseSSL,
 		S3PathStyle: cfg.Storage.S3PathStyle,
+		// Azure Blob Storage configuration for azure extension
+		AzureAccountName: cfg.Storage.AzureAccountName,
+		AzureAccountKey:  cfg.Storage.AzureAccountKey,
+		AzureEndpoint:    cfg.Storage.AzureEndpoint,
 	}
 
 	db, err := database.New(dbConfig, logger.Get("database"))

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -665,6 +665,10 @@ func (h *QueryHandler) getStoragePath(database, table string) string {
 	switch backend := h.storage.(type) {
 	case *storage.S3Backend:
 		return "s3://" + backend.GetBucket() + "/" + database + "/" + table + "/**/*.parquet"
+	case *storage.AzureBlobBackend:
+		// Use azure:// (Blob Storage endpoint)
+		// TODO v26.02.1: Add abfss:// (ADLS Gen2) support for better glob performance
+		return "azure://" + backend.GetContainer() + "/" + database + "/" + table + "/**/*.parquet"
 	case *storage.LocalBackend:
 		return backend.GetBasePath() + "/" + database + "/" + table + "/**/*.parquet"
 	default:

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -22,6 +22,7 @@ type AzureBlobBackend struct {
 	client        *azblob.Client
 	containerName string
 	accountName   string
+	accountKey    string // Stored for subprocess credential passing
 	endpoint      string
 	logger        zerolog.Logger
 }
@@ -126,6 +127,7 @@ func NewAzureBlobBackend(cfg *AzureBlobConfig, logger zerolog.Logger) (*AzureBlo
 		client:        client,
 		containerName: cfg.ContainerName,
 		accountName:   cfg.AccountName,
+		accountKey:    cfg.AccountKey,
 		endpoint:      endpoint,
 		logger:        log,
 	}
@@ -325,6 +327,11 @@ func (b *AzureBlobBackend) GetContainer() string {
 // GetAccountName returns the account name
 func (b *AzureBlobBackend) GetAccountName() string {
 	return b.accountName
+}
+
+// GetAccountKey returns the account key (for subprocess credential passing)
+func (b *AzureBlobBackend) GetAccountKey() string {
+	return b.accountKey
 }
 
 // Type returns the storage type identifier


### PR DESCRIPTION
## Summary
- Fix queries failing with "No files found" when using Azure Blob Storage backend
- Fix compaction subprocess failing with "DefaultAzureCredential: failed to acquire token"

## Changes
- Add `*storage.AzureBlobBackend` case to `getStoragePath()` to generate correct `azure://` paths
- Add `configureAzureAccess()` to set up DuckDB azure extension with credentials
- Pass Azure credentials to DuckDB via connection string secret
- Fix compaction subprocess by passing `AZURE_STORAGE_KEY` environment variable
- Add `GetAccountKey()` method to `AzureBlobBackend` for credential passing

## Test plan
- [x] Build succeeds
- [x] Queries work against Azure Blob Storage (~322ms for 100 rows)
- [x] Compaction works with Azure credentials
- [x] Existing tests pass