### PR TITLE
perf: Add x-arc-database header support for query optimization

### DIFF
--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -918,16 +918,16 @@ func BenchmarkGetTransformedSQL(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.queryCache.Invalidate() // Force cache miss
-				h.getTransformedSQL(tc.sql)
+				h.getTransformedSQL(tc.sql, "")
 			}
 		})
 
 		// Benchmark cache hit (pre-populated)
 		b.Run(tc.name+"_cache_hit", func(b *testing.B) {
-			h.getTransformedSQL(tc.sql) // Pre-populate cache
+			h.getTransformedSQL(tc.sql, "") // Pre-populate cache
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				h.getTransformedSQL(tc.sql)
+				h.getTransformedSQL(tc.sql, "")
 			}
 		})
 	}


### PR DESCRIPTION
Add support for x-arc-database header in query endpoints to skip database extraction regex patterns, providing 4-17% performance improvement.

Changes:
- Add hasCrossDatabaseSyntax() to detect db.table syntax
- Add convertSQLToStoragePathsWithHeaderDB() optimized conversion
- Update getTransformedSQL() to accept headerDB parameter
- Update executeQuery and executeQueryArrow with header support
- Reject cross-database queries when header is set
- Update benchmark suite with --use-header flag for A/B testing

Performance results:
- COUNT(*): 5-6% faster
- SELECT with LIMIT: 3-7% faster
- Aggregations: 10.6% faster
- GROUP BY: 17.3% faster
- Overall throughput: +5-7.5%