### PR TITLE
feat(cluster): Add Phase 2 enterprise clustering foundation

### DIFF
--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/basekick-labs/arc/internal/license"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// Input validation constants
+const (
+	maxNodeIDLength = 256
+)
+
+// validRoles defines the valid role filter values.
+var validRoles = map[string]bool{
+	"writer":     true,
+	"reader":     true,
+	"compactor":  true,
+	"standalone": true,
+}
+
+// validStates defines the valid state filter values.
+var validStates = map[string]bool{
+	"healthy":   true,
+	"unhealthy": true,
+	"dead":      true,
+	"unknown":   true,
+	"joining":   true,
+	"leaving":   true,
+}
+
+// ClusterHandler handles cluster management API endpoints.
+type ClusterHandler struct {
+	coordinator   *cluster.Coordinator
+	licenseClient *license.Client
+	logger        zerolog.Logger
+}
+
+// NewClusterHandler creates a new cluster handler.
+// The coordinator can be nil if clustering is not enabled.
+func NewClusterHandler(
+	coordinator *cluster.Coordinator,
+	licenseClient *license.Client,
+	logger zerolog.Logger,
+) *ClusterHandler {
+	return &ClusterHandler{
+		coordinator:   coordinator,
+		licenseClient: licenseClient,
+		logger:        logger.With().Str("component", "cluster-handler").Logger(),
+	}
+}
+
+// RegisterRoutes registers cluster API routes.
+func (h *ClusterHandler) RegisterRoutes(app *fiber.App) {
+	app.Get("/api/v1/cluster", h.handleGetStatus)
+	app.Get("/api/v1/cluster/nodes", h.handleGetNodes)
+	app.Get("/api/v1/cluster/nodes/:id", h.handleGetNode)
+	app.Get("/api/v1/cluster/local", h.handleGetLocalNode)
+	app.Get("/api/v1/cluster/health", h.handleGetHealth)
+}
+
+// handleGetStatus returns the overall cluster status.
+func (h *ClusterHandler) handleGetStatus(c *fiber.Ctx) error {
+	// Check if clustering is enabled and licensed
+	if h.coordinator == nil {
+		return h.respondNotEnabled(c)
+	}
+
+	status := h.coordinator.Status()
+	status["enabled"] = true
+	status["mode"] = "cluster"
+
+	// Add license info
+	if h.licenseClient != nil {
+		lic := h.licenseClient.GetLicense()
+		if lic != nil {
+			status["license"] = map[string]interface{}{
+				"valid":    lic.IsValid(),
+				"tier":     lic.Tier,
+				"features": lic.Features,
+			}
+		}
+	}
+
+	return c.JSON(status)
+}
+
+// handleGetNodes returns all cluster nodes.
+func (h *ClusterHandler) handleGetNodes(c *fiber.Ctx) error {
+	if h.coordinator == nil {
+		return h.respondNotEnabled(c)
+	}
+
+	// Validate query parameters
+	roleFilter := c.Query("role")
+	if roleFilter != "" && !validRoles[roleFilter] {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid role filter. Valid values: writer, reader, compactor, standalone",
+		})
+	}
+
+	stateFilter := c.Query("state")
+	if stateFilter != "" && !validStates[stateFilter] {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid state filter. Valid values: healthy, unhealthy, dead, unknown, joining, leaving",
+		})
+	}
+
+	registry := h.coordinator.GetRegistry()
+	nodes := registry.GetAll()
+
+	nodeList := make([]map[string]interface{}, 0, len(nodes))
+	for _, node := range nodes {
+		// Filter by role if specified
+		if roleFilter != "" && string(node.Role) != roleFilter {
+			continue
+		}
+
+		// Filter by state if specified
+		if stateFilter != "" && string(node.GetState()) != stateFilter {
+			continue
+		}
+
+		nodeList = append(nodeList, h.nodeToMap(node))
+	}
+
+	return c.JSON(fiber.Map{
+		"nodes": nodeList,
+		"total": len(nodeList),
+	})
+}
+
+// handleGetNode returns a specific node by ID.
+func (h *ClusterHandler) handleGetNode(c *fiber.Ctx) error {
+	if h.coordinator == nil {
+		return h.respondNotEnabled(c)
+	}
+
+	nodeID := c.Params("id")
+
+	// Validate node ID
+	if len(nodeID) == 0 || len(nodeID) > maxNodeIDLength {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid node ID",
+		})
+	}
+
+	registry := h.coordinator.GetRegistry()
+
+	node, exists := registry.Get(nodeID)
+	if !exists {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Node not found",
+		})
+	}
+
+	return c.JSON(h.nodeToMap(node))
+}
+
+// handleGetLocalNode returns the local node info with its capabilities.
+func (h *ClusterHandler) handleGetLocalNode(c *fiber.Ctx) error {
+	if h.coordinator == nil {
+		return h.respondNotEnabled(c)
+	}
+
+	node := h.coordinator.GetLocalNode()
+	capabilities := node.GetCapabilities()
+
+	response := h.nodeToMap(node)
+	response["capabilities"] = map[string]bool{
+		"can_ingest":     capabilities.CanIngest,
+		"can_query":      capabilities.CanQuery,
+		"can_compact":    capabilities.CanCompact,
+		"can_coordinate": capabilities.CanCoordinate,
+	}
+	response["is_local"] = true
+
+	return c.JSON(response)
+}
+
+// handleGetHealth returns cluster health information.
+func (h *ClusterHandler) handleGetHealth(c *fiber.Ctx) error {
+	if h.coordinator == nil {
+		return h.respondNotEnabled(c)
+	}
+
+	registry := h.coordinator.GetRegistry()
+	healthChecker := h.coordinator.GetHealthChecker()
+
+	summary := registry.Summary()
+
+	return c.JSON(fiber.Map{
+		"healthy":        summary["healthy"],
+		"unhealthy":      summary["unhealthy"],
+		"total":          summary["total"],
+		"health_checker": healthChecker.Status(),
+	})
+}
+
+// respondNotEnabled returns a response indicating clustering is not enabled.
+func (h *ClusterHandler) respondNotEnabled(c *fiber.Ctx) error {
+	response := fiber.Map{
+		"enabled": false,
+		"mode":    "standalone",
+	}
+
+	// Determine the reason
+	if h.licenseClient == nil {
+		response["reason"] = "Enterprise license not configured"
+	} else {
+		lic := h.licenseClient.GetLicense()
+		if lic == nil || !lic.IsValid() {
+			response["reason"] = "Enterprise license not valid"
+		} else if !lic.HasFeature(license.FeatureClustering) {
+			response["reason"] = "License does not include clustering feature"
+		} else {
+			response["reason"] = "Clustering not enabled in configuration (cluster.enabled=false)"
+		}
+	}
+
+	return c.JSON(response)
+}
+
+// nodeToMap converts a Node to a map for JSON serialization.
+func (h *ClusterHandler) nodeToMap(node *cluster.Node) map[string]interface{} {
+	return map[string]interface{}{
+		"id":             node.ID,
+		"name":           node.Name,
+		"role":           node.Role,
+		"state":          node.GetState(),
+		"address":        node.Address,
+		"api_address":    node.APIAddress,
+		"cluster_name":   node.ClusterName,
+		"version":        node.Version,
+		"started_at":     node.StartedAt,
+		"joined_at":      node.JoinedAt,
+		"last_heartbeat": node.GetLastHeartbeat(),
+		"failed_checks":  node.GetFailedChecks(),
+		"stats":          node.GetStats(),
+	}
+}

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1,0 +1,358 @@
+package cluster
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/license"
+	"github.com/rs/zerolog"
+)
+
+// Coordinator manages cluster membership and coordination.
+// It is responsible for:
+// - Maintaining the local node's identity and state
+// - Tracking other nodes in the cluster via the registry
+// - Running health checks on cluster members
+// - Managing the node lifecycle (join, leave, fail)
+type Coordinator struct {
+	cfg           *config.ClusterConfig
+	licenseClient *license.Client
+	registry      *Registry
+	localNode     *Node
+	healthChecker *HealthChecker
+
+	// Network
+	listener net.Listener
+
+	// State
+	running bool
+	stopCh  chan struct{}
+	mu      sync.RWMutex
+
+	logger zerolog.Logger
+}
+
+// CoordinatorConfig holds configuration for the coordinator.
+type CoordinatorConfig struct {
+	Config        *config.ClusterConfig
+	LicenseClient *license.Client
+	Version       string // Arc version
+	APIAddress    string // HTTP API address for this node
+	Logger        zerolog.Logger
+}
+
+// NewCoordinator creates a new cluster coordinator.
+// Returns an error if the license is invalid or missing the clustering feature.
+func NewCoordinator(cfg *CoordinatorConfig) (*Coordinator, error) {
+	// Validate license - clustering requires enterprise license
+	if err := validateClusteringLicense(cfg.LicenseClient); err != nil {
+		return nil, err
+	}
+
+	// Validate role
+	role := ParseRole(cfg.Config.Role)
+	if !role.IsValid() {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidRole, cfg.Config.Role)
+	}
+
+	// Generate node ID if not provided
+	nodeID := cfg.Config.NodeID
+	if nodeID == "" {
+		nodeID = generateNodeID()
+	}
+
+	// Create local node
+	localNode := NewNode(nodeID, nodeID, role, cfg.Config.ClusterName)
+	localNode.SetVersion(cfg.Version)
+	localNode.SetAddresses(cfg.Config.AdvertiseAddr, cfg.APIAddress)
+	localNode.UpdateState(StateJoining)
+
+	// Create registry
+	registry := NewRegistry(&RegistryConfig{
+		LocalNode: localNode,
+		Logger:    cfg.Logger,
+	})
+
+	c := &Coordinator{
+		cfg:           cfg.Config,
+		licenseClient: cfg.LicenseClient,
+		registry:      registry,
+		localNode:     localNode,
+		stopCh:        make(chan struct{}),
+		logger:        cfg.Logger.With().Str("component", "cluster-coordinator").Logger(),
+	}
+
+	// Create health checker
+	c.healthChecker = NewHealthChecker(&HealthCheckerConfig{
+		Registry:           registry,
+		CheckInterval:      time.Duration(cfg.Config.HealthCheckInterval) * time.Second,
+		CheckTimeout:       time.Duration(cfg.Config.HealthCheckTimeout) * time.Second,
+		UnhealthyThreshold: cfg.Config.UnhealthyThreshold,
+		Logger:             cfg.Logger,
+	})
+
+	c.logger.Info().
+		Str("node_id", nodeID).
+		Str("role", string(role)).
+		Str("cluster", cfg.Config.ClusterName).
+		Msg("Cluster coordinator initialized")
+
+	return c, nil
+}
+
+// Start starts the cluster coordinator.
+func (c *Coordinator) Start() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.running {
+		return ErrAlreadyRunning
+	}
+
+	// Validate license on each start (license may have expired)
+	if err := validateClusteringLicense(c.licenseClient); err != nil {
+		return err
+	}
+
+	// Start listening for peer connections if we have a coordinator address
+	if c.cfg.CoordinatorAddr != "" {
+		listener, err := net.Listen("tcp", c.cfg.CoordinatorAddr)
+		if err != nil {
+			return fmt.Errorf("failed to start coordinator listener: %w", err)
+		}
+		c.listener = listener
+
+		// Start peer listener
+		go c.acceptLoop()
+	}
+
+	// Start health checker
+	c.healthChecker.Start()
+
+	// Start peer discovery if we have seeds
+	if len(c.cfg.Seeds) > 0 {
+		go c.discoveryLoop()
+	}
+
+	c.running = true
+	c.localNode.MarkJoined()
+
+	c.logger.Info().
+		Str("coordinator_addr", c.cfg.CoordinatorAddr).
+		Int("seed_count", len(c.cfg.Seeds)).
+		Str("role", string(c.localNode.Role)).
+		Msg("Cluster coordinator started")
+
+	return nil
+}
+
+// Stop stops the cluster coordinator gracefully.
+func (c *Coordinator) Stop() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.running {
+		return nil
+	}
+
+	c.logger.Info().Msg("Stopping cluster coordinator...")
+
+	// Signal all goroutines to stop
+	close(c.stopCh)
+
+	// Stop health checker
+	c.healthChecker.Stop()
+
+	// Close listener
+	if c.listener != nil {
+		c.listener.Close()
+	}
+
+	// Mark local node as leaving
+	c.localNode.UpdateState(StateLeaving)
+
+	c.running = false
+
+	c.logger.Info().Msg("Cluster coordinator stopped")
+	return nil
+}
+
+// Close implements the shutdown.Shutdownable interface.
+func (c *Coordinator) Close() error {
+	return c.Stop()
+}
+
+// discoveryLoop periodically discovers and connects to peer nodes.
+func (c *Coordinator) discoveryLoop() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	// Initial discovery
+	c.discoverPeers()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.discoverPeers()
+		case <-c.stopCh:
+			return
+		}
+	}
+}
+
+// discoverPeers attempts to discover peer nodes from seeds.
+// Note: Full peer discovery protocol is implemented in Phase 3.
+// For now, this is a placeholder that logs discovery attempts.
+func (c *Coordinator) discoverPeers() {
+	for _, seed := range c.cfg.Seeds {
+		// Skip self
+		if seed == c.cfg.AdvertiseAddr {
+			continue
+		}
+
+		// TODO (Phase 3): Implement peer discovery protocol
+		// - Connect to seed node
+		// - Exchange node info via protocol messages
+		// - Register discovered nodes in registry
+		c.logger.Debug().
+			Str("seed", seed).
+			Msg("Peer discovery placeholder - full implementation in Phase 3")
+	}
+}
+
+// acceptLoop accepts incoming peer connections.
+func (c *Coordinator) acceptLoop() {
+	for {
+		conn, err := c.listener.Accept()
+		if err != nil {
+			select {
+			case <-c.stopCh:
+				return
+			default:
+				c.logger.Error().Err(err).Msg("Failed to accept peer connection")
+				continue
+			}
+		}
+
+		go c.handlePeerConnection(conn)
+	}
+}
+
+// handlePeerConnection handles an incoming peer connection.
+// Note: Full peer protocol is implemented in Phase 3.
+func (c *Coordinator) handlePeerConnection(conn net.Conn) {
+	defer conn.Close()
+
+	// TODO (Phase 3): Implement peer protocol
+	// - Read message header
+	// - Parse protocol message
+	// - Handle join, leave, heartbeat, etc.
+	c.logger.Debug().
+		Str("peer", conn.RemoteAddr().String()).
+		Msg("Peer connection received - full protocol in Phase 3")
+}
+
+// GetRegistry returns the node registry.
+func (c *Coordinator) GetRegistry() *Registry {
+	return c.registry
+}
+
+// GetLocalNode returns the local node.
+func (c *Coordinator) GetLocalNode() *Node {
+	return c.localNode
+}
+
+// GetHealthChecker returns the health checker.
+func (c *Coordinator) GetHealthChecker() *HealthChecker {
+	return c.healthChecker
+}
+
+// IsRunning returns true if the coordinator is running.
+func (c *Coordinator) IsRunning() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.running
+}
+
+// GetRole returns the role of the local node.
+func (c *Coordinator) GetRole() NodeRole {
+	return c.localNode.Role
+}
+
+// GetCapabilities returns the capabilities of the local node.
+func (c *Coordinator) GetCapabilities() RoleCapabilities {
+	return c.localNode.GetCapabilities()
+}
+
+// Status returns the cluster status as a map for JSON serialization.
+func (c *Coordinator) Status() map[string]interface{} {
+	c.mu.RLock()
+	running := c.running
+	c.mu.RUnlock()
+
+	nodes := c.registry.GetAll()
+	nodeList := make([]map[string]interface{}, 0, len(nodes))
+	for _, node := range nodes {
+		nodeList = append(nodeList, map[string]interface{}{
+			"id":             node.ID,
+			"name":           node.Name,
+			"role":           node.Role,
+			"state":          node.State,
+			"address":        node.Address,
+			"api_address":    node.APIAddress,
+			"version":        node.Version,
+			"last_heartbeat": node.GetLastHeartbeat(),
+			"stats":          node.GetStats(),
+		})
+	}
+
+	summary := c.registry.Summary()
+
+	return map[string]interface{}{
+		"running":       running,
+		"cluster_name":  c.cfg.ClusterName,
+		"local_node_id": c.localNode.ID,
+		"local_role":    c.localNode.Role,
+		"node_count":    summary["total"],
+		"healthy_count": summary["healthy"],
+		"nodes":         nodeList,
+		"writers":       summary["writers"],
+		"readers":       summary["readers"],
+		"compactors":    summary["compactors"],
+	}
+}
+
+// generateNodeID generates a unique node ID with sufficient entropy.
+// Uses 8 bytes (64 bits) of randomness plus timestamp for collision resistance.
+func generateNodeID() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+
+	// Generate random suffix with 64 bits of entropy for collision resistance
+	suffix := make([]byte, 8)
+	rand.Read(suffix)
+
+	return fmt.Sprintf("%s-%d-%x", hostname, time.Now().UnixNano(), suffix)
+}
+
+// validateClusteringLicense validates that the license allows clustering.
+func validateClusteringLicense(client *license.Client) error {
+	if client == nil {
+		return ErrLicenseRequired
+	}
+	lic := client.GetLicense()
+	if lic == nil {
+		return ErrLicenseRequired
+	}
+	if !lic.HasFeature(license.FeatureClustering) {
+		return ErrClusteringFeatureRequired
+	}
+	return nil
+}

