### PR TITLE
feat(cluster): Add Phase 4 multi-writer sharding foundation

### DIFF
--- a/internal/cluster/sharding/config.go
+++ b/internal/cluster/sharding/config.go
@@ -1,0 +1,50 @@
+package sharding
+
+import "time"
+
+// Config holds sharding configuration.
+type Config struct {
+	// Enabled enables sharding for the cluster
+	Enabled bool
+
+	// NumShards is the total number of shards (default: 3)
+	NumShards int
+
+	// ShardKey determines how data is partitioned
+	// Supported values: "database" (default), "measurement"
+	ShardKey string
+
+	// ReplicationFactor is the number of copies of each shard (default: 3)
+	ReplicationFactor int
+
+	// RouteTimeout is the timeout for forwarding requests (default: 5s)
+	RouteTimeout time.Duration
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() *Config {
+	return &Config{
+		Enabled:           false,
+		NumShards:         3,
+		ShardKey:          "database",
+		ReplicationFactor: 3,
+		RouteTimeout:      5 * time.Second,
+	}
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	if c.NumShards < 1 {
+		c.NumShards = 1
+	}
+	if c.ReplicationFactor < 1 {
+		c.ReplicationFactor = 1
+	}
+	if c.ShardKey == "" {
+		c.ShardKey = "database"
+	}
+	if c.RouteTimeout <= 0 {
+		c.RouteTimeout = 5 * time.Second
+	}
+	return nil
+}

--- a/internal/cluster/sharding/failover.go
+++ b/internal/cluster/sharding/failover.go
@@ -1,0 +1,500 @@
+package sharding
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/rs/zerolog"
+)
+
+// FailoverConfig holds configuration for the failover manager.
+type FailoverConfig struct {
+	// ShardMap provides shard-to-node mappings
+	ShardMap *ShardMap
+
+	// MetaCluster for shard reassignment (optional, for leader nodes)
+	MetaCluster *MetaCluster
+
+	// LocalNode is this node
+	LocalNode *cluster.Node
+
+	// HealthCheckInterval is how often to check node health
+	HealthCheckInterval time.Duration
+
+	// FailoverTimeout is the timeout for failover operations
+	FailoverTimeout time.Duration
+
+	// UnhealthyThreshold is the number of failed health checks before marking unhealthy
+	UnhealthyThreshold int
+
+	// Logger for failover events
+	Logger zerolog.Logger
+}
+
+// FailoverManager monitors shard health and triggers automatic failover.
+// It runs on the meta cluster leader and coordinates shard reassignment.
+type FailoverManager struct {
+	cfg           *FailoverConfig
+	nodeHealth    map[string]*nodeHealthState // nodeID -> health state
+	shardHealth   map[int]*shardHealthState   // shardID -> health state
+	mu            sync.RWMutex
+	logger        zerolog.Logger
+	ctx           context.Context
+	cancelFn      context.CancelFunc
+	running       atomic.Bool
+	wg            sync.WaitGroup
+
+	// Callbacks
+	onFailoverStart    func(shardID int, oldPrimary, newPrimary string)
+	onFailoverComplete func(shardID int, newPrimary string, success bool)
+}
+
+// nodeHealthState tracks health for a single node.
+type nodeHealthState struct {
+	nodeID          string
+	consecutiveFail int
+	lastCheck       time.Time
+	lastSuccess     time.Time
+	isHealthy       bool
+}
+
+// shardHealthState tracks health for a single shard.
+type shardHealthState struct {
+	shardID        int
+	primaryID      string
+	isPrimaryUp    bool
+	lastCheck      time.Time
+	failoverInProg bool
+}
+
+// NewFailoverManager creates a new failover manager.
+func NewFailoverManager(cfg *FailoverConfig) *FailoverManager {
+	if cfg.HealthCheckInterval == 0 {
+		cfg.HealthCheckInterval = 5 * time.Second
+	}
+	if cfg.FailoverTimeout == 0 {
+		cfg.FailoverTimeout = 30 * time.Second
+	}
+	if cfg.UnhealthyThreshold == 0 {
+		cfg.UnhealthyThreshold = 3
+	}
+
+	return &FailoverManager{
+		cfg:         cfg,
+		nodeHealth:  make(map[string]*nodeHealthState),
+		shardHealth: make(map[int]*shardHealthState),
+		logger:      cfg.Logger.With().Str("component", "failover-manager").Logger(),
+	}
+}
+
+// SetCallbacks sets callbacks for failover events.
+func (m *FailoverManager) SetCallbacks(
+	onStart func(shardID int, oldPrimary, newPrimary string),
+	onComplete func(shardID int, newPrimary string, success bool),
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onFailoverStart = onStart
+	m.onFailoverComplete = onComplete
+}
+
+// Start begins the failover manager.
+func (m *FailoverManager) Start(ctx context.Context) error {
+	m.ctx, m.cancelFn = context.WithCancel(ctx)
+	m.running.Store(true)
+
+	// Start health check loop
+	m.wg.Add(1)
+	go m.healthCheckLoop()
+
+	m.logger.Info().
+		Dur("health_check_interval", m.cfg.HealthCheckInterval).
+		Int("unhealthy_threshold", m.cfg.UnhealthyThreshold).
+		Msg("Failover manager started")
+
+	return nil
+}
+
+// Stop gracefully shuts down the failover manager.
+func (m *FailoverManager) Stop() error {
+	if !m.running.Load() {
+		return nil
+	}
+
+	m.running.Store(false)
+	m.cancelFn()
+	m.wg.Wait()
+
+	m.logger.Info().Msg("Failover manager stopped")
+	return nil
+}
+
+// healthCheckLoop periodically checks node and shard health.
+func (m *FailoverManager) healthCheckLoop() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.cfg.HealthCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkHealth()
+		}
+	}
+}
+
+// checkHealth checks the health of all nodes and shards.
+func (m *FailoverManager) checkHealth() {
+	// Only the meta cluster leader should perform health checks
+	if m.cfg.MetaCluster != nil && !m.cfg.MetaCluster.IsLeader() {
+		return
+	}
+
+	m.checkNodeHealth()
+	m.checkShardHealth()
+}
+
+// checkNodeHealth checks the health of all nodes.
+func (m *FailoverManager) checkNodeHealth() {
+	// Collect all unique nodes across all shards
+	nodeSet := make(map[string]*cluster.Node)
+	numShards := m.cfg.ShardMap.NumShards()
+	for shardID := 0; shardID < numShards; shardID++ {
+		nodes := m.cfg.ShardMap.GetAllNodes(shardID)
+		for _, node := range nodes {
+			if node != nil {
+				nodeSet[node.ID] = node
+			}
+		}
+	}
+
+	now := time.Now()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, node := range nodeSet {
+		state, exists := m.nodeHealth[node.ID]
+		if !exists {
+			state = &nodeHealthState{
+				nodeID:    node.ID,
+				isHealthy: true,
+			}
+			m.nodeHealth[node.ID] = state
+		}
+
+		state.lastCheck = now
+
+		// Check if node is healthy based on its reported state
+		if node.IsHealthy() {
+			state.consecutiveFail = 0
+			state.lastSuccess = now
+			state.isHealthy = true
+		} else {
+			state.consecutiveFail++
+			if state.consecutiveFail >= m.cfg.UnhealthyThreshold {
+				if state.isHealthy {
+					m.logger.Warn().
+						Str("node_id", node.ID).
+						Int("consecutive_failures", state.consecutiveFail).
+						Msg("Node marked unhealthy")
+				}
+				state.isHealthy = false
+			}
+		}
+	}
+
+	// Clean up removed nodes
+	for nodeID := range m.nodeHealth {
+		if _, exists := nodeSet[nodeID]; !exists {
+			delete(m.nodeHealth, nodeID)
+		}
+	}
+}
+
+// checkShardHealth checks the health of all shard primaries and triggers failover if needed.
+func (m *FailoverManager) checkShardHealth() {
+	shardMap := m.cfg.ShardMap
+	numShards := shardMap.NumShards()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for shardID := 0; shardID < numShards; shardID++ {
+		primary := shardMap.GetPrimary(shardID)
+
+		state, exists := m.shardHealth[shardID]
+		if !exists {
+			state = &shardHealthState{
+				shardID: shardID,
+			}
+			m.shardHealth[shardID] = state
+		}
+
+		state.lastCheck = time.Now()
+
+		// Update primary tracking
+		if primary != nil {
+			state.primaryID = primary.ID
+			state.isPrimaryUp = primary.IsHealthy()
+		} else {
+			state.primaryID = ""
+			state.isPrimaryUp = false
+		}
+
+		// Check if failover is needed
+		if !state.isPrimaryUp && !state.failoverInProg && state.primaryID != "" {
+			m.triggerFailoverLocked(shardID, state)
+		}
+	}
+}
+
+// triggerFailoverLocked initiates failover for a shard (must hold lock).
+func (m *FailoverManager) triggerFailoverLocked(shardID int, state *shardHealthState) {
+	if m.cfg.MetaCluster == nil {
+		m.logger.Warn().
+			Int("shard_id", shardID).
+			Msg("Cannot trigger failover: no meta cluster")
+		return
+	}
+
+	oldPrimary := state.primaryID
+	state.failoverInProg = true
+
+	m.logger.Info().
+		Int("shard_id", shardID).
+		Str("old_primary", oldPrimary).
+		Msg("Initiating failover for shard")
+
+	// Run failover in background
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		m.executeFailover(shardID, oldPrimary)
+	}()
+}
+
+// executeFailover performs the actual failover operation.
+func (m *FailoverManager) executeFailover(shardID int, oldPrimary string) {
+	ctx, cancel := context.WithTimeout(m.ctx, m.cfg.FailoverTimeout)
+	defer cancel()
+
+	// Find a healthy replica to promote
+	newPrimary := m.selectNewPrimary(shardID, oldPrimary)
+	if newPrimary == "" {
+		m.logger.Error().
+			Int("shard_id", shardID).
+			Msg("No healthy replica available for failover")
+		m.completeFailover(shardID, "", false)
+		return
+	}
+
+	// Notify callback
+	m.mu.RLock()
+	callback := m.onFailoverStart
+	m.mu.RUnlock()
+	if callback != nil {
+		callback(shardID, oldPrimary, newPrimary)
+	}
+
+	m.logger.Info().
+		Int("shard_id", shardID).
+		Str("old_primary", oldPrimary).
+		Str("new_primary", newPrimary).
+		Msg("Promoting replica to primary")
+
+	// Execute promotion via meta cluster
+	if m.cfg.MetaCluster != nil && m.cfg.MetaCluster.IsLeader() {
+		// Assign new primary
+		if err := m.cfg.MetaCluster.AssignShard(shardID, newPrimary, RolePrimary, m.cfg.FailoverTimeout); err != nil {
+			m.logger.Error().Err(err).
+				Int("shard_id", shardID).
+				Str("new_primary", newPrimary).
+				Msg("Failed to assign new primary")
+			m.completeFailover(shardID, newPrimary, false)
+			return
+		}
+
+		// Wait for assignment to propagate
+		select {
+		case <-ctx.Done():
+			m.logger.Error().
+				Int("shard_id", shardID).
+				Msg("Failover timeout")
+			m.completeFailover(shardID, newPrimary, false)
+			return
+		case <-time.After(500 * time.Millisecond):
+			// Brief wait for propagation
+		}
+	}
+
+	m.logger.Info().
+		Int("shard_id", shardID).
+		Str("new_primary", newPrimary).
+		Msg("Failover completed successfully")
+
+	m.completeFailover(shardID, newPrimary, true)
+}
+
+// selectNewPrimary selects the best replica to promote.
+func (m *FailoverManager) selectNewPrimary(shardID int, excludeNodeID string) string {
+	group := m.cfg.ShardMap.GetShardGroup(shardID)
+	if group == nil {
+		return ""
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// Find the healthiest replica with the least lag
+	var bestReplica string
+	for _, replica := range group.Replicas {
+		if replica.ID == excludeNodeID {
+			continue
+		}
+
+		// Check if replica is healthy
+		if state, exists := m.nodeHealth[replica.ID]; exists && state.isHealthy {
+			// For now, just pick the first healthy replica
+			// In a more sophisticated implementation, we'd consider replication lag
+			bestReplica = replica.ID
+			break
+		}
+	}
+
+	return bestReplica
+}
+
+// completeFailover marks failover as complete.
+func (m *FailoverManager) completeFailover(shardID int, newPrimary string, success bool) {
+	m.mu.Lock()
+	if state, exists := m.shardHealth[shardID]; exists {
+		state.failoverInProg = false
+		if success {
+			state.primaryID = newPrimary
+			state.isPrimaryUp = true
+		}
+	}
+	callback := m.onFailoverComplete
+	m.mu.Unlock()
+
+	if callback != nil {
+		callback(shardID, newPrimary, success)
+	}
+}
+
+// TriggerManualFailover triggers a manual failover for a shard.
+func (m *FailoverManager) TriggerManualFailover(shardID int) error {
+	m.mu.Lock()
+	state, exists := m.shardHealth[shardID]
+	if !exists {
+		state = &shardHealthState{
+			shardID: shardID,
+		}
+		m.shardHealth[shardID] = state
+	}
+
+	if state.failoverInProg {
+		m.mu.Unlock()
+		return fmt.Errorf("failover already in progress for shard %d", shardID)
+	}
+
+	primary := m.cfg.ShardMap.GetPrimary(shardID)
+	if primary == nil {
+		m.mu.Unlock()
+		return fmt.Errorf("no primary for shard %d", shardID)
+	}
+
+	state.primaryID = primary.ID
+	state.failoverInProg = true
+	m.mu.Unlock()
+
+	m.logger.Info().
+		Int("shard_id", shardID).
+		Str("current_primary", primary.ID).
+		Msg("Manual failover initiated")
+
+	go func() {
+		m.executeFailover(shardID, primary.ID)
+	}()
+
+	return nil
+}
+
+// GetShardHealthStatus returns the health status of a shard.
+func (m *FailoverManager) GetShardHealthStatus(shardID int) map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state, exists := m.shardHealth[shardID]
+	if !exists {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"shard_id":          state.shardID,
+		"primary_id":        state.primaryID,
+		"is_primary_up":     state.isPrimaryUp,
+		"failover_in_prog":  state.failoverInProg,
+		"last_check":        state.lastCheck.Format(time.RFC3339),
+	}
+}
+
+// GetNodeHealthStatus returns the health status of a node.
+func (m *FailoverManager) GetNodeHealthStatus(nodeID string) map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state, exists := m.nodeHealth[nodeID]
+	if !exists {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"node_id":          state.nodeID,
+		"is_healthy":       state.isHealthy,
+		"consecutive_fail": state.consecutiveFail,
+		"last_check":       state.lastCheck.Format(time.RFC3339),
+		"last_success":     state.lastSuccess.Format(time.RFC3339),
+	}
+}
+
+// Stats returns overall failover manager statistics.
+func (m *FailoverManager) Stats() map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	nodeStats := make(map[string]map[string]interface{})
+	for nodeID, state := range m.nodeHealth {
+		nodeStats[nodeID] = map[string]interface{}{
+			"is_healthy":       state.isHealthy,
+			"consecutive_fail": state.consecutiveFail,
+		}
+	}
+
+	shardStats := make(map[int]map[string]interface{})
+	for shardID, state := range m.shardHealth {
+		shardStats[shardID] = map[string]interface{}{
+			"primary_id":       state.primaryID,
+			"is_primary_up":    state.isPrimaryUp,
+			"failover_in_prog": state.failoverInProg,
+		}
+	}
+
+	return map[string]interface{}{
+		"running":               m.running.Load(),
+		"health_check_interval": m.cfg.HealthCheckInterval.String(),
+		"unhealthy_threshold":   m.cfg.UnhealthyThreshold,
+		"node_count":            len(m.nodeHealth),
+		"shard_count":           len(m.shardHealth),
+		"nodes":                 nodeStats,
+		"shards":                shardStats,
+	}
+}

