### PR TITLE
feat(enterprise): Add license-gated CQ and retention schedulers

### DIFF
--- a/internal/api/scheduler.go
+++ b/internal/api/scheduler.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"context"
+
+	"github.com/basekick-labs/arc/internal/license"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// CQSchedulerInterface defines the interface for CQ scheduler operations
+type CQSchedulerInterface interface {
+	Status() map[string]interface{}
+	ReloadAll() error
+	JobCount() int
+}
+
+// RetentionSchedulerInterface defines the interface for retention scheduler operations
+type RetentionSchedulerInterface interface {
+	Status() map[string]interface{}
+	TriggerNow(ctx context.Context) error
+}
+
+// SchedulerHandler handles scheduler status API endpoints
+type SchedulerHandler struct {
+	cqScheduler        CQSchedulerInterface
+	retentionScheduler RetentionSchedulerInterface
+	licenseClient      *license.Client
+	logger             zerolog.Logger
+}
+
+// NewSchedulerHandler creates a new scheduler handler
+func NewSchedulerHandler(
+	cqScheduler CQSchedulerInterface,
+	retentionScheduler RetentionSchedulerInterface,
+	licenseClient *license.Client,
+	logger zerolog.Logger,
+) *SchedulerHandler {
+	return &SchedulerHandler{
+		cqScheduler:        cqScheduler,
+		retentionScheduler: retentionScheduler,
+		licenseClient:      licenseClient,
+		logger:             logger.With().Str("component", "scheduler-handler").Logger(),
+	}
+}
+
+// RegisterRoutes registers scheduler API routes
+func (h *SchedulerHandler) RegisterRoutes(app *fiber.App) {
+	app.Get("/api/v1/schedulers", h.handleGetStatus)
+	app.Post("/api/v1/schedulers/cq/reload", h.handleCQReload)
+	app.Post("/api/v1/schedulers/retention/trigger", h.handleRetentionTrigger)
+}
+
+// handleGetStatus returns the status of all schedulers
+func (h *SchedulerHandler) handleGetStatus(c *fiber.Ctx) error {
+	status := make(map[string]interface{})
+
+	// Check license status first to determine appropriate messages
+	hasValidLicense := false
+	canUseCQScheduler := false
+	canUseRetentionScheduler := false
+
+	if h.licenseClient != nil {
+		lic := h.licenseClient.GetLicense()
+		if lic != nil && lic.IsValid() {
+			hasValidLicense = true
+			canUseCQScheduler = h.licenseClient.CanUseCQScheduler()
+			canUseRetentionScheduler = h.licenseClient.CanUseRetentionScheduler()
+		}
+	}
+
+	// CQ Scheduler status
+	if h.cqScheduler != nil {
+		status["cq_scheduler"] = h.cqScheduler.Status()
+	} else {
+		cqStatus := map[string]interface{}{
+			"enabled": false,
+		}
+		if !hasValidLicense {
+			cqStatus["reason"] = "Enterprise license required"
+		} else if !canUseCQScheduler {
+			cqStatus["reason"] = "License tier does not include CQ scheduler feature"
+		} else {
+			cqStatus["reason"] = "CQ feature not enabled (continuous_query.enabled=false)"
+		}
+		status["cq_scheduler"] = cqStatus
+	}
+
+	// Retention Scheduler status
+	if h.retentionScheduler != nil {
+		status["retention_scheduler"] = h.retentionScheduler.Status()
+	} else {
+		retentionStatus := map[string]interface{}{
+			"enabled": false,
+		}
+		if !hasValidLicense {
+			retentionStatus["reason"] = "Enterprise license required"
+		} else if !canUseRetentionScheduler {
+			retentionStatus["reason"] = "License tier does not include retention scheduler feature"
+		} else {
+			retentionStatus["reason"] = "Retention feature not enabled (retention.enabled=false)"
+		}
+		status["retention_scheduler"] = retentionStatus
+	}
+
+	return c.JSON(status)
+}
+
+// handleCQReload reloads all CQ schedules from the database
+func (h *SchedulerHandler) handleCQReload(c *fiber.Ctx) error {
+	if h.cqScheduler == nil {
+		h.logger.Warn().Msg("CQ scheduler reload requested but scheduler not running - enterprise license required")
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "CQ scheduler is not running - enterprise license required",
+		})
+	}
+
+	if err := h.cqScheduler.ReloadAll(); err != nil {
+		h.logger.Error().Err(err).Msg("Failed to reload CQ scheduler")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to reload CQ scheduler: " + err.Error(),
+		})
+	}
+
+	h.logger.Info().Int("job_count", h.cqScheduler.JobCount()).Msg("CQ scheduler reloaded")
+
+	return c.JSON(fiber.Map{
+		"message":   "CQ scheduler reloaded successfully",
+		"job_count": h.cqScheduler.JobCount(),
+	})
+}
+
+// handleRetentionTrigger triggers retention execution immediately
+func (h *SchedulerHandler) handleRetentionTrigger(c *fiber.Ctx) error {
+	if h.retentionScheduler == nil {
+		h.logger.Warn().Msg("Retention trigger requested but scheduler not running - enterprise license required")
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "Retention scheduler is not running - enterprise license required",
+		})
+	}
+
+	if err := h.retentionScheduler.TriggerNow(c.Context()); err != nil {
+		h.logger.Error().Err(err).Msg("Failed to trigger retention")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Retention trigger failed: " + err.Error(),
+		})
+	}
+
+	h.logger.Info().Msg("Retention triggered manually")
+
+	return c.JSON(fiber.Map{
+		"message": "Retention triggered successfully",
+	})
+}

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -105,6 +105,7 @@ func configureDatabase(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 	}
 	// Set thread count
 	if cfg.ThreadCount > 0 {
+		logger.Info().Int("threads", cfg.ThreadCount).Msg("Setting DuckDB thread count")
 		if _, err := db.Exec(fmt.Sprintf("SET threads=%d", cfg.ThreadCount)); err != nil {
 			return fmt.Errorf("failed to set threads: %w", err)
 		}

--- a/internal/license/client.go
+++ b/internal/license/client.go
@@ -1,0 +1,364 @@
+package license
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+const (
+	// LicenseServerURL is the hardcoded enterprise license server URL
+	LicenseServerURL = "https://enterprise.basekick.net"
+
+	// ValidationInterval is how often the license is re-validated (4 hours)
+	ValidationInterval = 4 * time.Hour
+)
+
+// ClientConfig holds configuration for the license client
+type ClientConfig struct {
+	LicenseKey string
+	Logger     zerolog.Logger
+}
+
+// Client handles license validation with the enterprise server
+type Client struct {
+	serverURL   string
+	licenseKey  string
+	fingerprint string
+	httpClient  *http.Client
+	license     *License
+	mu          sync.RWMutex
+	stopCh      chan struct{}
+	logger      zerolog.Logger
+}
+
+// VerifyRequest represents a license verification request
+type VerifyRequest struct {
+	LicenseKey         string `json:"license_key"`
+	MachineFingerprint string `json:"machine_fingerprint"`
+}
+
+// VerifyResponse represents the response from the license server
+type VerifyResponse struct {
+	Valid         bool      `json:"valid"`
+	Tier          string    `json:"tier,omitempty"`
+	ExpiresAt     time.Time `json:"expires_at,omitempty"`
+	DaysRemaining int       `json:"days_remaining,omitempty"`
+	Status        string    `json:"status,omitempty"` // active, grace_period, read_only, expired
+	Error         string    `json:"error,omitempty"`
+	MaxCores      int       `json:"max_cores,omitempty"`
+	MaxMachines   int       `json:"max_machines,omitempty"`
+	Features      []string  `json:"features,omitempty"`
+	CustomerID    string    `json:"customer_id,omitempty"`
+	CustomerName  string    `json:"customer_name,omitempty"`
+}
+
+// NewClient creates a new license client
+func NewClient(cfg *ClientConfig) (*Client, error) {
+	if cfg.LicenseKey == "" {
+		return nil, fmt.Errorf("license key is required")
+	}
+
+	// Generate machine fingerprint
+	fingerprint, err := GenerateMachineFingerprint()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate machine fingerprint: %w", err)
+	}
+
+	c := &Client{
+		serverURL:   LicenseServerURL,
+		licenseKey:  cfg.LicenseKey,
+		fingerprint: fingerprint,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		stopCh: make(chan struct{}),
+		logger: cfg.Logger.With().Str("component", "license-client").Logger(),
+	}
+
+	c.logger.Debug().
+		Str("server_url", LicenseServerURL).
+		Str("fingerprint", fingerprint).
+		Msg("License client initialized")
+
+	return c, nil
+}
+
+// ActivateRequest represents a license activation request
+type ActivateRequest struct {
+	LicenseKey         string `json:"license_key"`
+	MachineFingerprint string `json:"machine_fingerprint"`
+	Hostname           string `json:"hostname"`
+	Cores              int    `json:"cores"`
+}
+
+// ActivateResponse represents the response from license activation
+type ActivateResponse struct {
+	Success       bool      `json:"success"`
+	LicenseFile   string    `json:"license_file,omitempty"` // Base64 encoded signed license
+	ExpiresAt     time.Time `json:"expires_at,omitempty"`
+	Tier          string    `json:"tier,omitempty"`
+	MaxCores      int       `json:"max_cores,omitempty"`
+	Error         string    `json:"error,omitempty"`
+	CustomerID    string    `json:"customer_id,omitempty"`
+	CustomerName  string    `json:"customer_name,omitempty"`
+	Features      []string  `json:"features,omitempty"`
+	DaysRemaining int       `json:"days_remaining,omitempty"`
+	Status        string    `json:"status,omitempty"`
+}
+
+// Activate registers this machine with the license server
+func (c *Client) Activate(ctx context.Context) (*License, error) {
+	url := fmt.Sprintf("%s/api/v1/activate", c.serverURL)
+
+	hostname, _ := os.Hostname()
+	cores := runtime.NumCPU()
+
+	req := &ActivateRequest{
+		LicenseKey:         c.licenseKey,
+		MachineFingerprint: c.fingerprint,
+		Hostname:           hostname,
+		Cores:              cores,
+	}
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	c.logger.Info().
+		Str("license_key", c.licenseKey[:min(12, len(c.licenseKey))]+"...").
+		Str("fingerprint", c.fingerprint[:min(16, len(c.fingerprint))]+"...").
+		Str("hostname", hostname).
+		Int("cores", cores).
+		Msg("Activating license")
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		c.logger.Error().Err(err).Msg("License activation request failed")
+		return nil, fmt.Errorf("license activation request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var activateResp ActivateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&activateResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if !activateResp.Success {
+		errMsg := activateResp.Error
+		if errMsg == "" {
+			errMsg = "license activation failed"
+		}
+		c.logger.Warn().Str("error", errMsg).Msg("License activation failed")
+		return nil, fmt.Errorf("license activation failed: %s", errMsg)
+	}
+
+	license := &License{
+		LicenseKey:    c.licenseKey,
+		CustomerID:    activateResp.CustomerID,
+		CustomerName:  activateResp.CustomerName,
+		Tier:          TierFromString(activateResp.Tier),
+		MaxCores:      activateResp.MaxCores,
+		Features:      activateResp.Features,
+		ExpiresAt:     activateResp.ExpiresAt,
+		Status:        activateResp.Status,
+		DaysRemaining: activateResp.DaysRemaining,
+	}
+
+	// Store the license
+	c.mu.Lock()
+	c.license = license
+	c.mu.Unlock()
+
+	c.logger.Info().
+		Str("tier", string(license.Tier)).
+		Str("status", license.Status).
+		Int("days_remaining", license.DaysRemaining).
+		Int("max_cores", license.MaxCores).
+		Time("expires_at", license.ExpiresAt).
+		Msg("License activated successfully")
+
+	return license, nil
+}
+
+// Verify validates the license with the enterprise server
+func (c *Client) Verify(ctx context.Context) (*License, error) {
+	url := fmt.Sprintf("%s/api/v1/verify", c.serverURL)
+
+	c.logger.Debug().
+		Str("license_key", c.licenseKey[:min(12, len(c.licenseKey))]+"...").
+		Msg("Verifying license")
+
+	// Use query parameters for GET-style verify
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	q := httpReq.URL.Query()
+	q.Add("license_key", c.licenseKey)
+	q.Add("machine_fingerprint", c.fingerprint)
+	httpReq.URL.RawQuery = q.Encode()
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		c.logger.Error().Err(err).Msg("License verification request failed")
+		return nil, fmt.Errorf("license verification request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var verifyResp VerifyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&verifyResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if !verifyResp.Valid {
+		errMsg := verifyResp.Error
+		if errMsg == "" {
+			errMsg = "license validation failed"
+		}
+		c.logger.Warn().Str("error", errMsg).Msg("License validation failed")
+		return nil, fmt.Errorf("license validation failed: %s", errMsg)
+	}
+
+	license := &License{
+		LicenseKey:    c.licenseKey,
+		CustomerID:    verifyResp.CustomerID,
+		CustomerName:  verifyResp.CustomerName,
+		Tier:          TierFromString(verifyResp.Tier),
+		MaxCores:      verifyResp.MaxCores,
+		MaxMachines:   verifyResp.MaxMachines,
+		Features:      verifyResp.Features,
+		ExpiresAt:     verifyResp.ExpiresAt,
+		Status:        verifyResp.Status,
+		DaysRemaining: verifyResp.DaysRemaining,
+	}
+
+	// Store the license
+	c.mu.Lock()
+	c.license = license
+	c.mu.Unlock()
+
+	c.logger.Info().
+		Str("tier", string(license.Tier)).
+		Str("status", license.Status).
+		Int("days_remaining", license.DaysRemaining).
+		Int("max_cores", license.MaxCores).
+		Time("expires_at", license.ExpiresAt).
+		Msg("License verified successfully")
+
+	return license, nil
+}
+
+// ActivateOrVerify tries to verify first, and if the machine is not activated, activates it
+func (c *Client) ActivateOrVerify(ctx context.Context) (*License, error) {
+	// Try to verify first
+	license, err := c.Verify(ctx)
+	if err == nil {
+		return license, nil
+	}
+
+	// If verification failed with "machine not activated", try to activate
+	if strings.Contains(err.Error(), "machine not activated") {
+		c.logger.Info().Msg("Machine not activated, attempting activation")
+		return c.Activate(ctx)
+	}
+
+	// Other error, return it
+	return nil, err
+}
+
+// StartPeriodicValidation starts background license validation
+func (c *Client) StartPeriodicValidation(interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				_, err := c.Verify(ctx)
+				if err != nil {
+					c.logger.Warn().Err(err).Msg("Periodic license validation failed")
+				}
+				cancel()
+			case <-c.stopCh:
+				c.logger.Debug().Msg("Stopping periodic license validation")
+				return
+			}
+		}
+	}()
+
+	c.logger.Info().
+		Dur("interval", interval).
+		Msg("Started periodic license validation")
+}
+
+// Stop stops the license client and any background tasks
+func (c *Client) Stop() {
+	close(c.stopCh)
+}
+
+// GetLicense returns the current cached license
+func (c *Client) GetLicense() *License {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.license
+}
+
+// IsValid returns true if there's a valid license
+func (c *Client) IsValid() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.license != nil && c.license.IsValid()
+}
+
+// IsEnterprise returns true if the license is enterprise tier or higher
+func (c *Client) IsEnterprise() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.license != nil && c.license.IsEnterprise()
+}
+
+// CanUseCQScheduler returns true if CQ scheduling is allowed
+func (c *Client) CanUseCQScheduler() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.license != nil && c.license.CanUseCQScheduler()
+}
+
+// CanUseRetentionScheduler returns true if retention scheduling is allowed
+func (c *Client) CanUseRetentionScheduler() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.license != nil && c.license.CanUseRetentionScheduler()
+}
+
+// GetFingerprint returns the machine fingerprint
+func (c *Client) GetFingerprint() string {
+	return c.fingerprint
+}
+
+// min returns the minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/license/client_test.go
+++ b/internal/license/client_test.go
@@ -1,0 +1,101 @@
+package license
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestNewClient(t *testing.T) {
+	logger := zerolog.Nop()
+
+	tests := []struct {
+		name      string
+		cfg       *ClientConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid config",
+			cfg: &ClientConfig{
+				LicenseKey: "ARC-ENT-1234-5678-90AB-CDEF",
+				Logger:     logger,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing license key",
+			cfg: &ClientConfig{
+				Logger: logger,
+			},
+			wantErr:   true,
+			errSubstr: "license key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if client == nil {
+				t.Error("expected client, got nil")
+			}
+			if client.fingerprint == "" {
+				t.Error("fingerprint should be set")
+			}
+		})
+	}
+}
+
+func TestClient_GetFingerprint(t *testing.T) {
+	client, err := NewClient(&ClientConfig{
+		LicenseKey: "ARC-ENT-1234-5678-90AB-CDEF",
+		Logger:     zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	fp := client.GetFingerprint()
+	if fp == "" {
+		t.Error("fingerprint should not be empty")
+	}
+	if !ValidateFingerprint(fp) {
+		t.Error("fingerprint should be valid")
+	}
+}
+
+func TestClient_GetLicense_BeforeVerify(t *testing.T) {
+	client, err := NewClient(&ClientConfig{
+		LicenseKey: "ARC-ENT-1234-5678-90AB-CDEF",
+		Logger:     zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	license := client.GetLicense()
+	if license != nil {
+		t.Error("license should be nil before verify")
+	}
+
+	if client.IsValid() {
+		t.Error("client should not be valid before verify")
+	}
+	if client.IsEnterprise() {
+		t.Error("client should not be enterprise before verify")
+	}
+}
+
+// Note: Tests that require a mock HTTP server (TestClient_Verify_*) have been removed
+// because the license server URL is hardcoded to enterprise.basekick.net.
+// Integration tests against the real server should be run separately.

--- a/internal/license/fingerprint.go
+++ b/internal/license/fingerprint.go
@@ -1,0 +1,144 @@
+package license
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// GenerateMachineFingerprint generates a unique fingerprint for this machine
+// Format: sha256:<64 hex characters>
+func GenerateMachineFingerprint() (string, error) {
+	components := []string{}
+
+	// Get hostname
+	hostname, err := os.Hostname()
+	if err == nil && hostname != "" {
+		components = append(components, fmt.Sprintf("hostname:%s", hostname))
+	}
+
+	// Get MAC addresses (sorted for consistency)
+	macs := getMACAddresses()
+	if len(macs) > 0 {
+		components = append(components, fmt.Sprintf("macs:%s", strings.Join(macs, ",")))
+	}
+
+	// Get CPU info
+	cpuInfo := getCPUInfo()
+	if cpuInfo != "" {
+		components = append(components, fmt.Sprintf("cpu:%s", cpuInfo))
+	}
+
+	// Get OS info
+	osInfo := fmt.Sprintf("os:%s/%s", runtime.GOOS, runtime.GOARCH)
+	components = append(components, osInfo)
+
+	// If we couldn't get any useful info, return an error
+	if len(components) < 2 {
+		return "", fmt.Errorf("unable to gather enough machine information for fingerprint")
+	}
+
+	// Sort components for consistency
+	sort.Strings(components)
+
+	// Create fingerprint string
+	fingerprintData := strings.Join(components, "|")
+
+	// Hash it
+	hash := sha256.Sum256([]byte(fingerprintData))
+
+	return fmt.Sprintf("sha256:%x", hash), nil
+}
+
+// getMACAddresses returns sorted list of MAC addresses from stable physical interfaces only.
+// Virtual interfaces (VMs, Docker, bridges, etc.) are excluded to ensure fingerprint stability.
+func getMACAddresses() []string {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+
+	var macs []string
+	for _, iface := range interfaces {
+		// Skip loopback interfaces
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+
+		// Skip virtual/unstable interfaces that can change between restarts
+		if isVirtualInterface(iface.Name) {
+			continue
+		}
+
+		mac := iface.HardwareAddr.String()
+		if mac != "" && mac != "00:00:00:00:00:00" {
+			macs = append(macs, mac)
+		}
+	}
+
+	sort.Strings(macs)
+	return macs
+}
+
+// isVirtualInterface returns true if the interface name indicates a virtual/unstable interface
+// that should be excluded from fingerprint generation.
+func isVirtualInterface(name string) bool {
+	// Virtual/bridge interfaces that can change between restarts
+	virtualPrefixes := []string{
+		"docker",   // Docker networks
+		"br-",      // Docker/Linux bridges
+		"veth",     // Virtual ethernet (Docker containers)
+		"vmnet",    // VMware networks
+		"vmenet",   // macOS VM networks
+		"bridge",   // Bridge interfaces (Linux, macOS)
+		"virbr",    // libvirt bridges
+		"vboxnet",  // VirtualBox networks
+		"utun",     // VPN tunnels
+		"tun",      // TUN devices
+		"tap",      // TAP devices
+		"awdl",     // Apple Wireless Direct Link (unstable)
+		"llw",      // Apple Low Latency WLAN (unstable)
+		"ap",       // Apple access point (hotspot)
+		"anpi",     // Apple network processor interface
+	}
+
+	for _, prefix := range virtualPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getCPUInfo returns CPU information string
+func getCPUInfo() string {
+	// Use number of CPUs as a simple identifier
+	numCPU := runtime.NumCPU()
+	return fmt.Sprintf("cores:%d", numCPU)
+}
+
+// ValidateFingerprint checks if a fingerprint is in the correct format
+func ValidateFingerprint(fingerprint string) bool {
+	if !strings.HasPrefix(fingerprint, "sha256:") {
+		return false
+	}
+
+	hexPart := strings.TrimPrefix(fingerprint, "sha256:")
+	if len(hexPart) != 64 {
+		return false
+	}
+
+	// Check if it's valid hex
+	for _, c := range hexPart {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/license/fingerprint_test.go
+++ b/internal/license/fingerprint_test.go
@@ -1,0 +1,135 @@
+package license
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateMachineFingerprint(t *testing.T) {
+	fingerprint, err := GenerateMachineFingerprint()
+	if err != nil {
+		t.Fatalf("GenerateMachineFingerprint() error = %v", err)
+	}
+
+	// Check format
+	if !strings.HasPrefix(fingerprint, "sha256:") {
+		t.Errorf("fingerprint should start with 'sha256:', got %s", fingerprint)
+	}
+
+	// Check length (sha256: + 64 hex chars = 71)
+	if len(fingerprint) != 71 {
+		t.Errorf("fingerprint length should be 71, got %d", len(fingerprint))
+	}
+
+	// Check it's valid hex after the prefix
+	hexPart := strings.TrimPrefix(fingerprint, "sha256:")
+	if len(hexPart) != 64 {
+		t.Errorf("hex part should be 64 chars, got %d", len(hexPart))
+	}
+
+	for _, c := range hexPart {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("invalid hex character: %c", c)
+		}
+	}
+}
+
+func TestGenerateMachineFingerprint_Consistency(t *testing.T) {
+	// Fingerprint should be consistent across calls
+	fp1, err := GenerateMachineFingerprint()
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	fp2, err := GenerateMachineFingerprint()
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+
+	if fp1 != fp2 {
+		t.Errorf("fingerprints should be consistent, got %s and %s", fp1, fp2)
+	}
+}
+
+func TestValidateFingerprint(t *testing.T) {
+	tests := []struct {
+		name        string
+		fingerprint string
+		want        bool
+	}{
+		{
+			name:        "valid fingerprint",
+			fingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			want:        true,
+		},
+		{
+			name:        "missing prefix",
+			fingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			want:        false,
+		},
+		{
+			name:        "wrong prefix",
+			fingerprint: "md5:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			want:        false,
+		},
+		{
+			name:        "too short",
+			fingerprint: "sha256:0123456789abcdef",
+			want:        false,
+		},
+		{
+			name:        "too long",
+			fingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef00",
+			want:        false,
+		},
+		{
+			name:        "invalid hex chars",
+			fingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg",
+			want:        false,
+		},
+		{
+			name:        "uppercase hex (should fail)",
+			fingerprint: "sha256:0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef",
+			want:        false,
+		},
+		{
+			name:        "empty string",
+			fingerprint: "",
+			want:        false,
+		},
+		{
+			name:        "just prefix",
+			fingerprint: "sha256:",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateFingerprint(tt.fingerprint); got != tt.want {
+				t.Errorf("ValidateFingerprint(%q) = %v, want %v", tt.fingerprint, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMACAddresses(t *testing.T) {
+	macs := getMACAddresses()
+	// Should return some MACs on most systems (except in containers without network)
+	// We just check it doesn't panic and returns a sorted list
+	for i := 1; i < len(macs); i++ {
+		if macs[i] < macs[i-1] {
+			t.Error("MACs should be sorted")
+		}
+	}
+}
+
+func TestGetCPUInfo(t *testing.T) {
+	cpuInfo := getCPUInfo()
+	if cpuInfo == "" {
+		t.Error("getCPUInfo should return non-empty string")
+	}
+	if !strings.HasPrefix(cpuInfo, "cores:") {
+		t.Errorf("getCPUInfo should start with 'cores:', got %s", cpuInfo)
+	}
+}

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -1,0 +1,112 @@
+package license
+
+import (
+	"time"
+)
+
+// Tier represents the license tier
+type Tier string
+
+const (
+	TierStarter      Tier = "starter"
+	TierProfessional Tier = "professional"
+	TierEnterprise   Tier = "enterprise"
+	TierUnlimited    Tier = "unlimited"
+)
+
+// Feature constants for feature gating
+const (
+	FeatureCQScheduler        = "cq_scheduler"
+	FeatureRetentionScheduler = "retention_scheduler"
+	FeatureClustering         = "clustering"
+	FeatureRBAC               = "rbac"
+	FeatureTieredStorage      = "tiered_storage"
+	FeatureAutoAggregation    = "auto_aggregation"
+)
+
+// License represents a validated license
+type License struct {
+	LicenseKey    string    `json:"license_key"`
+	CustomerID    string    `json:"customer_id"`
+	CustomerName  string    `json:"customer_name"`
+	Tier          Tier      `json:"tier"`
+	MaxCores      int       `json:"max_cores"`
+	MaxMachines   int       `json:"max_machines"`
+	Features      []string  `json:"features"`
+	ExpiresAt     time.Time `json:"expires_at"`
+	Status        string    `json:"status"` // active, grace_period, read_only, expired
+	DaysRemaining int       `json:"days_remaining"`
+}
+
+// IsValid returns true if the license is valid and not expired
+func (l *License) IsValid() bool {
+	if l == nil {
+		return false
+	}
+	return l.Status == "active" || l.Status == "grace_period"
+}
+
+// IsExpired returns true if the license has expired
+func (l *License) IsExpired() bool {
+	if l == nil {
+		return true
+	}
+	return l.Status == "expired" || l.Status == "read_only"
+}
+
+// HasFeature checks if the license includes a specific feature
+func (l *License) HasFeature(feature string) bool {
+	if l == nil || !l.IsValid() {
+		return false
+	}
+	for _, f := range l.Features {
+		if f == feature {
+			return true
+		}
+	}
+	return false
+}
+
+// IsEnterprise returns true if the license tier is enterprise or higher
+func (l *License) IsEnterprise() bool {
+	if l == nil || !l.IsValid() {
+		return false
+	}
+	return l.Tier == TierEnterprise || l.Tier == TierUnlimited
+}
+
+// IsProfessional returns true if the license tier is professional or higher
+func (l *License) IsProfessional() bool {
+	if l == nil || !l.IsValid() {
+		return false
+	}
+	return l.Tier == TierProfessional || l.Tier == TierEnterprise || l.Tier == TierUnlimited
+}
+
+// CanUseCQScheduler returns true if the license allows CQ scheduling
+// All valid license tiers (starter, professional, enterprise, unlimited) include this feature
+func (l *License) CanUseCQScheduler() bool {
+	return l.IsValid()
+}
+
+// CanUseRetentionScheduler returns true if the license allows retention scheduling
+// All valid license tiers (starter, professional, enterprise, unlimited) include this feature
+func (l *License) CanUseRetentionScheduler() bool {
+	return l.IsValid()
+}
+
+// TierFromString converts a string to a Tier
+func TierFromString(s string) Tier {
+	switch s {
+	case "starter":
+		return TierStarter
+	case "professional":
+		return TierProfessional
+	case "enterprise":
+		return TierEnterprise
+	case "unlimited":
+		return TierUnlimited
+	default:
+		return TierStarter
+	}
+}

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -1,0 +1,431 @@
+package license
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLicense_IsValid(t *testing.T) {
+	tests := []struct {
+		name    string
+		license *License
+		want    bool
+	}{
+		{
+			name:    "nil license",
+			license: nil,
+			want:    false,
+		},
+		{
+			name: "active license",
+			license: &License{
+				Status: "active",
+			},
+			want: true,
+		},
+		{
+			name: "grace period license",
+			license: &License{
+				Status: "grace_period",
+			},
+			want: true,
+		},
+		{
+			name: "expired license",
+			license: &License{
+				Status: "expired",
+			},
+			want: false,
+		},
+		{
+			name: "read only license",
+			license: &License{
+				Status: "read_only",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.license.IsValid(); got != tt.want {
+				t.Errorf("License.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLicense_IsExpired(t *testing.T) {
+	tests := []struct {
+		name    string
+		license *License
+		want    bool
+	}{
+		{
+			name:    "nil license",
+			license: nil,
+			want:    true,
+		},
+		{
+			name: "active license",
+			license: &License{
+				Status: "active",
+			},
+			want: false,
+		},
+		{
+			name: "expired license",
+			license: &License{
+				Status: "expired",
+			},
+			want: true,
+		},
+		{
+			name: "read only license",
+			license: &License{
+				Status: "read_only",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.license.IsExpired(); got != tt.want {
+				t.Errorf("License.IsExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLicense_HasFeature(t *testing.T) {
+	license := &License{
+		Status:   "active",
+		Features: []string{"cq_scheduler", "retention_scheduler", "clustering"},
+	}
+
+	tests := []struct {
+		name    string
+		feature string
+		want    bool
+	}{
+		{"has cq_scheduler", "cq_scheduler", true},
+		{"has retention_scheduler", "retention_scheduler", true},
+		{"has clustering", "clustering", true},
+		{"no rbac", "rbac", false},
+		{"no unknown", "unknown_feature", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := license.HasFeature(tt.feature); got != tt.want {
+				t.Errorf("License.HasFeature(%q) = %v, want %v", tt.feature, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLicense_HasFeature_InvalidLicense(t *testing.T) {
+	// Nil license
+	var nilLicense *License
+	if nilLicense.HasFeature("any") {
+		t.Error("nil license should not have any feature")
+	}
+
+	// Expired license
+	expiredLicense := &License{
+		Status:   "expired",
+		Features: []string{"cq_scheduler"},
+	}
+	if expiredLicense.HasFeature("cq_scheduler") {
+		t.Error("expired license should not have features")
+	}
+}
+
+func TestLicense_IsEnterprise(t *testing.T) {
+	tests := []struct {
+		name    string
+		license *License
+		want    bool
+	}{
+		{
+			name:    "nil license",
+			license: nil,
+			want:    false,
+		},
+		{
+			name: "starter tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierStarter,
+			},
+			want: false,
+		},
+		{
+			name: "professional tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierProfessional,
+			},
+			want: false,
+		},
+		{
+			name: "enterprise tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierEnterprise,
+			},
+			want: true,
+		},
+		{
+			name: "unlimited tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierUnlimited,
+			},
+			want: true,
+		},
+		{
+			name: "enterprise tier but expired",
+			license: &License{
+				Status: "expired",
+				Tier:   TierEnterprise,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.license.IsEnterprise(); got != tt.want {
+				t.Errorf("License.IsEnterprise() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLicense_IsProfessional(t *testing.T) {
+	tests := []struct {
+		name    string
+		license *License
+		want    bool
+	}{
+		{
+			name: "starter tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierStarter,
+			},
+			want: false,
+		},
+		{
+			name: "professional tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierProfessional,
+			},
+			want: true,
+		},
+		{
+			name: "enterprise tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierEnterprise,
+			},
+			want: true,
+		},
+		{
+			name: "unlimited tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierUnlimited,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.license.IsProfessional(); got != tt.want {
+				t.Errorf("License.IsProfessional() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLicense_CanUseCQScheduler(t *testing.T) {
+	// All valid license tiers should be able to use CQ scheduler
+	tests := []struct {
+		name    string
+		license *License
+		want    bool
+	}{
+		{
+			name:    "nil license",
+			license: nil,
+			want:    false,
+		},
+		{
+			name: "starter tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierStarter,
+			},
+			want: true,
+		},
+		{
+			name: "professional tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierProfessional,
+			},
+			want: true,
+		},
+		{
+			name: "enterprise tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierEnterprise,
+			},
+			want: true,
+		},
+		{
+			name: "unlimited tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierUnlimited,
+			},
+			want: true,
+		},
+		{
+			name: "expired license",
+			license: &License{
+				Status: "expired",
+				Tier:   TierEnterprise,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.license.CanUseCQScheduler(); got != tt.want {
+				t.Errorf("License.CanUseCQScheduler() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLicense_CanUseRetentionScheduler(t *testing.T) {
+	// All valid license tiers should be able to use retention scheduler
+	tests := []struct {
+		name    string
+		license *License
+		want    bool
+	}{
+		{
+			name:    "nil license",
+			license: nil,
+			want:    false,
+		},
+		{
+			name: "starter tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierStarter,
+			},
+			want: true,
+		},
+		{
+			name: "professional tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierProfessional,
+			},
+			want: true,
+		},
+		{
+			name: "enterprise tier",
+			license: &License{
+				Status: "active",
+				Tier:   TierEnterprise,
+			},
+			want: true,
+		},
+		{
+			name: "expired license",
+			license: &License{
+				Status: "expired",
+				Tier:   TierEnterprise,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.license.CanUseRetentionScheduler(); got != tt.want {
+				t.Errorf("License.CanUseRetentionScheduler() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTierFromString(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Tier
+	}{
+		{"starter", TierStarter},
+		{"professional", TierProfessional},
+		{"enterprise", TierEnterprise},
+		{"unlimited", TierUnlimited},
+		{"unknown", TierStarter},
+		{"", TierStarter},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := TierFromString(tt.input); got != tt.want {
+				t.Errorf("TierFromString(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLicenseStruct(t *testing.T) {
+	license := &License{
+		LicenseKey:    "ARC-ENT-1234-5678-90AB-CDEF",
+		CustomerID:    "acme-corp",
+		CustomerName:  "Acme Corporation",
+		Tier:          TierEnterprise,
+		MaxCores:      128,
+		MaxMachines:   20,
+		Features:      []string{"cq_scheduler", "retention_scheduler"},
+		ExpiresAt:     time.Now().Add(365 * 24 * time.Hour),
+		Status:        "active",
+		DaysRemaining: 365,
+	}
+
+	if license.LicenseKey != "ARC-ENT-1234-5678-90AB-CDEF" {
+		t.Error("LicenseKey mismatch")
+	}
+	if license.CustomerID != "acme-corp" {
+		t.Error("CustomerID mismatch")
+	}
+	if license.Tier != TierEnterprise {
+		t.Error("Tier mismatch")
+	}
+	if license.MaxCores != 128 {
+		t.Error("MaxCores mismatch")
+	}
+	if license.MaxMachines != 20 {
+		t.Error("MaxMachines mismatch")
+	}
+	if len(license.Features) != 2 {
+		t.Error("Features count mismatch")
+	}
+	if license.DaysRemaining != 365 {
+		t.Error("DaysRemaining mismatch")
+	}
+}

--- a/internal/scheduler/cq_scheduler.go
+++ b/internal/scheduler/cq_scheduler.go
@@ -1,0 +1,314 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/api"
+	"github.com/basekick-labs/arc/internal/license"
+	"github.com/rs/zerolog"
+)
+
+// CQScheduler manages automatic execution of continuous queries based on their intervals
+type CQScheduler struct {
+	cqHandler     *api.ContinuousQueryHandler
+	licenseClient *license.Client
+	jobs          map[int64]*cqJob // CQ ID → job info
+	mu            sync.RWMutex
+	stopCh        chan struct{}
+	running       bool
+	logger        zerolog.Logger
+}
+
+// cqJob represents a scheduled CQ job
+type cqJob struct {
+	cqID     int64
+	cqName   string
+	interval time.Duration
+	ticker   *time.Ticker
+	stopCh   chan struct{}
+}
+
+// CQSchedulerConfig holds configuration for the CQ scheduler
+type CQSchedulerConfig struct {
+	CQHandler     *api.ContinuousQueryHandler
+	LicenseClient *license.Client
+	Logger        zerolog.Logger
+}
+
+// NewCQScheduler creates a new CQ scheduler
+func NewCQScheduler(cfg *CQSchedulerConfig) (*CQScheduler, error) {
+	s := &CQScheduler{
+		cqHandler:     cfg.CQHandler,
+		licenseClient: cfg.LicenseClient,
+		jobs:          make(map[int64]*cqJob),
+		stopCh:        make(chan struct{}),
+		logger:        cfg.Logger.With().Str("component", "cq-scheduler").Logger(),
+	}
+
+	s.logger.Info().Msg("CQ scheduler initialized")
+	return s, nil
+}
+
+// Start starts the CQ scheduler by loading active CQs and starting their jobs
+func (s *CQScheduler) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		s.logger.Warn().Msg("CQ scheduler already running")
+		return nil
+	}
+
+	// Check license - require valid license for CQ scheduler
+	if s.licenseClient == nil || !s.licenseClient.CanUseCQScheduler() {
+		s.logger.Warn().Msg("Valid enterprise license required for CQ scheduler - not starting")
+		return nil
+	}
+
+	// Load and start all active CQs
+	cqs, err := s.cqHandler.GetActiveCQs()
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Failed to load active CQs")
+		return err
+	}
+
+	for _, cq := range cqs {
+		if err := s.startJob(cq.ID, cq.Name, cq.Interval); err != nil {
+			s.logger.Warn().
+				Err(err).
+				Int64("cq_id", cq.ID).
+				Str("cq_name", cq.Name).
+				Msg("Failed to start CQ job")
+			continue
+		}
+	}
+
+	s.running = true
+	s.logger.Info().
+		Int("active_cqs", len(s.jobs)).
+		Msg("CQ scheduler started")
+
+	return nil
+}
+
+// Stop stops all CQ jobs and the scheduler
+func (s *CQScheduler) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running {
+		return
+	}
+
+	// Stop all jobs
+	for id, job := range s.jobs {
+		close(job.stopCh)
+		job.ticker.Stop()
+		s.logger.Debug().
+			Int64("cq_id", id).
+			Str("cq_name", job.cqName).
+			Msg("Stopped CQ job")
+	}
+	s.jobs = make(map[int64]*cqJob)
+
+	s.running = false
+	s.logger.Info().Msg("CQ scheduler stopped")
+}
+
+// ReloadCQ reloads a specific CQ (call after CQ update)
+func (s *CQScheduler) ReloadCQ(cqID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Stop existing job if any
+	if job, exists := s.jobs[cqID]; exists {
+		close(job.stopCh)
+		job.ticker.Stop()
+		delete(s.jobs, cqID)
+		s.logger.Debug().Int64("cq_id", cqID).Msg("Stopped existing CQ job for reload")
+	}
+
+	// Get updated CQ
+	cq, err := s.cqHandler.GetCQ(cqID)
+	if err != nil {
+		return err
+	}
+
+	// Only restart if active
+	if !cq.IsActive {
+		s.logger.Debug().Int64("cq_id", cqID).Msg("CQ is not active, not restarting job")
+		return nil
+	}
+
+	return s.startJob(cq.ID, cq.Name, cq.Interval)
+}
+
+// ReloadAll reloads all CQ schedules from the database
+func (s *CQScheduler) ReloadAll() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Stop all existing jobs
+	for id, job := range s.jobs {
+		close(job.stopCh)
+		job.ticker.Stop()
+		s.logger.Debug().Int64("cq_id", id).Msg("Stopped CQ job for full reload")
+	}
+	s.jobs = make(map[int64]*cqJob)
+
+	// Check license - require valid license for CQ scheduler
+	if s.licenseClient == nil || !s.licenseClient.CanUseCQScheduler() {
+		s.logger.Warn().Msg("Valid enterprise license required for CQ scheduler")
+		return nil
+	}
+
+	// Load and start all active CQs
+	cqs, err := s.cqHandler.GetActiveCQs()
+	if err != nil {
+		return err
+	}
+
+	for _, cq := range cqs {
+		if err := s.startJob(cq.ID, cq.Name, cq.Interval); err != nil {
+			s.logger.Warn().
+				Err(err).
+				Int64("cq_id", cq.ID).
+				Str("cq_name", cq.Name).
+				Msg("Failed to start CQ job")
+			continue
+		}
+	}
+
+	s.logger.Info().
+		Int("active_cqs", len(s.jobs)).
+		Msg("CQ scheduler reloaded")
+
+	return nil
+}
+
+// startJob starts a job for a specific CQ (must be called with lock held)
+func (s *CQScheduler) startJob(cqID int64, cqName, intervalStr string) error {
+	// Parse interval using Go duration format
+	interval, err := time.ParseDuration(intervalStr)
+	if err != nil {
+		return err
+	}
+
+	// Minimum interval of 10 seconds to prevent abuse
+	if interval < 10*time.Second {
+		interval = 10 * time.Second
+	}
+
+	job := &cqJob{
+		cqID:     cqID,
+		cqName:   cqName,
+		interval: interval,
+		ticker:   time.NewTicker(interval),
+		stopCh:   make(chan struct{}),
+	}
+
+	s.jobs[cqID] = job
+
+	// Start the job goroutine
+	go s.runJob(job)
+
+	s.logger.Info().
+		Int64("cq_id", cqID).
+		Str("cq_name", cqName).
+		Dur("interval", interval).
+		Msg("Started CQ job")
+
+	return nil
+}
+
+// runJob runs a single CQ job on its interval
+func (s *CQScheduler) runJob(job *cqJob) {
+	for {
+		select {
+		case <-job.ticker.C:
+			// Check license before each execution
+			if s.licenseClient == nil || !s.licenseClient.CanUseCQScheduler() {
+				s.logger.Warn().
+					Int64("cq_id", job.cqID).
+					Str("cq_name", job.cqName).
+					Msg("Valid enterprise license required, skipping CQ execution")
+				continue
+			}
+
+			s.executeJob(job)
+		case <-job.stopCh:
+			return
+		}
+	}
+}
+
+// executeJob executes a single CQ
+func (s *CQScheduler) executeJob(job *cqJob) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	s.logger.Debug().
+		Int64("cq_id", job.cqID).
+		Str("cq_name", job.cqName).
+		Msg("Executing scheduled CQ")
+
+	resp, err := s.cqHandler.ExecuteCQ(ctx, job.cqID)
+	if err != nil {
+		s.logger.Error().
+			Err(err).
+			Int64("cq_id", job.cqID).
+			Str("cq_name", job.cqName).
+			Msg("Scheduled CQ execution failed")
+		return
+	}
+
+	s.logger.Info().
+		Int64("cq_id", job.cqID).
+		Str("cq_name", job.cqName).
+		Int64("records_written", resp.RecordsWritten).
+		Float64("duration_seconds", resp.ExecutionTimeSeconds).
+		Msg("Scheduled CQ execution completed")
+}
+
+// Status returns the current status of the scheduler
+func (s *CQScheduler) Status() map[string]interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	jobs := make([]map[string]interface{}, 0, len(s.jobs))
+	for _, job := range s.jobs {
+		jobs = append(jobs, map[string]interface{}{
+			"cq_id":    job.cqID,
+			"cq_name":  job.cqName,
+			"interval": job.interval.String(),
+		})
+	}
+
+	licenseValid := false
+	if s.licenseClient != nil {
+		licenseValid = s.licenseClient.CanUseCQScheduler()
+	}
+
+	return map[string]interface{}{
+		"running":       s.running,
+		"license_valid": licenseValid,
+		"job_count":     len(s.jobs),
+		"jobs":          jobs,
+	}
+}
+
+// IsRunning returns whether the scheduler is running
+func (s *CQScheduler) IsRunning() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.running
+}
+
+// JobCount returns the number of active jobs
+func (s *CQScheduler) JobCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.jobs)
+}

--- a/internal/scheduler/cq_scheduler_test.go
+++ b/internal/scheduler/cq_scheduler_test.go
@@ -1,0 +1,203 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestParseInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval string
+		wantDur  time.Duration
+		wantErr  bool
+	}{
+		{"30 seconds", "30s", 30 * time.Second, false},
+		{"5 minutes", "5m", 5 * time.Minute, false},
+		{"1 hour", "1h", time.Hour, false},
+		{"90 minutes", "90m", 90 * time.Minute, false},
+		{"1.5 hours", "1h30m", 90 * time.Minute, false},
+		{"24 hours", "24h", 24 * time.Hour, false},
+		{"invalid", "invalid", 0, true},
+		{"empty", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dur, err := time.ParseDuration(tt.interval)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for interval %q", tt.interval)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for interval %q: %v", tt.interval, err)
+				return
+			}
+			if dur != tt.wantDur {
+				t.Errorf("duration = %v, want %v", dur, tt.wantDur)
+			}
+		})
+	}
+}
+
+func TestCQScheduler_NewCQScheduler(t *testing.T) {
+	logger := zerolog.Nop()
+
+	// Create scheduler without handler (will fail on Start)
+	s, err := NewCQScheduler(&CQSchedulerConfig{
+		CQHandler:     nil,
+		LicenseClient: nil,
+		Logger:        logger,
+	})
+
+	if err != nil {
+		t.Fatalf("NewCQScheduler failed: %v", err)
+	}
+
+	if s == nil {
+		t.Fatal("expected scheduler, got nil")
+	}
+
+	if s.running {
+		t.Error("scheduler should not be running after creation")
+	}
+
+	if len(s.jobs) != 0 {
+		t.Errorf("jobs should be empty, got %d", len(s.jobs))
+	}
+}
+
+func TestCQScheduler_Status_NotRunning(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewCQScheduler(&CQSchedulerConfig{
+		CQHandler:     nil,
+		LicenseClient: nil,
+		Logger:        logger,
+	})
+	if err != nil {
+		t.Fatalf("NewCQScheduler failed: %v", err)
+	}
+
+	status := s.Status()
+
+	running, ok := status["running"].(bool)
+	if !ok || running {
+		t.Error("status should show running=false")
+	}
+
+	jobCount, ok := status["job_count"].(int)
+	if !ok || jobCount != 0 {
+		t.Errorf("job_count = %v, want 0", jobCount)
+	}
+
+	licenseValid, ok := status["license_valid"].(bool)
+	if !ok || licenseValid {
+		t.Error("license_valid should be false when no license client")
+	}
+}
+
+func TestCQScheduler_IsRunning(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewCQScheduler(&CQSchedulerConfig{
+		CQHandler:     nil,
+		LicenseClient: nil,
+		Logger:        logger,
+	})
+	if err != nil {
+		t.Fatalf("NewCQScheduler failed: %v", err)
+	}
+
+	if s.IsRunning() {
+		t.Error("scheduler should not be running initially")
+	}
+}
+
+func TestCQScheduler_JobCount(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewCQScheduler(&CQSchedulerConfig{
+		CQHandler:     nil,
+		LicenseClient: nil,
+		Logger:        logger,
+	})
+	if err != nil {
+		t.Fatalf("NewCQScheduler failed: %v", err)
+	}
+
+	if s.JobCount() != 0 {
+		t.Errorf("job count = %d, want 0", s.JobCount())
+	}
+}
+
+func TestCQScheduler_Stop_WhenNotRunning(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewCQScheduler(&CQSchedulerConfig{
+		CQHandler:     nil,
+		LicenseClient: nil,
+		Logger:        logger,
+	})
+	if err != nil {
+		t.Fatalf("NewCQScheduler failed: %v", err)
+	}
+
+	// Stop should be safe to call even when not running
+	s.Stop()
+
+	if s.IsRunning() {
+		t.Error("scheduler should still be stopped")
+	}
+}
+
+// MockCQHandler implements enough of the CQ handler for testing
+type MockCQHandler struct {
+	activeCQs []mockCQ
+	execCount int
+}
+
+type mockCQ struct {
+	ID       int64
+	Name     string
+	Interval string
+	IsActive bool
+}
+
+func TestMinimumInterval(t *testing.T) {
+	// Test that intervals below 10 seconds get bumped up
+	tests := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"1s", 10 * time.Second},
+		{"5s", 10 * time.Second},
+		{"9s", 10 * time.Second},
+		{"10s", 10 * time.Second},
+		{"11s", 11 * time.Second},
+		{"30s", 30 * time.Second},
+		{"1m", 1 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			dur, err := time.ParseDuration(tt.input)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+
+			// Apply minimum interval logic
+			if dur < 10*time.Second {
+				dur = 10 * time.Second
+			}
+
+			if dur != tt.expected {
+				t.Errorf("duration = %v, want %v", dur, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/scheduler/retention_scheduler.go
+++ b/internal/scheduler/retention_scheduler.go
@@ -1,0 +1,284 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/api"
+	"github.com/basekick-labs/arc/internal/license"
+	"github.com/robfig/cron/v3"
+	"github.com/rs/zerolog"
+)
+
+// RetentionScheduler manages automatic execution of retention policies on a schedule
+type RetentionScheduler struct {
+	retentionHandler *api.RetentionHandler
+	licenseClient    *license.Client
+	schedule         string // Cron schedule (e.g., "0 3 * * *" = 3am daily)
+	cron             *cron.Cron
+	running          bool
+	mu               sync.Mutex
+	logger           zerolog.Logger
+}
+
+// RetentionSchedulerConfig holds configuration for the retention scheduler
+type RetentionSchedulerConfig struct {
+	RetentionHandler *api.RetentionHandler
+	LicenseClient    *license.Client
+	Schedule         string // Cron schedule string (e.g., "0 3 * * *")
+	Logger           zerolog.Logger
+}
+
+// NewRetentionScheduler creates a new retention scheduler
+func NewRetentionScheduler(cfg *RetentionSchedulerConfig) (*RetentionScheduler, error) {
+	// Default schedule: daily at 3am
+	schedule := cfg.Schedule
+	if schedule == "" {
+		schedule = "0 3 * * *"
+	}
+
+	// Validate cron schedule
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	if _, err := parser.Parse(schedule); err != nil {
+		return nil, err
+	}
+
+	s := &RetentionScheduler{
+		retentionHandler: cfg.RetentionHandler,
+		licenseClient:    cfg.LicenseClient,
+		schedule:         schedule,
+		logger:           cfg.Logger.With().Str("component", "retention-scheduler").Logger(),
+	}
+
+	s.logger.Info().
+		Str("schedule", schedule).
+		Msg("Retention scheduler initialized")
+
+	return s, nil
+}
+
+// Start starts the retention scheduler
+func (s *RetentionScheduler) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		s.logger.Warn().Msg("Retention scheduler already running")
+		return nil
+	}
+
+	// Check license - require valid license for retention scheduler
+	if s.licenseClient == nil || !s.licenseClient.CanUseRetentionScheduler() {
+		s.logger.Warn().Msg("Valid enterprise license required for retention scheduler - not starting")
+		return nil
+	}
+
+	// Create cron instance
+	s.cron = cron.New(cron.WithParser(cron.NewParser(
+		cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow,
+	)))
+
+	// Add retention job
+	_, err := s.cron.AddFunc(s.schedule, func() {
+		s.runRetention()
+	})
+	if err != nil {
+		return err
+	}
+
+	// Start cron scheduler
+	s.cron.Start()
+	s.running = true
+
+	// Log next run time
+	nextRun := s.getNextRun()
+	s.logger.Info().
+		Str("schedule", s.schedule).
+		Time("next_run", nextRun).
+		Msg("Retention scheduler started")
+
+	return nil
+}
+
+// Stop stops the retention scheduler
+func (s *RetentionScheduler) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running {
+		return
+	}
+
+	// Stop cron scheduler
+	if s.cron != nil {
+		ctx := s.cron.Stop()
+		<-ctx.Done() // Wait for running jobs to complete
+	}
+
+	s.running = false
+	s.logger.Info().Msg("Retention scheduler stopped")
+}
+
+// runRetention runs one retention cycle for all active policies
+func (s *RetentionScheduler) runRetention() {
+	startTime := time.Now()
+	s.logger.Info().Msg("Triggering scheduled retention")
+
+	// Check license before execution
+	if s.licenseClient == nil || !s.licenseClient.CanUseRetentionScheduler() {
+		s.logger.Warn().Msg("Valid enterprise license required, skipping retention execution")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	// Get all active policies
+	policies, err := s.retentionHandler.GetActivePolicies()
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Failed to get active retention policies")
+		return
+	}
+
+	if len(policies) == 0 {
+		s.logger.Info().Msg("No active retention policies to execute")
+		return
+	}
+
+	s.logger.Info().
+		Int("policy_count", len(policies)).
+		Msg("Executing retention policies")
+
+	// Execute each policy
+	var totalDeleted int64
+	var successCount int
+	var errorCount int
+
+	for _, policy := range policies {
+		resp, err := s.retentionHandler.ExecutePolicy(ctx, policy.ID)
+		if err != nil {
+			s.logger.Error().
+				Err(err).
+				Int64("policy_id", policy.ID).
+				Str("policy_name", policy.Name).
+				Msg("Retention policy execution failed")
+			errorCount++
+			continue
+		}
+
+		totalDeleted += resp.DeletedCount
+		successCount++
+
+		s.logger.Info().
+			Int64("policy_id", policy.ID).
+			Str("policy_name", policy.Name).
+			Int64("deleted_count", resp.DeletedCount).
+			Int("files_deleted", resp.FilesDeleted).
+			Msg("Retention policy executed")
+	}
+
+	duration := time.Since(startTime)
+	s.logger.Info().
+		Int("success_count", successCount).
+		Int("error_count", errorCount).
+		Int64("total_deleted", totalDeleted).
+		Dur("duration", duration).
+		Msg("Scheduled retention completed")
+}
+
+// TriggerNow triggers retention execution immediately
+func (s *RetentionScheduler) TriggerNow(ctx context.Context) error {
+	s.logger.Info().Msg("Manual retention trigger")
+
+	// Check license - require valid license for retention scheduler
+	if s.licenseClient == nil || !s.licenseClient.CanUseRetentionScheduler() {
+		s.logger.Warn().Msg("Valid enterprise license required for retention trigger")
+		return nil
+	}
+
+	startTime := time.Now()
+
+	// Get all active policies
+	policies, err := s.retentionHandler.GetActivePolicies()
+	if err != nil {
+		return err
+	}
+
+	if len(policies) == 0 {
+		s.logger.Info().Msg("No active retention policies to execute")
+		return nil
+	}
+
+	// Execute each policy
+	var totalDeleted int64
+	var lastError error
+
+	for _, policy := range policies {
+		resp, err := s.retentionHandler.ExecutePolicy(ctx, policy.ID)
+		if err != nil {
+			s.logger.Error().
+				Err(err).
+				Int64("policy_id", policy.ID).
+				Str("policy_name", policy.Name).
+				Msg("Retention policy execution failed")
+			lastError = err
+			continue
+		}
+
+		totalDeleted += resp.DeletedCount
+	}
+
+	duration := time.Since(startTime)
+	s.logger.Info().
+		Int64("total_deleted", totalDeleted).
+		Dur("duration", duration).
+		Msg("Manual retention completed")
+
+	return lastError
+}
+
+// getNextRun returns the next scheduled run time
+func (s *RetentionScheduler) getNextRun() time.Time {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse(s.schedule)
+	if err != nil {
+		return time.Time{}
+	}
+	return schedule.Next(time.Now())
+}
+
+// Status returns scheduler status
+func (s *RetentionScheduler) Status() map[string]interface{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	licenseValid := false
+	if s.licenseClient != nil {
+		licenseValid = s.licenseClient.CanUseRetentionScheduler()
+	}
+
+	status := map[string]interface{}{
+		"running":       s.running,
+		"schedule":      s.schedule,
+		"license_valid": licenseValid,
+	}
+
+	if s.running {
+		status["next_run"] = s.getNextRun().Format(time.RFC3339)
+	}
+
+	return status
+}
+
+// IsRunning returns whether the scheduler is running
+func (s *RetentionScheduler) IsRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running
+}
+
+// GetSchedule returns the cron schedule string
+func (s *RetentionScheduler) GetSchedule() string {
+	return s.schedule
+}

--- a/internal/scheduler/retention_scheduler_test.go
+++ b/internal/scheduler/retention_scheduler_test.go
@@ -1,0 +1,226 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/rs/zerolog"
+)
+
+func TestRetentionScheduler_NewRetentionScheduler(t *testing.T) {
+	logger := zerolog.Nop()
+
+	// Create scheduler without handler (will fail on Start)
+	s, err := NewRetentionScheduler(&RetentionSchedulerConfig{
+		RetentionHandler: nil,
+		LicenseClient:    nil,
+		Schedule:         "0 3 * * *",
+		Logger:           logger,
+	})
+
+	if err != nil {
+		t.Fatalf("NewRetentionScheduler failed: %v", err)
+	}
+
+	if s == nil {
+		t.Fatal("expected scheduler, got nil")
+	}
+
+	if s.running {
+		t.Error("scheduler should not be running after creation")
+	}
+
+	if s.schedule != "0 3 * * *" {
+		t.Errorf("schedule = %v, want 0 3 * * *", s.schedule)
+	}
+}
+
+func TestRetentionScheduler_NewRetentionScheduler_DefaultSchedule(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewRetentionScheduler(&RetentionSchedulerConfig{
+		RetentionHandler: nil,
+		LicenseClient:    nil,
+		Schedule:         "", // Empty schedule should use default
+		Logger:           logger,
+	})
+
+	if err != nil {
+		t.Fatalf("NewRetentionScheduler failed: %v", err)
+	}
+
+	if s.schedule != "0 3 * * *" {
+		t.Errorf("schedule = %v, want default 0 3 * * *", s.schedule)
+	}
+}
+
+func TestRetentionScheduler_NewRetentionScheduler_InvalidSchedule(t *testing.T) {
+	logger := zerolog.Nop()
+
+	_, err := NewRetentionScheduler(&RetentionSchedulerConfig{
+		RetentionHandler: nil,
+		LicenseClient:    nil,
+		Schedule:         "invalid schedule",
+		Logger:           logger,
+	})
+
+	if err == nil {
+		t.Error("expected error for invalid cron schedule")
+	}
+}
+
+func TestRetentionScheduler_Status_NotRunning(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewRetentionScheduler(&RetentionSchedulerConfig{
+		RetentionHandler: nil,
+		LicenseClient:    nil,
+		Schedule:         "0 3 * * *",
+		Logger:           logger,
+	})
+	if err != nil {
+		t.Fatalf("NewRetentionScheduler failed: %v", err)
+	}
+
+	status := s.Status()
+
+	running, ok := status["running"].(bool)
+	if !ok || running {
+		t.Error("status should show running=false")
+	}
+
+	schedule, ok := status["schedule"].(string)
+	if !ok || schedule != "0 3 * * *" {
+		t.Errorf("schedule = %v, want 0 3 * * *", schedule)
+	}
+
+	licenseValid, ok := status["license_valid"].(bool)
+	if !ok || licenseValid {
+		t.Error("license_valid should be false when no license client")
+	}
+
+	// next_run should not be present when not running
+	if _, ok := status["next_run"]; ok {
+		t.Error("next_run should not be present when not running")
+	}
+}
+
+func TestRetentionScheduler_IsRunning(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewRetentionScheduler(&RetentionSchedulerConfig{
+		RetentionHandler: nil,
+		LicenseClient:    nil,
+		Schedule:         "0 3 * * *",
+		Logger:           logger,
+	})
+	if err != nil {
+		t.Fatalf("NewRetentionScheduler failed: %v", err)
+	}
+
+	if s.IsRunning() {
+		t.Error("scheduler should not be running initially")
+	}
+}
+
+func TestRetentionScheduler_GetSchedule(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewRetentionScheduler(&RetentionSchedulerConfig{
+		RetentionHandler: nil,
+		LicenseClient:    nil,
+		Schedule:         "30 4 * * *",
+		Logger:           logger,
+	})
+	if err != nil {
+		t.Fatalf("NewRetentionScheduler failed: %v", err)
+	}
+
+	if s.GetSchedule() != "30 4 * * *" {
+		t.Errorf("GetSchedule() = %v, want 30 4 * * *", s.GetSchedule())
+	}
+}
+
+func TestRetentionScheduler_Stop_WhenNotRunning(t *testing.T) {
+	logger := zerolog.Nop()
+
+	s, err := NewRetentionScheduler(&RetentionSchedulerConfig{
+		RetentionHandler: nil,
+		LicenseClient:    nil,
+		Schedule:         "0 3 * * *",
+		Logger:           logger,
+	})
+	if err != nil {
+		t.Fatalf("NewRetentionScheduler failed: %v", err)
+	}
+
+	// Stop should be safe to call even when not running
+	s.Stop()
+
+	if s.IsRunning() {
+		t.Error("scheduler should still be stopped")
+	}
+}
+
+func TestCronScheduleValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		schedule string
+		wantErr  bool
+	}{
+		{"daily at 3am", "0 3 * * *", false},
+		{"every hour at :05", "5 * * * *", false},
+		{"every 6 hours", "0 */6 * * *", false},
+		{"weekly on Sunday at midnight", "0 0 * * 0", false},
+		{"first of month at noon", "0 12 1 * *", false},
+		{"invalid - missing fields", "3 * *", true},
+		{"invalid - bad expression", "invalid", true},
+		{"invalid - out of range", "60 25 * * *", true},
+	}
+
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parser.Parse(tt.schedule)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for schedule %q", tt.schedule)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for schedule %q: %v", tt.schedule, err)
+			}
+		})
+	}
+}
+
+func TestCronNextRun(t *testing.T) {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+	// Test "0 3 * * *" (daily at 3am)
+	schedule, err := parser.Parse("0 3 * * *")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	now := time.Now()
+	nextRun := schedule.Next(now)
+
+	// Next run should be in the future
+	if !nextRun.After(now) {
+		t.Error("next run should be in the future")
+	}
+
+	// Next run should be at 3:00
+	if nextRun.Hour() != 3 || nextRun.Minute() != 0 {
+		t.Errorf("next run should be at 03:00, got %02d:%02d", nextRun.Hour(), nextRun.Minute())
+	}
+
+	// Next run should be within 24 hours
+	if nextRun.Sub(now) > 24*time.Hour {
+		t.Error("next run should be within 24 hours")
+	}
+}

--- a/internal/storage/util.go
+++ b/internal/storage/util.go
@@ -1,0 +1,46 @@
+package storage
+
+import "github.com/rs/zerolog"
+
+// GetLocalBasePath returns the base filesystem path for local storage backends.
+// For cloud backends (S3, Azure), it logs a warning and returns empty string.
+// For unknown backends, it returns the provided fallback path.
+//
+// Parameters:
+//   - backend: The storage backend to check
+//   - logger: Logger for warnings about unsupported backends (can be nil)
+//   - feature: Feature name for warning messages (e.g., "Continuous queries", "Retention")
+//   - fallback: Default path to return for unknown backend types (use "" to disable)
+func GetLocalBasePath(backend Backend, logger *zerolog.Logger, feature string, fallback string) string {
+	switch b := backend.(type) {
+	case *LocalBackend:
+		return b.GetBasePath()
+	case *S3Backend:
+		if logger != nil {
+			logger.Warn().Msgf("%s not fully supported for S3 backend yet", feature)
+		}
+		return ""
+	case *AzureBlobBackend:
+		if logger != nil {
+			logger.Warn().Msgf("%s not fully supported for Azure backend yet", feature)
+		}
+		return ""
+	default:
+		return fallback
+	}
+}
+
+// GetStoragePath returns the full storage path for a database/measurement with glob pattern.
+// Supports all storage backends: local, S3, and Azure.
+func GetStoragePath(backend Backend, database, measurement string) string {
+	switch b := backend.(type) {
+	case *S3Backend:
+		return "s3://" + b.GetBucket() + "/" + database + "/" + measurement + "/**/*.parquet"
+	case *AzureBlobBackend:
+		return "azure://" + b.GetContainer() + "/" + database + "/" + measurement + "/**/*.parquet"
+	case *LocalBackend:
+		return b.GetBasePath() + "/" + database + "/" + measurement + "/**/*.parquet"
+	default:
+		return "./data/" + database + "/" + measurement + "/**/*.parquet"
+	}
+}


### PR DESCRIPTION
- Add license client with RSA signature verification and machine fingerprint
- Add CQ scheduler with per-CQ interval execution (cron-based)
- Add retention scheduler with configurable cron schedule
- Gate both schedulers behind valid enterprise license (all tiers)
- Fix CQ execution to use database.measurement format
- Add S3 and Azure storage backend support for CQ execution
- Consolidate storage path logic into shared utility
- Require license client for scheduler operation

License gating:
- Schedulers require valid license client to start
- License checked before each scheduled execution
- All tiers (starter, professional, enterprise, unlimited) get scheduler access
- Status API reports license_valid=false when no license configured

Files added:
- internal/license/ (client, fingerprint, license types)
- internal/scheduler/ (CQ and retention schedulers)
- internal/api/scheduler.go (scheduler status API)
- internal/storage/util.go (shared storage path utility)