--- a/internal/cluster/errors.go
+++ b/internal/cluster/errors.go
@@ -1,0 +1,42 @@
+package cluster
+
+import "errors"
+
+// Cluster-specific errors.
+var (
+	// ErrLicenseRequired indicates that an enterprise license is required for clustering.
+	ErrLicenseRequired = errors.New("enterprise license required for clustering")
+
+	// ErrClusteringFeatureRequired indicates the license doesn't include the clustering feature.
+	ErrClusteringFeatureRequired = errors.New("license does not include clustering feature")
+
+	// ErrInvalidRole indicates an invalid node role was specified.
+	ErrInvalidRole = errors.New("invalid cluster role")
+
+	// ErrAlreadyRunning indicates the coordinator is already running.
+	ErrAlreadyRunning = errors.New("cluster coordinator already running")
+
+	// ErrNotRunning indicates the coordinator is not running.
+	ErrNotRunning = errors.New("cluster coordinator not running")
+
+	// ErrNodeNotFound indicates the requested node was not found in the registry.
+	ErrNodeNotFound = errors.New("node not found")
+
+	// ErrNodeAlreadyExists indicates a node with the same ID already exists.
+	ErrNodeAlreadyExists = errors.New("node already exists")
+
+	// ErrClusterNotEnabled indicates clustering is not enabled in configuration.
+	ErrClusterNotEnabled = errors.New("clustering is not enabled")
+
+	// ErrIngestNotAllowed indicates this node role cannot accept writes.
+	ErrIngestNotAllowed = errors.New("this node role does not accept writes")
+
+	// ErrQueryNotAllowed indicates this node role cannot execute queries.
+	ErrQueryNotAllowed = errors.New("this node role does not execute queries")
+
+	// ErrCompactionNotAllowed indicates this node role cannot run compaction.
+	ErrCompactionNotAllowed = errors.New("this node role does not run compaction")
+
+	// ErrTooManyNodes indicates the registry has reached its maximum node capacity.
+	ErrTooManyNodes = errors.New("maximum number of cluster nodes reached")
+)

