### PR TITLE
fix: Buffer flush bug and Arrow endpoint SQL cache

### DIFF
--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -63,8 +63,8 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		})
 	}
 
-	// Convert SQL to storage paths
-	convertedSQL := h.convertSQLToStoragePaths(req.SQL)
+	// Convert SQL to storage paths (with caching)
+	convertedSQL, _ := h.getTransformedSQL(req.SQL)
 
 	h.logger.Debug().
 		Str("original_sql", req.SQL).


### PR DESCRIPTION
1. Fix age-based buffer flush not triggering after size-based flush
   - After size-based flush, code set buffers[key] = nil instead of deleting
   - When flushAgedBuffers() cleaned up bufferStartTimes for empty buffer, subsequent writes never re-initialized start time (key still existed)
   - Data would accumulate without age tracking until server shutdown
   - Changed to use delete() to fully remove key, ensuring fresh tracking

2. Fix HTTP Arrow endpoint not using SQL transform cache
   - Changed from convertSQLToStoragePaths() to getTransformedSQL()
   - Matches behavior of JSON query endpoint
   - Repeated queries now benefit from cached transformations