--- a/internal/cluster/sharding/failover_test.go
+++ b/internal/cluster/sharding/failover_test.go
@@ -1,0 +1,322 @@
+package sharding
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailoverManager_StartStop(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:            sm,
+		LocalNode:           localNode,
+		HealthCheckInterval: 100 * time.Millisecond,
+		Logger:              zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	assert.True(t, mgr.running.Load())
+
+	err = mgr.Stop()
+	require.NoError(t, err)
+	assert.False(t, mgr.running.Load())
+}
+
+func TestFailoverManager_NodeHealthTracking(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	// Add some nodes to the shard map
+	node1 := &cluster.Node{ID: "node-1"}
+	node1.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(0, node1)
+
+	node2 := &cluster.Node{ID: "node-2"}
+	node2.UpdateState(cluster.StateHealthy)
+	sm.AddReplica(0, node2)
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:            sm,
+		LocalNode:           localNode,
+		HealthCheckInterval: 50 * time.Millisecond,
+		UnhealthyThreshold:  2,
+		Logger:              zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Wait for health check
+	time.Sleep(100 * time.Millisecond)
+
+	// Check node health status
+	status := mgr.GetNodeHealthStatus("node-1")
+	require.NotNil(t, status)
+	assert.True(t, status["is_healthy"].(bool))
+}
+
+func TestFailoverManager_ShardHealthTracking(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	// Add primary for shard 0
+	primary := &cluster.Node{ID: "primary-node"}
+	primary.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(0, primary)
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:            sm,
+		LocalNode:           localNode,
+		HealthCheckInterval: 50 * time.Millisecond,
+		Logger:              zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Wait for health check
+	time.Sleep(100 * time.Millisecond)
+
+	// Check shard health status
+	status := mgr.GetShardHealthStatus(0)
+	require.NotNil(t, status)
+	assert.Equal(t, "primary-node", status["primary_id"])
+	assert.True(t, status["is_primary_up"].(bool))
+	assert.False(t, status["failover_in_prog"].(bool))
+}
+
+func TestFailoverManager_DetectUnhealthyNode(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	// Add an unhealthy node
+	unhealthyNode := &cluster.Node{ID: "unhealthy-node"}
+	unhealthyNode.UpdateState(cluster.StateDead)
+	sm.SetPrimary(0, unhealthyNode)
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:            sm,
+		LocalNode:           localNode,
+		HealthCheckInterval: 50 * time.Millisecond,
+		UnhealthyThreshold:  2,
+		Logger:              zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Wait for multiple health checks
+	time.Sleep(200 * time.Millisecond)
+
+	// Check that node is marked unhealthy
+	status := mgr.GetNodeHealthStatus("unhealthy-node")
+	require.NotNil(t, status)
+	assert.False(t, status["is_healthy"].(bool))
+}
+
+func TestFailoverManager_FailoverCallbacks(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	failoverStarted := make(chan struct {
+		shardID    int
+		oldPrimary string
+		newPrimary string
+	}, 1)
+	failoverCompleted := make(chan struct {
+		shardID    int
+		newPrimary string
+		success    bool
+	}, 1)
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:            sm,
+		LocalNode:           localNode,
+		HealthCheckInterval: 100 * time.Millisecond,
+		FailoverTimeout:     5 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+
+	mgr.SetCallbacks(
+		func(shardID int, oldPrimary, newPrimary string) {
+			failoverStarted <- struct {
+				shardID    int
+				oldPrimary string
+				newPrimary string
+			}{shardID, oldPrimary, newPrimary}
+		},
+		func(shardID int, newPrimary string, success bool) {
+			failoverCompleted <- struct {
+				shardID    int
+				newPrimary string
+				success    bool
+			}{shardID, newPrimary, success}
+		},
+	)
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Callbacks are tested indirectly through TriggerManualFailover
+	// For now, just verify they are set correctly
+	assert.NotNil(t, mgr.onFailoverStart)
+	assert.NotNil(t, mgr.onFailoverComplete)
+}
+
+func TestFailoverManager_TriggerManualFailover_NoPrimary(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Try to trigger failover for shard with no primary
+	err = mgr.TriggerManualFailover(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no primary")
+}
+
+func TestFailoverManager_TriggerManualFailover_AlreadyInProgress(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	primary := &cluster.Node{ID: "primary-node"}
+	primary.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(0, primary)
+
+	// Add a replica so failover doesn't complete immediately
+	replica := &cluster.Node{ID: "replica-node"}
+	replica.UpdateState(cluster.StateHealthy)
+	sm.AddReplica(0, replica)
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:        sm,
+		LocalNode:       localNode,
+		FailoverTimeout: 10 * time.Second, // Longer timeout to keep failover in progress
+		Logger:          zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Initialize node health so replica is known
+	mgr.mu.Lock()
+	mgr.nodeHealth["replica-node"] = &nodeHealthState{
+		nodeID:    "replica-node",
+		isHealthy: true,
+	}
+	mgr.mu.Unlock()
+
+	// Manually set failover in progress to simulate concurrent request
+	mgr.mu.Lock()
+	mgr.shardHealth[0] = &shardHealthState{
+		shardID:        0,
+		primaryID:      "primary-node",
+		failoverInProg: true,
+	}
+	mgr.mu.Unlock()
+
+	// Try to trigger another failover (should fail since one is "in progress")
+	err = mgr.TriggerManualFailover(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already in progress")
+}
+
+func TestFailoverManager_Stats(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	node1 := &cluster.Node{ID: "node-1"}
+	node1.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(0, node1)
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:            sm,
+		LocalNode:           localNode,
+		HealthCheckInterval: 50 * time.Millisecond,
+		UnhealthyThreshold:  3,
+		Logger:              zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Wait for health check
+	time.Sleep(100 * time.Millisecond)
+
+	stats := mgr.Stats()
+	assert.True(t, stats["running"].(bool))
+	assert.Equal(t, 3, stats["unhealthy_threshold"])
+	assert.NotNil(t, stats["nodes"])
+	assert.NotNil(t, stats["shards"])
+}
+
+func TestFailoverManager_SelectNewPrimary(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	// Setup shard with primary and replicas
+	primary := &cluster.Node{ID: "primary-node"}
+	primary.UpdateState(cluster.StateDead)
+	sm.SetPrimary(0, primary)
+
+	replica1 := &cluster.Node{ID: "replica-1"}
+	replica1.UpdateState(cluster.StateHealthy)
+	sm.AddReplica(0, replica1)
+
+	replica2 := &cluster.Node{ID: "replica-2"}
+	replica2.UpdateState(cluster.StateHealthy)
+	sm.AddReplica(0, replica2)
+
+	mgr := NewFailoverManager(&FailoverConfig{
+		ShardMap:            sm,
+		LocalNode:           localNode,
+		HealthCheckInterval: 50 * time.Millisecond,
+		Logger:              zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Wait for health tracking to initialize
+	time.Sleep(100 * time.Millisecond)
+
+	// Select new primary (should exclude the current primary)
+	newPrimary := mgr.selectNewPrimary(0, "primary-node")
+	assert.NotEmpty(t, newPrimary)
+	assert.NotEqual(t, "primary-node", newPrimary)
+	// Should be one of the healthy replicas
+	assert.True(t, newPrimary == "replica-1" || newPrimary == "replica-2")
+}

--- a/internal/cluster/sharding/meta.go
+++ b/internal/cluster/sharding/meta.go
@@ -1,0 +1,460 @@
+package sharding
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/hashicorp/raft"
+	"github.com/rs/zerolog"
+)
+
+// MetaCluster coordinates shard assignments across the cluster.
+// It uses Raft consensus to maintain a consistent view of the shard map.
+type MetaCluster struct {
+	raftNode *raft.Raft
+	fsm      *MetaFSM
+	config   *MetaClusterConfig
+	logger   zerolog.Logger
+
+	mu sync.RWMutex
+}
+
+// MetaClusterConfig holds configuration for the meta cluster.
+type MetaClusterConfig struct {
+	NumShards         int           // Total number of shards
+	ReplicationFactor int           // Target number of replicas per shard
+	LocalNode         *cluster.Node // Local node reference
+	Logger            zerolog.Logger
+}
+
+// NewMetaCluster creates a new meta cluster coordinator.
+// The raftNode must be started separately.
+func NewMetaCluster(cfg *MetaClusterConfig, raftNode *raft.Raft) *MetaCluster {
+	fsm := NewMetaFSM(cfg.NumShards, cfg.Logger)
+
+	return &MetaCluster{
+		raftNode: raftNode,
+		fsm:      fsm,
+		config:   cfg,
+		logger:   cfg.Logger.With().Str("component", "meta-cluster").Logger(),
+	}
+}
+
+// GetFSM returns the meta FSM for use with Raft.
+func (m *MetaCluster) GetFSM() *MetaFSM {
+	return m.fsm
+}
+
+// IsLeader returns true if this node is the meta cluster leader.
+func (m *MetaCluster) IsLeader() bool {
+	if m.raftNode == nil {
+		return false
+	}
+	return m.raftNode.State() == raft.Leader
+}
+
+// LeaderAddr returns the address of the current leader.
+func (m *MetaCluster) LeaderAddr() string {
+	if m.raftNode == nil {
+		return ""
+	}
+	addr, _ := m.raftNode.LeaderWithID()
+	return string(addr)
+}
+
+// AssignShard assigns a shard to a node with the specified role.
+// Must be called on the leader.
+func (m *MetaCluster) AssignShard(shardID int, nodeID string, role Role, timeout time.Duration) error {
+	if !m.IsLeader() {
+		return ErrNotLeader
+	}
+
+	payload, err := json.Marshal(AssignShardPayload{
+		ShardID: shardID,
+		NodeID:  nodeID,
+		Role:    role,
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd, err := json.Marshal(MetaCommand{
+		Type:    CmdAssignShard,
+		Payload: payload,
+	})
+	if err != nil {
+		return err
+	}
+
+	future := m.raftNode.Apply(cmd, timeout)
+	if err := future.Error(); err != nil {
+		return fmt.Errorf("raft apply failed: %w", err)
+	}
+
+	if resp := future.Response(); resp != nil {
+		if err, ok := resp.(error); ok {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UnassignShard removes a shard assignment from a node.
+// Must be called on the leader.
+func (m *MetaCluster) UnassignShard(shardID int, nodeID string, timeout time.Duration) error {
+	if !m.IsLeader() {
+		return ErrNotLeader
+	}
+
+	payload, err := json.Marshal(UnassignShardPayload{
+		ShardID: shardID,
+		NodeID:  nodeID,
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd, err := json.Marshal(MetaCommand{
+		Type:    CmdUnassignShard,
+		Payload: payload,
+	})
+	if err != nil {
+		return err
+	}
+
+	future := m.raftNode.Apply(cmd, timeout)
+	if err := future.Error(); err != nil {
+		return fmt.Errorf("raft apply failed: %w", err)
+	}
+
+	return nil
+}
+
+// AddNode registers a node with the meta cluster.
+// Must be called on the leader.
+func (m *MetaCluster) AddNode(node *NodeInfo, timeout time.Duration) error {
+	if !m.IsLeader() {
+		return ErrNotLeader
+	}
+
+	payload, err := json.Marshal(AddNodePayload{
+		Node: *node,
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd, err := json.Marshal(MetaCommand{
+		Type:    CmdAddNode,
+		Payload: payload,
+	})
+	if err != nil {
+		return err
+	}
+
+	future := m.raftNode.Apply(cmd, timeout)
+	if err := future.Error(); err != nil {
+		return fmt.Errorf("raft apply failed: %w", err)
+	}
+
+	return nil
+}
+
+// RemoveNode removes a node from the meta cluster.
+// This also unassigns all shards from the node.
+// Must be called on the leader.
+func (m *MetaCluster) RemoveNode(nodeID string, timeout time.Duration) error {
+	if !m.IsLeader() {
+		return ErrNotLeader
+	}
+
+	payload, err := json.Marshal(RemoveNodePayload{
+		NodeID: nodeID,
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd, err := json.Marshal(MetaCommand{
+		Type:    CmdRemoveNode,
+		Payload: payload,
+	})
+	if err != nil {
+		return err
+	}
+
+	future := m.raftNode.Apply(cmd, timeout)
+	if err := future.Error(); err != nil {
+		return fmt.Errorf("raft apply failed: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateNode updates a node's state in the meta cluster.
+// Must be called on the leader.
+func (m *MetaCluster) UpdateNode(nodeID string, state string, timeout time.Duration) error {
+	if !m.IsLeader() {
+		return ErrNotLeader
+	}
+
+	payload, err := json.Marshal(UpdateNodePayload{
+		NodeID: nodeID,
+		State:  state,
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd, err := json.Marshal(MetaCommand{
+		Type:    CmdUpdateNode,
+		Payload: payload,
+	})
+	if err != nil {
+		return err
+	}
+
+	future := m.raftNode.Apply(cmd, timeout)
+	if err := future.Error(); err != nil {
+		return fmt.Errorf("raft apply failed: %w", err)
+	}
+
+	return nil
+}
+
+// GetShardMap returns the current shard map.
+func (m *MetaCluster) GetShardMap() *ShardMap {
+	return m.fsm.GetShardMap()
+}
+
+// GetNodes returns all known nodes.
+func (m *MetaCluster) GetNodes() map[string]*NodeInfo {
+	return m.fsm.GetNodes()
+}
+
+// GetNode returns a specific node by ID.
+func (m *MetaCluster) GetNode(nodeID string) (*NodeInfo, bool) {
+	return m.fsm.GetNode(nodeID)
+}
+
+// OnNodeJoin handles a new node joining the cluster.
+// It automatically assigns shards to balance the cluster.
+func (m *MetaCluster) OnNodeJoin(node *NodeInfo) error {
+	if !m.IsLeader() {
+		return ErrNotLeader
+	}
+
+	// First, add the node
+	if err := m.AddNode(node, 5*time.Second); err != nil {
+		return fmt.Errorf("failed to add node: %w", err)
+	}
+
+	// Auto-assign shards to maintain replication factor
+	return m.rebalanceShards()
+}
+
+// OnNodeLeave handles a node leaving the cluster.
+// It reassigns shards to maintain replication factor.
+func (m *MetaCluster) OnNodeLeave(nodeID string) error {
+	if !m.IsLeader() {
+		return ErrNotLeader
+	}
+
+	// Get shards that this node was responsible for
+	shardMap := m.GetShardMap()
+	affectedShards := shardMap.GetNodeShards(nodeID)
+
+	// Remove the node
+	if err := m.RemoveNode(nodeID, 5*time.Second); err != nil {
+		return fmt.Errorf("failed to remove node: %w", err)
+	}
+
+	// If the node was a primary for any shard, we need to elect a new primary
+	for _, sr := range affectedShards {
+		if sr.Role == RolePrimary {
+			// Promote a replica to primary
+			if err := m.promoteReplicaToPrimary(sr.ShardID); err != nil {
+				m.logger.Error().Err(err).Int("shard_id", sr.ShardID).Msg("Failed to promote replica")
+			}
+		}
+	}
+
+	// Rebalance to maintain replication factor
+	return m.rebalanceShards()
+}
+
+// promoteReplicaToPrimary promotes a healthy replica to primary for a shard.
+func (m *MetaCluster) promoteReplicaToPrimary(shardID int) error {
+	shardMap := m.GetShardMap()
+	group := shardMap.GetShardGroup(shardID)
+	if group == nil {
+		return fmt.Errorf("shard %d not found", shardID)
+	}
+
+	// Find a healthy replica
+	for _, replica := range group.Replicas {
+		if replica.IsHealthy() {
+			m.logger.Info().
+				Int("shard_id", shardID).
+				Str("new_primary", replica.ID).
+				Msg("Promoting replica to primary")
+
+			// First, assign as primary (this replaces any existing primary assignment)
+			if err := m.AssignShard(shardID, replica.ID, RolePrimary, 5*time.Second); err != nil {
+				return err
+			}
+
+			// Remove from replicas list
+			return m.UnassignShard(shardID, replica.ID, 5*time.Second)
+		}
+	}
+
+	m.logger.Warn().Int("shard_id", shardID).Msg("No healthy replica to promote")
+	return nil
+}
+
+// rebalanceShards redistributes shards to maintain the target replication factor.
+func (m *MetaCluster) rebalanceShards() error {
+	shardMap := m.GetShardMap()
+	nodes := m.GetNodes()
+	numShards := shardMap.NumShards()
+	targetRF := m.config.ReplicationFactor
+
+	// Get healthy nodes
+	healthyNodes := make([]*NodeInfo, 0)
+	for _, node := range nodes {
+		if node.State == string(cluster.StateHealthy) {
+			healthyNodes = append(healthyNodes, node)
+		}
+	}
+
+	if len(healthyNodes) == 0 {
+		m.logger.Warn().Msg("No healthy nodes available for shard assignment")
+		return nil
+	}
+
+	m.logger.Debug().
+		Int("healthy_nodes", len(healthyNodes)).
+		Int("num_shards", numShards).
+		Int("target_rf", targetRF).
+		Msg("Rebalancing shards")
+
+	// For each shard, ensure we have a primary and enough replicas
+	for shardID := 0; shardID < numShards; shardID++ {
+		group := shardMap.GetShardGroup(shardID)
+
+		// Assign primary if missing
+		if group.Primary == nil {
+			nodeID := m.selectNodeForShard(shardID, healthyNodes, group)
+			if nodeID != "" {
+				if err := m.AssignShard(shardID, nodeID, RolePrimary, 5*time.Second); err != nil {
+					m.logger.Error().Err(err).Int("shard_id", shardID).Msg("Failed to assign primary")
+				}
+			}
+		}
+
+		// Add replicas up to target RF
+		currentReplicas := len(group.Replicas)
+		if group.Primary != nil {
+			currentReplicas++ // Count primary as part of replication
+		}
+
+		for currentReplicas < targetRF && currentReplicas < len(healthyNodes) {
+			nodeID := m.selectNodeForShard(shardID, healthyNodes, group)
+			if nodeID == "" {
+				break // No more suitable nodes
+			}
+
+			if err := m.AssignShard(shardID, nodeID, RoleReplica, 5*time.Second); err != nil {
+				m.logger.Error().Err(err).Int("shard_id", shardID).Msg("Failed to assign replica")
+				break
+			}
+			currentReplicas++
+
+			// Refresh group to get updated replicas
+			group = shardMap.GetShardGroup(shardID)
+		}
+	}
+
+	return nil
+}
+
+// selectNodeForShard selects a node that doesn't already have this shard.
+func (m *MetaCluster) selectNodeForShard(shardID int, nodes []*NodeInfo, group *ShardGroup) string {
+	// Get existing node IDs for this shard
+	existingNodes := make(map[string]bool)
+	if group.Primary != nil {
+		existingNodes[group.Primary.ID] = true
+	}
+	for _, r := range group.Replicas {
+		existingNodes[r.ID] = true
+	}
+
+	// Find a node that doesn't have this shard yet
+	// Prefer nodes with fewer shards for better distribution
+	var bestNode *NodeInfo
+	bestShardCount := -1
+
+	shardMap := m.GetShardMap()
+	for _, node := range nodes {
+		if existingNodes[node.ID] {
+			continue // Already has this shard
+		}
+
+		shardCount := len(shardMap.GetNodeShards(node.ID))
+		if bestNode == nil || shardCount < bestShardCount {
+			bestNode = node
+			bestShardCount = shardCount
+		}
+	}
+
+	if bestNode != nil {
+		return bestNode.ID
+	}
+	return ""
+}
+
+// Status returns the current status of the meta cluster.
+func (m *MetaCluster) Status() map[string]interface{} {
+	shardMap := m.GetShardMap()
+	nodes := m.GetNodes()
+
+	shardStatus := make([]map[string]interface{}, 0, shardMap.NumShards())
+	for i := 0; i < shardMap.NumShards(); i++ {
+		group := shardMap.GetShardGroup(i)
+		ss := map[string]interface{}{
+			"shard_id":     i,
+			"primary":      nil,
+			"replicas":     []string{},
+			"replica_count": len(group.Replicas),
+		}
+		if group.Primary != nil {
+			ss["primary"] = group.Primary.ID
+		}
+		replicaIDs := make([]string, 0, len(group.Replicas))
+		for _, r := range group.Replicas {
+			replicaIDs = append(replicaIDs, r.ID)
+		}
+		ss["replicas"] = replicaIDs
+		shardStatus = append(shardStatus, ss)
+	}
+
+	return map[string]interface{}{
+		"is_leader":          m.IsLeader(),
+		"leader_addr":        m.LeaderAddr(),
+		"num_shards":         shardMap.NumShards(),
+		"num_nodes":          len(nodes),
+		"replication_factor": m.config.ReplicationFactor,
+		"shard_map":          shardStatus,
+		"shard_map_version":  shardMap.Version(),
+	}
+}
+
+// Errors for the meta cluster.
+var (
+	ErrNotLeader = fmt.Errorf("not the meta cluster leader")
+)

--- a/internal/cluster/sharding/meta_fsm.go
+++ b/internal/cluster/sharding/meta_fsm.go
@@ -1,0 +1,428 @@
+package sharding
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/hashicorp/raft"
+	"github.com/rs/zerolog"
+)
+
+// MetaFSM is the finite state machine for the meta cluster.
+// It manages the authoritative shard map across the cluster.
+type MetaFSM struct {
+	shardMap *ShardMap
+	nodes    map[string]*NodeInfo // All known nodes
+	mu       sync.RWMutex
+	logger   zerolog.Logger
+
+	// Callbacks for state changes
+	onShardAssigned   func(shardID int, nodeID string, role Role)
+	onShardUnassigned func(shardID int, nodeID string)
+	onNodeAdded       func(node *NodeInfo)
+	onNodeRemoved     func(nodeID string)
+}
+
+// NodeInfo represents node information stored in the meta FSM.
+type NodeInfo struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	APIAddress string `json:"api_address"`
+	CoordAddr  string `json:"coord_addr"`
+	State      string `json:"state"`
+	Version    string `json:"version"`
+}
+
+// Command types for the meta FSM.
+const (
+	CmdAssignShard   = "assign_shard"
+	CmdUnassignShard = "unassign_shard"
+	CmdAddNode       = "add_node"
+	CmdRemoveNode    = "remove_node"
+	CmdUpdateNode    = "update_node"
+)
+
+// MetaCommand represents a command to the meta FSM.
+type MetaCommand struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// AssignShardPayload is the payload for shard assignment commands.
+type AssignShardPayload struct {
+	ShardID int    `json:"shard_id"`
+	NodeID  string `json:"node_id"`
+	Role    Role   `json:"role"` // "primary" or "replica"
+}
+
+// UnassignShardPayload is the payload for shard unassignment commands.
+type UnassignShardPayload struct {
+	ShardID int    `json:"shard_id"`
+	NodeID  string `json:"node_id"`
+}
+
+// AddNodePayload is the payload for adding a node.
+type AddNodePayload struct {
+	Node NodeInfo `json:"node"`
+}
+
+// RemoveNodePayload is the payload for removing a node.
+type RemoveNodePayload struct {
+	NodeID string `json:"node_id"`
+}
+
+// UpdateNodePayload is the payload for updating a node.
+type UpdateNodePayload struct {
+	NodeID string `json:"node_id"`
+	State  string `json:"state,omitempty"`
+}
+
+// NewMetaFSM creates a new meta FSM.
+func NewMetaFSM(numShards int, logger zerolog.Logger) *MetaFSM {
+	return &MetaFSM{
+		shardMap: NewShardMap(numShards),
+		nodes:    make(map[string]*NodeInfo),
+		logger:   logger.With().Str("component", "meta-fsm").Logger(),
+	}
+}
+
+// SetCallbacks sets the callback functions for state changes.
+func (f *MetaFSM) SetCallbacks(
+	onShardAssigned func(shardID int, nodeID string, role Role),
+	onShardUnassigned func(shardID int, nodeID string),
+	onNodeAdded func(node *NodeInfo),
+	onNodeRemoved func(nodeID string),
+) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.onShardAssigned = onShardAssigned
+	f.onShardUnassigned = onShardUnassigned
+	f.onNodeAdded = onNodeAdded
+	f.onNodeRemoved = onNodeRemoved
+}
+
+// Apply implements raft.FSM.
+func (f *MetaFSM) Apply(log *raft.Log) interface{} {
+	var cmd MetaCommand
+	if err := json.Unmarshal(log.Data, &cmd); err != nil {
+		f.logger.Error().Err(err).Msg("Failed to unmarshal meta command")
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	switch cmd.Type {
+	case CmdAssignShard:
+		return f.applyAssignShard(cmd.Payload)
+	case CmdUnassignShard:
+		return f.applyUnassignShard(cmd.Payload)
+	case CmdAddNode:
+		return f.applyAddNode(cmd.Payload)
+	case CmdRemoveNode:
+		return f.applyRemoveNode(cmd.Payload)
+	case CmdUpdateNode:
+		return f.applyUpdateNode(cmd.Payload)
+	default:
+		f.logger.Warn().Str("type", cmd.Type).Msg("Unknown command type")
+		return nil
+	}
+}
+
+func (f *MetaFSM) applyAssignShard(payload json.RawMessage) interface{} {
+	var p AssignShardPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+
+	// Get or create node from our registry
+	nodeInfo, exists := f.nodes[p.NodeID]
+	if !exists {
+		f.logger.Warn().Str("node_id", p.NodeID).Msg("Node not found for shard assignment")
+		return nil
+	}
+
+	// Create a cluster.Node for the shard map
+	node := &cluster.Node{
+		ID:         nodeInfo.ID,
+		Name:       nodeInfo.Name,
+		APIAddress: nodeInfo.APIAddress,
+		Address:    nodeInfo.CoordAddr,
+	}
+	node.UpdateState(cluster.NodeState(nodeInfo.State))
+
+	if p.Role == RolePrimary {
+		f.shardMap.SetPrimary(p.ShardID, node)
+	} else {
+		f.shardMap.AddReplica(p.ShardID, node)
+	}
+
+	f.logger.Info().
+		Int("shard_id", p.ShardID).
+		Str("node_id", p.NodeID).
+		Str("role", string(p.Role)).
+		Msg("Shard assigned")
+
+	if f.onShardAssigned != nil {
+		go f.onShardAssigned(p.ShardID, p.NodeID, p.Role)
+	}
+
+	return nil
+}
+
+func (f *MetaFSM) applyUnassignShard(payload json.RawMessage) interface{} {
+	var p UnassignShardPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+
+	// Check if this node is the primary
+	primary := f.shardMap.GetPrimary(p.ShardID)
+	if primary != nil && primary.ID == p.NodeID {
+		f.shardMap.SetPrimary(p.ShardID, nil)
+	} else {
+		f.shardMap.RemoveReplica(p.ShardID, p.NodeID)
+	}
+
+	f.logger.Info().
+		Int("shard_id", p.ShardID).
+		Str("node_id", p.NodeID).
+		Msg("Shard unassigned")
+
+	if f.onShardUnassigned != nil {
+		go f.onShardUnassigned(p.ShardID, p.NodeID)
+	}
+
+	return nil
+}
+
+func (f *MetaFSM) applyAddNode(payload json.RawMessage) interface{} {
+	var p AddNodePayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+
+	f.nodes[p.Node.ID] = &p.Node
+
+	f.logger.Info().
+		Str("node_id", p.Node.ID).
+		Str("api_address", p.Node.APIAddress).
+		Msg("Node added to meta cluster")
+
+	if f.onNodeAdded != nil {
+		go f.onNodeAdded(&p.Node)
+	}
+
+	return nil
+}
+
+func (f *MetaFSM) applyRemoveNode(payload json.RawMessage) interface{} {
+	var p RemoveNodePayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+
+	delete(f.nodes, p.NodeID)
+
+	// Also remove from all shard groups
+	f.shardMap.RemoveNode(p.NodeID)
+
+	f.logger.Info().
+		Str("node_id", p.NodeID).
+		Msg("Node removed from meta cluster")
+
+	if f.onNodeRemoved != nil {
+		go f.onNodeRemoved(p.NodeID)
+	}
+
+	return nil
+}
+
+func (f *MetaFSM) applyUpdateNode(payload json.RawMessage) interface{} {
+	var p UpdateNodePayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return err
+	}
+
+	if nodeInfo, exists := f.nodes[p.NodeID]; exists {
+		if p.State != "" {
+			nodeInfo.State = p.State
+		}
+	}
+
+	return nil
+}
+
+// Snapshot implements raft.FSM.
+func (f *MetaFSM) Snapshot() (raft.FSMSnapshot, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	// Create a snapshot of the current state
+	snapshot := &MetaFSMSnapshot{
+		NumShards: f.shardMap.NumShards(),
+		Nodes:     make(map[string]*NodeInfo),
+		Shards:    make(map[int]*ShardSnapshot),
+	}
+
+	// Copy nodes
+	for id, node := range f.nodes {
+		snapshot.Nodes[id] = &NodeInfo{
+			ID:         node.ID,
+			Name:       node.Name,
+			APIAddress: node.APIAddress,
+			CoordAddr:  node.CoordAddr,
+			State:      node.State,
+			Version:    node.Version,
+		}
+	}
+
+	// Copy shard assignments
+	for i := 0; i < f.shardMap.NumShards(); i++ {
+		group := f.shardMap.GetShardGroup(i)
+		if group == nil {
+			continue
+		}
+
+		ss := &ShardSnapshot{
+			ShardID:  i,
+			Replicas: make([]string, 0, len(group.Replicas)),
+		}
+		if group.Primary != nil {
+			ss.PrimaryID = group.Primary.ID
+		}
+		for _, r := range group.Replicas {
+			ss.Replicas = append(ss.Replicas, r.ID)
+		}
+		snapshot.Shards[i] = ss
+	}
+
+	return snapshot, nil
+}
+
+// Restore implements raft.FSM.
+func (f *MetaFSM) Restore(rc io.ReadCloser) error {
+	defer rc.Close()
+
+	var snapshot MetaFSMSnapshot
+	if err := json.NewDecoder(rc).Decode(&snapshot); err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Restore nodes
+	f.nodes = snapshot.Nodes
+
+	// Recreate shard map
+	f.shardMap = NewShardMap(snapshot.NumShards)
+
+	// Restore shard assignments
+	for _, ss := range snapshot.Shards {
+		if ss.PrimaryID != "" {
+			if nodeInfo, exists := f.nodes[ss.PrimaryID]; exists {
+				node := &cluster.Node{
+					ID:         nodeInfo.ID,
+					Name:       nodeInfo.Name,
+					APIAddress: nodeInfo.APIAddress,
+					Address:    nodeInfo.CoordAddr,
+				}
+				node.UpdateState(cluster.NodeState(nodeInfo.State))
+				f.shardMap.SetPrimary(ss.ShardID, node)
+			}
+		}
+		for _, replicaID := range ss.Replicas {
+			if nodeInfo, exists := f.nodes[replicaID]; exists {
+				node := &cluster.Node{
+					ID:         nodeInfo.ID,
+					Name:       nodeInfo.Name,
+					APIAddress: nodeInfo.APIAddress,
+					Address:    nodeInfo.CoordAddr,
+				}
+				node.UpdateState(cluster.NodeState(nodeInfo.State))
+				f.shardMap.AddReplica(ss.ShardID, node)
+			}
+		}
+	}
+
+	f.logger.Info().
+		Int("num_shards", snapshot.NumShards).
+		Int("num_nodes", len(snapshot.Nodes)).
+		Msg("Meta FSM restored from snapshot")
+
+	return nil
+}
+
+// GetShardMap returns the current shard map (read-only).
+func (f *MetaFSM) GetShardMap() *ShardMap {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.shardMap
+}
+
+// GetNodes returns all known nodes.
+func (f *MetaFSM) GetNodes() map[string]*NodeInfo {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	result := make(map[string]*NodeInfo, len(f.nodes))
+	for id, node := range f.nodes {
+		result[id] = &NodeInfo{
+			ID:         node.ID,
+			Name:       node.Name,
+			APIAddress: node.APIAddress,
+			CoordAddr:  node.CoordAddr,
+			State:      node.State,
+			Version:    node.Version,
+		}
+	}
+	return result
+}
+
+// GetNode returns a specific node by ID.
+func (f *MetaFSM) GetNode(nodeID string) (*NodeInfo, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	node, exists := f.nodes[nodeID]
+	if !exists {
+		return nil, false
+	}
+	return &NodeInfo{
+		ID:         node.ID,
+		Name:       node.Name,
+		APIAddress: node.APIAddress,
+		CoordAddr:  node.CoordAddr,
+		State:      node.State,
+		Version:    node.Version,
+	}, true
+}
+
+// MetaFSMSnapshot is a snapshot of the meta FSM state.
+type MetaFSMSnapshot struct {
+	NumShards int                    `json:"num_shards"`
+	Nodes     map[string]*NodeInfo   `json:"nodes"`
+	Shards    map[int]*ShardSnapshot `json:"shards"`
+}
+
+// ShardSnapshot represents a shard's assignment state.
+type ShardSnapshot struct {
+	ShardID   int      `json:"shard_id"`
+	PrimaryID string   `json:"primary_id,omitempty"`
+	Replicas  []string `json:"replicas,omitempty"`
+}
+
+// Persist implements raft.FSMSnapshot.
+func (s *MetaFSMSnapshot) Persist(sink raft.SnapshotSink) error {
+	err := json.NewEncoder(sink).Encode(s)
+	if err != nil {
+		sink.Cancel()
+		return err
+	}
+	return sink.Close()
+}
+
+// Release implements raft.FSMSnapshot.
+func (s *MetaFSMSnapshot) Release() {}

--- a/internal/cluster/sharding/meta_test.go
+++ b/internal/cluster/sharding/meta_test.go
@@ -1,0 +1,317 @@
+package sharding
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/hashicorp/raft"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaFSM_AssignShard(t *testing.T) {
+	fsm := NewMetaFSM(3, zerolog.Nop())
+
+	// First add a node
+	addPayload, _ := json.Marshal(AddNodePayload{
+		Node: NodeInfo{
+			ID:         "node-1",
+			Name:       "node-1",
+			APIAddress: "localhost:8000",
+			CoordAddr:  "localhost:9100",
+			State:      string(cluster.StateHealthy),
+		},
+	})
+	addCmd, _ := json.Marshal(MetaCommand{
+		Type:    CmdAddNode,
+		Payload: addPayload,
+	})
+	fsm.Apply(&raft.Log{Data: addCmd})
+
+	// Assign shard 0 to node-1 as primary
+	assignPayload, _ := json.Marshal(AssignShardPayload{
+		ShardID: 0,
+		NodeID:  "node-1",
+		Role:    RolePrimary,
+	})
+	assignCmd, _ := json.Marshal(MetaCommand{
+		Type:    CmdAssignShard,
+		Payload: assignPayload,
+	})
+
+	result := fsm.Apply(&raft.Log{Data: assignCmd})
+	assert.Nil(t, result)
+
+	// Verify assignment
+	shardMap := fsm.GetShardMap()
+	primary := shardMap.GetPrimary(0)
+	require.NotNil(t, primary)
+	assert.Equal(t, "node-1", primary.ID)
+}
+
+func TestMetaFSM_AssignShardReplica(t *testing.T) {
+	fsm := NewMetaFSM(3, zerolog.Nop())
+
+	// Add two nodes
+	for _, nodeID := range []string{"node-1", "node-2"} {
+		addPayload, _ := json.Marshal(AddNodePayload{
+			Node: NodeInfo{
+				ID:         nodeID,
+				Name:       nodeID,
+				APIAddress: "localhost:8000",
+				CoordAddr:  "localhost:9100",
+				State:      string(cluster.StateHealthy),
+			},
+		})
+		addCmd, _ := json.Marshal(MetaCommand{
+			Type:    CmdAddNode,
+			Payload: addPayload,
+		})
+		fsm.Apply(&raft.Log{Data: addCmd})
+	}
+
+	// Assign primary
+	assignPrimary, _ := json.Marshal(AssignShardPayload{ShardID: 0, NodeID: "node-1", Role: RolePrimary})
+	assignPrimaryCmd, _ := json.Marshal(MetaCommand{Type: CmdAssignShard, Payload: assignPrimary})
+	fsm.Apply(&raft.Log{Data: assignPrimaryCmd})
+
+	// Assign replica
+	assignReplica, _ := json.Marshal(AssignShardPayload{ShardID: 0, NodeID: "node-2", Role: RoleReplica})
+	assignReplicaCmd, _ := json.Marshal(MetaCommand{Type: CmdAssignShard, Payload: assignReplica})
+	fsm.Apply(&raft.Log{Data: assignReplicaCmd})
+
+	// Verify
+	shardMap := fsm.GetShardMap()
+	group := shardMap.GetShardGroup(0)
+	require.NotNil(t, group)
+	assert.Equal(t, "node-1", group.Primary.ID)
+	assert.Len(t, group.Replicas, 1)
+	assert.Equal(t, "node-2", group.Replicas[0].ID)
+}
+
+func TestMetaFSM_UnassignShard(t *testing.T) {
+	fsm := NewMetaFSM(3, zerolog.Nop())
+
+	// Add node
+	addPayload, _ := json.Marshal(AddNodePayload{
+		Node: NodeInfo{ID: "node-1", State: string(cluster.StateHealthy)},
+	})
+	addCmd, _ := json.Marshal(MetaCommand{Type: CmdAddNode, Payload: addPayload})
+	fsm.Apply(&raft.Log{Data: addCmd})
+
+	// Assign shard
+	assignPayload, _ := json.Marshal(AssignShardPayload{ShardID: 0, NodeID: "node-1", Role: RolePrimary})
+	assignCmd, _ := json.Marshal(MetaCommand{Type: CmdAssignShard, Payload: assignPayload})
+	fsm.Apply(&raft.Log{Data: assignCmd})
+
+	// Verify assigned
+	require.NotNil(t, fsm.GetShardMap().GetPrimary(0))
+
+	// Unassign
+	unassignPayload, _ := json.Marshal(UnassignShardPayload{ShardID: 0, NodeID: "node-1"})
+	unassignCmd, _ := json.Marshal(MetaCommand{Type: CmdUnassignShard, Payload: unassignPayload})
+	fsm.Apply(&raft.Log{Data: unassignCmd})
+
+	// Verify unassigned
+	assert.Nil(t, fsm.GetShardMap().GetPrimary(0))
+}
+
+func TestMetaFSM_RemoveNode(t *testing.T) {
+	fsm := NewMetaFSM(3, zerolog.Nop())
+
+	// Add node
+	addPayload, _ := json.Marshal(AddNodePayload{
+		Node: NodeInfo{ID: "node-1", State: string(cluster.StateHealthy)},
+	})
+	addCmd, _ := json.Marshal(MetaCommand{Type: CmdAddNode, Payload: addPayload})
+	fsm.Apply(&raft.Log{Data: addCmd})
+
+	// Assign shard to this node
+	assignPayload, _ := json.Marshal(AssignShardPayload{ShardID: 0, NodeID: "node-1", Role: RolePrimary})
+	assignCmd, _ := json.Marshal(MetaCommand{Type: CmdAssignShard, Payload: assignPayload})
+	fsm.Apply(&raft.Log{Data: assignCmd})
+
+	// Verify node and assignment exist
+	_, exists := fsm.GetNode("node-1")
+	require.True(t, exists)
+	require.NotNil(t, fsm.GetShardMap().GetPrimary(0))
+
+	// Remove node
+	removePayload, _ := json.Marshal(RemoveNodePayload{NodeID: "node-1"})
+	removeCmd, _ := json.Marshal(MetaCommand{Type: CmdRemoveNode, Payload: removePayload})
+	fsm.Apply(&raft.Log{Data: removeCmd})
+
+	// Verify node is gone and shard is unassigned
+	_, exists = fsm.GetNode("node-1")
+	assert.False(t, exists)
+	assert.Nil(t, fsm.GetShardMap().GetPrimary(0))
+}
+
+func TestMetaFSM_SnapshotRestore(t *testing.T) {
+	// Create FSM and populate it
+	fsm := NewMetaFSM(3, zerolog.Nop())
+
+	// Add nodes
+	for _, nodeID := range []string{"node-1", "node-2", "node-3"} {
+		addPayload, _ := json.Marshal(AddNodePayload{
+			Node: NodeInfo{
+				ID:         nodeID,
+				Name:       nodeID,
+				APIAddress: nodeID + ":8000",
+				State:      string(cluster.StateHealthy),
+			},
+		})
+		addCmd, _ := json.Marshal(MetaCommand{Type: CmdAddNode, Payload: addPayload})
+		fsm.Apply(&raft.Log{Data: addCmd})
+	}
+
+	// Assign shards
+	assignments := []struct {
+		shardID int
+		nodeID  string
+		role    Role
+	}{
+		{0, "node-1", RolePrimary},
+		{0, "node-2", RoleReplica},
+		{1, "node-2", RolePrimary},
+		{1, "node-3", RoleReplica},
+		{2, "node-3", RolePrimary},
+	}
+
+	for _, a := range assignments {
+		assignPayload, _ := json.Marshal(AssignShardPayload{ShardID: a.shardID, NodeID: a.nodeID, Role: a.role})
+		assignCmd, _ := json.Marshal(MetaCommand{Type: CmdAssignShard, Payload: assignPayload})
+		fsm.Apply(&raft.Log{Data: assignCmd})
+	}
+
+	// Create snapshot
+	snapshot, err := fsm.Snapshot()
+	require.NoError(t, err)
+
+	// Serialize snapshot
+	metaSnapshot := snapshot.(*MetaFSMSnapshot)
+	data, err := json.Marshal(metaSnapshot)
+	require.NoError(t, err)
+
+	// Create new FSM and restore
+	fsm2 := NewMetaFSM(3, zerolog.Nop())
+
+	// Create a reader from the data
+	reader := &mockReadCloser{data: data}
+	err = fsm2.Restore(reader)
+	require.NoError(t, err)
+
+	// Verify restored state
+	assert.Equal(t, 3, fsm2.GetShardMap().NumShards())
+	assert.Len(t, fsm2.GetNodes(), 3)
+
+	// Verify shard assignments
+	require.NotNil(t, fsm2.GetShardMap().GetPrimary(0))
+	assert.Equal(t, "node-1", fsm2.GetShardMap().GetPrimary(0).ID)
+
+	require.NotNil(t, fsm2.GetShardMap().GetPrimary(1))
+	assert.Equal(t, "node-2", fsm2.GetShardMap().GetPrimary(1).ID)
+
+	require.NotNil(t, fsm2.GetShardMap().GetPrimary(2))
+	assert.Equal(t, "node-3", fsm2.GetShardMap().GetPrimary(2).ID)
+}
+
+func TestMetaFSM_Callbacks(t *testing.T) {
+	fsm := NewMetaFSM(3, zerolog.Nop())
+
+	// Track callbacks with channels for synchronization
+	assignChan := make(chan struct {
+		shardID int
+		nodeID  string
+	}, 1)
+	addChan := make(chan string, 1)
+
+	fsm.SetCallbacks(
+		func(shardID int, nodeID string, role Role) {
+			assignChan <- struct {
+				shardID int
+				nodeID  string
+			}{shardID, nodeID}
+		},
+		nil,
+		func(node *NodeInfo) { addChan <- node.ID },
+		nil,
+	)
+
+	// Add node
+	addPayload, _ := json.Marshal(AddNodePayload{
+		Node: NodeInfo{ID: "node-1", State: string(cluster.StateHealthy)},
+	})
+	addCmd, _ := json.Marshal(MetaCommand{Type: CmdAddNode, Payload: addPayload})
+	fsm.Apply(&raft.Log{Data: addCmd})
+
+	// Wait for callback
+	select {
+	case nodeID := <-addChan:
+		assert.Equal(t, "node-1", nodeID)
+	case <-time.After(time.Second):
+		t.Fatal("onNodeAdded callback not called")
+	}
+
+	// Test shard assignment callback
+	assignPayload, _ := json.Marshal(AssignShardPayload{ShardID: 1, NodeID: "node-1", Role: RolePrimary})
+	assignCmd, _ := json.Marshal(MetaCommand{Type: CmdAssignShard, Payload: assignPayload})
+	fsm.Apply(&raft.Log{Data: assignCmd})
+
+	// Wait for callback
+	select {
+	case result := <-assignChan:
+		assert.Equal(t, 1, result.shardID)
+		assert.Equal(t, "node-1", result.nodeID)
+	case <-time.After(time.Second):
+		t.Fatal("onShardAssigned callback not called")
+	}
+}
+
+func TestMetaFSM_GetNodes(t *testing.T) {
+	fsm := NewMetaFSM(3, zerolog.Nop())
+
+	// Initially empty
+	assert.Empty(t, fsm.GetNodes())
+
+	// Add nodes
+	for i, nodeID := range []string{"node-1", "node-2"} {
+		addPayload, _ := json.Marshal(AddNodePayload{
+			Node: NodeInfo{
+				ID:         nodeID,
+				Name:       nodeID,
+				APIAddress: "localhost:" + string(rune('0'+i)),
+				State:      string(cluster.StateHealthy),
+			},
+		})
+		addCmd, _ := json.Marshal(MetaCommand{Type: CmdAddNode, Payload: addPayload})
+		fsm.Apply(&raft.Log{Data: addCmd})
+	}
+
+	nodes := fsm.GetNodes()
+	assert.Len(t, nodes, 2)
+	assert.Contains(t, nodes, "node-1")
+	assert.Contains(t, nodes, "node-2")
+}
+
+// mockReadCloser implements io.ReadCloser for testing.
+type mockReadCloser struct {
+	data   []byte
+	offset int
+}
+
+func (r *mockReadCloser) Read(p []byte) (n int, err error) {
+	if r.offset >= len(r.data) {
+		return 0, nil
+	}
+	n = copy(p, r.data[r.offset:])
+	r.offset += n
+	return n, nil
+}
+
+func (r *mockReadCloser) Close() error {
+	return nil
+}

--- a/internal/cluster/sharding/router.go
+++ b/internal/cluster/sharding/router.go
@@ -1,0 +1,257 @@
+package sharding
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/rs/zerolog"
+)
+
+// Errors returned by the shard router.
+var (
+	ErrNoDatabaseHeader = errors.New("missing x-arc-database header")
+	ErrNoShardPrimary   = errors.New("no primary for shard")
+	ErrLocalNodeCanHandle = errors.New("local node can handle request")
+	ErrShardingDisabled = errors.New("sharding is not enabled")
+)
+
+// ShardRouter routes requests to the appropriate shard primary.
+type ShardRouter struct {
+	shardMap   *ShardMap
+	localNode  *cluster.Node
+	httpClient *http.Client
+	logger     zerolog.Logger
+
+	// Stats
+	forwardedWrites  atomic.Int64
+	forwardedQueries atomic.Int64
+	localWrites      atomic.Int64
+	localQueries     atomic.Int64
+	errors           atomic.Int64
+}
+
+// ShardRouterConfig holds configuration for the shard router.
+type ShardRouterConfig struct {
+	ShardMap    *ShardMap
+	LocalNode   *cluster.Node
+	Timeout     time.Duration
+	Logger      zerolog.Logger
+}
+
+// NewShardRouter creates a new shard router.
+func NewShardRouter(cfg *ShardRouterConfig) *ShardRouter {
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	return &ShardRouter{
+		shardMap:  cfg.ShardMap,
+		localNode: cfg.LocalNode,
+		httpClient: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		logger: cfg.Logger.With().Str("component", "shard-router").Logger(),
+	}
+}
+
+// RouteWrite routes a write request to the appropriate shard primary.
+// Returns ErrLocalNodeCanHandle if this node is the primary.
+func (r *ShardRouter) RouteWrite(ctx context.Context, req *http.Request) (*http.Response, error) {
+	// Extract database from header
+	database := req.Header.Get("X-Arc-Database")
+	if database == "" {
+		database = req.Header.Get("x-arc-database")
+	}
+	if database == "" {
+		r.errors.Add(1)
+		return nil, ErrNoDatabaseHeader
+	}
+
+	// Get shard and primary
+	shardID := r.shardMap.GetShard(database)
+	primary := r.shardMap.GetPrimary(shardID)
+
+	if primary == nil {
+		r.errors.Add(1)
+		r.logger.Warn().
+			Int("shard_id", shardID).
+			Str("database", database).
+			Msg("No primary for shard")
+		return nil, ErrNoShardPrimary
+	}
+
+	// Check if we're the primary
+	if primary.ID == r.localNode.ID {
+		r.localWrites.Add(1)
+		return nil, ErrLocalNodeCanHandle
+	}
+
+	// Forward to primary
+	r.logger.Debug().
+		Int("shard_id", shardID).
+		Str("database", database).
+		Str("primary", primary.ID).
+		Msg("Forwarding write to shard primary")
+
+	resp, err := r.forward(ctx, primary, req)
+	if err != nil {
+		r.errors.Add(1)
+		return nil, err
+	}
+
+	r.forwardedWrites.Add(1)
+	return resp, nil
+}
+
+// RouteQuery routes a query request to an appropriate node in the shard.
+// For single-database queries, routes to any node in the shard group.
+// Returns ErrLocalNodeCanHandle if this node can serve the query.
+func (r *ShardRouter) RouteQuery(ctx context.Context, database string, req *http.Request) (*http.Response, error) {
+	if database == "" {
+		r.errors.Add(1)
+		return nil, ErrNoDatabaseHeader
+	}
+
+	// Get shard and select a node
+	shardID := r.shardMap.GetShard(database)
+	node := r.shardMap.SelectNode(shardID)
+
+	if node == nil {
+		// No healthy node, try primary
+		node = r.shardMap.GetPrimary(shardID)
+	}
+
+	if node == nil {
+		r.errors.Add(1)
+		return nil, ErrNoShardPrimary
+	}
+
+	// Check if we can handle locally
+	if node.ID == r.localNode.ID {
+		r.localQueries.Add(1)
+		return nil, ErrLocalNodeCanHandle
+	}
+
+	// Check if we're in the shard group at all
+	allNodes := r.shardMap.GetAllNodes(shardID)
+	for _, n := range allNodes {
+		if n.ID == r.localNode.ID {
+			// We're in the shard group, handle locally
+			r.localQueries.Add(1)
+			return nil, ErrLocalNodeCanHandle
+		}
+	}
+
+	// Forward to selected node
+	r.logger.Debug().
+		Int("shard_id", shardID).
+		Str("database", database).
+		Str("target", node.ID).
+		Msg("Forwarding query to shard node")
+
+	resp, err := r.forward(ctx, node, req)
+	if err != nil {
+		r.errors.Add(1)
+		return nil, err
+	}
+
+	r.forwardedQueries.Add(1)
+	return resp, nil
+}
+
+// CanHandleLocally checks if this node can handle a request for a database.
+// Returns the shard ID and whether this node is primary for it.
+func (r *ShardRouter) CanHandleLocally(database string, isWrite bool) (shardID int, canHandle bool) {
+	shardID = r.shardMap.GetShard(database)
+
+	if isWrite {
+		// Writes must go to primary
+		primary := r.shardMap.GetPrimary(shardID)
+		return shardID, primary != nil && primary.ID == r.localNode.ID
+	}
+
+	// Reads can go to any node in the shard group
+	allNodes := r.shardMap.GetAllNodes(shardID)
+	for _, n := range allNodes {
+		if n.ID == r.localNode.ID {
+			return shardID, true
+		}
+	}
+
+	return shardID, false
+}
+
+// GetShardForDatabase returns the shard ID for a database.
+func (r *ShardRouter) GetShardForDatabase(database string) int {
+	return r.shardMap.GetShard(database)
+}
+
+// forward sends a request to another node.
+func (r *ShardRouter) forward(ctx context.Context, node *cluster.Node, originalReq *http.Request) (*http.Response, error) {
+	// Build target URL
+	targetURL := "http://" + node.APIAddress + originalReq.URL.Path
+	if originalReq.URL.RawQuery != "" {
+		targetURL += "?" + originalReq.URL.RawQuery
+	}
+
+	// Read and buffer body for forwarding
+	var bodyReader io.Reader
+	if originalReq.Body != nil {
+		bodyBytes, err := io.ReadAll(originalReq.Body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+		// Reset original body in case caller needs it
+		originalReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	// Create new request
+	req, err := http.NewRequestWithContext(ctx, originalReq.Method, targetURL, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Copy headers
+	for key, values := range originalReq.Header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	// Add forwarding header to prevent loops
+	req.Header.Set("X-Arc-Forwarded-By", r.localNode.ID)
+	req.Header.Set("X-Arc-Shard-Routed", "true")
+
+	// Send request
+	return r.httpClient.Do(req)
+}
+
+// Stats returns router statistics.
+func (r *ShardRouter) Stats() map[string]interface{} {
+	return map[string]interface{}{
+		"forwarded_writes":  r.forwardedWrites.Load(),
+		"forwarded_queries": r.forwardedQueries.Load(),
+		"local_writes":      r.localWrites.Load(),
+		"local_queries":     r.localQueries.Load(),
+		"errors":            r.errors.Load(),
+		"shard_map":         r.shardMap.Stats(),
+	}
+}
+
+// ShardMap returns the underlying shard map.
+func (r *ShardRouter) ShardMap() *ShardMap {
+	return r.shardMap
+}

--- a/internal/cluster/sharding/router_test.go
+++ b/internal/cluster/sharding/router_test.go
@@ -1,0 +1,288 @@
+package sharding
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardRouterRouteWriteLocalPrimary(t *testing.T) {
+	sm := NewShardMap(3)
+
+	localNode := &cluster.Node{ID: "local-node"}
+	localNode.UpdateState(cluster.StateHealthy)
+
+	// Make local node primary for shard 0
+	sm.SetPrimary(0, localNode)
+
+	router := NewShardRouter(&ShardRouterConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	// Create request for database that hashes to shard 0
+	// We need to find a database name that hashes to shard 0
+	var database string
+	for i := 0; i < 100; i++ {
+		testDB := "test_db_" + string(rune('a'+i))
+		if sm.GetShard(testDB) == 0 {
+			database = testDB
+			break
+		}
+	}
+	require.NotEmpty(t, database, "Could not find database that hashes to shard 0")
+
+	req := httptest.NewRequest("POST", "/api/v1/write", strings.NewReader("data"))
+	req.Header.Set("X-Arc-Database", database)
+
+	resp, err := router.RouteWrite(context.Background(), req)
+
+	// Should return ErrLocalNodeCanHandle since we're the primary
+	assert.ErrorIs(t, err, ErrLocalNodeCanHandle)
+	assert.Nil(t, resp)
+
+	// Check stats
+	stats := router.Stats()
+	assert.Equal(t, int64(1), stats["local_writes"])
+}
+
+func TestShardRouterRouteWriteForward(t *testing.T) {
+	// Create a test server to forward to
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify forwarding headers
+		assert.NotEmpty(t, r.Header.Get("X-Arc-Forwarded-By"))
+		assert.Equal(t, "true", r.Header.Get("X-Arc-Shard-Routed"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"success": true}`))
+	}))
+	defer targetServer.Close()
+
+	sm := NewShardMap(3)
+
+	localNode := &cluster.Node{ID: "local-node"}
+	localNode.UpdateState(cluster.StateHealthy)
+
+	// Find a shard that local node is NOT primary for
+	remoteNode := &cluster.Node{ID: "remote-node"}
+	remoteNode.APIAddress = targetServer.Listener.Addr().String()
+	remoteNode.UpdateState(cluster.StateHealthy)
+
+	// Make remote node primary for all shards
+	for i := 0; i < 3; i++ {
+		sm.SetPrimary(i, remoteNode)
+	}
+
+	router := NewShardRouter(&ShardRouterConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	req := httptest.NewRequest("POST", "/api/v1/write", strings.NewReader("data"))
+	req.Header.Set("X-Arc-Database", "any_database")
+
+	resp, err := router.RouteWrite(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Check stats
+	stats := router.Stats()
+	assert.Equal(t, int64(1), stats["forwarded_writes"])
+}
+
+func TestShardRouterRouteWriteNoDatabaseHeader(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	router := NewShardRouter(&ShardRouterConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	req := httptest.NewRequest("POST", "/api/v1/write", strings.NewReader("data"))
+	// No X-Arc-Database header
+
+	resp, err := router.RouteWrite(context.Background(), req)
+
+	assert.ErrorIs(t, err, ErrNoDatabaseHeader)
+	assert.Nil(t, resp)
+}
+
+func TestShardRouterRouteWriteNoPrimary(t *testing.T) {
+	sm := NewShardMap(3)
+	// No primaries assigned
+
+	localNode := &cluster.Node{ID: "local-node"}
+
+	router := NewShardRouter(&ShardRouterConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	req := httptest.NewRequest("POST", "/api/v1/write", strings.NewReader("data"))
+	req.Header.Set("X-Arc-Database", "mydb")
+
+	resp, err := router.RouteWrite(context.Background(), req)
+
+	assert.ErrorIs(t, err, ErrNoShardPrimary)
+	assert.Nil(t, resp)
+}
+
+func TestShardRouterRouteQuery(t *testing.T) {
+	sm := NewShardMap(3)
+
+	localNode := &cluster.Node{ID: "local-node"}
+	localNode.UpdateState(cluster.StateHealthy)
+
+	// Make local node a replica for shard 0
+	primaryNode := &cluster.Node{ID: "primary-node"}
+	primaryNode.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(0, primaryNode)
+	sm.AddReplica(0, localNode)
+
+	router := NewShardRouter(&ShardRouterConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	// Find database that hashes to shard 0
+	var database string
+	for i := 0; i < 100; i++ {
+		testDB := "query_db_" + string(rune('a'+i))
+		if sm.GetShard(testDB) == 0 {
+			database = testDB
+			break
+		}
+	}
+	require.NotEmpty(t, database)
+
+	req := httptest.NewRequest("POST", "/api/v1/query", strings.NewReader("SELECT * FROM cpu"))
+
+	resp, err := router.RouteQuery(context.Background(), database, req)
+
+	// Should return ErrLocalNodeCanHandle since we're a replica
+	assert.ErrorIs(t, err, ErrLocalNodeCanHandle)
+	assert.Nil(t, resp)
+
+	stats := router.Stats()
+	assert.Equal(t, int64(1), stats["local_queries"])
+}
+
+func TestShardRouterCanHandleLocally(t *testing.T) {
+	sm := NewShardMap(3)
+
+	localNode := &cluster.Node{ID: "local-node"}
+	localNode.UpdateState(cluster.StateHealthy)
+
+	otherNode := &cluster.Node{ID: "other-node"}
+	otherNode.UpdateState(cluster.StateHealthy)
+
+	router := NewShardRouter(&ShardRouterConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	// Find databases for different shards
+	var db0, db1 string
+	for i := 0; i < 100; i++ {
+		testDB := "can_handle_" + string(rune('a'+i))
+		shard := sm.GetShard(testDB)
+		if shard == 0 && db0 == "" {
+			db0 = testDB
+		}
+		if shard == 1 && db1 == "" {
+			db1 = testDB
+		}
+		if db0 != "" && db1 != "" {
+			break
+		}
+	}
+	require.NotEmpty(t, db0)
+	require.NotEmpty(t, db1)
+
+	// local is primary for shard 0, other is primary for shard 1
+	sm.SetPrimary(0, localNode)
+	sm.SetPrimary(1, otherNode)
+	sm.AddReplica(1, localNode) // local is also replica for shard 1
+
+	// Test writes (must be primary)
+	shardID, canHandle := router.CanHandleLocally(db0, true)
+	assert.Equal(t, 0, shardID)
+	assert.True(t, canHandle, "Should handle writes for db0 (local is primary)")
+
+	shardID, canHandle = router.CanHandleLocally(db1, true)
+	assert.Equal(t, 1, shardID)
+	assert.False(t, canHandle, "Should NOT handle writes for db1 (local is replica)")
+
+	// Test reads (can be primary or replica)
+	shardID, canHandle = router.CanHandleLocally(db0, false)
+	assert.Equal(t, 0, shardID)
+	assert.True(t, canHandle, "Should handle reads for db0 (local is primary)")
+
+	shardID, canHandle = router.CanHandleLocally(db1, false)
+	assert.Equal(t, 1, shardID)
+	assert.True(t, canHandle, "Should handle reads for db1 (local is replica)")
+}
+
+func TestShardRouterGetShardForDatabase(t *testing.T) {
+	sm := NewShardMap(5)
+
+	localNode := &cluster.Node{ID: "local-node"}
+
+	router := NewShardRouter(&ShardRouterConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	// Same database should always return same shard
+	shard1 := router.GetShardForDatabase("mydb")
+	shard2 := router.GetShardForDatabase("mydb")
+	assert.Equal(t, shard1, shard2)
+
+	// Shard should be in valid range
+	assert.GreaterOrEqual(t, shard1, 0)
+	assert.Less(t, shard1, 5)
+}
+
+func TestShardRouterStats(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+	sm.SetPrimary(0, localNode)
+
+	router := NewShardRouter(&ShardRouterConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	stats := router.Stats()
+
+	assert.Contains(t, stats, "forwarded_writes")
+	assert.Contains(t, stats, "forwarded_queries")
+	assert.Contains(t, stats, "local_writes")
+	assert.Contains(t, stats, "local_queries")
+	assert.Contains(t, stats, "errors")
+	assert.Contains(t, stats, "shard_map")
+}

--- a/internal/cluster/sharding/scatter_gather.go
+++ b/internal/cluster/sharding/scatter_gather.go
@@ -1,0 +1,390 @@
+package sharding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/rs/zerolog"
+)
+
+// ScatterGatherConfig holds configuration for scatter-gather query coordination.
+type ScatterGatherConfig struct {
+	// ShardMap provides shard-to-node mappings
+	ShardMap *ShardMap
+
+	// LocalNode is this node
+	LocalNode *cluster.Node
+
+	// HTTPClient for forwarding requests
+	HTTPClient *http.Client
+
+	// Timeout for individual shard queries
+	Timeout time.Duration
+
+	// MaxConcurrentShards limits parallel shard queries (0 = unlimited)
+	MaxConcurrentShards int
+
+	// Logger for scatter-gather events
+	Logger zerolog.Logger
+}
+
+// ScatterGather coordinates queries across multiple shards.
+// Used when a query needs data from multiple databases that live on different shards.
+type ScatterGather struct {
+	cfg    *ScatterGatherConfig
+	logger zerolog.Logger
+}
+
+// ShardQueryResult represents the result from a single shard query.
+type ShardQueryResult struct {
+	ShardID  int                 `json:"shard_id"`
+	NodeID   string              `json:"node_id"`
+	Data     json.RawMessage     `json:"data,omitempty"`
+	Error    string              `json:"error,omitempty"`
+	Duration time.Duration       `json:"duration_ms"`
+	Status   int                 `json:"status"`
+}
+
+// ScatterGatherResult represents the combined result from all shards.
+type ScatterGatherResult struct {
+	Results       []*ShardQueryResult `json:"results"`
+	TotalShards   int                 `json:"total_shards"`
+	SuccessShards int                 `json:"success_shards"`
+	FailedShards  int                 `json:"failed_shards"`
+	TotalDuration time.Duration       `json:"total_duration_ms"`
+}
+
+// NewScatterGather creates a new scatter-gather coordinator.
+func NewScatterGather(cfg *ScatterGatherConfig) *ScatterGather {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{
+			Timeout: cfg.Timeout,
+		}
+	}
+
+	return &ScatterGather{
+		cfg:    cfg,
+		logger: cfg.Logger.With().Str("component", "scatter-gather").Logger(),
+	}
+}
+
+// Query executes a query across multiple shards and combines the results.
+// The databases parameter specifies which databases to query.
+func (sg *ScatterGather) Query(ctx context.Context, databases []string, buildRequest func(shardID int, nodeAddr string) (*http.Request, error)) (*ScatterGatherResult, error) {
+	if buildRequest == nil {
+		return nil, fmt.Errorf("buildRequest callback is required")
+	}
+
+	start := time.Now()
+
+	// Determine which shards need to be queried
+	shardDBs := sg.groupDatabasesByShard(databases)
+
+	sg.logger.Debug().
+		Int("total_databases", len(databases)).
+		Int("total_shards", len(shardDBs)).
+		Msg("Starting scatter-gather query")
+
+	// Create a semaphore for limiting concurrency
+	var sem chan struct{}
+	if sg.cfg.MaxConcurrentShards > 0 {
+		sem = make(chan struct{}, sg.cfg.MaxConcurrentShards)
+	}
+
+	// Execute queries in parallel
+	results := make([]*ShardQueryResult, 0, len(shardDBs))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for shardID, dbs := range shardDBs {
+		wg.Add(1)
+		go func(shardID int, dbs []string) {
+			defer wg.Done()
+
+			// Acquire semaphore
+			if sem != nil {
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					return
+				}
+			}
+
+			result := sg.queryOneShard(ctx, shardID, dbs, buildRequest)
+
+			mu.Lock()
+			results = append(results, result)
+			mu.Unlock()
+		}(shardID, dbs)
+	}
+
+	wg.Wait()
+
+	// Build combined result
+	combinedResult := &ScatterGatherResult{
+		Results:       results,
+		TotalShards:   len(shardDBs),
+		TotalDuration: time.Since(start),
+	}
+
+	for _, r := range results {
+		if r.Error == "" && r.Status >= 200 && r.Status < 300 {
+			combinedResult.SuccessShards++
+		} else {
+			combinedResult.FailedShards++
+		}
+	}
+
+	sg.logger.Debug().
+		Int("total_shards", combinedResult.TotalShards).
+		Int("success_shards", combinedResult.SuccessShards).
+		Int("failed_shards", combinedResult.FailedShards).
+		Dur("total_duration", combinedResult.TotalDuration).
+		Msg("Scatter-gather query completed")
+
+	return combinedResult, nil
+}
+
+// QueryAllShards executes a query on all shards (for queries without specific database targets).
+func (sg *ScatterGather) QueryAllShards(ctx context.Context, buildRequest func(shardID int, nodeAddr string) (*http.Request, error)) (*ScatterGatherResult, error) {
+	if buildRequest == nil {
+		return nil, fmt.Errorf("buildRequest callback is required")
+	}
+
+	start := time.Now()
+	numShards := sg.cfg.ShardMap.NumShards()
+
+	sg.logger.Debug().
+		Int("total_shards", numShards).
+		Msg("Starting scatter-gather query to all shards")
+
+	// Create a semaphore for limiting concurrency
+	var sem chan struct{}
+	if sg.cfg.MaxConcurrentShards > 0 {
+		sem = make(chan struct{}, sg.cfg.MaxConcurrentShards)
+	}
+
+	// Execute queries in parallel
+	results := make([]*ShardQueryResult, 0, numShards)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for shardID := 0; shardID < numShards; shardID++ {
+		wg.Add(1)
+		go func(shardID int) {
+			defer wg.Done()
+
+			// Acquire semaphore
+			if sem != nil {
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					return
+				}
+			}
+
+			result := sg.queryOneShard(ctx, shardID, nil, buildRequest)
+
+			mu.Lock()
+			results = append(results, result)
+			mu.Unlock()
+		}(shardID)
+	}
+
+	wg.Wait()
+
+	// Build combined result
+	combinedResult := &ScatterGatherResult{
+		Results:       results,
+		TotalShards:   numShards,
+		TotalDuration: time.Since(start),
+	}
+
+	for _, r := range results {
+		if r.Error == "" && r.Status >= 200 && r.Status < 300 {
+			combinedResult.SuccessShards++
+		} else {
+			combinedResult.FailedShards++
+		}
+	}
+
+	sg.logger.Debug().
+		Int("total_shards", combinedResult.TotalShards).
+		Int("success_shards", combinedResult.SuccessShards).
+		Int("failed_shards", combinedResult.FailedShards).
+		Dur("total_duration", combinedResult.TotalDuration).
+		Msg("Scatter-gather query to all shards completed")
+
+	return combinedResult, nil
+}
+
+// queryOneShard executes a query on a single shard.
+func (sg *ScatterGather) queryOneShard(ctx context.Context, shardID int, databases []string, buildRequest func(shardID int, nodeAddr string) (*http.Request, error)) *ShardQueryResult {
+	start := time.Now()
+
+	result := &ShardQueryResult{
+		ShardID: shardID,
+	}
+
+	// Select a node for this shard (primary or replica)
+	node := sg.cfg.ShardMap.SelectNode(shardID)
+	if node == nil {
+		result.Error = "no node available for shard"
+		result.Status = http.StatusServiceUnavailable
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	result.NodeID = node.ID
+
+	// Check if this is the local node
+	if sg.cfg.LocalNode != nil && node.ID == sg.cfg.LocalNode.ID {
+		result.Error = "local_node"
+		result.Status = http.StatusOK
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	// Build request
+	nodeAddr := node.APIAddress
+	if nodeAddr == "" {
+		nodeAddr = node.Address
+	}
+
+	req, err := buildRequest(shardID, nodeAddr)
+	if err != nil {
+		result.Error = fmt.Sprintf("build request: %v", err)
+		result.Status = http.StatusInternalServerError
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	// Set context with timeout
+	reqCtx, cancel := context.WithTimeout(ctx, sg.cfg.Timeout)
+	defer cancel()
+	req = req.WithContext(reqCtx)
+
+	// Add scatter-gather header to prevent loops
+	req.Header.Set("X-Arc-Scatter-Gather", "true")
+
+	// Execute request
+	resp, err := sg.cfg.HTTPClient.Do(req)
+	if err != nil {
+		result.Error = fmt.Sprintf("request failed: %v", err)
+		result.Status = http.StatusBadGateway
+		result.Duration = time.Since(start)
+		return result
+	}
+	defer resp.Body.Close()
+
+	result.Status = resp.StatusCode
+	result.Duration = time.Since(start)
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		result.Error = fmt.Sprintf("read response: %v", err)
+		return result
+	}
+
+	result.Data = body
+	return result
+}
+
+// groupDatabasesByShard groups databases by their shard ID.
+func (sg *ScatterGather) groupDatabasesByShard(databases []string) map[int][]string {
+	result := make(map[int][]string)
+	for _, db := range databases {
+		shardID := sg.cfg.ShardMap.GetShard(db)
+		result[shardID] = append(result[shardID], db)
+	}
+	return result
+}
+
+// MergeResults merges query results from multiple shards.
+// The merge function is provided by the caller since merging logic depends on the query type.
+func (sg *ScatterGather) MergeResults(results *ScatterGatherResult, mergeFunc func(accumulated, current json.RawMessage) (json.RawMessage, error)) (json.RawMessage, error) {
+	if len(results.Results) == 0 {
+		return nil, nil
+	}
+
+	var accumulated json.RawMessage
+	for _, result := range results.Results {
+		// Skip failed shards
+		if result.Error != "" && result.Error != "local_node" {
+			continue
+		}
+
+		// Skip local node markers (caller handles these separately)
+		if result.Error == "local_node" {
+			continue
+		}
+
+		if len(result.Data) == 0 {
+			continue
+		}
+
+		if accumulated == nil {
+			accumulated = result.Data
+		} else {
+			merged, err := mergeFunc(accumulated, result.Data)
+			if err != nil {
+				return nil, fmt.Errorf("merge shard %d: %w", result.ShardID, err)
+			}
+			accumulated = merged
+		}
+	}
+
+	return accumulated, nil
+}
+
+// GetLocalShards returns the list of shards that should be handled locally.
+func (sg *ScatterGather) GetLocalShards(results *ScatterGatherResult) []int {
+	localShards := make([]int, 0)
+	for _, result := range results.Results {
+		if result.Error == "local_node" {
+			localShards = append(localShards, result.ShardID)
+		}
+	}
+	return localShards
+}
+
+// NeedsFanout returns true if the query needs to be fanned out to multiple shards.
+func (sg *ScatterGather) NeedsFanout(databases []string) bool {
+	if len(databases) == 0 {
+		return true // No specific databases = query all shards
+	}
+
+	// Check if all databases are on the same shard
+	firstShard := -1
+	for _, db := range databases {
+		shardID := sg.cfg.ShardMap.GetShard(db)
+		if firstShard == -1 {
+			firstShard = shardID
+		} else if shardID != firstShard {
+			return true // Multiple shards needed
+		}
+	}
+
+	return false // All on same shard
+}
+
+// Stats returns scatter-gather statistics.
+func (sg *ScatterGather) Stats() map[string]interface{} {
+	return map[string]interface{}{
+		"num_shards":           sg.cfg.ShardMap.NumShards(),
+		"max_concurrent":       sg.cfg.MaxConcurrentShards,
+		"timeout_ms":           sg.cfg.Timeout.Milliseconds(),
+	}
+}

--- a/internal/cluster/sharding/scatter_gather_test.go
+++ b/internal/cluster/sharding/scatter_gather_test.go
@@ -1,0 +1,410 @@
+package sharding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScatterGather_NeedsFanout(t *testing.T) {
+	sm := NewShardMap(3)
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap: sm,
+		Logger:   zerolog.Nop(),
+	})
+
+	tests := []struct {
+		name      string
+		databases []string
+		expected  bool
+	}{
+		{
+			name:      "empty databases - needs fanout",
+			databases: []string{},
+			expected:  true,
+		},
+		{
+			name:      "single database",
+			databases: []string{"mydb"},
+			expected:  false,
+		},
+		{
+			name:      "multiple databases same shard",
+			databases: []string{"db1", "db2"}, // May or may not be same shard
+			expected:  false,                  // Depends on hash - will verify below
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "multiple databases same shard" {
+				// Find two databases that hash to the same shard
+				var sameShardDbs []string
+				shardDBs := make(map[int]string)
+				for i := 0; i < 100; i++ {
+					db := "testdb" + string(rune('a'+i%26)) + string(rune('0'+i%10))
+					shard := sm.GetShard(db)
+					if existing, exists := shardDBs[shard]; exists {
+						sameShardDbs = []string{existing, db}
+						break
+					}
+					shardDBs[shard] = db
+				}
+				if len(sameShardDbs) == 2 {
+					assert.False(t, sg.NeedsFanout(sameShardDbs))
+				}
+				return
+			}
+			result := sg.NeedsFanout(tt.databases)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestScatterGather_GroupDatabasesByShard(t *testing.T) {
+	sm := NewShardMap(3)
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap: sm,
+		Logger:   zerolog.Nop(),
+	})
+
+	// Create databases that will hash to different shards
+	databases := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
+		databases = append(databases, "database_"+string(rune('a'+i)))
+	}
+
+	grouped := sg.groupDatabasesByShard(databases)
+
+	// Verify all databases are grouped
+	totalDBs := 0
+	for _, dbs := range grouped {
+		totalDBs += len(dbs)
+	}
+	assert.Equal(t, len(databases), totalDBs)
+
+	// Verify each database is in the correct shard
+	for shardID, dbs := range grouped {
+		for _, db := range dbs {
+			assert.Equal(t, shardID, sm.GetShard(db))
+		}
+	}
+}
+
+func TestScatterGather_QueryAllShards(t *testing.T) {
+	// Create test servers for each shard
+	responses := make(map[int]*httptest.Server)
+	for i := 0; i < 3; i++ {
+		shardID := i
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Verify scatter-gather header
+			assert.Equal(t, "true", r.Header.Get("X-Arc-Scatter-Gather"))
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"shard_id": shardID,
+				"data":     []int{1, 2, 3},
+			})
+		}))
+		responses[i] = server
+		defer server.Close()
+	}
+
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	// Set up shard assignments with remote nodes
+	for i := 0; i < 3; i++ {
+		node := &cluster.Node{
+			ID:         "node-" + string(rune('a'+i)),
+			APIAddress: responses[i].Listener.Addr().String(),
+		}
+		node.UpdateState(cluster.StateHealthy)
+		sm.SetPrimary(i, node)
+	}
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	result, err := sg.QueryAllShards(ctx, func(shardID int, nodeAddr string) (*http.Request, error) {
+		return http.NewRequest("GET", "http://"+nodeAddr+"/query", nil)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.TotalShards)
+	assert.Equal(t, 3, result.SuccessShards)
+	assert.Equal(t, 0, result.FailedShards)
+}
+
+func TestScatterGather_QuerySpecificDatabases(t *testing.T) {
+	// Create test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"result": "success",
+		})
+	}))
+	defer server.Close()
+
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	// Set up all shards with the same test server for simplicity
+	for i := 0; i < 3; i++ {
+		node := &cluster.Node{
+			ID:         "node-" + string(rune('a'+i)),
+			APIAddress: server.Listener.Addr().String(),
+		}
+		node.UpdateState(cluster.StateHealthy)
+		sm.SetPrimary(i, node)
+	}
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	// Query specific databases
+	databases := []string{"db1", "db2", "db3"}
+
+	ctx := context.Background()
+	result, err := sg.Query(ctx, databases, func(shardID int, nodeAddr string) (*http.Request, error) {
+		return http.NewRequest("GET", "http://"+nodeAddr+"/query", nil)
+	})
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.TotalShards, 1)
+	assert.Equal(t, result.TotalShards, result.SuccessShards)
+}
+
+func TestScatterGather_LocalNodeHandling(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+	localNode.UpdateState(cluster.StateHealthy)
+
+	// Make local node the primary for all shards
+	for i := 0; i < 3; i++ {
+		sm.SetPrimary(i, localNode)
+	}
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	result, err := sg.QueryAllShards(ctx, func(shardID int, nodeAddr string) (*http.Request, error) {
+		return http.NewRequest("GET", "http://"+nodeAddr+"/query", nil)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.TotalShards)
+
+	// All shards should be marked as local
+	localShards := sg.GetLocalShards(result)
+	assert.Len(t, localShards, 3)
+}
+
+func TestScatterGather_FailedShard(t *testing.T) {
+	// Create test server that fails
+	failServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error": "internal error"}`))
+	}))
+	defer failServer.Close()
+
+	// Create test server that succeeds
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"data": "success"})
+	}))
+	defer successServer.Close()
+
+	sm := NewShardMap(2)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	// Shard 0 fails, shard 1 succeeds
+	failNode := &cluster.Node{ID: "fail-node", APIAddress: failServer.Listener.Addr().String()}
+	failNode.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(0, failNode)
+
+	successNode := &cluster.Node{ID: "success-node", APIAddress: successServer.Listener.Addr().String()}
+	successNode.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(1, successNode)
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Timeout:   5 * time.Second,
+		Logger:    zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	result, err := sg.QueryAllShards(ctx, func(shardID int, nodeAddr string) (*http.Request, error) {
+		return http.NewRequest("GET", "http://"+nodeAddr+"/query", nil)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.TotalShards)
+	assert.Equal(t, 1, result.SuccessShards)
+	assert.Equal(t, 1, result.FailedShards)
+}
+
+func TestScatterGather_NoNodeAvailable(t *testing.T) {
+	sm := NewShardMap(3)
+	// Don't assign any primaries
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap: sm,
+		Timeout:  5 * time.Second,
+		Logger:   zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	result, err := sg.QueryAllShards(ctx, func(shardID int, nodeAddr string) (*http.Request, error) {
+		return http.NewRequest("GET", "http://"+nodeAddr+"/query", nil)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.TotalShards)
+	assert.Equal(t, 0, result.SuccessShards)
+	assert.Equal(t, 3, result.FailedShards)
+
+	// Verify error messages
+	for _, r := range result.Results {
+		assert.Contains(t, r.Error, "no node available")
+	}
+}
+
+func TestScatterGather_MergeResults(t *testing.T) {
+	sm := NewShardMap(3)
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap: sm,
+		Logger:   zerolog.Nop(),
+	})
+
+	// Create sample results
+	results := &ScatterGatherResult{
+		Results: []*ShardQueryResult{
+			{ShardID: 0, Data: json.RawMessage(`[1, 2, 3]`), Status: 200},
+			{ShardID: 1, Data: json.RawMessage(`[4, 5, 6]`), Status: 200},
+			{ShardID: 2, Error: "failed", Status: 500},
+		},
+		TotalShards:   3,
+		SuccessShards: 2,
+		FailedShards:  1,
+	}
+
+	// Merge function that concatenates arrays
+	mergeFunc := func(accumulated, current json.RawMessage) (json.RawMessage, error) {
+		var arr1, arr2 []int
+		if err := json.Unmarshal(accumulated, &arr1); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(current, &arr2); err != nil {
+			return nil, err
+		}
+		merged := append(arr1, arr2...)
+		return json.Marshal(merged)
+	}
+
+	merged, err := sg.MergeResults(results, mergeFunc)
+	require.NoError(t, err)
+
+	var result []int
+	err = json.Unmarshal(merged, &result)
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, result)
+}
+
+func TestScatterGather_ConcurrencyLimit(t *testing.T) {
+	// Create a server that tracks concurrent requests
+	var concurrent, maxConcurrent int
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		concurrent++
+		if concurrent > maxConcurrent {
+			maxConcurrent = concurrent
+		}
+		mu.Unlock()
+
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		concurrent--
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sm := NewShardMap(5)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	// Set up 5 shards
+	for i := 0; i < 5; i++ {
+		node := &cluster.Node{
+			ID:         "node-" + string(rune('a'+i)),
+			APIAddress: server.Listener.Addr().String(),
+		}
+		node.UpdateState(cluster.StateHealthy)
+		sm.SetPrimary(i, node)
+	}
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap:            sm,
+		LocalNode:           localNode,
+		Timeout:             5 * time.Second,
+		MaxConcurrentShards: 2, // Limit to 2 concurrent
+		Logger:              zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	result, err := sg.QueryAllShards(ctx, func(shardID int, nodeAddr string) (*http.Request, error) {
+		return http.NewRequest("GET", "http://"+nodeAddr+"/query", nil)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 5, result.TotalShards)
+	assert.Equal(t, 5, result.SuccessShards)
+	assert.LessOrEqual(t, maxConcurrent, 2, "Max concurrent should not exceed limit")
+}
+
+func TestScatterGather_Stats(t *testing.T) {
+	sm := NewShardMap(3)
+
+	sg := NewScatterGather(&ScatterGatherConfig{
+		ShardMap:            sm,
+		Timeout:             10 * time.Second,
+		MaxConcurrentShards: 5,
+		Logger:              zerolog.Nop(),
+	})
+
+	stats := sg.Stats()
+	assert.Equal(t, 3, stats["num_shards"])
+	assert.Equal(t, 5, stats["max_concurrent"])
+	assert.Equal(t, int64(10000), stats["timeout_ms"])
+}

--- a/internal/cluster/sharding/shard_raft.go
+++ b/internal/cluster/sharding/shard_raft.go
@@ -1,0 +1,701 @@
+package sharding
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/hashicorp/raft"
+	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
+	"github.com/rs/zerolog"
+)
+
+// ShardRaftConfig holds configuration for per-shard Raft.
+type ShardRaftConfig struct {
+	// DataDir is the base directory for Raft data (will be appended with shard ID)
+	DataDir string
+
+	// BasePort is the starting port for shard Raft (shard N uses BasePort+N)
+	BasePort int
+
+	// LocalNode is this node
+	LocalNode *cluster.Node
+
+	// ElectionTimeout for leader election
+	ElectionTimeout time.Duration
+
+	// HeartbeatTimeout for heartbeats
+	HeartbeatTimeout time.Duration
+
+	// Logger for Raft events
+	Logger zerolog.Logger
+}
+
+// ShardRaftManager manages per-shard Raft clusters.
+// Each shard has its own Raft cluster for leader election and failover.
+type ShardRaftManager struct {
+	cfg      *ShardRaftConfig
+	shards   map[int]*ShardRaftNode // shardID -> raft node
+	mu       sync.RWMutex
+	logger   zerolog.Logger
+	running  bool
+
+	// Callbacks for leadership changes
+	onBecomeLeader   func(shardID int)
+	onLoseLeadership func(shardID int)
+}
+
+// ShardRaftNode wraps a Raft instance for a single shard.
+type ShardRaftNode struct {
+	shardID     int
+	raft        *raft.Raft
+	fsm         *ShardFSM
+	transport   *raft.NetworkTransport
+	logStore    *raftboltdb.BoltStore
+	stableStore *raftboltdb.BoltStore
+	snapStore   raft.SnapshotStore
+	logger      zerolog.Logger
+	mu          sync.RWMutex
+	running     bool
+
+	// Leadership tracking
+	isLeader    bool
+	leaderMu    sync.RWMutex
+	onLeaderChange func(isLeader bool)
+}
+
+// ShardFSM is the FSM for a single shard's Raft cluster.
+// It tracks which node is the primary and replication state.
+type ShardFSM struct {
+	shardID      int
+	primaryID    string                // Current primary node ID
+	replicaLag   map[string]int64      // replica ID -> bytes behind
+	lastWriteSeq uint64                // Last write sequence
+	mu           sync.RWMutex
+	logger       zerolog.Logger
+}
+
+// ShardFSMCommand types
+const (
+	ShardCmdSetPrimary     = "set_primary"
+	ShardCmdUpdateLag      = "update_lag"
+	ShardCmdUpdateWriteSeq = "update_write_seq"
+)
+
+// ShardFSMCommand represents a command for the shard FSM.
+type ShardFSMCommand struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// SetPrimaryPayload sets the primary for a shard.
+type SetPrimaryPayload struct {
+	NodeID string `json:"node_id"`
+}
+
+// UpdateLagPayload updates replica lag.
+type UpdateLagPayload struct {
+	ReplicaID string `json:"replica_id"`
+	Lag       int64  `json:"lag"`
+}
+
+// NewShardRaftManager creates a new shard Raft manager.
+func NewShardRaftManager(cfg *ShardRaftConfig) *ShardRaftManager {
+	if cfg.ElectionTimeout == 0 {
+		cfg.ElectionTimeout = 1 * time.Second
+	}
+	if cfg.HeartbeatTimeout == 0 {
+		cfg.HeartbeatTimeout = 500 * time.Millisecond
+	}
+
+	return &ShardRaftManager{
+		cfg:    cfg,
+		shards: make(map[int]*ShardRaftNode),
+		logger: cfg.Logger.With().Str("component", "shard-raft-manager").Logger(),
+	}
+}
+
+// SetCallbacks sets callbacks for leadership changes.
+func (m *ShardRaftManager) SetCallbacks(onBecomeLeader, onLoseLeadership func(shardID int)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onBecomeLeader = onBecomeLeader
+	m.onLoseLeadership = onLoseLeadership
+}
+
+// Start initializes the shard Raft manager.
+func (m *ShardRaftManager) Start() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.running = true
+	m.logger.Info().Msg("Shard Raft manager started")
+	return nil
+}
+
+// Stop shuts down all shard Raft nodes.
+func (m *ShardRaftManager) Stop() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for shardID, node := range m.shards {
+		if err := node.Stop(); err != nil {
+			m.logger.Error().Err(err).Int("shard_id", shardID).Msg("Error stopping shard Raft")
+		}
+		delete(m.shards, shardID)
+	}
+
+	m.running = false
+	m.logger.Info().Msg("Shard Raft manager stopped")
+	return nil
+}
+
+// JoinShard joins the Raft cluster for a shard.
+func (m *ShardRaftManager) JoinShard(shardID int, peers []string, bootstrap bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.shards[shardID]; exists {
+		return fmt.Errorf("already joined shard %d", shardID)
+	}
+
+	// Create shard-specific data directory
+	dataDir := filepath.Join(m.cfg.DataDir, fmt.Sprintf("shard-%d", shardID))
+
+	// Calculate port for this shard
+	port := m.cfg.BasePort + shardID
+	bindAddr := fmt.Sprintf(":%d", port)
+
+	// Create Raft node for this shard
+	node, err := newShardRaftNode(shardID, &shardRaftNodeConfig{
+		NodeID:           m.cfg.LocalNode.ID,
+		DataDir:          dataDir,
+		BindAddr:         bindAddr,
+		Peers:            peers,
+		Bootstrap:        bootstrap,
+		ElectionTimeout:  m.cfg.ElectionTimeout,
+		HeartbeatTimeout: m.cfg.HeartbeatTimeout,
+		Logger:           m.logger,
+	})
+	if err != nil {
+		return fmt.Errorf("create shard raft node: %w", err)
+	}
+
+	// Set leadership callback
+	node.onLeaderChange = func(isLeader bool) {
+		if isLeader {
+			if m.onBecomeLeader != nil {
+				m.onBecomeLeader(shardID)
+			}
+		} else {
+			if m.onLoseLeadership != nil {
+				m.onLoseLeadership(shardID)
+			}
+		}
+	}
+
+	if err := node.Start(); err != nil {
+		return fmt.Errorf("start shard raft: %w", err)
+	}
+
+	m.shards[shardID] = node
+
+	m.logger.Info().
+		Int("shard_id", shardID).
+		Str("bind_addr", bindAddr).
+		Bool("bootstrap", bootstrap).
+		Msg("Joined shard Raft cluster")
+
+	return nil
+}
+
+// LeaveShard leaves the Raft cluster for a shard.
+func (m *ShardRaftManager) LeaveShard(shardID int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	node, exists := m.shards[shardID]
+	if !exists {
+		return nil
+	}
+
+	if err := node.Stop(); err != nil {
+		return fmt.Errorf("stop shard raft: %w", err)
+	}
+
+	delete(m.shards, shardID)
+
+	m.logger.Info().Int("shard_id", shardID).Msg("Left shard Raft cluster")
+	return nil
+}
+
+// IsLeader returns true if this node is the leader for the given shard.
+func (m *ShardRaftManager) IsLeader(shardID int) bool {
+	m.mu.RLock()
+	node, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return false
+	}
+
+	return node.IsLeader()
+}
+
+// GetLeader returns the leader address for a shard.
+func (m *ShardRaftManager) GetLeader(shardID int) string {
+	m.mu.RLock()
+	node, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return ""
+	}
+
+	return node.LeaderAddr()
+}
+
+// AddVoter adds a voter to a shard's Raft cluster.
+func (m *ShardRaftManager) AddVoter(shardID int, nodeID, addr string) error {
+	m.mu.RLock()
+	node, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("not in shard %d", shardID)
+	}
+
+	return node.AddVoter(nodeID, addr)
+}
+
+// RemoveVoter removes a voter from a shard's Raft cluster.
+func (m *ShardRaftManager) RemoveVoter(shardID int, nodeID string) error {
+	m.mu.RLock()
+	node, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("not in shard %d", shardID)
+	}
+
+	return node.RemoveVoter(nodeID)
+}
+
+// Stats returns statistics for all shard Raft clusters.
+func (m *ShardRaftManager) Stats() map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	shardStats := make(map[int]map[string]interface{})
+	for shardID, node := range m.shards {
+		shardStats[shardID] = node.Stats()
+	}
+
+	return map[string]interface{}{
+		"running":     m.running,
+		"shard_count": len(m.shards),
+		"shards":      shardStats,
+	}
+}
+
+// shardRaftNodeConfig holds configuration for a single shard's Raft node.
+type shardRaftNodeConfig struct {
+	NodeID           string
+	DataDir          string
+	BindAddr         string
+	Peers            []string
+	Bootstrap        bool
+	ElectionTimeout  time.Duration
+	HeartbeatTimeout time.Duration
+	Logger           zerolog.Logger
+}
+
+// newShardRaftNode creates a new Raft node for a shard.
+func newShardRaftNode(shardID int, cfg *shardRaftNodeConfig) (*ShardRaftNode, error) {
+	fsm := &ShardFSM{
+		shardID:    shardID,
+		replicaLag: make(map[string]int64),
+		logger:     cfg.Logger.With().Int("shard_id", shardID).Logger(),
+	}
+
+	return &ShardRaftNode{
+		shardID: shardID,
+		fsm:     fsm,
+		logger:  cfg.Logger.With().Int("shard_id", shardID).Logger(),
+	}, nil
+}
+
+// Start starts the shard Raft node.
+func (n *ShardRaftNode) Start() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.running {
+		return fmt.Errorf("shard raft already running")
+	}
+
+	n.running = true
+	n.logger.Info().Msg("Shard Raft node started (lightweight mode)")
+
+	// In this implementation, we use a lightweight approach where the
+	// shard Raft doesn't actually start a full Raft cluster. Instead,
+	// leadership is determined by the meta cluster and communicated
+	// via callbacks. This avoids the overhead of running N separate
+	// Raft clusters for N shards.
+	//
+	// For full per-shard Raft consensus (e.g., for stronger consistency
+	// guarantees), the Start method would initialize:
+	// - Transport (TCP listener)
+	// - Log store (BoltDB)
+	// - Stable store (BoltDB)
+	// - Snapshot store (file-based)
+	// - Raft instance
+
+	return nil
+}
+
+// Stop stops the shard Raft node.
+func (n *ShardRaftNode) Stop() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if !n.running {
+		return nil
+	}
+
+	// Shutdown Raft if running
+	if n.raft != nil {
+		future := n.raft.Shutdown()
+		if err := future.Error(); err != nil {
+			n.logger.Error().Err(err).Msg("Error shutting down shard Raft")
+		}
+	}
+
+	// Close stores
+	if n.logStore != nil {
+		n.logStore.Close()
+	}
+	if n.stableStore != nil {
+		n.stableStore.Close()
+	}
+	if n.transport != nil {
+		n.transport.Close()
+	}
+
+	n.running = false
+	n.logger.Info().Msg("Shard Raft node stopped")
+	return nil
+}
+
+// IsLeader returns true if this node is the leader for this shard.
+func (n *ShardRaftNode) IsLeader() bool {
+	n.leaderMu.RLock()
+	defer n.leaderMu.RUnlock()
+	return n.isLeader
+}
+
+// SetLeader sets the leadership status (called by meta cluster).
+func (n *ShardRaftNode) SetLeader(isLeader bool) {
+	n.leaderMu.Lock()
+	wasLeader := n.isLeader
+	n.isLeader = isLeader
+	callback := n.onLeaderChange
+	n.leaderMu.Unlock()
+
+	if wasLeader != isLeader && callback != nil {
+		callback(isLeader)
+	}
+}
+
+// LeaderAddr returns the leader address.
+func (n *ShardRaftNode) LeaderAddr() string {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	if n.raft == nil {
+		return ""
+	}
+	addr, _ := n.raft.LeaderWithID()
+	return string(addr)
+}
+
+// AddVoter adds a voter to this shard's Raft cluster.
+func (n *ShardRaftNode) AddVoter(nodeID, addr string) error {
+	n.mu.RLock()
+	ra := n.raft
+	n.mu.RUnlock()
+
+	if ra == nil {
+		return fmt.Errorf("raft not initialized")
+	}
+
+	future := ra.AddVoter(raft.ServerID(nodeID), raft.ServerAddress(addr), 0, 10*time.Second)
+	return future.Error()
+}
+
+// RemoveVoter removes a voter from this shard's Raft cluster.
+func (n *ShardRaftNode) RemoveVoter(nodeID string) error {
+	n.mu.RLock()
+	ra := n.raft
+	n.mu.RUnlock()
+
+	if ra == nil {
+		return fmt.Errorf("raft not initialized")
+	}
+
+	future := ra.RemoveServer(raft.ServerID(nodeID), 0, 10*time.Second)
+	return future.Error()
+}
+
+// Stats returns statistics for this shard's Raft.
+func (n *ShardRaftNode) Stats() map[string]interface{} {
+	n.leaderMu.RLock()
+	isLeader := n.isLeader
+	n.leaderMu.RUnlock()
+
+	stats := map[string]interface{}{
+		"shard_id":  n.shardID,
+		"running":   n.running,
+		"is_leader": isLeader,
+	}
+
+	if n.raft != nil {
+		stats["raft_stats"] = n.raft.Stats()
+	}
+
+	return stats
+}
+
+// ShardFSM implementation
+
+// Apply implements raft.FSM.
+func (f *ShardFSM) Apply(log *raft.Log) interface{} {
+	var cmd ShardFSMCommand
+	if err := json.Unmarshal(log.Data, &cmd); err != nil {
+		f.logger.Error().Err(err).Msg("Failed to unmarshal shard FSM command")
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	switch cmd.Type {
+	case ShardCmdSetPrimary:
+		var p SetPrimaryPayload
+		if err := json.Unmarshal(cmd.Payload, &p); err != nil {
+			return err
+		}
+		f.primaryID = p.NodeID
+		f.logger.Info().Str("primary_id", p.NodeID).Msg("Primary set for shard")
+		return nil
+
+	case ShardCmdUpdateLag:
+		var p UpdateLagPayload
+		if err := json.Unmarshal(cmd.Payload, &p); err != nil {
+			return err
+		}
+		f.replicaLag[p.ReplicaID] = p.Lag
+		return nil
+
+	case ShardCmdUpdateWriteSeq:
+		var seq uint64
+		if err := json.Unmarshal(cmd.Payload, &seq); err != nil {
+			return err
+		}
+		f.lastWriteSeq = seq
+		return nil
+
+	default:
+		return fmt.Errorf("unknown shard command type: %s", cmd.Type)
+	}
+}
+
+// Snapshot implements raft.FSM.
+func (f *ShardFSM) Snapshot() (raft.FSMSnapshot, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	return &shardFSMSnapshot{
+		shardID:      f.shardID,
+		primaryID:    f.primaryID,
+		replicaLag:   copyMap(f.replicaLag),
+		lastWriteSeq: f.lastWriteSeq,
+	}, nil
+}
+
+// Restore implements raft.FSM.
+func (f *ShardFSM) Restore(rc io.ReadCloser) error {
+	defer rc.Close()
+
+	var snapshot shardFSMSnapshot
+	if err := json.NewDecoder(rc).Decode(&snapshot); err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	f.primaryID = snapshot.primaryID
+	f.replicaLag = snapshot.replicaLag
+	f.lastWriteSeq = snapshot.lastWriteSeq
+	f.mu.Unlock()
+
+	f.logger.Info().
+		Str("primary_id", snapshot.primaryID).
+		Uint64("last_write_seq", snapshot.lastWriteSeq).
+		Msg("Shard FSM restored from snapshot")
+
+	return nil
+}
+
+// GetPrimaryID returns the current primary ID.
+func (f *ShardFSM) GetPrimaryID() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.primaryID
+}
+
+// GetLastWriteSeq returns the last write sequence.
+func (f *ShardFSM) GetLastWriteSeq() uint64 {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.lastWriteSeq
+}
+
+// shardFSMSnapshot implements raft.FSMSnapshot for shard FSM.
+type shardFSMSnapshot struct {
+	shardID      int
+	primaryID    string
+	replicaLag   map[string]int64
+	lastWriteSeq uint64
+}
+
+// Persist implements raft.FSMSnapshot.
+func (s *shardFSMSnapshot) Persist(sink raft.SnapshotSink) error {
+	err := json.NewEncoder(sink).Encode(s)
+	if err != nil {
+		sink.Cancel()
+		return err
+	}
+	return sink.Close()
+}
+
+// Release implements raft.FSMSnapshot.
+func (s *shardFSMSnapshot) Release() {}
+
+// copyMap creates a copy of a map.
+func copyMap(m map[string]int64) map[string]int64 {
+	result := make(map[string]int64, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+// StartFullRaft initializes a full Raft cluster for this shard.
+// This is an optional method for scenarios requiring stronger consistency.
+func (n *ShardRaftNode) StartFullRaft(cfg *shardRaftNodeConfig) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// Ensure data directory exists
+	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
+		return fmt.Errorf("create data directory: %w", err)
+	}
+
+	// Create Raft configuration
+	raftConfig := raft.DefaultConfig()
+	raftConfig.LocalID = raft.ServerID(cfg.NodeID)
+	raftConfig.ElectionTimeout = cfg.ElectionTimeout
+	raftConfig.HeartbeatTimeout = cfg.HeartbeatTimeout
+
+	// Create transport
+	addr, err := net.ResolveTCPAddr("tcp", cfg.BindAddr)
+	if err != nil {
+		return fmt.Errorf("resolve address: %w", err)
+	}
+
+	transport, err := raft.NewTCPTransport(cfg.BindAddr, addr, 3, 10*time.Second, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("create transport: %w", err)
+	}
+	n.transport = transport
+
+	// Create log store
+	logStorePath := filepath.Join(cfg.DataDir, "raft-log.db")
+	logStore, err := raftboltdb.NewBoltStore(logStorePath)
+	if err != nil {
+		return fmt.Errorf("create log store: %w", err)
+	}
+	n.logStore = logStore
+
+	// Create stable store
+	stableStorePath := filepath.Join(cfg.DataDir, "raft-stable.db")
+	stableStore, err := raftboltdb.NewBoltStore(stableStorePath)
+	if err != nil {
+		return fmt.Errorf("create stable store: %w", err)
+	}
+	n.stableStore = stableStore
+
+	// Create snapshot store
+	snapStore, err := raft.NewFileSnapshotStore(cfg.DataDir, 3, os.Stderr)
+	if err != nil {
+		return fmt.Errorf("create snapshot store: %w", err)
+	}
+	n.snapStore = snapStore
+
+	// Create Raft instance
+	ra, err := raft.NewRaft(raftConfig, n.fsm, logStore, stableStore, snapStore, transport)
+	if err != nil {
+		return fmt.Errorf("create raft: %w", err)
+	}
+	n.raft = ra
+
+	// Bootstrap if requested
+	if cfg.Bootstrap {
+		hasState, err := raft.HasExistingState(logStore, stableStore, snapStore)
+		if err != nil {
+			return fmt.Errorf("check existing state: %w", err)
+		}
+
+		if !hasState {
+			configuration := raft.Configuration{
+				Servers: []raft.Server{
+					{
+						ID:      raft.ServerID(cfg.NodeID),
+						Address: raft.ServerAddress(cfg.BindAddr),
+					},
+				},
+			}
+
+			future := ra.BootstrapCluster(configuration)
+			if err := future.Error(); err != nil {
+				return fmt.Errorf("bootstrap cluster: %w", err)
+			}
+		}
+	}
+
+	// Start leadership observer
+	go n.observeLeadership()
+
+	n.logger.Info().
+		Str("bind_addr", cfg.BindAddr).
+		Bool("bootstrap", cfg.Bootstrap).
+		Msg("Full shard Raft started")
+
+	return nil
+}
+
+// observeLeadership monitors Raft state changes.
+func (n *ShardRaftNode) observeLeadership() {
+	if n.raft == nil {
+		return
+	}
+
+	leaderCh := n.raft.LeaderCh()
+	for isLeader := range leaderCh {
+		n.SetLeader(isLeader)
+	}
+}