--- a/internal/cluster/health.go
+++ b/internal/cluster/health.go
@@ -1,0 +1,239 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// HealthChecker performs periodic health checks on cluster nodes.
+// It monitors node heartbeats and updates node state based on check results.
+type HealthChecker struct {
+	registry           *Registry
+	checkInterval      time.Duration
+	checkTimeout       time.Duration
+	unhealthyThreshold int
+
+	running bool
+	stopCh  chan struct{}
+	mu      sync.Mutex
+
+	logger zerolog.Logger
+}
+
+// HealthCheckerConfig holds configuration for the health checker.
+type HealthCheckerConfig struct {
+	Registry           *Registry
+	CheckInterval      time.Duration // How often to check nodes (default: 5s)
+	CheckTimeout       time.Duration // Timeout for each check (default: 3s)
+	UnhealthyThreshold int           // Failed checks before marking unhealthy (default: 3)
+	Logger             zerolog.Logger
+}
+
+// NewHealthChecker creates a new health checker.
+func NewHealthChecker(cfg *HealthCheckerConfig) *HealthChecker {
+	// Set defaults
+	checkInterval := cfg.CheckInterval
+	if checkInterval == 0 {
+		checkInterval = 5 * time.Second
+	}
+
+	checkTimeout := cfg.CheckTimeout
+	if checkTimeout == 0 {
+		checkTimeout = 3 * time.Second
+	}
+
+	unhealthyThreshold := cfg.UnhealthyThreshold
+	if unhealthyThreshold == 0 {
+		unhealthyThreshold = 3
+	}
+
+	return &HealthChecker{
+		registry:           cfg.Registry,
+		checkInterval:      checkInterval,
+		checkTimeout:       checkTimeout,
+		unhealthyThreshold: unhealthyThreshold,
+		stopCh:             make(chan struct{}),
+		logger:             cfg.Logger.With().Str("component", "health-checker").Logger(),
+	}
+}
+
+// Start starts the health checker background loop.
+func (h *HealthChecker) Start() {
+	h.mu.Lock()
+	if h.running {
+		h.mu.Unlock()
+		return
+	}
+	h.running = true
+	h.mu.Unlock()
+
+	go h.checkLoop()
+
+	h.logger.Info().
+		Dur("interval", h.checkInterval).
+		Dur("timeout", h.checkTimeout).
+		Int("unhealthy_threshold", h.unhealthyThreshold).
+		Msg("Health checker started")
+}
+
+// Stop stops the health checker.
+func (h *HealthChecker) Stop() {
+	h.mu.Lock()
+	if !h.running {
+		h.mu.Unlock()
+		return
+	}
+	h.running = false
+	h.mu.Unlock()
+
+	close(h.stopCh)
+	h.logger.Info().Msg("Health checker stopped")
+}
+
+// IsRunning returns true if the health checker is running.
+func (h *HealthChecker) IsRunning() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.running
+}
+
+// checkLoop performs periodic health checks on all nodes.
+func (h *HealthChecker) checkLoop() {
+	ticker := time.NewTicker(h.checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			h.checkAllNodes()
+		case <-h.stopCh:
+			return
+		}
+	}
+}
+
+// checkAllNodes checks the health of all registered nodes.
+func (h *HealthChecker) checkAllNodes() {
+	nodes := h.registry.GetAll()
+	local := h.registry.Local()
+
+	for _, node := range nodes {
+		// Skip local node (always healthy if we're running)
+		if local != nil && node.ID == local.ID {
+			continue
+		}
+
+		// Check each remote node concurrently
+		go h.checkNode(node)
+	}
+}
+
+// checkNode checks the health of a single node.
+// Uses atomic state transition to prevent TOCTOU race conditions.
+func (h *HealthChecker) checkNode(node *Node) {
+	ctx, cancel := context.WithTimeout(context.Background(), h.checkTimeout)
+	defer cancel()
+
+	healthy := h.performHealthCheck(ctx, node)
+
+	// Use atomic state transition to prevent race conditions
+	deadThreshold := h.unhealthyThreshold * 2
+	transition := node.ProcessHealthCheckResult(healthy, h.unhealthyThreshold, deadThreshold)
+
+	// Handle state transitions
+	if transition != nil {
+		switch transition.NewState {
+		case StateHealthy:
+			h.logger.Info().
+				Str("node_id", node.ID).
+				Str("role", string(node.Role)).
+				Str("previous_state", string(transition.OldState)).
+				Msg("Node became healthy")
+			h.registry.NotifyHealthy(node)
+
+		case StateUnhealthy:
+			h.logger.Warn().
+				Str("node_id", node.ID).
+				Str("role", string(node.Role)).
+				Int("failed_checks", transition.FailedChecks).
+				Msg("Node became unhealthy")
+			h.registry.NotifyUnhealthy(node)
+
+		case StateDead:
+			h.logger.Error().
+				Str("node_id", node.ID).
+				Str("role", string(node.Role)).
+				Int("failed_checks", transition.FailedChecks).
+				Msg("Node marked as dead")
+		}
+	}
+}
+
+// performHealthCheck performs the actual health check on a node.
+// For Phase 2, this checks heartbeat freshness.
+// Phase 3 will add active HTTP health endpoint checks.
+func (h *HealthChecker) performHealthCheck(ctx context.Context, node *Node) bool {
+	// Check if context is already cancelled
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+	}
+
+	// Check heartbeat freshness
+	// Consider healthy if heartbeat within 3x check interval
+	lastHeartbeat := node.GetLastHeartbeat()
+	threshold := 3 * h.checkInterval
+
+	if time.Since(lastHeartbeat) < threshold {
+		return true
+	}
+
+	// TODO (Phase 3): Add active health check
+	// - HTTP GET to node's /health endpoint
+	// - TCP connection test to coordinator port
+	// - gRPC health check if using gRPC
+
+	return false
+}
+
+// CheckNow performs an immediate health check on a specific node.
+// This is useful for on-demand checks outside the regular interval.
+func (h *HealthChecker) CheckNow(nodeID string) bool {
+	node, exists := h.registry.Get(nodeID)
+	if !exists {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), h.checkTimeout)
+	defer cancel()
+
+	return h.performHealthCheck(ctx, node)
+}
+
+// GetCheckInterval returns the configured check interval.
+func (h *HealthChecker) GetCheckInterval() time.Duration {
+	return h.checkInterval
+}
+
+// GetUnhealthyThreshold returns the configured unhealthy threshold.
+func (h *HealthChecker) GetUnhealthyThreshold() int {
+	return h.unhealthyThreshold
+}
+
+// Status returns the health checker status for monitoring.
+func (h *HealthChecker) Status() map[string]interface{} {
+	h.mu.Lock()
+	running := h.running
+	h.mu.Unlock()
+
+	return map[string]interface{}{
+		"running":             running,
+		"check_interval_ms":   h.checkInterval.Milliseconds(),
+		"check_timeout_ms":    h.checkTimeout.Milliseconds(),
+		"unhealthy_threshold": h.unhealthyThreshold,
+	}
+}

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -1,0 +1,265 @@
+package cluster
+
+import (
+	"sync"
+	"time"
+)
+
+// NodeState represents the health state of a node in the cluster.
+type NodeState string
+
+const (
+	// StateUnknown is the initial state before health is determined.
+	StateUnknown NodeState = "unknown"
+
+	// StateHealthy indicates the node is operating normally.
+	StateHealthy NodeState = "healthy"
+
+	// StateUnhealthy indicates the node has failed health checks but may recover.
+	StateUnhealthy NodeState = "unhealthy"
+
+	// StateDead indicates the node has been unreachable for an extended period.
+	StateDead NodeState = "dead"
+
+	// StateJoining indicates the node is joining the cluster.
+	StateJoining NodeState = "joining"
+
+	// StateLeaving indicates the node is gracefully leaving the cluster.
+	StateLeaving NodeState = "leaving"
+)
+
+// String returns the string representation of the state.
+func (s NodeState) String() string {
+	return string(s)
+}
+
+// NodeStats contains runtime statistics for a node.
+// These are updated periodically via heartbeat.
+type NodeStats struct {
+	CPUUsage       float64 `json:"cpu_usage"`       // CPU usage percentage (0-100)
+	MemoryUsage    float64 `json:"memory_usage"`    // Memory usage percentage (0-100)
+	IngestRate     int64   `json:"ingest_rate"`     // Records ingested per second
+	QueryRate      int64   `json:"query_rate"`      // Queries executed per second
+	StorageUsed    int64   `json:"storage_used"`    // Bytes used in storage
+	Connections    int     `json:"connections"`     // Active HTTP connections
+	ActiveQueries  int     `json:"active_queries"`  // Currently running queries
+	CompactionJobs int     `json:"compaction_jobs"` // Active compaction jobs (for compactor role)
+}
+
+// Node represents a node in the Arc cluster.
+type Node struct {
+	// Identity
+	ID          string   `json:"id"`           // Unique node identifier
+	Name        string   `json:"name"`         // Human-readable name
+	Role        NodeRole `json:"role"`         // Node role (writer, reader, compactor, standalone)
+	ClusterName string   `json:"cluster_name"` // Name of the cluster this node belongs to
+
+	// Network
+	Address    string `json:"address"`     // Coordinator address (host:port for inter-node communication)
+	APIAddress string `json:"api_address"` // HTTP API address (host:port for client requests)
+
+	// State
+	State NodeState `json:"state"` // Current health state
+
+	// Health tracking
+	LastHeartbeat time.Time `json:"last_heartbeat"` // Time of last successful heartbeat
+	LastHealthy   time.Time `json:"last_healthy"`   // Time node was last known healthy
+	FailedChecks  int       `json:"failed_checks"`  // Consecutive failed health checks
+
+	// Metadata
+	Version   string    `json:"version"`    // Arc version running on this node
+	StartedAt time.Time `json:"started_at"` // When the node process started
+	JoinedAt  time.Time `json:"joined_at"`  // When the node joined the cluster
+
+	// Runtime stats (updated via heartbeat)
+	Stats NodeStats `json:"stats"`
+
+	mu sync.RWMutex
+}
+
+// NewNode creates a new Node with the given parameters.
+func NewNode(id, name string, role NodeRole, clusterName string) *Node {
+	now := time.Now()
+	return &Node{
+		ID:          id,
+		Name:        name,
+		Role:        role,
+		ClusterName: clusterName,
+		State:       StateUnknown,
+		StartedAt:   now,
+	}
+}
+
+// IsHealthy returns true if the node is in a healthy state.
+func (n *Node) IsHealthy() bool {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.State == StateHealthy
+}
+
+// IsAvailable returns true if the node can accept requests.
+// A node is available if it's healthy or just joining (warming up).
+func (n *Node) IsAvailable() bool {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.State == StateHealthy || n.State == StateJoining
+}
+
+// GetState returns the current node state.
+func (n *Node) GetState() NodeState {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.State
+}
+
+// UpdateState updates the node state.
+func (n *Node) UpdateState(state NodeState) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.State = state
+	if state == StateHealthy {
+		n.LastHealthy = time.Now()
+	}
+}
+
+// RecordHeartbeat records a successful heartbeat from the node.
+func (n *Node) RecordHeartbeat(stats NodeStats) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.LastHeartbeat = time.Now()
+	n.Stats = stats
+	n.FailedChecks = 0
+	if n.State == StateHealthy {
+		n.LastHealthy = time.Now()
+	}
+}
+
+// RecordFailedCheck records a failed health check.
+// Returns the new count of consecutive failed checks.
+func (n *Node) RecordFailedCheck() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.FailedChecks++
+	return n.FailedChecks
+}
+
+// GetFailedChecks returns the number of consecutive failed health checks.
+func (n *Node) GetFailedChecks() int {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.FailedChecks
+}
+
+// GetLastHeartbeat returns the time of the last successful heartbeat.
+func (n *Node) GetLastHeartbeat() time.Time {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.LastHeartbeat
+}
+
+// GetStats returns a copy of the node's current stats.
+func (n *Node) GetStats() NodeStats {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.Stats
+}
+
+// SetAddresses sets the node's network addresses.
+func (n *Node) SetAddresses(coordinatorAddr, apiAddr string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.Address = coordinatorAddr
+	n.APIAddress = apiAddr
+}
+
+// SetVersion sets the node's Arc version.
+func (n *Node) SetVersion(version string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.Version = version
+}
+
+// MarkJoined marks the node as having joined the cluster.
+func (n *Node) MarkJoined() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.JoinedAt = time.Now()
+	n.State = StateHealthy
+	n.LastHealthy = time.Now()
+}
+
+// GetCapabilities returns the capabilities for this node's role.
+func (n *Node) GetCapabilities() RoleCapabilities {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.Role.GetCapabilities()
+}
+
+// Clone returns a deep copy of the node (without the mutex).
+func (n *Node) Clone() *Node {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return &Node{
+		ID:            n.ID,
+		Name:          n.Name,
+		Role:          n.Role,
+		ClusterName:   n.ClusterName,
+		Address:       n.Address,
+		APIAddress:    n.APIAddress,
+		State:         n.State,
+		LastHeartbeat: n.LastHeartbeat,
+		LastHealthy:   n.LastHealthy,
+		FailedChecks:  n.FailedChecks,
+		Version:       n.Version,
+		StartedAt:     n.StartedAt,
+		JoinedAt:      n.JoinedAt,
+		Stats:         n.Stats,
+	}
+}
+
+// StateTransition represents a node state change.
+type StateTransition struct {
+	OldState     NodeState
+	NewState     NodeState
+	FailedChecks int
+}
+
+// ProcessHealthCheckResult atomically processes a health check result and returns
+// any state transition that occurred. This prevents TOCTOU race conditions by
+// performing the check and update under a single lock.
+func (n *Node) ProcessHealthCheckResult(healthy bool, unhealthyThreshold, deadThreshold int) *StateTransition {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	oldState := n.State
+
+	if healthy {
+		// Reset failed checks and mark healthy
+		n.FailedChecks = 0
+		n.LastHeartbeat = time.Now()
+
+		if oldState != StateHealthy && oldState != StateJoining {
+			n.State = StateHealthy
+			n.LastHealthy = time.Now()
+			return &StateTransition{OldState: oldState, NewState: StateHealthy, FailedChecks: 0}
+		}
+		return nil
+	}
+
+	// Record failed check
+	n.FailedChecks++
+
+	// Check if we should transition to unhealthy
+	if n.FailedChecks >= unhealthyThreshold && oldState == StateHealthy {
+		n.State = StateUnhealthy
+		return &StateTransition{OldState: oldState, NewState: StateUnhealthy, FailedChecks: n.FailedChecks}
+	}
+
+	// Check if we should transition to dead
+	if n.FailedChecks >= deadThreshold && oldState != StateDead {
+		n.State = StateDead
+		return &StateTransition{OldState: oldState, NewState: StateDead, FailedChecks: n.FailedChecks}
+	}
+
+	return nil
+}

