### PR TITLE
feat(api): InfluxDB-compatible endpoints for drop-in client migration

### DIFF
--- a/internal/api/lineprotocol.go
+++ b/internal/api/lineprotocol.go
@@ -101,13 +101,13 @@ func (h *LineProtocolHandler) checkWritePermissions(c *fiber.Ctx, database strin
 
 // RegisterRoutes registers Line Protocol routes
 func (h *LineProtocolHandler) RegisterRoutes(app *fiber.App) {
-	// InfluxDB 1.x compatible endpoint
-	app.Post("/api/v1/write", h.WriteV1)
+	// InfluxDB 1.x compatible endpoint (matches InfluxDB API)
+	app.Post("/write", h.WriteV1)
 
-	// InfluxDB 2.x compatible endpoint
-	app.Post("/api/v1/write/influxdb", h.WriteInfluxDB)
+	// InfluxDB 2.x compatible endpoint (matches InfluxDB API)
+	app.Post("/api/v2/write", h.WriteInfluxDB)
 
-	// Simple write endpoint (no query parameters)
+	// Arc native endpoint (no query parameters, uses x-arc-database header)
 	app.Post("/api/v1/write/line-protocol", h.WriteSimple)
 
 	// Stats endpoint
@@ -123,7 +123,7 @@ func (h *LineProtocolHandler) RegisterRoutes(app *fiber.App) {
 }
 
 // WriteV1 handles InfluxDB 1.x compatible write requests
-// POST /api/v1/write?db=telegraf&rp=default&precision=ns
+// POST /write?db=telegraf&rp=default&precision=ns
 func (h *LineProtocolHandler) WriteV1(c *fiber.Ctx) error {
 	h.totalRequests.Add(1)
 
@@ -141,7 +141,7 @@ func (h *LineProtocolHandler) WriteV1(c *fiber.Ctx) error {
 }
 
 // WriteInfluxDB handles InfluxDB 2.x compatible write requests
-// POST /api/v1/write/influxdb?org=myorg&bucket=mybucket&precision=ns
+// POST /api/v2/write?org=myorg&bucket=mybucket&precision=ns
 func (h *LineProtocolHandler) WriteInfluxDB(c *fiber.Ctx) error {
 	h.totalRequests.Add(1)
 


### PR DESCRIPTION
## Summary

- Change Line Protocol endpoints to match InfluxDB API paths (`/write`, `/api/v2/write`)
- Add InfluxDB-compatible authentication methods (`Token` header, `?p=` query param)
- Enable all official InfluxDB client libraries to work without code changes

## Motivation

Users reported difficulty using `node-red-contrib-influxdb` and other InfluxDB client libraries because they hardcode endpoint paths. This change makes Arc a true drop-in replacement for InfluxDB.

## Changes

| Old Path | New Path | Compatible With |
|----------|----------|-----------------|
| `/api/v1/write` | `/write` | InfluxDB 1.x clients, Telegraf |
| `/api/v1/write/influxdb` | `/api/v2/write` | InfluxDB 2.x clients |

## Authentication Methods

| Method | Example |
|--------|---------|
| Bearer token | `Authorization: Bearer <token>` |
| Token header | `Authorization: Token <token>` |
| Query parameter | `?p=<token>` (InfluxDB 1.x) |

## Supported Clients

- Go: `github.com/influxdata/influxdb-client-go`
- Python: `influxdb-client`
- JavaScript/Node.js: `@influxdata/influxdb-client`
- Telegraf, Node-RED `node-red-contrib-influxdb`, and more

## Test Plan

- [x] Existing tests pass
- [x] Load tested with 170k+ requests at 50 concurrent connections
- [x] 0 server-side errors during stress testing
- [x] Manual testing with curl using all auth methods

## Breaking Changes

Old paths `/api/v1/write` and `/api/v1/write/influxdb` are removed. Users must update to new paths or use standard InfluxDB clients (which now work out of the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)