### PR TITLE
fix(compaction): Resolve OOM and segfaults with large datasets (#102)

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -462,6 +462,7 @@ func main() {
 			StorageBackend:  storageBackend,
 			LockManager:     lockManager,
 			MaxConcurrent:   cfg.Compaction.MaxConcurrent,
+			MemoryLimit:     cfg.Database.MemoryLimit, // Use same limit as main DuckDB
 			SortKeysConfig:  sortKeysConfig,
 			DefaultSortKeys: defaultSortKeys,
 			Tiers:           tiers,


### PR DESCRIPTION
- Stream downloads using ReadTo() instead of loading files into memory
- Stream uploads using WriteReader() instead of loading files into memory
- Pass database.memory_limit config to DuckDB subprocess
- Add file batching (max 1000 files per job) to prevent DuckDB segfaults
- Add optional heap profiling via ARC_COMPACTION_PROFILE=1 env var

Fixes compaction failures on tables with 2B+ rows and thousands of files. Query performance improved ~2x after successful compaction.