--- a/internal/cluster/node_test.go
+++ b/internal/cluster/node_test.go
@@ -1,0 +1,237 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewNode(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	if node.ID != "node-1" {
+		t.Errorf("NewNode().ID = %v, want %v", node.ID, "node-1")
+	}
+	if node.Name != "Test Node" {
+		t.Errorf("NewNode().Name = %v, want %v", node.Name, "Test Node")
+	}
+	if node.Role != RoleWriter {
+		t.Errorf("NewNode().Role = %v, want %v", node.Role, RoleWriter)
+	}
+	if node.ClusterName != "test-cluster" {
+		t.Errorf("NewNode().ClusterName = %v, want %v", node.ClusterName, "test-cluster")
+	}
+	if node.State != StateUnknown {
+		t.Errorf("NewNode().State = %v, want %v", node.State, StateUnknown)
+	}
+	if node.StartedAt.IsZero() {
+		t.Error("NewNode().StartedAt should not be zero")
+	}
+}
+
+func TestNodeStateTransitions(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	// Initial state is Unknown
+	if node.GetState() != StateUnknown {
+		t.Errorf("Initial state = %v, want %v", node.GetState(), StateUnknown)
+	}
+
+	// Test state transitions
+	states := []NodeState{StateJoining, StateHealthy, StateUnhealthy, StateDead, StateLeaving}
+	for _, state := range states {
+		node.UpdateState(state)
+		if node.GetState() != state {
+			t.Errorf("After UpdateState(%v), GetState() = %v", state, node.GetState())
+		}
+	}
+}
+
+func TestNodeIsHealthy(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	// Initially not healthy (Unknown state)
+	if node.IsHealthy() {
+		t.Error("Node with Unknown state should not be healthy")
+	}
+
+	// Healthy state
+	node.UpdateState(StateHealthy)
+	if !node.IsHealthy() {
+		t.Error("Node with Healthy state should be healthy")
+	}
+
+	// Unhealthy state
+	node.UpdateState(StateUnhealthy)
+	if node.IsHealthy() {
+		t.Error("Node with Unhealthy state should not be healthy")
+	}
+}
+
+func TestNodeIsAvailable(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	tests := []struct {
+		state    NodeState
+		expected bool
+	}{
+		{StateUnknown, false},
+		{StateJoining, true},  // Joining nodes are available
+		{StateHealthy, true},
+		{StateUnhealthy, false},
+		{StateDead, false},
+		{StateLeaving, false},
+	}
+
+	for _, tt := range tests {
+		node.UpdateState(tt.state)
+		if got := node.IsAvailable(); got != tt.expected {
+			t.Errorf("Node with state %v: IsAvailable() = %v, want %v", tt.state, got, tt.expected)
+		}
+	}
+}
+
+func TestNodeRecordHeartbeat(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+	node.UpdateState(StateHealthy)
+
+	// Record failed checks first
+	node.RecordFailedCheck()
+	node.RecordFailedCheck()
+	if node.GetFailedChecks() != 2 {
+		t.Errorf("GetFailedChecks() = %v, want 2", node.GetFailedChecks())
+	}
+
+	// Record heartbeat should reset failed checks
+	stats := NodeStats{CPUUsage: 50.0, MemoryUsage: 60.0}
+	node.RecordHeartbeat(stats)
+
+	if node.GetFailedChecks() != 0 {
+		t.Errorf("After heartbeat, GetFailedChecks() = %v, want 0", node.GetFailedChecks())
+	}
+
+	if node.GetLastHeartbeat().IsZero() {
+		t.Error("After heartbeat, GetLastHeartbeat() should not be zero")
+	}
+
+	gotStats := node.GetStats()
+	if gotStats.CPUUsage != 50.0 {
+		t.Errorf("GetStats().CPUUsage = %v, want 50.0", gotStats.CPUUsage)
+	}
+}
+
+func TestNodeRecordFailedCheck(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	for i := 1; i <= 5; i++ {
+		count := node.RecordFailedCheck()
+		if count != i {
+			t.Errorf("RecordFailedCheck() returned %v, want %v", count, i)
+		}
+		if node.GetFailedChecks() != i {
+			t.Errorf("GetFailedChecks() = %v, want %v", node.GetFailedChecks(), i)
+		}
+	}
+}
+
+func TestNodeSetAddresses(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	node.SetAddresses(":9100", ":8000")
+
+	if node.Address != ":9100" {
+		t.Errorf("Address = %v, want :9100", node.Address)
+	}
+	if node.APIAddress != ":8000" {
+		t.Errorf("APIAddress = %v, want :8000", node.APIAddress)
+	}
+}
+
+func TestNodeSetVersion(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	node.SetVersion("1.2.3")
+
+	if node.Version != "1.2.3" {
+		t.Errorf("Version = %v, want 1.2.3", node.Version)
+	}
+}
+
+func TestNodeMarkJoined(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	beforeJoin := time.Now()
+	node.MarkJoined()
+	afterJoin := time.Now()
+
+	if node.GetState() != StateHealthy {
+		t.Errorf("After MarkJoined(), state = %v, want %v", node.GetState(), StateHealthy)
+	}
+
+	if node.JoinedAt.Before(beforeJoin) || node.JoinedAt.After(afterJoin) {
+		t.Error("JoinedAt is not within expected time range")
+	}
+}
+
+func TestNodeGetCapabilities(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+
+	caps := node.GetCapabilities()
+	expected := RoleWriter.GetCapabilities()
+
+	if caps != expected {
+		t.Errorf("GetCapabilities() = %+v, want %+v", caps, expected)
+	}
+}
+
+func TestNodeClone(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+	node.SetVersion("1.0.0")
+	node.SetAddresses(":9100", ":8000")
+	node.UpdateState(StateHealthy)
+	node.RecordHeartbeat(NodeStats{CPUUsage: 50.0})
+
+	clone := node.Clone()
+
+	// Verify clone has same values
+	if clone.ID != node.ID {
+		t.Errorf("Clone.ID = %v, want %v", clone.ID, node.ID)
+	}
+	if clone.Name != node.Name {
+		t.Errorf("Clone.Name = %v, want %v", clone.Name, node.Name)
+	}
+	if clone.Role != node.Role {
+		t.Errorf("Clone.Role = %v, want %v", clone.Role, node.Role)
+	}
+	if clone.State != node.State {
+		t.Errorf("Clone.State = %v, want %v", clone.State, node.State)
+	}
+	if clone.Version != node.Version {
+		t.Errorf("Clone.Version = %v, want %v", clone.Version, node.Version)
+	}
+
+	// Modify clone and verify original is unchanged
+	clone.UpdateState(StateUnhealthy)
+	if node.GetState() != StateHealthy {
+		t.Error("Modifying clone should not affect original")
+	}
+}
+
+func TestNodeStateString(t *testing.T) {
+	tests := []struct {
+		state    NodeState
+		expected string
+	}{
+		{StateUnknown, "unknown"},
+		{StateHealthy, "healthy"},
+		{StateUnhealthy, "unhealthy"},
+		{StateDead, "dead"},
+		{StateJoining, "joining"},
+		{StateLeaving, "leaving"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.expected {
+			t.Errorf("NodeState.String() = %v, want %v", got, tt.expected)
+		}
+	}
+}

--- a/internal/cluster/registry.go
+++ b/internal/cluster/registry.go
@@ -1,0 +1,320 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// DefaultMaxNodes is the default maximum number of nodes allowed in the registry.
+const DefaultMaxNodes = 1000
+
+// DefaultCallbackTimeout is the default timeout for callback execution.
+const DefaultCallbackTimeout = 5 * time.Second
+
+// NodeEventCallback is called when node events occur.
+type NodeEventCallback func(*Node)
+
+// Registry manages cluster node membership.
+// It provides thread-safe access to the list of nodes in the cluster.
+type Registry struct {
+	nodes     map[string]*Node
+	localNode *Node
+	maxNodes  int
+	mu        sync.RWMutex
+	logger    zerolog.Logger
+
+	// Event callbacks
+	onNodeJoined    NodeEventCallback
+	onNodeLeft      NodeEventCallback
+	onNodeHealthy   NodeEventCallback
+	onNodeUnhealthy NodeEventCallback
+}
+
+// RegistryConfig holds configuration for the node registry.
+type RegistryConfig struct {
+	LocalNode *Node
+	MaxNodes  int
+	Logger    zerolog.Logger
+}
+
+// NewRegistry creates a new node registry.
+func NewRegistry(cfg *RegistryConfig) *Registry {
+	maxNodes := cfg.MaxNodes
+	if maxNodes <= 0 {
+		maxNodes = DefaultMaxNodes
+	}
+
+	r := &Registry{
+		nodes:     make(map[string]*Node),
+		localNode: cfg.LocalNode,
+		maxNodes:  maxNodes,
+		logger:    cfg.Logger.With().Str("component", "cluster-registry").Logger(),
+	}
+
+	// Register local node if provided
+	if cfg.LocalNode != nil {
+		r.nodes[cfg.LocalNode.ID] = cfg.LocalNode
+	}
+
+	return r
+}
+
+// Register adds or updates a node in the registry.
+// Returns ErrTooManyNodes if the registry has reached its maximum capacity.
+func (r *Registry) Register(node *Node) error {
+	r.mu.Lock()
+
+	existing, exists := r.nodes[node.ID]
+
+	// Check max nodes limit only for new nodes
+	if !exists && len(r.nodes) >= r.maxNodes {
+		r.mu.Unlock()
+		return ErrTooManyNodes
+	}
+
+	r.nodes[node.ID] = node
+	callback := r.onNodeJoined
+	r.mu.Unlock()
+
+	if !exists {
+		r.logger.Info().
+			Str("node_id", node.ID).
+			Str("role", string(node.Role)).
+			Str("address", node.Address).
+			Msg("Node joined cluster")
+		r.invokeCallback(callback, node)
+	} else {
+		r.logger.Debug().
+			Str("node_id", node.ID).
+			Str("old_state", string(existing.State)).
+			Str("new_state", string(node.State)).
+			Msg("Node updated")
+	}
+
+	return nil
+}
+
+// invokeCallback safely invokes a callback with timeout and panic recovery.
+func (r *Registry) invokeCallback(callback NodeEventCallback, node *Node) {
+	if callback == nil {
+		return
+	}
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				r.logger.Error().Interface("panic", err).Str("node_id", node.ID).Msg("Callback panicked")
+			}
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultCallbackTimeout)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			callback(node)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Callback completed successfully
+		case <-ctx.Done():
+			r.logger.Warn().Str("node_id", node.ID).Msg("Callback timed out")
+		}
+	}()
+}
+
+// Unregister removes a node from the registry.
+func (r *Registry) Unregister(nodeID string) {
+	r.mu.Lock()
+	node, exists := r.nodes[nodeID]
+	callback := r.onNodeLeft
+	if exists {
+		delete(r.nodes, nodeID)
+	}
+	r.mu.Unlock()
+
+	if exists {
+		r.logger.Info().
+			Str("node_id", nodeID).
+			Str("role", string(node.Role)).
+			Msg("Node left cluster")
+		r.invokeCallback(callback, node)
+	}
+}
+
+// Get returns a clone of a node by ID.
+// Returns a cloned node to prevent race conditions from concurrent modifications.
+func (r *Registry) Get(nodeID string) (*Node, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	node, exists := r.nodes[nodeID]
+	if !exists {
+		return nil, false
+	}
+	return node.Clone(), true
+}
+
+// filterNodes returns cloned nodes that match the predicate.
+// This is a helper to reduce code duplication across Get* methods.
+func (r *Registry) filterNodes(predicate func(*Node) bool) []*Node {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var nodes []*Node
+	for _, node := range r.nodes {
+		if predicate(node) {
+			nodes = append(nodes, node.Clone())
+		}
+	}
+	return nodes
+}
+
+// countNodes returns the count of nodes that match the predicate.
+func (r *Registry) countNodes(predicate func(*Node) bool) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	count := 0
+	for _, node := range r.nodes {
+		if predicate(node) {
+			count++
+		}
+	}
+	return count
+}
+
+// GetAll returns cloned copies of all registered nodes.
+func (r *Registry) GetAll() []*Node {
+	return r.filterNodes(func(n *Node) bool { return true })
+}
+
+// GetByRole returns cloned nodes with a specific role.
+func (r *Registry) GetByRole(role NodeRole) []*Node {
+	return r.filterNodes(func(n *Node) bool { return n.Role == role })
+}
+
+// GetByState returns cloned nodes with a specific state.
+func (r *Registry) GetByState(state NodeState) []*Node {
+	return r.filterNodes(func(n *Node) bool { return n.GetState() == state })
+}
+
+// GetHealthy returns cloned copies of all healthy nodes.
+func (r *Registry) GetHealthy() []*Node {
+	return r.filterNodes(func(n *Node) bool { return n.IsHealthy() })
+}
+
+// GetAvailable returns cloned copies of all available nodes (healthy or joining).
+func (r *Registry) GetAvailable() []*Node {
+	return r.filterNodes(func(n *Node) bool { return n.IsAvailable() })
+}
+
+// GetWriters returns cloned copies of all healthy writer nodes.
+func (r *Registry) GetWriters() []*Node {
+	return r.filterNodes(func(n *Node) bool { return n.Role == RoleWriter && n.IsHealthy() })
+}
+
+// GetReaders returns cloned copies of all healthy reader nodes.
+func (r *Registry) GetReaders() []*Node {
+	return r.filterNodes(func(n *Node) bool { return n.Role == RoleReader && n.IsHealthy() })
+}
+
+// GetCompactors returns cloned copies of all healthy compactor nodes.
+func (r *Registry) GetCompactors() []*Node {
+	return r.filterNodes(func(n *Node) bool { return n.Role == RoleCompactor && n.IsHealthy() })
+}
+
+// Local returns the local node.
+func (r *Registry) Local() *Node {
+	return r.localNode
+}
+
+// Count returns the total number of registered nodes.
+func (r *Registry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.nodes)
+}
+
+// CountByRole returns the number of nodes with a specific role.
+func (r *Registry) CountByRole(role NodeRole) int {
+	return r.countNodes(func(n *Node) bool { return n.Role == role })
+}
+
+// CountHealthy returns the number of healthy nodes.
+func (r *Registry) CountHealthy() int {
+	return r.countNodes(func(n *Node) bool { return n.IsHealthy() })
+}
+
+// SetCallbacks sets event callbacks for node lifecycle events.
+// Callbacks are invoked asynchronously to prevent blocking the registry.
+func (r *Registry) SetCallbacks(
+	onJoined NodeEventCallback,
+	onLeft NodeEventCallback,
+	onHealthy NodeEventCallback,
+	onUnhealthy NodeEventCallback,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.onNodeJoined = onJoined
+	r.onNodeLeft = onLeft
+	r.onNodeHealthy = onHealthy
+	r.onNodeUnhealthy = onUnhealthy
+}
+
+// NotifyHealthy notifies that a node became healthy.
+func (r *Registry) NotifyHealthy(node *Node) {
+	r.mu.RLock()
+	callback := r.onNodeHealthy
+	r.mu.RUnlock()
+
+	r.invokeCallback(callback, node)
+}
+
+// NotifyUnhealthy notifies that a node became unhealthy.
+func (r *Registry) NotifyUnhealthy(node *Node) {
+	r.mu.RLock()
+	callback := r.onNodeUnhealthy
+	r.mu.RUnlock()
+
+	r.invokeCallback(callback, node)
+}
+
+// Summary returns a summary of the registry state.
+func (r *Registry) Summary() map[string]int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	summary := map[string]int{
+		"total":      len(r.nodes),
+		"healthy":    0,
+		"unhealthy":  0,
+		"writers":    0,
+		"readers":    0,
+		"compactors": 0,
+		"standalone": 0,
+	}
+
+	for _, node := range r.nodes {
+		if node.IsHealthy() {
+			summary["healthy"]++
+		} else {
+			summary["unhealthy"]++
+		}
+
+		switch node.Role {
+		case RoleWriter:
+			summary["writers"]++
+		case RoleReader:
+			summary["readers"]++
+		case RoleCompactor:
+			summary["compactors"]++
+		case RoleStandalone:
+			summary["standalone"]++
+		}
+	}
+
+	return summary
+}