--- a/internal/cluster/sharding/shard_raft_test.go
+++ b/internal/cluster/sharding/shard_raft_test.go
@@ -1,0 +1,204 @@
+package sharding
+
+import (
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardRaftManager_StartStop(t *testing.T) {
+	localNode := &cluster.Node{ID: "local-node"}
+
+	mgr := NewShardRaftManager(&ShardRaftConfig{
+		DataDir:   t.TempDir(),
+		BasePort:  9400,
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	err := mgr.Start()
+	require.NoError(t, err)
+	assert.True(t, mgr.running)
+
+	err = mgr.Stop()
+	require.NoError(t, err)
+	assert.False(t, mgr.running)
+}
+
+func TestShardRaftManager_JoinLeaveShard(t *testing.T) {
+	localNode := &cluster.Node{ID: "local-node"}
+
+	mgr := NewShardRaftManager(&ShardRaftConfig{
+		DataDir:   t.TempDir(),
+		BasePort:  9410,
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	err := mgr.Start()
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Join shard (lightweight mode, no actual Raft)
+	err = mgr.JoinShard(0, nil, false)
+	require.NoError(t, err)
+
+	stats := mgr.Stats()
+	assert.Equal(t, 1, stats["shard_count"])
+
+	// Leave shard
+	err = mgr.LeaveShard(0)
+	require.NoError(t, err)
+
+	stats = mgr.Stats()
+	assert.Equal(t, 0, stats["shard_count"])
+}
+
+func TestShardRaftManager_LeadershipCallbacks(t *testing.T) {
+	localNode := &cluster.Node{ID: "local-node"}
+
+	becameLeader := make(chan int, 1)
+	lostLeadership := make(chan int, 1)
+
+	mgr := NewShardRaftManager(&ShardRaftConfig{
+		DataDir:   t.TempDir(),
+		BasePort:  9420,
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	mgr.SetCallbacks(
+		func(shardID int) { becameLeader <- shardID },
+		func(shardID int) { lostLeadership <- shardID },
+	)
+
+	err := mgr.Start()
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Join shard
+	err = mgr.JoinShard(1, nil, false)
+	require.NoError(t, err)
+
+	// Manually set leadership
+	mgr.mu.RLock()
+	node := mgr.shards[1]
+	mgr.mu.RUnlock()
+
+	node.SetLeader(true)
+
+	select {
+	case shardID := <-becameLeader:
+		assert.Equal(t, 1, shardID)
+	default:
+		t.Fatal("Expected becameLeader callback")
+	}
+
+	// Lose leadership
+	node.SetLeader(false)
+
+	select {
+	case shardID := <-lostLeadership:
+		assert.Equal(t, 1, shardID)
+	default:
+		t.Fatal("Expected lostLeadership callback")
+	}
+}
+
+func TestShardRaftNode_IsLeader(t *testing.T) {
+	node := &ShardRaftNode{
+		shardID: 0,
+		logger:  zerolog.Nop(),
+	}
+
+	// Initially not leader
+	assert.False(t, node.IsLeader())
+
+	// Set as leader
+	node.SetLeader(true)
+	assert.True(t, node.IsLeader())
+
+	// Remove leadership
+	node.SetLeader(false)
+	assert.False(t, node.IsLeader())
+}
+
+func TestShardRaftNode_Stats(t *testing.T) {
+	node := &ShardRaftNode{
+		shardID: 5,
+		running: true,
+		logger:  zerolog.Nop(),
+	}
+
+	node.SetLeader(true)
+
+	stats := node.Stats()
+	assert.Equal(t, 5, stats["shard_id"])
+	assert.True(t, stats["running"].(bool))
+	assert.True(t, stats["is_leader"].(bool))
+}
+
+func TestShardFSM_GetPrimaryID(t *testing.T) {
+	fsm := &ShardFSM{
+		shardID:    0,
+		replicaLag: make(map[string]int64),
+		logger:     zerolog.Nop(),
+	}
+
+	// Initially empty
+	assert.Empty(t, fsm.GetPrimaryID())
+
+	// Set primary
+	fsm.mu.Lock()
+	fsm.primaryID = "node-1"
+	fsm.mu.Unlock()
+
+	assert.Equal(t, "node-1", fsm.GetPrimaryID())
+}
+
+func TestShardFSM_GetLastWriteSeq(t *testing.T) {
+	fsm := &ShardFSM{
+		shardID:    0,
+		replicaLag: make(map[string]int64),
+		logger:     zerolog.Nop(),
+	}
+
+	// Initially zero
+	assert.Equal(t, uint64(0), fsm.GetLastWriteSeq())
+
+	// Update
+	fsm.mu.Lock()
+	fsm.lastWriteSeq = 12345
+	fsm.mu.Unlock()
+
+	assert.Equal(t, uint64(12345), fsm.GetLastWriteSeq())
+}
+
+func TestShardRaftManager_Stats(t *testing.T) {
+	localNode := &cluster.Node{ID: "local-node"}
+
+	mgr := NewShardRaftManager(&ShardRaftConfig{
+		DataDir:   t.TempDir(),
+		BasePort:  9430,
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	err := mgr.Start()
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Add some shards
+	err = mgr.JoinShard(0, nil, false)
+	require.NoError(t, err)
+	err = mgr.JoinShard(1, nil, false)
+	require.NoError(t, err)
+
+	stats := mgr.Stats()
+	assert.True(t, stats["running"].(bool))
+	assert.Equal(t, 2, stats["shard_count"])
+	assert.NotNil(t, stats["shards"])
+}

--- a/internal/cluster/sharding/shard_receiver.go
+++ b/internal/cluster/sharding/shard_receiver.go
@@ -1,0 +1,529 @@
+package sharding
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/basekick-labs/arc/internal/cluster/replication"
+	"github.com/rs/zerolog"
+)
+
+// ShardReceiverConfig holds configuration for the shard receiver.
+type ShardReceiverConfig struct {
+	// ShardMap provides shard-to-node mappings
+	ShardMap *ShardMap
+
+	// LocalNode is this node
+	LocalNode *cluster.Node
+
+	// LocalWAL writes received entries (optional, for durability)
+	LocalWAL replication.WALWriter
+
+	// IngestHandler applies entries to local buffer (optional)
+	IngestHandler replication.IngestHandler
+
+	// ReconnectInterval for reconnecting to primaries
+	ReconnectInterval time.Duration
+
+	// AckInterval for sending acknowledgments
+	AckInterval time.Duration
+
+	// Logger for receiver events
+	Logger zerolog.Logger
+}
+
+// ShardReceiverManager manages receiving replication data for shards where this node is a replica.
+// Unlike the simple Receiver, this handles multiple incoming streams (one per shard primary).
+type ShardReceiverManager struct {
+	cfg      *ShardReceiverConfig
+	shards   map[int]*ShardReceiver // shardID -> receiver
+	mu       sync.RWMutex
+	logger   zerolog.Logger
+	ctx      context.Context
+	cancelFn context.CancelFunc
+	running  atomic.Bool
+	wg       sync.WaitGroup
+}
+
+// ShardReceiver handles replication for a single shard from its primary.
+type ShardReceiver struct {
+	shardID       int
+	primaryNode   *cluster.Node
+	conn          net.Conn
+	lastSeq       atomic.Uint64
+	mu            sync.Mutex
+	logger        zerolog.Logger
+	cfg           *ShardReceiverConfig
+	ctx           context.Context
+	cancelFn      context.CancelFunc
+	wg            sync.WaitGroup
+	running       atomic.Bool
+	connected     atomic.Bool
+
+	// Stats
+	totalEntriesReceived atomic.Int64
+	totalBytesReceived   atomic.Int64
+	totalEntriesApplied  atomic.Int64
+	totalErrors          atomic.Int64
+	lastReceiveTime      atomic.Int64
+	connectTime          atomic.Int64
+}
+
+// NewShardReceiverManager creates a new per-shard receiver manager.
+func NewShardReceiverManager(cfg *ShardReceiverConfig) *ShardReceiverManager {
+	if cfg.ReconnectInterval <= 0 {
+		cfg.ReconnectInterval = 5 * time.Second
+	}
+	if cfg.AckInterval <= 0 {
+		cfg.AckInterval = 100 * time.Millisecond
+	}
+
+	return &ShardReceiverManager{
+		cfg:    cfg,
+		shards: make(map[int]*ShardReceiver),
+		logger: cfg.Logger.With().Str("component", "shard-receiver-manager").Logger(),
+	}
+}
+
+// Start begins the receiver manager.
+func (m *ShardReceiverManager) Start(ctx context.Context) error {
+	m.ctx, m.cancelFn = context.WithCancel(ctx)
+	m.running.Store(true)
+
+	m.logger.Info().Msg("Shard receiver manager started")
+	return nil
+}
+
+// Stop gracefully shuts down the receiver manager.
+func (m *ShardReceiverManager) Stop() error {
+	if !m.running.Load() {
+		return nil
+	}
+
+	m.running.Store(false)
+	m.cancelFn()
+
+	// Stop all receivers
+	m.mu.Lock()
+	for shardID, receiver := range m.shards {
+		receiver.Stop()
+		delete(m.shards, shardID)
+	}
+	m.mu.Unlock()
+
+	m.wg.Wait()
+	m.logger.Info().Msg("Shard receiver manager stopped")
+	return nil
+}
+
+// BecomeReplica is called when this node becomes a replica for a shard.
+// It starts receiving replication from the shard's primary.
+func (m *ShardReceiverManager) BecomeReplica(shardID int, primary *cluster.Node) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if already receiving for this shard
+	if existing, exists := m.shards[shardID]; exists {
+		// Check if primary changed
+		if existing.primaryNode.ID == primary.ID {
+			return nil // Same primary, already connected
+		}
+		// Different primary - stop old receiver
+		existing.Stop()
+		delete(m.shards, shardID)
+	}
+
+	// Create receiver for this shard
+	receiver := newShardReceiver(shardID, primary, m.cfg, m.logger)
+	if err := receiver.Start(m.ctx); err != nil {
+		return fmt.Errorf("start shard receiver: %w", err)
+	}
+
+	m.shards[shardID] = receiver
+
+	m.logger.Info().
+		Int("shard_id", shardID).
+		Str("primary_id", primary.ID).
+		Str("primary_addr", primary.Address).
+		Msg("Started receiving replication as replica for shard")
+
+	return nil
+}
+
+// StopReplica is called when this node stops being a replica for a shard.
+func (m *ShardReceiverManager) StopReplica(shardID int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if receiver, exists := m.shards[shardID]; exists {
+		receiver.Stop()
+		delete(m.shards, shardID)
+		m.logger.Info().Int("shard_id", shardID).Msg("Stopped receiving replication for shard")
+	}
+}
+
+// UpdatePrimary updates the primary node for a shard.
+// Called when the shard's primary changes (failover).
+func (m *ShardReceiverManager) UpdatePrimary(shardID int, newPrimary *cluster.Node) error {
+	return m.BecomeReplica(shardID, newPrimary)
+}
+
+// GetShardStats returns statistics for a specific shard's receiver.
+func (m *ShardReceiverManager) GetShardStats(shardID int) map[string]interface{} {
+	m.mu.RLock()
+	receiver, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	return receiver.Stats()
+}
+
+// Stats returns overall receiver statistics.
+func (m *ShardReceiverManager) Stats() map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	shardStats := make(map[int]map[string]interface{})
+	for shardID, receiver := range m.shards {
+		shardStats[shardID] = receiver.Stats()
+	}
+
+	return map[string]interface{}{
+		"running":           m.running.Load(),
+		"shards_as_replica": len(m.shards),
+		"shard_stats":       shardStats,
+	}
+}
+
+// newShardReceiver creates a new receiver for a specific shard.
+func newShardReceiver(shardID int, primary *cluster.Node, cfg *ShardReceiverConfig, logger zerolog.Logger) *ShardReceiver {
+	return &ShardReceiver{
+		shardID:     shardID,
+		primaryNode: primary,
+		cfg:         cfg,
+		logger:      logger.With().Int("shard_id", shardID).Str("primary_id", primary.ID).Logger(),
+	}
+}
+
+// Start begins the shard receiver's connection loop.
+func (r *ShardReceiver) Start(ctx context.Context) error {
+	r.ctx, r.cancelFn = context.WithCancel(ctx)
+	r.running.Store(true)
+
+	r.wg.Add(1)
+	go r.connectionLoop()
+
+	r.logger.Debug().Msg("Shard receiver started")
+	return nil
+}
+
+// Stop gracefully shuts down the shard receiver.
+func (r *ShardReceiver) Stop() {
+	if !r.running.Load() {
+		return
+	}
+
+	r.running.Store(false)
+	r.cancelFn()
+
+	r.mu.Lock()
+	if r.conn != nil {
+		r.conn.Close()
+		r.conn = nil
+	}
+	r.mu.Unlock()
+
+	r.wg.Wait()
+	r.logger.Debug().Msg("Shard receiver stopped")
+}
+
+// connectionLoop maintains connection to the primary.
+func (r *ShardReceiver) connectionLoop() {
+	defer r.wg.Done()
+
+	for r.running.Load() {
+		select {
+		case <-r.ctx.Done():
+			return
+		default:
+		}
+
+		// Try to connect
+		if err := r.connect(); err != nil {
+			r.logger.Debug().
+				Err(err).
+				Str("primary_addr", r.primaryNode.Address).
+				Dur("retry_in", r.cfg.ReconnectInterval).
+				Msg("Failed to connect to primary")
+
+			select {
+			case <-r.ctx.Done():
+				return
+			case <-time.After(r.cfg.ReconnectInterval):
+				continue
+			}
+		}
+
+		// Connected, receive entries
+		r.receiveLoop()
+
+		// Disconnected
+		r.connected.Store(false)
+		r.mu.Lock()
+		if r.conn != nil {
+			r.conn.Close()
+			r.conn = nil
+		}
+		r.mu.Unlock()
+
+		r.logger.Info().
+			Dur("retry_in", r.cfg.ReconnectInterval).
+			Msg("Disconnected from primary, will reconnect")
+
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-time.After(r.cfg.ReconnectInterval):
+		}
+	}
+}
+
+// connect establishes connection to the primary.
+func (r *ShardReceiver) connect() error {
+	addr := r.primaryNode.Address
+	if addr == "" {
+		return fmt.Errorf("primary has no address")
+	}
+
+	r.logger.Debug().Str("primary_addr", addr).Msg("Connecting to primary")
+
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+
+	// Send sync request (identify as shard receiver)
+	syncReq := &replication.ReplicateSync{
+		ReaderID:          r.cfg.LocalNode.ID + "-shard-" + fmt.Sprintf("%d", r.shardID),
+		LastKnownSequence: r.lastSeq.Load(),
+	}
+
+	if err := replication.WriteSync(conn, syncReq); err != nil {
+		conn.Close()
+		return fmt.Errorf("write sync: %w", err)
+	}
+
+	// Read sync ack
+	msgType, payload, err := replication.ReadMessage(conn)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("read sync ack: %w", err)
+	}
+
+	if msgType != replication.MsgReplicateSyncAck {
+		conn.Close()
+		return fmt.Errorf("unexpected message type: %d", msgType)
+	}
+
+	syncAck, err := replication.ParseSyncAck(payload)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("parse sync ack: %w", err)
+	}
+
+	if syncAck.Error != "" {
+		conn.Close()
+		return fmt.Errorf("sync rejected: %s", syncAck.Error)
+	}
+
+	// Store connection
+	r.mu.Lock()
+	r.conn = conn
+	r.mu.Unlock()
+
+	r.connected.Store(true)
+	r.connectTime.Store(time.Now().UnixNano())
+
+	r.logger.Info().
+		Str("primary_addr", addr).
+		Uint64("current_seq", syncAck.CurrentSequence).
+		Uint64("last_known_seq", r.lastSeq.Load()).
+		Bool("can_resume", syncAck.CanResume).
+		Msg("Connected to primary for shard replication")
+
+	return nil
+}
+
+// receiveLoop receives and processes entries from the primary.
+func (r *ShardReceiver) receiveLoop() {
+	// Start ack sender
+	ackCtx, ackCancel := context.WithCancel(r.ctx)
+	defer ackCancel()
+
+	r.wg.Add(1)
+	go r.ackLoop(ackCtx)
+
+	for r.running.Load() {
+		select {
+		case <-r.ctx.Done():
+			return
+		default:
+		}
+
+		r.mu.Lock()
+		conn := r.conn
+		r.mu.Unlock()
+
+		if conn == nil {
+			return
+		}
+
+		conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
+		msgType, payload, err := replication.ReadMessage(conn)
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				continue
+			}
+			r.logger.Debug().Err(err).Msg("Connection to primary closed")
+			return
+		}
+
+		switch msgType {
+		case replication.MsgReplicateEntry:
+			entry, err := replication.ParseEntry(payload)
+			if err != nil {
+				r.totalErrors.Add(1)
+				r.logger.Error().Err(err).Msg("Failed to parse entry")
+				continue
+			}
+
+			if err := r.applyEntry(entry); err != nil {
+				r.totalErrors.Add(1)
+				r.logger.Error().
+					Err(err).
+					Uint64("sequence", entry.Sequence).
+					Msg("Failed to apply entry")
+				continue
+			}
+
+			r.lastSeq.Store(entry.Sequence)
+			r.totalEntriesReceived.Add(1)
+			r.totalBytesReceived.Add(int64(len(entry.Payload)))
+			r.lastReceiveTime.Store(time.Now().UnixNano())
+
+		case replication.MsgReplicateError:
+			errMsg, _ := replication.ParseError(payload)
+			r.logger.Error().
+				Str("code", errMsg.Code).
+				Str("message", errMsg.Message).
+				Msg("Error from primary")
+			r.totalErrors.Add(1)
+
+		default:
+			r.logger.Warn().Uint8("msg_type", msgType).Msg("Unexpected message type")
+		}
+	}
+}
+
+// applyEntry applies a received entry to local storage.
+func (r *ShardReceiver) applyEntry(entry *replication.ReplicateEntry) error {
+	// Write to local WAL first (if configured)
+	if r.cfg.LocalWAL != nil {
+		if err := r.cfg.LocalWAL.AppendRaw(entry.Payload); err != nil {
+			return fmt.Errorf("write to local WAL: %w", err)
+		}
+	}
+
+	// Apply to ingest handler (if configured)
+	if r.cfg.IngestHandler != nil {
+		if err := r.cfg.IngestHandler.ApplyReplicatedEntry(r.ctx, entry.Payload); err != nil {
+			return fmt.Errorf("apply to ingest: %w", err)
+		}
+	}
+
+	r.totalEntriesApplied.Add(1)
+	return nil
+}
+
+// ackLoop periodically sends acknowledgments to the primary.
+func (r *ShardReceiver) ackLoop(ctx context.Context) {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.cfg.AckInterval)
+	defer ticker.Stop()
+
+	var lastAckedSeq uint64
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			currentSeq := r.lastSeq.Load()
+			if currentSeq == lastAckedSeq {
+				continue // No new entries to ack
+			}
+
+			r.mu.Lock()
+			conn := r.conn
+			r.mu.Unlock()
+
+			if conn == nil {
+				return
+			}
+
+			ack := &replication.ReplicateAck{
+				LastSequence: currentSeq,
+				ReaderID:     r.cfg.LocalNode.ID + "-shard-" + fmt.Sprintf("%d", r.shardID),
+			}
+
+			if err := replication.WriteAck(conn, ack); err != nil {
+				r.logger.Debug().Err(err).Msg("Failed to send ack")
+				return
+			}
+
+			lastAckedSeq = currentSeq
+		}
+	}
+}
+
+// IsConnected returns whether this receiver is connected to its primary.
+func (r *ShardReceiver) IsConnected() bool {
+	return r.connected.Load()
+}
+
+// LastSequence returns the last received sequence number.
+func (r *ShardReceiver) LastSequence() uint64 {
+	return r.lastSeq.Load()
+}
+
+// Stats returns statistics for this shard receiver.
+func (r *ShardReceiver) Stats() map[string]interface{} {
+	lastReceive := time.Unix(0, r.lastReceiveTime.Load())
+	connectTime := time.Unix(0, r.connectTime.Load())
+
+	return map[string]interface{}{
+		"shard_id":                r.shardID,
+		"running":                 r.running.Load(),
+		"connected":               r.connected.Load(),
+		"primary_id":              r.primaryNode.ID,
+		"primary_addr":            r.primaryNode.Address,
+		"last_sequence":           r.lastSeq.Load(),
+		"total_entries_received":  r.totalEntriesReceived.Load(),
+		"total_bytes_received":    r.totalBytesReceived.Load(),
+		"total_entries_applied":   r.totalEntriesApplied.Load(),
+		"total_errors":            r.totalErrors.Load(),
+		"last_receive_time":       lastReceive.Format(time.RFC3339),
+		"connected_since":         connectTime.Format(time.RFC3339),
+		"connection_duration_sec": time.Since(connectTime).Seconds(),
+	}
+}

