### PR TITLE
fix(api): Apply MaxPayloadSize config to Fiber BodyLimit

### DIFF
--- a/RELEASE_NOTES_2026.02.1.md
+++ b/RELEASE_NOTES_2026.02.1.md
@@ -160,6 +160,14 @@ WHERE time > NOW() - INTERVAL '4 minutes'
 
 ## Bug Fixes
 
+### Large Payload Ingestion (413 Request Entity Too Large)
+
+Fixed an issue where large ingestion requests (>4MB) would fail with `413 Request Entity Too Large` even though `server.max_payload_size` was configured to allow larger payloads (default: 1GB).
+
+**Cause:** The `MaxPayloadSize` config value was not being passed to Fiber's `BodyLimit` setting, so Fiber used its default 4MB limit.
+
+**Fix:** Now passes the configured `MaxPayloadSize` to Fiber's `BodyLimit`, allowing payloads up to the configured limit (default 1GB).
+
 ### Query Results Timestamp Timezone Inconsistency
 
 Fixed a bug where `time.Time` values in query results could be returned with the server's local timezone instead of UTC. This caused timestamp inconsistencies when servers were running in non-UTC timezones.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -68,6 +68,7 @@ func NewServer(config *ServerConfig, logger zerolog.Logger) *Server {
 		ReadTimeout:           config.ReadTimeout,
 		WriteTimeout:          config.WriteTimeout,
 		IdleTimeout:           config.IdleTimeout,
+		BodyLimit:             int(config.MaxPayloadSize),
 		DisableStartupMessage: true,
 		ErrorHandler:          customErrorHandler(logger),
 		// CRITICAL: Disable automatic request body parsing to preserve gzip-compressed payloads


### PR DESCRIPTION
## Summary

Fix Fiber's default 4MB body limit blocking large ingestion requests.

## Problem

- `ServerConfig.MaxPayloadSize` exists and defaults to 1GB
- But it was never passed to Fiber's `BodyLimit` config
- Fiber defaults to 4MB, causing 413 errors on large payloads

## Fix

One-line change: pass `config.MaxPayloadSize` to `fiber.Config.BodyLimit`.

## Test Plan

- [x] API tests pass
- [ ] Manual test with payload > 4MB