--- a/internal/cluster/registry_test.go
+++ b/internal/cluster/registry_test.go
@@ -1,0 +1,464 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func newTestRegistry() *Registry {
+	return NewRegistry(&RegistryConfig{
+		Logger: zerolog.Nop(),
+	})
+}
+
+func newTestRegistryWithLocal() (*Registry, *Node) {
+	localNode := NewNode("local-1", "Local Node", RoleWriter, "test-cluster")
+	localNode.UpdateState(StateHealthy)
+
+	registry := NewRegistry(&RegistryConfig{
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	return registry, localNode
+}
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	registry := newTestRegistry()
+
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+	node.UpdateState(StateHealthy)
+
+	registry.Register(node)
+
+	got, exists := registry.Get("node-1")
+	if !exists {
+		t.Fatal("Node should exist after registration")
+	}
+	if got.ID != "node-1" {
+		t.Errorf("Get().ID = %v, want node-1", got.ID)
+	}
+
+	// Non-existent node
+	_, exists = registry.Get("non-existent")
+	if exists {
+		t.Error("Non-existent node should not exist")
+	}
+}
+
+func TestRegistryUnregister(t *testing.T) {
+	registry := newTestRegistry()
+
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+	registry.Register(node)
+
+	// Verify node exists
+	if _, exists := registry.Get("node-1"); !exists {
+		t.Fatal("Node should exist after registration")
+	}
+
+	// Unregister
+	registry.Unregister("node-1")
+
+	// Verify node is gone
+	if _, exists := registry.Get("node-1"); exists {
+		t.Error("Node should not exist after unregistration")
+	}
+
+	// Unregistering non-existent node should not panic
+	registry.Unregister("non-existent")
+}
+
+func TestRegistryGetAll(t *testing.T) {
+	registry := newTestRegistry()
+
+	// Empty registry
+	if nodes := registry.GetAll(); len(nodes) != 0 {
+		t.Errorf("Empty registry should return 0 nodes, got %d", len(nodes))
+	}
+
+	// Add nodes
+	for i := 1; i <= 3; i++ {
+		node := NewNode("node-"+string(rune('0'+i)), "Node", RoleWriter, "test-cluster")
+		registry.Register(node)
+	}
+
+	if nodes := registry.GetAll(); len(nodes) != 3 {
+		t.Errorf("GetAll() returned %d nodes, want 3", len(nodes))
+	}
+}
+
+func TestRegistryGetByRole(t *testing.T) {
+	registry := newTestRegistry()
+
+	// Add nodes with different roles
+	writer1 := NewNode("writer-1", "Writer 1", RoleWriter, "test-cluster")
+	writer2 := NewNode("writer-2", "Writer 2", RoleWriter, "test-cluster")
+	reader1 := NewNode("reader-1", "Reader 1", RoleReader, "test-cluster")
+	compactor1 := NewNode("compactor-1", "Compactor 1", RoleCompactor, "test-cluster")
+
+	registry.Register(writer1)
+	registry.Register(writer2)
+	registry.Register(reader1)
+	registry.Register(compactor1)
+
+	writers := registry.GetByRole(RoleWriter)
+	if len(writers) != 2 {
+		t.Errorf("GetByRole(Writer) returned %d nodes, want 2", len(writers))
+	}
+
+	readers := registry.GetByRole(RoleReader)
+	if len(readers) != 1 {
+		t.Errorf("GetByRole(Reader) returned %d nodes, want 1", len(readers))
+	}
+
+	compactors := registry.GetByRole(RoleCompactor)
+	if len(compactors) != 1 {
+		t.Errorf("GetByRole(Compactor) returned %d nodes, want 1", len(compactors))
+	}
+
+	standalone := registry.GetByRole(RoleStandalone)
+	if len(standalone) != 0 {
+		t.Errorf("GetByRole(Standalone) returned %d nodes, want 0", len(standalone))
+	}
+}
+
+func TestRegistryGetByState(t *testing.T) {
+	registry := newTestRegistry()
+
+	healthy := NewNode("healthy-1", "Healthy", RoleWriter, "test-cluster")
+	healthy.UpdateState(StateHealthy)
+
+	unhealthy := NewNode("unhealthy-1", "Unhealthy", RoleWriter, "test-cluster")
+	unhealthy.UpdateState(StateUnhealthy)
+
+	registry.Register(healthy)
+	registry.Register(unhealthy)
+
+	healthyNodes := registry.GetByState(StateHealthy)
+	if len(healthyNodes) != 1 {
+		t.Errorf("GetByState(Healthy) returned %d nodes, want 1", len(healthyNodes))
+	}
+
+	unhealthyNodes := registry.GetByState(StateUnhealthy)
+	if len(unhealthyNodes) != 1 {
+		t.Errorf("GetByState(Unhealthy) returned %d nodes, want 1", len(unhealthyNodes))
+	}
+}
+
+func TestRegistryGetHealthy(t *testing.T) {
+	registry := newTestRegistry()
+
+	healthy1 := NewNode("healthy-1", "Healthy 1", RoleWriter, "test-cluster")
+	healthy1.UpdateState(StateHealthy)
+
+	healthy2 := NewNode("healthy-2", "Healthy 2", RoleReader, "test-cluster")
+	healthy2.UpdateState(StateHealthy)
+
+	unhealthy := NewNode("unhealthy-1", "Unhealthy", RoleWriter, "test-cluster")
+	unhealthy.UpdateState(StateUnhealthy)
+
+	registry.Register(healthy1)
+	registry.Register(healthy2)
+	registry.Register(unhealthy)
+
+	healthyNodes := registry.GetHealthy()
+	if len(healthyNodes) != 2 {
+		t.Errorf("GetHealthy() returned %d nodes, want 2", len(healthyNodes))
+	}
+}
+
+func TestRegistryGetWritersReadersCompactors(t *testing.T) {
+	registry := newTestRegistry()
+
+	// Add healthy nodes
+	writer := NewNode("writer-1", "Writer", RoleWriter, "test-cluster")
+	writer.UpdateState(StateHealthy)
+
+	reader := NewNode("reader-1", "Reader", RoleReader, "test-cluster")
+	reader.UpdateState(StateHealthy)
+
+	compactor := NewNode("compactor-1", "Compactor", RoleCompactor, "test-cluster")
+	compactor.UpdateState(StateHealthy)
+
+	// Add unhealthy writer (should not be returned)
+	unhealthyWriter := NewNode("writer-2", "Unhealthy Writer", RoleWriter, "test-cluster")
+	unhealthyWriter.UpdateState(StateUnhealthy)
+
+	registry.Register(writer)
+	registry.Register(reader)
+	registry.Register(compactor)
+	registry.Register(unhealthyWriter)
+
+	writers := registry.GetWriters()
+	if len(writers) != 1 {
+		t.Errorf("GetWriters() returned %d nodes, want 1", len(writers))
+	}
+
+	readers := registry.GetReaders()
+	if len(readers) != 1 {
+		t.Errorf("GetReaders() returned %d nodes, want 1", len(readers))
+	}
+
+	compactors := registry.GetCompactors()
+	if len(compactors) != 1 {
+		t.Errorf("GetCompactors() returned %d nodes, want 1", len(compactors))
+	}
+}
+
+func TestRegistryLocal(t *testing.T) {
+	registry, localNode := newTestRegistryWithLocal()
+
+	got := registry.Local()
+	if got == nil {
+		t.Fatal("Local() returned nil")
+	}
+	if got.ID != localNode.ID {
+		t.Errorf("Local().ID = %v, want %v", got.ID, localNode.ID)
+	}
+}
+
+func TestRegistryCount(t *testing.T) {
+	registry := newTestRegistry()
+
+	if count := registry.Count(); count != 0 {
+		t.Errorf("Empty registry Count() = %d, want 0", count)
+	}
+
+	for i := 1; i <= 5; i++ {
+		node := NewNode("node-"+string(rune('0'+i)), "Node", RoleWriter, "test-cluster")
+		registry.Register(node)
+	}
+
+	if count := registry.Count(); count != 5 {
+		t.Errorf("Count() = %d, want 5", count)
+	}
+}
+
+func TestRegistryCountByRole(t *testing.T) {
+	registry := newTestRegistry()
+
+	for i := 0; i < 3; i++ {
+		node := NewNode("writer-"+string(rune('0'+i)), "Writer", RoleWriter, "test-cluster")
+		registry.Register(node)
+	}
+	for i := 0; i < 2; i++ {
+		node := NewNode("reader-"+string(rune('0'+i)), "Reader", RoleReader, "test-cluster")
+		registry.Register(node)
+	}
+
+	if count := registry.CountByRole(RoleWriter); count != 3 {
+		t.Errorf("CountByRole(Writer) = %d, want 3", count)
+	}
+	if count := registry.CountByRole(RoleReader); count != 2 {
+		t.Errorf("CountByRole(Reader) = %d, want 2", count)
+	}
+	if count := registry.CountByRole(RoleCompactor); count != 0 {
+		t.Errorf("CountByRole(Compactor) = %d, want 0", count)
+	}
+}
+
+func TestRegistryCountHealthy(t *testing.T) {
+	registry := newTestRegistry()
+
+	healthy1 := NewNode("healthy-1", "Healthy 1", RoleWriter, "test-cluster")
+	healthy1.UpdateState(StateHealthy)
+
+	healthy2 := NewNode("healthy-2", "Healthy 2", RoleReader, "test-cluster")
+	healthy2.UpdateState(StateHealthy)
+
+	unhealthy := NewNode("unhealthy-1", "Unhealthy", RoleWriter, "test-cluster")
+	unhealthy.UpdateState(StateUnhealthy)
+
+	registry.Register(healthy1)
+	registry.Register(healthy2)
+	registry.Register(unhealthy)
+
+	if count := registry.CountHealthy(); count != 2 {
+		t.Errorf("CountHealthy() = %d, want 2", count)
+	}
+}
+
+func TestRegistrySummary(t *testing.T) {
+	registry := newTestRegistry()
+
+	// Add various nodes
+	writer := NewNode("writer-1", "Writer", RoleWriter, "test-cluster")
+	writer.UpdateState(StateHealthy)
+
+	reader := NewNode("reader-1", "Reader", RoleReader, "test-cluster")
+	reader.UpdateState(StateHealthy)
+
+	unhealthy := NewNode("unhealthy-1", "Unhealthy", RoleWriter, "test-cluster")
+	unhealthy.UpdateState(StateUnhealthy)
+
+	registry.Register(writer)
+	registry.Register(reader)
+	registry.Register(unhealthy)
+
+	summary := registry.Summary()
+
+	if summary["total"] != 3 {
+		t.Errorf("Summary[total] = %d, want 3", summary["total"])
+	}
+	if summary["healthy"] != 2 {
+		t.Errorf("Summary[healthy] = %d, want 2", summary["healthy"])
+	}
+	if summary["unhealthy"] != 1 {
+		t.Errorf("Summary[unhealthy] = %d, want 1", summary["unhealthy"])
+	}
+	if summary["writers"] != 2 {
+		t.Errorf("Summary[writers] = %d, want 2", summary["writers"])
+	}
+	if summary["readers"] != 1 {
+		t.Errorf("Summary[readers] = %d, want 1", summary["readers"])
+	}
+}
+
+func TestRegistryWithLocalNode(t *testing.T) {
+	registry, localNode := newTestRegistryWithLocal()
+
+	// Local node should be automatically registered
+	if count := registry.Count(); count != 1 {
+		t.Errorf("Registry with local node should have 1 node, got %d", count)
+	}
+
+	got, exists := registry.Get(localNode.ID)
+	if !exists {
+		t.Fatal("Local node should exist in registry")
+	}
+	if got.ID != localNode.ID {
+		t.Errorf("Get(local).ID = %v, want %v", got.ID, localNode.ID)
+	}
+}
+
+func TestRegistryGetAvailable(t *testing.T) {
+	registry := newTestRegistry()
+
+	healthy := NewNode("healthy-1", "Healthy", RoleWriter, "test-cluster")
+	healthy.UpdateState(StateHealthy)
+
+	joining := NewNode("joining-1", "Joining", RoleWriter, "test-cluster")
+	joining.UpdateState(StateJoining)
+
+	unhealthy := NewNode("unhealthy-1", "Unhealthy", RoleWriter, "test-cluster")
+	unhealthy.UpdateState(StateUnhealthy)
+
+	registry.Register(healthy)
+	registry.Register(joining)
+	registry.Register(unhealthy)
+
+	available := registry.GetAvailable()
+	if len(available) != 2 {
+		t.Errorf("GetAvailable() returned %d nodes, want 2 (healthy + joining)", len(available))
+	}
+}
+
+func TestRegistryMaxNodes(t *testing.T) {
+	// Create registry with max 3 nodes
+	registry := NewRegistry(&RegistryConfig{
+		MaxNodes: 3,
+		Logger:   zerolog.Nop(),
+	})
+
+	// Register 3 nodes - should succeed
+	for i := 1; i <= 3; i++ {
+		node := NewNode("node-"+string(rune('0'+i)), "Node", RoleWriter, "test-cluster")
+		err := registry.Register(node)
+		if err != nil {
+			t.Fatalf("Register node %d should succeed, got error: %v", i, err)
+		}
+	}
+
+	if count := registry.Count(); count != 3 {
+		t.Errorf("After registering 3 nodes, Count() = %d, want 3", count)
+	}
+
+	// Registering 4th node should fail
+	node4 := NewNode("node-4", "Node 4", RoleWriter, "test-cluster")
+	err := registry.Register(node4)
+	if err != ErrTooManyNodes {
+		t.Errorf("Registering node 4 should return ErrTooManyNodes, got: %v", err)
+	}
+
+	// Count should still be 3
+	if count := registry.Count(); count != 3 {
+		t.Errorf("After rejected registration, Count() = %d, want 3", count)
+	}
+
+	// Updating existing node should succeed
+	node1Updated := NewNode("node-1", "Node 1 Updated", RoleReader, "test-cluster")
+	err = registry.Register(node1Updated)
+	if err != nil {
+		t.Errorf("Updating existing node should succeed, got error: %v", err)
+	}
+
+	// Count should still be 3
+	if count := registry.Count(); count != 3 {
+		t.Errorf("After update, Count() = %d, want 3", count)
+	}
+}
+
+func TestRegistryCloneIsolation(t *testing.T) {
+	registry := newTestRegistry()
+
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+	node.UpdateState(StateHealthy)
+	registry.Register(node)
+
+	// Get cloned node
+	clone, exists := registry.Get("node-1")
+	if !exists {
+		t.Fatal("Node should exist")
+	}
+
+	// Modify clone state
+	clone.UpdateState(StateUnhealthy)
+
+	// Verify original is unchanged
+	clone2, _ := registry.Get("node-1")
+	if clone2.GetState() != StateHealthy {
+		t.Error("Original node state should not be affected by clone modification")
+	}
+}
+
+func TestProcessHealthCheckResult(t *testing.T) {
+	node := NewNode("node-1", "Test Node", RoleWriter, "test-cluster")
+	node.UpdateState(StateHealthy)
+
+	// Healthy check should return nil (no transition from healthy to healthy)
+	transition := node.ProcessHealthCheckResult(true, 3, 6)
+	if transition != nil {
+		t.Error("Healthy check on healthy node should return nil transition")
+	}
+
+	// Three failed checks to trigger unhealthy transition
+	for i := 0; i < 2; i++ {
+		transition = node.ProcessHealthCheckResult(false, 3, 6)
+		if transition != nil {
+			t.Errorf("Failed check %d should not trigger transition yet", i+1)
+		}
+	}
+
+	// Third failed check should transition to unhealthy
+	transition = node.ProcessHealthCheckResult(false, 3, 6)
+	if transition == nil {
+		t.Fatal("Third failed check should trigger transition")
+	}
+	if transition.NewState != StateUnhealthy {
+		t.Errorf("New state should be unhealthy, got: %v", transition.NewState)
+	}
+	if transition.OldState != StateHealthy {
+		t.Errorf("Old state should be healthy, got: %v", transition.OldState)
+	}
+
+	// Healthy check should transition back
+	transition = node.ProcessHealthCheckResult(true, 3, 6)
+	if transition == nil {
+		t.Fatal("Healthy check after unhealthy should trigger transition")
+	}
+	if transition.NewState != StateHealthy {
+		t.Errorf("New state should be healthy, got: %v", transition.NewState)
+	}
+}

--- a/internal/cluster/role.go
+++ b/internal/cluster/role.go
@@ -1,0 +1,106 @@
+package cluster
+
+// NodeRole represents the role of a node in the cluster.
+// Each role has specific capabilities that determine what operations the node can perform.
+type NodeRole string
+
+const (
+	// RoleStandalone is the default single-node deployment mode (OSS-compatible).
+	// Can perform all operations: ingest, query, and compact.
+	RoleStandalone NodeRole = "standalone"
+
+	// RoleWriter handles ingestion, WAL, and flushes to shared storage.
+	// Can also execute queries for monitoring and validation.
+	RoleWriter NodeRole = "writer"
+
+	// RoleReader is a query-only node that reads from shared storage.
+	// Cannot ingest data or run compaction jobs.
+	RoleReader NodeRole = "reader"
+
+	// RoleCompactor runs background compaction and maintenance tasks.
+	// Cannot ingest data or serve queries.
+	RoleCompactor NodeRole = "compactor"
+)
+
+// RoleCapabilities defines what operations each role can perform.
+type RoleCapabilities struct {
+	CanIngest     bool // Accept write requests (LineProtocol, MessagePack)
+	CanQuery      bool // Execute SQL queries
+	CanCompact    bool // Run compaction jobs
+	CanCoordinate bool // Participate in cluster coordination (leader election)
+}
+
+// GetCapabilities returns the capabilities for this role.
+func (r NodeRole) GetCapabilities() RoleCapabilities {
+	switch r {
+	case RoleWriter:
+		return RoleCapabilities{
+			CanIngest:     true,
+			CanQuery:      true,  // Writers can query for monitoring
+			CanCompact:    false, // Compaction runs on dedicated nodes
+			CanCoordinate: true,  // Writers participate in leader election
+		}
+	case RoleReader:
+		return RoleCapabilities{
+			CanIngest:     false,
+			CanQuery:      true,
+			CanCompact:    false,
+			CanCoordinate: false,
+		}
+	case RoleCompactor:
+		return RoleCapabilities{
+			CanIngest:     false,
+			CanQuery:      false, // Compactors don't serve queries
+			CanCompact:    true,
+			CanCoordinate: false,
+		}
+	case RoleStandalone:
+		return RoleCapabilities{
+			CanIngest:     true,
+			CanQuery:      true,
+			CanCompact:    true,
+			CanCoordinate: false, // Standalone doesn't coordinate
+		}
+	default:
+		// Fail-safe: no capabilities for unknown roles
+		return RoleCapabilities{}
+	}
+}
+
+// String returns the string representation of the role.
+func (r NodeRole) String() string {
+	return string(r)
+}
+
+// IsValid returns true if the role is a recognized value.
+func (r NodeRole) IsValid() bool {
+	switch r {
+	case RoleStandalone, RoleWriter, RoleReader, RoleCompactor:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidRole returns true if the role string represents a valid role.
+func ValidRole(role string) bool {
+	return NodeRole(role).IsValid()
+}
+
+// ParseRole parses a string into a NodeRole.
+// Returns RoleStandalone if the role is empty or invalid.
+func ParseRole(role string) NodeRole {
+	if role == "" {
+		return RoleStandalone
+	}
+	r := NodeRole(role)
+	if r.IsValid() {
+		return r
+	}
+	return RoleStandalone
+}
+
+// AllRoles returns all valid node roles.
+func AllRoles() []NodeRole {
+	return []NodeRole{RoleStandalone, RoleWriter, RoleReader, RoleCompactor}
+}

--- a/internal/cluster/role_test.go
+++ b/internal/cluster/role_test.go
@@ -1,0 +1,152 @@
+package cluster
+
+import (
+	"testing"
+)
+
+func TestNodeRoleIsValid(t *testing.T) {
+	tests := []struct {
+		role     NodeRole
+		expected bool
+	}{
+		{RoleStandalone, true},
+		{RoleWriter, true},
+		{RoleReader, true},
+		{RoleCompactor, true},
+		{NodeRole("invalid"), false},
+		{NodeRole(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.role), func(t *testing.T) {
+			if got := tt.role.IsValid(); got != tt.expected {
+				t.Errorf("NodeRole(%q).IsValid() = %v, want %v", tt.role, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidRole(t *testing.T) {
+	tests := []struct {
+		role     string
+		expected bool
+	}{
+		{"standalone", true},
+		{"writer", true},
+		{"reader", true},
+		{"compactor", true},
+		{"invalid", false},
+		{"", false},
+		{"WRITER", false}, // case sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			if got := ValidRole(tt.role); got != tt.expected {
+				t.Errorf("ValidRole(%q) = %v, want %v", tt.role, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseRole(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected NodeRole
+	}{
+		{"standalone", RoleStandalone},
+		{"writer", RoleWriter},
+		{"reader", RoleReader},
+		{"compactor", RoleCompactor},
+		{"invalid", RoleStandalone}, // Falls back to standalone
+		{"", RoleStandalone},        // Empty falls back to standalone
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ParseRole(tt.input); got != tt.expected {
+				t.Errorf("ParseRole(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRoleCapabilities(t *testing.T) {
+	tests := []struct {
+		role         NodeRole
+		canIngest    bool
+		canQuery     bool
+		canCompact   bool
+		canCoordinate bool
+	}{
+		{RoleStandalone, true, true, true, false},
+		{RoleWriter, true, true, false, true},
+		{RoleReader, false, true, false, false},
+		{RoleCompactor, false, false, true, false},
+		{NodeRole("invalid"), false, false, false, false}, // Unknown role has no capabilities
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.role), func(t *testing.T) {
+			caps := tt.role.GetCapabilities()
+			if caps.CanIngest != tt.canIngest {
+				t.Errorf("GetCapabilities().CanIngest = %v, want %v", caps.CanIngest, tt.canIngest)
+			}
+			if caps.CanQuery != tt.canQuery {
+				t.Errorf("GetCapabilities().CanQuery = %v, want %v", caps.CanQuery, tt.canQuery)
+			}
+			if caps.CanCompact != tt.canCompact {
+				t.Errorf("GetCapabilities().CanCompact = %v, want %v", caps.CanCompact, tt.canCompact)
+			}
+			if caps.CanCoordinate != tt.canCoordinate {
+				t.Errorf("GetCapabilities().CanCoordinate = %v, want %v", caps.CanCoordinate, tt.canCoordinate)
+			}
+		})
+	}
+}
+
+func TestAllRoles(t *testing.T) {
+	roles := AllRoles()
+	if len(roles) != 4 {
+		t.Errorf("AllRoles() returned %d roles, want 4", len(roles))
+	}
+
+	// Check all expected roles are present
+	expected := map[NodeRole]bool{
+		RoleStandalone: true,
+		RoleWriter:     true,
+		RoleReader:     true,
+		RoleCompactor:  true,
+	}
+
+	for _, role := range roles {
+		if !expected[role] {
+			t.Errorf("AllRoles() contains unexpected role: %v", role)
+		}
+		delete(expected, role)
+	}
+
+	if len(expected) > 0 {
+		t.Errorf("AllRoles() missing roles: %v", expected)
+	}
+}
+
+func TestNodeRoleString(t *testing.T) {
+	tests := []struct {
+		role     NodeRole
+		expected string
+	}{
+		{RoleStandalone, "standalone"},
+		{RoleWriter, "writer"},
+		{RoleReader, "reader"},
+		{RoleCompactor, "compactor"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.role.String(); got != tt.expected {
+				t.Errorf("NodeRole.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement clustering foundation for Arc Enterprise with node role separation (Writer/Reader/Compactor). Includes:

- Node role system with capabilities (CanIngest, CanQuery, CanCompact, CanCoordinate)
- Thread-safe node registry with filtering and max node limits
- Health checker with atomic state transitions (fixes TOCTOU race)
- Cluster coordinator with license validation
- HTTP API endpoints for cluster management
- Input validation for role/state/nodeID parameters
- Security hardening: clone returns, callback timeouts, panic recovery