### PR TITLE
fix(auth): Add CodeQL suppression comments for SHA256 false positives

### DIFF
--- a/RELEASE_NOTES_2026.02.1.md
+++ b/RELEASE_NOTES_2026.02.1.md
@@ -231,6 +231,19 @@ When `client_id` is not specified in the MQTT configuration, Arc now auto-genera
 
 Added `/api/v1/restart` endpoint to restart the MQTT client, allowing configuration changes to be applied without restarting the entire Arc server.
 
+## Security
+
+### Token Hashing Security Model
+
+Arc uses a defense-in-depth approach for API token security:
+
+- **Storage**: All new tokens are hashed with **bcrypt** (cost factor 10) before storage
+- **Lookup optimization**: SHA256-based prefixes enable O(1) database lookups without exposing tokens
+- **Cache keys**: In-memory cache uses SHA256 for fast key derivation (not security-sensitive)
+- **Legacy support**: Pre-v26 tokens using SHA256 hashes continue to work for backward compatibility
+
+New tokens created since v26 use bcrypt exclusively for storage. The SHA256 usage for cache keys and database indexes is a performance optimization - security is provided by the bcrypt-hashed storage, not the lookup indexes.
+
 ## Breaking Changes
 
 None


### PR DESCRIPTION
## Summary

Suppress CodeQL alerts for SHA256 usage that are false positives or intentional design decisions.

## CodeQL Alerts Addressed

| Line | Function | Assessment | Action |
|------|----------|------------|--------|
| 342 | `verifyTokenHash` | Legacy compatibility | Documented + suppressed |
| 348 | `cacheKey` | False positive | Documented + suppressed |
| 355 | `tokenPrefix` | False positive | Documented + suppressed |

## Context

The code already uses **bcrypt** for new token hashing (line 328). The SHA256 usage is intentional for:

1. **Legacy compatibility** (`verifyTokenHash`): Pre-v26 tokens were stored with SHA256. This allows existing tokens to continue working without forcing rotation.

2. **Cache key derivation** (`cacheKey`): Creates an in-memory cache lookup key. This is NOT password storage - it's a fast O(1) lookup index. Security comes from bcrypt storage, not the cache key.

3. **Database index** (`tokenPrefix`): Generates a prefix for O(1) database queries instead of O(n) full table scan. Again, security is provided by bcrypt - this is just an index optimization.

## Changes

Added `#nosec G401` comments with clear documentation explaining why SHA256 is acceptable in each case.

## Test Plan

- [x] All auth tests pass
- [x] No functional changes to code behavior