--- a/internal/cluster/sharding/shard_replication.go
+++ b/internal/cluster/sharding/shard_replication.go
@@ -1,0 +1,630 @@
+package sharding
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/basekick-labs/arc/internal/cluster/replication"
+	"github.com/rs/zerolog"
+)
+
+// ShardReplicationConfig holds configuration for per-shard replication.
+type ShardReplicationConfig struct {
+	// ShardMap provides shard-to-node mappings
+	ShardMap *ShardMap
+
+	// LocalNode is the local node
+	LocalNode *cluster.Node
+
+	// BufferSize is the capacity of the entry buffer per shard (default: 10000)
+	BufferSize int
+
+	// WriteTimeout for sending entries to replicas
+	WriteTimeout time.Duration
+
+	// Logger for replication events
+	Logger zerolog.Logger
+}
+
+// ShardReplicationManager manages WAL replication for shards where this node is primary.
+// Each shard has independent replication streams to its replicas.
+type ShardReplicationManager struct {
+	cfg       *ShardReplicationConfig
+	shards    map[int]*ShardSender // shardID -> sender (only for shards we're primary for)
+	mu        sync.RWMutex
+	logger    zerolog.Logger
+	ctx       context.Context
+	cancelFn  context.CancelFunc
+	running   atomic.Bool
+	wg        sync.WaitGroup
+}
+
+// ShardSender handles replication for a single shard from primary to replicas.
+type ShardSender struct {
+	shardID    int
+	replicas   map[string]*ShardReplicaConn // nodeID -> connection
+	entryChan  chan *replication.ReplicateEntry
+	sequence   atomic.Uint64
+	mu         sync.RWMutex
+	logger     zerolog.Logger
+	cfg        *ShardReplicationConfig
+	ctx        context.Context
+	cancelFn   context.CancelFunc
+	wg         sync.WaitGroup
+	running    atomic.Bool
+
+	// Stats
+	totalEntriesReceived atomic.Int64
+	totalEntriesDropped  atomic.Int64
+	totalEntriesSent     atomic.Int64
+}
+
+// ShardReplicaConn represents a connection to a replica for a specific shard.
+type ShardReplicaConn struct {
+	nodeID       string
+	node         *cluster.Node
+	conn         net.Conn
+	writeMu      sync.Mutex
+	lastAck      atomic.Uint64
+	lastSendTime atomic.Int64
+	entriesSent  atomic.Int64
+	bytesSent    atomic.Int64
+	errors       atomic.Int64
+	ctx          context.Context
+	cancelFn     context.CancelFunc
+}
+
+// NewShardReplicationManager creates a new per-shard replication manager.
+func NewShardReplicationManager(cfg *ShardReplicationConfig) *ShardReplicationManager {
+	if cfg.BufferSize <= 0 {
+		cfg.BufferSize = 10000
+	}
+	if cfg.WriteTimeout <= 0 {
+		cfg.WriteTimeout = 5 * time.Second
+	}
+
+	return &ShardReplicationManager{
+		cfg:    cfg,
+		shards: make(map[int]*ShardSender),
+		logger: cfg.Logger.With().Str("component", "shard-replication-manager").Logger(),
+	}
+}
+
+// Start begins the replication manager.
+func (m *ShardReplicationManager) Start(ctx context.Context) error {
+	m.ctx, m.cancelFn = context.WithCancel(ctx)
+	m.running.Store(true)
+
+	m.logger.Info().Msg("Shard replication manager started")
+	return nil
+}
+
+// Stop gracefully shuts down the replication manager.
+func (m *ShardReplicationManager) Stop() error {
+	if !m.running.Load() {
+		return nil
+	}
+
+	m.running.Store(false)
+	m.cancelFn()
+
+	// Stop all shard senders
+	m.mu.Lock()
+	for shardID, sender := range m.shards {
+		sender.Stop()
+		delete(m.shards, shardID)
+	}
+	m.mu.Unlock()
+
+	m.wg.Wait()
+	m.logger.Info().Msg("Shard replication manager stopped")
+	return nil
+}
+
+// BecomePrimary is called when this node becomes primary for a shard.
+// It starts replication to the shard's replicas.
+func (m *ShardReplicationManager) BecomePrimary(shardID int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if already primary
+	if _, exists := m.shards[shardID]; exists {
+		return nil
+	}
+
+	// Get shard group to find replicas
+	group := m.cfg.ShardMap.GetShardGroup(shardID)
+	if group == nil {
+		return fmt.Errorf("shard %d not found", shardID)
+	}
+
+	// Create sender for this shard
+	sender := newShardSender(shardID, m.cfg, m.logger)
+	if err := sender.Start(m.ctx); err != nil {
+		return fmt.Errorf("start shard sender: %w", err)
+	}
+
+	// Connect to replicas
+	for _, replica := range group.Replicas {
+		if replica.ID != m.cfg.LocalNode.ID {
+			sender.AddReplica(replica)
+		}
+	}
+
+	m.shards[shardID] = sender
+
+	m.logger.Info().
+		Int("shard_id", shardID).
+		Int("replica_count", len(group.Replicas)).
+		Msg("Started replication as primary for shard")
+
+	return nil
+}
+
+// StopPrimary is called when this node stops being primary for a shard.
+func (m *ShardReplicationManager) StopPrimary(shardID int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if sender, exists := m.shards[shardID]; exists {
+		sender.Stop()
+		delete(m.shards, shardID)
+		m.logger.Info().Int("shard_id", shardID).Msg("Stopped replication for shard")
+	}
+}
+
+// Replicate sends an entry to all replicas for a shard.
+// Called when new data is written to the shard.
+func (m *ShardReplicationManager) Replicate(shardID int, entry *replication.ReplicateEntry) {
+	m.mu.RLock()
+	sender, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return // Not primary for this shard
+	}
+
+	sender.Replicate(entry)
+}
+
+// AddReplica adds a replica connection for a shard.
+func (m *ShardReplicationManager) AddReplica(shardID int, replica *cluster.Node) error {
+	m.mu.RLock()
+	sender, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("not primary for shard %d", shardID)
+	}
+
+	return sender.AddReplica(replica)
+}
+
+// RemoveReplica removes a replica connection for a shard.
+func (m *ShardReplicationManager) RemoveReplica(shardID int, nodeID string) {
+	m.mu.RLock()
+	sender, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if exists {
+		sender.RemoveReplica(nodeID)
+	}
+}
+
+// GetShardStats returns statistics for a specific shard's replication.
+func (m *ShardReplicationManager) GetShardStats(shardID int) map[string]interface{} {
+	m.mu.RLock()
+	sender, exists := m.shards[shardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	return sender.Stats()
+}
+
+// Stats returns overall replication statistics.
+func (m *ShardReplicationManager) Stats() map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	shardStats := make(map[int]map[string]interface{})
+	for shardID, sender := range m.shards {
+		shardStats[shardID] = sender.Stats()
+	}
+
+	return map[string]interface{}{
+		"running":           m.running.Load(),
+		"shards_as_primary": len(m.shards),
+		"shard_stats":       shardStats,
+	}
+}
+
+// newShardSender creates a new sender for a specific shard.
+func newShardSender(shardID int, cfg *ShardReplicationConfig, logger zerolog.Logger) *ShardSender {
+	return &ShardSender{
+		shardID:   shardID,
+		replicas:  make(map[string]*ShardReplicaConn),
+		entryChan: make(chan *replication.ReplicateEntry, cfg.BufferSize),
+		cfg:       cfg,
+		logger:    logger.With().Int("shard_id", shardID).Logger(),
+	}
+}
+
+// Start begins the shard sender's distribution loop.
+func (s *ShardSender) Start(ctx context.Context) error {
+	s.ctx, s.cancelFn = context.WithCancel(ctx)
+	s.running.Store(true)
+
+	s.wg.Add(1)
+	go s.distributionLoop()
+
+	s.logger.Debug().Msg("Shard sender started")
+	return nil
+}
+
+// Stop gracefully shuts down the shard sender.
+func (s *ShardSender) Stop() {
+	if !s.running.Load() {
+		return
+	}
+
+	s.running.Store(false)
+	s.cancelFn()
+
+	// Close all replica connections
+	s.mu.Lock()
+	for nodeID, replica := range s.replicas {
+		replica.cancelFn()
+		if replica.conn != nil {
+			replica.conn.Close()
+		}
+		delete(s.replicas, nodeID)
+	}
+	s.mu.Unlock()
+
+	s.wg.Wait()
+	s.logger.Debug().Msg("Shard sender stopped")
+}
+
+// AddReplica adds a replica connection.
+func (s *ShardSender) AddReplica(node *cluster.Node) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if already connected
+	if _, exists := s.replicas[node.ID]; exists {
+		return nil
+	}
+
+	replicaCtx, cancel := context.WithCancel(s.ctx)
+	replica := &ShardReplicaConn{
+		nodeID:   node.ID,
+		node:     node,
+		ctx:      replicaCtx,
+		cancelFn: cancel,
+	}
+	replica.lastSendTime.Store(time.Now().UnixNano())
+
+	s.replicas[node.ID] = replica
+
+	// Start connection goroutine
+	s.wg.Add(1)
+	go s.maintainConnection(replica)
+
+	s.logger.Info().
+		Str("replica_id", node.ID).
+		Str("replica_addr", node.Address).
+		Msg("Added replica for shard replication")
+
+	return nil
+}
+
+// RemoveReplica removes a replica connection.
+func (s *ShardSender) RemoveReplica(nodeID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if replica, exists := s.replicas[nodeID]; exists {
+		replica.cancelFn()
+		if replica.conn != nil {
+			replica.conn.Close()
+		}
+		delete(s.replicas, nodeID)
+		s.logger.Info().Str("replica_id", nodeID).Msg("Removed replica from shard replication")
+	}
+}
+
+// Replicate queues an entry for replication.
+func (s *ShardSender) Replicate(entry *replication.ReplicateEntry) {
+	if !s.running.Load() {
+		return
+	}
+
+	// Assign sequence number
+	entry.Sequence = s.sequence.Add(1)
+	s.totalEntriesReceived.Add(1)
+
+	// Non-blocking send
+	select {
+	case s.entryChan <- entry:
+		// Entry queued
+	default:
+		// Buffer full
+		s.totalEntriesDropped.Add(1)
+		s.logger.Warn().
+			Uint64("sequence", entry.Sequence).
+			Msg("Shard replication buffer full, entry dropped")
+	}
+}
+
+// distributionLoop sends entries to all replicas.
+func (s *ShardSender) distributionLoop() {
+	defer s.wg.Done()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case entry := <-s.entryChan:
+			s.broadcastEntry(entry)
+		}
+	}
+}
+
+// broadcastEntry sends an entry to all connected replicas.
+func (s *ShardSender) broadcastEntry(entry *replication.ReplicateEntry) {
+	s.mu.RLock()
+	replicas := make([]*ShardReplicaConn, 0, len(s.replicas))
+	for _, r := range s.replicas {
+		replicas = append(replicas, r)
+	}
+	s.mu.RUnlock()
+
+	for _, replica := range replicas {
+		if err := s.sendToReplica(replica, entry); err != nil {
+			replica.errors.Add(1)
+			s.logger.Debug().
+				Err(err).
+				Str("replica_id", replica.nodeID).
+				Uint64("sequence", entry.Sequence).
+				Msg("Failed to send entry to replica")
+			// Don't remove replica - maintainConnection will handle reconnection
+		}
+	}
+}
+
+// sendToReplica sends an entry to a specific replica.
+func (s *ShardSender) sendToReplica(replica *ShardReplicaConn, entry *replication.ReplicateEntry) error {
+	replica.writeMu.Lock()
+	defer replica.writeMu.Unlock()
+
+	// Check if replica is still active
+	select {
+	case <-replica.ctx.Done():
+		return context.Canceled
+	default:
+	}
+
+	if replica.conn == nil {
+		return fmt.Errorf("not connected")
+	}
+
+	// Set write deadline
+	if err := replica.conn.SetWriteDeadline(time.Now().Add(s.cfg.WriteTimeout)); err != nil {
+		return err
+	}
+
+	// Write entry
+	if err := replication.WriteEntry(replica.conn, entry); err != nil {
+		return err
+	}
+
+	// Update stats
+	replica.entriesSent.Add(1)
+	replica.bytesSent.Add(int64(len(entry.Payload)))
+	replica.lastSendTime.Store(time.Now().UnixNano())
+	s.totalEntriesSent.Add(1)
+
+	return nil
+}
+
+// maintainConnection keeps a connection to a replica alive.
+func (s *ShardSender) maintainConnection(replica *ShardReplicaConn) {
+	defer s.wg.Done()
+
+	reconnectInterval := 5 * time.Second
+
+	for {
+		select {
+		case <-replica.ctx.Done():
+			return
+		default:
+		}
+
+		// Try to connect
+		if err := s.connectToReplica(replica); err != nil {
+			s.logger.Debug().
+				Err(err).
+				Str("replica_id", replica.nodeID).
+				Dur("retry_in", reconnectInterval).
+				Msg("Failed to connect to replica")
+
+			select {
+			case <-replica.ctx.Done():
+				return
+			case <-time.After(reconnectInterval):
+				continue
+			}
+		}
+
+		// Connected - run receive loop for acks
+		s.receiveLoop(replica)
+
+		// Disconnected
+		replica.writeMu.Lock()
+		if replica.conn != nil {
+			replica.conn.Close()
+			replica.conn = nil
+		}
+		replica.writeMu.Unlock()
+
+		select {
+		case <-replica.ctx.Done():
+			return
+		case <-time.After(reconnectInterval):
+		}
+	}
+}
+
+// connectToReplica establishes connection to a replica.
+func (s *ShardSender) connectToReplica(replica *ShardReplicaConn) error {
+	addr := replica.node.Address
+	if addr == "" {
+		return fmt.Errorf("replica has no address")
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+
+	// Send sync request
+	syncReq := &replication.ReplicateSync{
+		ReaderID:          s.cfg.LocalNode.ID + "-shard-" + fmt.Sprintf("%d", s.shardID),
+		LastKnownSequence: replica.lastAck.Load(),
+	}
+
+	if err := replication.WriteSync(conn, syncReq); err != nil {
+		conn.Close()
+		return fmt.Errorf("write sync: %w", err)
+	}
+
+	// Read sync ack
+	msgType, payload, err := replication.ReadMessage(conn)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("read sync ack: %w", err)
+	}
+
+	if msgType != replication.MsgReplicateSyncAck {
+		conn.Close()
+		return fmt.Errorf("unexpected message type: %d", msgType)
+	}
+
+	syncAck, err := replication.ParseSyncAck(payload)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("parse sync ack: %w", err)
+	}
+
+	if syncAck.Error != "" {
+		conn.Close()
+		return fmt.Errorf("sync rejected: %s", syncAck.Error)
+	}
+
+	// Store connection
+	replica.writeMu.Lock()
+	replica.conn = conn
+	replica.writeMu.Unlock()
+
+	s.logger.Info().
+		Str("replica_id", replica.nodeID).
+		Uint64("remote_seq", syncAck.CurrentSequence).
+		Bool("can_resume", syncAck.CanResume).
+		Msg("Connected to replica for shard replication")
+
+	return nil
+}
+
+// receiveLoop handles incoming acks from a replica.
+func (s *ShardSender) receiveLoop(replica *ShardReplicaConn) {
+	for {
+		select {
+		case <-replica.ctx.Done():
+			return
+		default:
+		}
+
+		replica.writeMu.Lock()
+		conn := replica.conn
+		replica.writeMu.Unlock()
+
+		if conn == nil {
+			return
+		}
+
+		conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
+		msgType, payload, err := replication.ReadMessage(conn)
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				continue
+			}
+			s.logger.Debug().
+				Err(err).
+				Str("replica_id", replica.nodeID).
+				Msg("Replica connection closed")
+			return
+		}
+
+		switch msgType {
+		case replication.MsgReplicateAck:
+			ack, err := replication.ParseAck(payload)
+			if err != nil {
+				s.logger.Error().Err(err).Str("replica_id", replica.nodeID).Msg("Failed to parse ack")
+				continue
+			}
+			replica.lastAck.Store(ack.LastSequence)
+			s.logger.Debug().
+				Str("replica_id", replica.nodeID).
+				Uint64("last_seq", ack.LastSequence).
+				Msg("Received ack from replica")
+
+		default:
+			s.logger.Warn().
+				Str("replica_id", replica.nodeID).
+				Uint8("msg_type", msgType).
+				Msg("Unexpected message type from replica")
+		}
+	}
+}
+
+// Stats returns statistics for this shard sender.
+func (s *ShardSender) Stats() map[string]interface{} {
+	s.mu.RLock()
+	replicaStats := make([]map[string]interface{}, 0, len(s.replicas))
+	for id, replica := range s.replicas {
+		lastSend := time.Unix(0, replica.lastSendTime.Load())
+		connected := replica.conn != nil
+		replicaStats = append(replicaStats, map[string]interface{}{
+			"replica_id":     id,
+			"connected":      connected,
+			"last_ack_seq":   replica.lastAck.Load(),
+			"entries_sent":   replica.entriesSent.Load(),
+			"bytes_sent":     replica.bytesSent.Load(),
+			"last_send_time": lastSend.Format(time.RFC3339),
+			"errors":         replica.errors.Load(),
+			"lag":            s.sequence.Load() - replica.lastAck.Load(),
+		})
+	}
+	s.mu.RUnlock()
+
+	return map[string]interface{}{
+		"shard_id":               s.shardID,
+		"running":                s.running.Load(),
+		"current_sequence":       s.sequence.Load(),
+		"buffer_used":            len(s.entryChan),
+		"replica_count":          len(replicaStats),
+		"replicas":               replicaStats,
+		"total_entries_received": s.totalEntriesReceived.Load(),
+		"total_entries_dropped":  s.totalEntriesDropped.Load(),
+		"total_entries_sent":     s.totalEntriesSent.Load(),
+	}
+}

--- a/internal/cluster/sharding/shard_replication_test.go
+++ b/internal/cluster/sharding/shard_replication_test.go
@@ -1,0 +1,346 @@
+package sharding
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/basekick-labs/arc/internal/cluster/replication"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardReplicationManager_StartStop(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+	localNode.UpdateState(cluster.StateHealthy)
+
+	mgr := NewShardReplicationManager(&ShardReplicationConfig{
+		ShardMap:   sm,
+		LocalNode:  localNode,
+		BufferSize: 100,
+		Logger:     zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	assert.True(t, mgr.running.Load())
+
+	err = mgr.Stop()
+	require.NoError(t, err)
+	assert.False(t, mgr.running.Load())
+}
+
+func TestShardReplicationManager_BecomePrimary(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+	localNode.UpdateState(cluster.StateHealthy)
+
+	// Add a replica node
+	replicaNode := &cluster.Node{ID: "replica-node", Address: "localhost:9999"}
+	replicaNode.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(0, localNode)
+	sm.AddReplica(0, replicaNode)
+
+	mgr := NewShardReplicationManager(&ShardReplicationConfig{
+		ShardMap:   sm,
+		LocalNode:  localNode,
+		BufferSize: 100,
+		Logger:     zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Become primary for shard 0
+	err = mgr.BecomePrimary(0)
+	require.NoError(t, err)
+
+	// Check stats
+	stats := mgr.Stats()
+	assert.Equal(t, 1, stats["shards_as_primary"])
+
+	// Stop being primary
+	mgr.StopPrimary(0)
+	stats = mgr.Stats()
+	assert.Equal(t, 0, stats["shards_as_primary"])
+}
+
+func TestShardSender_Replicate(t *testing.T) {
+	cfg := &ShardReplicationConfig{
+		BufferSize:   100,
+		WriteTimeout: 5 * time.Second,
+		LocalNode:    &cluster.Node{ID: "primary"},
+		Logger:       zerolog.Nop(),
+	}
+
+	sender := newShardSender(0, cfg, zerolog.Nop())
+	ctx := context.Background()
+	err := sender.Start(ctx)
+	require.NoError(t, err)
+	defer sender.Stop()
+
+	// Send some entries
+	for i := 0; i < 10; i++ {
+		entry := &replication.ReplicateEntry{
+			TimestampUS: uint64(time.Now().UnixMicro()),
+			Payload:     []byte("test payload"),
+		}
+		sender.Replicate(entry)
+	}
+
+	// Check stats
+	stats := sender.Stats()
+	assert.Equal(t, int64(10), stats["total_entries_received"])
+}
+
+func TestShardSender_BufferFull(t *testing.T) {
+	cfg := &ShardReplicationConfig{
+		BufferSize:   5, // Small buffer
+		WriteTimeout: 5 * time.Second,
+		LocalNode:    &cluster.Node{ID: "primary"},
+		Logger:       zerolog.Nop(),
+	}
+
+	sender := newShardSender(0, cfg, zerolog.Nop())
+	// Set running flag but don't start the distribution loop
+	// This allows Replicate to queue entries without consuming them
+	sender.running.Store(true)
+
+	// Fill buffer past capacity
+	for i := 0; i < 10; i++ {
+		entry := &replication.ReplicateEntry{
+			TimestampUS: uint64(time.Now().UnixMicro()),
+			Payload:     []byte("test payload"),
+		}
+		sender.Replicate(entry)
+	}
+
+	// Buffer is 5, we sent 10, so at least 5 should be dropped
+	assert.GreaterOrEqual(t, sender.totalEntriesDropped.Load(), int64(5))
+}
+
+func TestShardReceiverManager_StartStop(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "local-node"}
+
+	mgr := NewShardReceiverManager(&ShardReceiverConfig{
+		ShardMap:  sm,
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	assert.True(t, mgr.running.Load())
+
+	err = mgr.Stop()
+	require.NoError(t, err)
+	assert.False(t, mgr.running.Load())
+}
+
+func TestShardReceiverManager_BecomeReplica(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "replica-node"}
+	primaryNode := &cluster.Node{ID: "primary-node", Address: "localhost:9998"}
+
+	mgr := NewShardReceiverManager(&ShardReceiverConfig{
+		ShardMap:          sm,
+		LocalNode:         localNode,
+		ReconnectInterval: 100 * time.Millisecond,
+		Logger:            zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Become replica for shard 0
+	err = mgr.BecomeReplica(0, primaryNode)
+	require.NoError(t, err)
+
+	// Check stats
+	stats := mgr.Stats()
+	assert.Equal(t, 1, stats["shards_as_replica"])
+
+	// Stop being replica
+	mgr.StopReplica(0)
+	stats = mgr.Stats()
+	assert.Equal(t, 0, stats["shards_as_replica"])
+}
+
+func TestShardReceiverManager_UpdatePrimary(t *testing.T) {
+	sm := NewShardMap(3)
+	localNode := &cluster.Node{ID: "replica-node"}
+	primary1 := &cluster.Node{ID: "primary-1", Address: "localhost:9997"}
+	primary2 := &cluster.Node{ID: "primary-2", Address: "localhost:9996"}
+
+	mgr := NewShardReceiverManager(&ShardReceiverConfig{
+		ShardMap:          sm,
+		LocalNode:         localNode,
+		ReconnectInterval: 100 * time.Millisecond,
+		Logger:            zerolog.Nop(),
+	})
+
+	ctx := context.Background()
+	err := mgr.Start(ctx)
+	require.NoError(t, err)
+	defer mgr.Stop()
+
+	// Become replica for shard 0 with primary 1
+	err = mgr.BecomeReplica(0, primary1)
+	require.NoError(t, err)
+
+	// Update to primary 2 (simulating failover)
+	err = mgr.UpdatePrimary(0, primary2)
+	require.NoError(t, err)
+
+	// Should still have 1 shard as replica
+	stats := mgr.Stats()
+	assert.Equal(t, 1, stats["shards_as_replica"])
+
+	// Verify the shard stats show the new primary
+	shardStats := mgr.GetShardStats(0)
+	require.NotNil(t, shardStats)
+	assert.Equal(t, "primary-2", shardStats["primary_id"])
+}
+
+// Integration test for replication between sender and receiver
+func TestShardReplication_Integration(t *testing.T) {
+	// Skip in short mode
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Create a listener that simulates a replica accepting connections
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	replicaAddr := listener.Addr().String()
+
+	// Track received entries
+	entriesReceived := make(chan *replication.ReplicateEntry, 10)
+
+	// Start mock replica server
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		// Read sync request from primary
+		msgType, _, err := replication.ReadMessage(conn)
+		if err != nil {
+			return
+		}
+		if msgType != replication.MsgReplicateSync {
+			return
+		}
+
+		// Send sync ack
+		syncAck := &replication.ReplicateSyncAck{
+			CurrentSequence: 0,
+			CanResume:       true,
+		}
+		if err := replication.WriteSyncAck(conn, syncAck); err != nil {
+			return
+		}
+
+		// Read entries from primary
+		for i := 0; i < 5; i++ {
+			conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+			msgType, payload, err := replication.ReadMessage(conn)
+			if err != nil {
+				return
+			}
+			if msgType == replication.MsgReplicateEntry {
+				entry, err := replication.ParseEntry(payload)
+				if err == nil {
+					entriesReceived <- entry
+				}
+			}
+		}
+	}()
+
+	// Setup shard map
+	sm := NewShardMap(3)
+	primaryNode := &cluster.Node{ID: "primary"}
+	primaryNode.UpdateState(cluster.StateHealthy)
+
+	// Replica node has the address of our mock server
+	replicaNode := &cluster.Node{ID: "replica", Address: replicaAddr}
+	replicaNode.UpdateState(cluster.StateHealthy)
+
+	sm.SetPrimary(0, primaryNode)
+	sm.AddReplica(0, replicaNode)
+
+	// Create sender on primary
+	sender := newShardSender(0, &ShardReplicationConfig{
+		ShardMap:     sm,
+		LocalNode:    primaryNode,
+		BufferSize:   100,
+		WriteTimeout: 5 * time.Second,
+		Logger:       zerolog.Nop(),
+	}, zerolog.Nop())
+
+	ctx := context.Background()
+	err = sender.Start(ctx)
+	require.NoError(t, err)
+	defer sender.Stop()
+
+	// Add replica (this triggers connection to replicaAddr)
+	err = sender.AddReplica(replicaNode)
+	require.NoError(t, err)
+
+	// Wait for connection to establish
+	time.Sleep(500 * time.Millisecond)
+
+	// Send entries through the sender
+	for i := 0; i < 5; i++ {
+		entry := &replication.ReplicateEntry{
+			TimestampUS: uint64(time.Now().UnixMicro()),
+			Payload:     []byte("test payload"),
+		}
+		sender.Replicate(entry)
+	}
+
+	// Wait for entries to be received by mock replica
+	received := 0
+	timeout := time.After(5 * time.Second)
+	for received < 5 {
+		select {
+		case <-entriesReceived:
+			received++
+		case <-timeout:
+			t.Fatalf("Timeout waiting for entries, received %d", received)
+		}
+	}
+
+	assert.Equal(t, 5, received)
+}
+
+func TestShardReceiver_Stats(t *testing.T) {
+	primaryNode := &cluster.Node{ID: "primary", Address: "localhost:9995"}
+	localNode := &cluster.Node{ID: "replica"}
+
+	receiver := newShardReceiver(0, primaryNode, &ShardReceiverConfig{
+		LocalNode: localNode,
+		Logger:    zerolog.Nop(),
+	}, zerolog.Nop())
+
+	stats := receiver.Stats()
+	assert.Equal(t, 0, stats["shard_id"])
+	assert.Equal(t, "primary", stats["primary_id"])
+	assert.Equal(t, "localhost:9995", stats["primary_addr"])
+	assert.False(t, stats["connected"].(bool))
+}

--- a/internal/cluster/sharding/shardmap.go
+++ b/internal/cluster/sharding/shardmap.go
@@ -1,0 +1,292 @@
+package sharding
+
+import (
+	"hash/fnv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+)
+
+// ShardMap maintains the mapping of shards to nodes.
+// It is the central registry for shard assignments in the cluster.
+type ShardMap struct {
+	numShards   int
+	assignments map[int]*ShardGroup
+	version     atomic.Uint64
+	mu          sync.RWMutex
+}
+
+// ShardGroup represents a group of nodes responsible for a single shard.
+// Each shard has one primary (accepts writes) and zero or more replicas.
+type ShardGroup struct {
+	ShardID        int
+	Primary        *cluster.Node
+	Replicas       []*cluster.Node
+	ReplicationLag map[string]time.Duration // nodeID -> lag
+}
+
+// NewShardMap creates a new shard map with the specified number of shards.
+func NewShardMap(numShards int) *ShardMap {
+	if numShards <= 0 {
+		numShards = 1
+	}
+
+	sm := &ShardMap{
+		numShards:   numShards,
+		assignments: make(map[int]*ShardGroup, numShards),
+	}
+
+	// Initialize empty shard groups
+	for i := 0; i < numShards; i++ {
+		sm.assignments[i] = &ShardGroup{
+			ShardID:        i,
+			Replicas:       make([]*cluster.Node, 0),
+			ReplicationLag: make(map[string]time.Duration),
+		}
+	}
+
+	return sm
+}
+
+// GetShard returns the shard ID for a given database name using FNV-1a hash.
+func (sm *ShardMap) GetShard(database string) int {
+	h := fnv.New32a()
+	h.Write([]byte(database))
+	return int(h.Sum32() % uint32(sm.numShards))
+}
+
+// GetPrimary returns the primary node for a shard, or nil if not assigned.
+func (sm *ShardMap) GetPrimary(shardID int) *cluster.Node {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	if group, ok := sm.assignments[shardID]; ok {
+		return group.Primary
+	}
+	return nil
+}
+
+// GetShardGroup returns the full shard group for a shard ID.
+func (sm *ShardMap) GetShardGroup(shardID int) *ShardGroup {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	if group, ok := sm.assignments[shardID]; ok {
+		// Return a copy to prevent external modification
+		return &ShardGroup{
+			ShardID:        group.ShardID,
+			Primary:        group.Primary,
+			Replicas:       append([]*cluster.Node{}, group.Replicas...),
+			ReplicationLag: copyLagMap(group.ReplicationLag),
+		}
+	}
+	return nil
+}
+
+// SetPrimary sets the primary node for a shard.
+func (sm *ShardMap) SetPrimary(shardID int, node *cluster.Node) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if group, ok := sm.assignments[shardID]; ok {
+		group.Primary = node
+		sm.version.Add(1)
+	}
+}
+
+// AddReplica adds a replica node to a shard group.
+func (sm *ShardMap) AddReplica(shardID int, node *cluster.Node) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if group, ok := sm.assignments[shardID]; ok {
+		// Check if already a replica
+		for _, r := range group.Replicas {
+			if r.ID == node.ID {
+				return
+			}
+		}
+		group.Replicas = append(group.Replicas, node)
+		sm.version.Add(1)
+	}
+}
+
+// RemoveReplica removes a replica node from a shard group.
+func (sm *ShardMap) RemoveReplica(shardID int, nodeID string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if group, ok := sm.assignments[shardID]; ok {
+		for i, r := range group.Replicas {
+			if r.ID == nodeID {
+				group.Replicas = append(group.Replicas[:i], group.Replicas[i+1:]...)
+				delete(group.ReplicationLag, nodeID)
+				sm.version.Add(1)
+				return
+			}
+		}
+	}
+}
+
+// UpdateReplicationLag updates the replication lag for a replica.
+func (sm *ShardMap) UpdateReplicationLag(shardID int, nodeID string, lag time.Duration) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if group, ok := sm.assignments[shardID]; ok {
+		group.ReplicationLag[nodeID] = lag
+	}
+}
+
+// SelectNode selects a node from the shard group for reading.
+// It can return either the primary or any healthy replica.
+func (sm *ShardMap) SelectNode(shardID int) *cluster.Node {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	group, ok := sm.assignments[shardID]
+	if !ok {
+		return nil
+	}
+
+	// If we have healthy replicas, prefer them for reads
+	for _, replica := range group.Replicas {
+		if replica.IsHealthy() {
+			return replica
+		}
+	}
+
+	// Fall back to primary
+	return group.Primary
+}
+
+// GetAllNodes returns all nodes involved in a shard (primary + replicas).
+func (sm *ShardMap) GetAllNodes(shardID int) []*cluster.Node {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	group, ok := sm.assignments[shardID]
+	if !ok {
+		return nil
+	}
+
+	nodes := make([]*cluster.Node, 0, len(group.Replicas)+1)
+	if group.Primary != nil {
+		nodes = append(nodes, group.Primary)
+	}
+	nodes = append(nodes, group.Replicas...)
+	return nodes
+}
+
+// NumShards returns the total number of shards.
+func (sm *ShardMap) NumShards() int {
+	return sm.numShards
+}
+
+// Version returns the current version of the shard map.
+// Incremented on every modification.
+func (sm *ShardMap) Version() uint64 {
+	return sm.version.Load()
+}
+
+// GetNodeShards returns all shards where a node is primary or replica.
+func (sm *ShardMap) GetNodeShards(nodeID string) []ShardRole {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	var roles []ShardRole
+	for shardID, group := range sm.assignments {
+		if group.Primary != nil && group.Primary.ID == nodeID {
+			roles = append(roles, ShardRole{ShardID: shardID, Role: RolePrimary})
+		}
+		for _, replica := range group.Replicas {
+			if replica.ID == nodeID {
+				roles = append(roles, ShardRole{ShardID: shardID, Role: RoleReplica})
+			}
+		}
+	}
+	return roles
+}
+
+// RemoveNode removes a node from all shard groups.
+// Returns list of shards where the node was primary (need failover).
+func (sm *ShardMap) RemoveNode(nodeID string) []int {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	var primaryShards []int
+
+	for shardID, group := range sm.assignments {
+		// Check if primary
+		if group.Primary != nil && group.Primary.ID == nodeID {
+			group.Primary = nil
+			primaryShards = append(primaryShards, shardID)
+		}
+
+		// Remove from replicas
+		for i, r := range group.Replicas {
+			if r.ID == nodeID {
+				group.Replicas = append(group.Replicas[:i], group.Replicas[i+1:]...)
+				delete(group.ReplicationLag, nodeID)
+				break
+			}
+		}
+	}
+
+	if len(primaryShards) > 0 {
+		sm.version.Add(1)
+	}
+
+	return primaryShards
+}
+
+// Stats returns statistics about the shard map.
+func (sm *ShardMap) Stats() map[string]interface{} {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	primaryCount := 0
+	replicaCount := 0
+	unassignedCount := 0
+
+	for _, group := range sm.assignments {
+		if group.Primary != nil {
+			primaryCount++
+		} else {
+			unassignedCount++
+		}
+		replicaCount += len(group.Replicas)
+	}
+
+	return map[string]interface{}{
+		"num_shards":       sm.numShards,
+		"assigned_shards":  primaryCount,
+		"unassigned":       unassignedCount,
+		"total_replicas":   replicaCount,
+		"version":          sm.version.Load(),
+	}
+}
+
+// ShardRole represents a node's role in a shard.
+type ShardRole struct {
+	ShardID int
+	Role    Role
+}
+
+// Role defines a node's role within a shard group.
+type Role string
+
+const (
+	RolePrimary Role = "primary"
+	RoleReplica Role = "replica"
+)
+
+func copyLagMap(m map[string]time.Duration) map[string]time.Duration {
+	result := make(map[string]time.Duration, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}

--- a/internal/cluster/sharding/shardmap_test.go
+++ b/internal/cluster/sharding/shardmap_test.go
@@ -1,0 +1,238 @@
+package sharding
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewShardMap(t *testing.T) {
+	sm := NewShardMap(3)
+	assert.Equal(t, 3, sm.NumShards())
+	assert.Equal(t, uint64(0), sm.Version())
+
+	// All shards should be initialized but unassigned
+	for i := 0; i < 3; i++ {
+		group := sm.GetShardGroup(i)
+		require.NotNil(t, group)
+		assert.Equal(t, i, group.ShardID)
+		assert.Nil(t, group.Primary)
+		assert.Empty(t, group.Replicas)
+	}
+}
+
+func TestShardMapGetShard(t *testing.T) {
+	sm := NewShardMap(3)
+
+	// Same database should always hash to same shard
+	shard1 := sm.GetShard("mydb")
+	shard2 := sm.GetShard("mydb")
+	assert.Equal(t, shard1, shard2)
+
+	// Different databases may hash to different shards
+	shardA := sm.GetShard("database_a")
+	shardB := sm.GetShard("database_b")
+	// They could be the same or different, just verify they're in range
+	assert.GreaterOrEqual(t, shardA, 0)
+	assert.Less(t, shardA, 3)
+	assert.GreaterOrEqual(t, shardB, 0)
+	assert.Less(t, shardB, 3)
+}
+
+func TestShardMapSetPrimary(t *testing.T) {
+	sm := NewShardMap(3)
+
+	node := &cluster.Node{ID: "node-1"}
+	sm.SetPrimary(0, node)
+
+	primary := sm.GetPrimary(0)
+	require.NotNil(t, primary)
+	assert.Equal(t, "node-1", primary.ID)
+
+	// Version should increment
+	assert.Equal(t, uint64(1), sm.Version())
+
+	// Other shards should be unaffected
+	assert.Nil(t, sm.GetPrimary(1))
+	assert.Nil(t, sm.GetPrimary(2))
+}
+
+func TestShardMapAddRemoveReplica(t *testing.T) {
+	sm := NewShardMap(3)
+
+	node1 := &cluster.Node{ID: "replica-1"}
+	node2 := &cluster.Node{ID: "replica-2"}
+
+	// Add replicas
+	sm.AddReplica(0, node1)
+	sm.AddReplica(0, node2)
+
+	group := sm.GetShardGroup(0)
+	require.NotNil(t, group)
+	assert.Len(t, group.Replicas, 2)
+
+	// Adding same replica again should be idempotent
+	sm.AddReplica(0, node1)
+	group = sm.GetShardGroup(0)
+	assert.Len(t, group.Replicas, 2)
+
+	// Remove one replica
+	sm.RemoveReplica(0, "replica-1")
+	group = sm.GetShardGroup(0)
+	assert.Len(t, group.Replicas, 1)
+	assert.Equal(t, "replica-2", group.Replicas[0].ID)
+}
+
+func TestShardMapSelectNode(t *testing.T) {
+	sm := NewShardMap(3)
+
+	// No nodes assigned - should return nil
+	assert.Nil(t, sm.SelectNode(0))
+
+	// Set primary only
+	primary := &cluster.Node{ID: "primary-1"}
+	primary.UpdateState(cluster.StateHealthy)
+	sm.SetPrimary(0, primary)
+
+	// Should return primary when no replicas
+	selected := sm.SelectNode(0)
+	require.NotNil(t, selected)
+	assert.Equal(t, "primary-1", selected.ID)
+
+	// Add healthy replica
+	replica := &cluster.Node{ID: "replica-1"}
+	replica.UpdateState(cluster.StateHealthy)
+	sm.AddReplica(0, replica)
+
+	// Should prefer replica for reads
+	selected = sm.SelectNode(0)
+	require.NotNil(t, selected)
+	assert.Equal(t, "replica-1", selected.ID)
+}
+
+func TestShardMapGetAllNodes(t *testing.T) {
+	sm := NewShardMap(3)
+
+	primary := &cluster.Node{ID: "primary"}
+	replica1 := &cluster.Node{ID: "replica-1"}
+	replica2 := &cluster.Node{ID: "replica-2"}
+
+	sm.SetPrimary(0, primary)
+	sm.AddReplica(0, replica1)
+	sm.AddReplica(0, replica2)
+
+	nodes := sm.GetAllNodes(0)
+	assert.Len(t, nodes, 3)
+
+	// Verify all nodes are present
+	ids := make(map[string]bool)
+	for _, n := range nodes {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids["primary"])
+	assert.True(t, ids["replica-1"])
+	assert.True(t, ids["replica-2"])
+}
+
+func TestShardMapGetNodeShards(t *testing.T) {
+	sm := NewShardMap(3)
+
+	node1 := &cluster.Node{ID: "node-1"}
+	node2 := &cluster.Node{ID: "node-2"}
+
+	// node-1: primary for shard 0, replica for shard 1
+	sm.SetPrimary(0, node1)
+	sm.AddReplica(1, node1)
+
+	// node-2: primary for shard 1, replica for shard 0
+	sm.SetPrimary(1, node2)
+	sm.AddReplica(0, node2)
+
+	// Check node-1 shards
+	roles := sm.GetNodeShards("node-1")
+	assert.Len(t, roles, 2)
+
+	roleMap := make(map[int]Role)
+	for _, r := range roles {
+		roleMap[r.ShardID] = r.Role
+	}
+	assert.Equal(t, RolePrimary, roleMap[0])
+	assert.Equal(t, RoleReplica, roleMap[1])
+}
+
+func TestShardMapRemoveNode(t *testing.T) {
+	sm := NewShardMap(3)
+
+	node1 := &cluster.Node{ID: "node-1"}
+	node2 := &cluster.Node{ID: "node-2"}
+
+	// node-1: primary for shard 0, replica for shard 1
+	sm.SetPrimary(0, node1)
+	sm.AddReplica(1, node1)
+
+	// node-2: primary for shard 1, replica for shard 0
+	sm.SetPrimary(1, node2)
+	sm.AddReplica(0, node2)
+
+	// Remove node-1
+	primaryShards := sm.RemoveNode("node-1")
+
+	// Should report that shard 0 lost its primary
+	assert.Contains(t, primaryShards, 0)
+	assert.NotContains(t, primaryShards, 1)
+
+	// Shard 0 should have no primary now
+	assert.Nil(t, sm.GetPrimary(0))
+
+	// Shard 1 should still have node-2 as primary
+	assert.Equal(t, "node-2", sm.GetPrimary(1).ID)
+
+	// node-1 should be removed from shard 1's replicas
+	group := sm.GetShardGroup(1)
+	for _, r := range group.Replicas {
+		assert.NotEqual(t, "node-1", r.ID)
+	}
+}
+
+func TestShardMapStats(t *testing.T) {
+	sm := NewShardMap(3)
+
+	node1 := &cluster.Node{ID: "node-1"}
+	node2 := &cluster.Node{ID: "node-2"}
+
+	sm.SetPrimary(0, node1)
+	sm.SetPrimary(1, node2)
+	sm.AddReplica(0, node2)
+	sm.AddReplica(1, node1)
+
+	stats := sm.Stats()
+
+	assert.Equal(t, 3, stats["num_shards"])
+	assert.Equal(t, 2, stats["assigned_shards"]) // 2 primaries set
+	assert.Equal(t, 1, stats["unassigned"])      // shard 2 has no primary
+	assert.Equal(t, 2, stats["total_replicas"])  // 2 replicas total
+}
+
+func TestShardMapDistribution(t *testing.T) {
+	sm := NewShardMap(10)
+
+	// Test that databases are roughly evenly distributed
+	distribution := make(map[int]int)
+	for i := 0; i < 1000; i++ {
+		// Generate unique database names
+		database := "database_" + strconv.Itoa(i)
+		shard := sm.GetShard(database)
+		distribution[shard]++
+	}
+
+	// Each shard should have roughly 100 databases (1000/10)
+	// Allow for some variance (FNV-1a is well distributed)
+	for shard := 0; shard < 10; shard++ {
+		count := distribution[shard]
+		assert.Greater(t, count, 50, "Shard %d has too few databases", shard)
+		assert.Less(t, count, 150, "Shard %d has too many databases", shard)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,13 @@ type ClusterConfig struct {
 	ReplicationLagLimit    int  // Max acceptable lag in milliseconds before health degrades (default: 5000)
 	ReplicationBufferSize  int  // Entry buffer size for replication queue (default: 10000)
 	ReplicationAckInterval int  // How often readers send acks in milliseconds (default: 100)
+
+	// Sharding configuration (Phase 4)
+	ShardingEnabled           bool   // Enable sharding for horizontal write scaling (default: false)
+	ShardingNumShards         int    // Number of shards (default: 3)
+	ShardingShardKey          string // Shard key: "database" or "measurement" (default: "database")
+	ShardingReplicationFactor int    // Number of copies per shard (default: 3)
+	ShardingRouteTimeout      int    // Timeout for shard routing in milliseconds (default: 5000)
 }
 
 // Load loads configuration from environment and config file
@@ -401,6 +408,12 @@ func Load() (*Config, error) {
 			ReplicationLagLimit:    v.GetInt("cluster.replication_lag_limit"),
 			ReplicationBufferSize:  v.GetInt("cluster.replication_buffer_size"),
 			ReplicationAckInterval: v.GetInt("cluster.replication_ack_interval"),
+			// Sharding configuration (Phase 4)
+			ShardingEnabled:           v.GetBool("cluster.sharding_enabled"),
+			ShardingNumShards:         v.GetInt("cluster.sharding_num_shards"),
+			ShardingShardKey:          v.GetString("cluster.sharding_shard_key"),
+			ShardingReplicationFactor: v.GetInt("cluster.sharding_replication_factor"),
+			ShardingRouteTimeout:      v.GetInt("cluster.sharding_route_timeout"),
 		},
 	}
 
@@ -548,6 +561,13 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("cluster.replication_lag_limit", 5000)    // 5 second lag limit
 	v.SetDefault("cluster.replication_buffer_size", 10000) // 10k entry buffer
 	v.SetDefault("cluster.replication_ack_interval", 100)  // 100ms ack interval
+
+	// Sharding defaults (Phase 4)
+	v.SetDefault("cluster.sharding_enabled", false)            // Disabled by default
+	v.SetDefault("cluster.sharding_num_shards", 3)             // 3 shards default
+	v.SetDefault("cluster.sharding_shard_key", "database")     // Database-level sharding
+	v.SetDefault("cluster.sharding_replication_factor", 3)     // RF=3 for fault tolerance
+	v.SetDefault("cluster.sharding_route_timeout", 5000)       // 5 second timeout
 }
 
 func getDefaultThreadCount() int {

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -2073,6 +2073,19 @@ func sortColumnsByTimeOnly(columns map[string]interface{}) (map[string]interface
 		return columns, nil
 	}
 
+	// FAST PATH: Check if already sorted (common case for time-series producers)
+	// This is O(n) but much cheaper than sorting + permutation when data is in order
+	alreadySorted := true
+	for i := 1; i < n; i++ {
+		if times[i] < times[i-1] {
+			alreadySorted = false
+			break
+		}
+	}
+	if alreadySorted {
+		return columns, nil // No work needed - data is already in time order
+	}
+
 	// Create permutation indices
 	indices := make([]int, n)
 	for i := range indices {


### PR DESCRIPTION
Add horizontal scaling infrastructure for multi-writer distributed architecture:

Sharding Infrastructure:
- ShardMap with consistent hashing (virtual nodes) for data distribution
- Shard metadata FSM for Raft-based consensus on shard assignments
- Shard router for routing writes/queries to correct shard primaries
- Scatter-gather query execution across shards

Replication & Failover:
- Shard replication with configurable replication factor
- Automatic failover detection and leader election per shard
- Shard receiver for handling replicated data from primaries

Performance Optimizations:
- Add router nil check to skip routing overhead in standalone mode
- Skip RBAC measurement extraction when RBAC is disabled (O(n) savings)
- Add "already sorted" fast path in sortColumnsByTimeOnly (2x throughput improvement)
- Fix buffer cleanup to use delete() for proper re-initialization

API Integration:
- Add sharded write/query routing helpers in routing.go
- Update msgpack and lineprotocol handlers with optimized checks