### PR TITLE
fix(api): Validate measurement names to prevent S3 XML parsing errors

### DIFF
--- a/internal/api/continuous_query.go
+++ b/internal/api/continuous_query.go
@@ -230,6 +230,11 @@ func (h *ContinuousQueryHandler) handleCreate(c *fiber.Ctx) error {
 	if req.DestinationMeasurement == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "destination_measurement is required"})
 	}
+	if !isValidMeasurementName(req.DestinationMeasurement) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid destination_measurement: must start with a letter and contain only alphanumeric characters, underscores, or hyphens",
+		})
+	}
 	if req.Query == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "query is required"})
 	}
@@ -319,6 +324,13 @@ func (h *ContinuousQueryHandler) handleUpdate(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid request body: " + err.Error(),
+		})
+	}
+
+	// Validate destination_measurement if provided
+	if req.DestinationMeasurement != "" && !isValidMeasurementName(req.DestinationMeasurement) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid destination_measurement: must start with a letter and contain only alphanumeric characters, underscores, or hyphens",
 		})
 	}
 

--- a/internal/api/lineprotocol_test.go
+++ b/internal/api/lineprotocol_test.go
@@ -1,0 +1,80 @@
+package api
+
+import "testing"
+
+func TestIsValidMeasurementName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Valid names
+		{"simple lowercase", "cpu", true},
+		{"simple uppercase", "CPU", true},
+		{"mixed case", "CpuMetrics", true},
+		{"with underscore", "cpu_usage", true},
+		{"with hyphen", "cpu-usage", true},
+		{"with numbers", "cpu123", true},
+		{"complex valid", "System-Metrics_v2", true},
+
+		// Invalid: starts with non-letter
+		{"starts with number", "123cpu", false},
+		{"starts with underscore", "_cpu", false},
+		{"starts with hyphen", "-cpu", false},
+
+		// Invalid: contains illegal characters
+		{"contains space", "cpu usage", false},
+		{"contains dot", "cpu.usage", false},
+		{"contains slash", "cpu/usage", false},
+		{"contains colon", "cpu:usage", false},
+		{"contains at", "cpu@host", false},
+
+		// Invalid: control characters (the main fix for issue #122)
+		{"control char 0x01", "test\x01name", false},
+		{"control char 0x05", "test\x05name", false},
+		{"control char 0x08", "test\x08name", false},
+		{"control char 0x0B", "test\x0Bname", false},
+		{"control char 0x0C", "test\x0Cname", false},
+		{"control char 0x1F", "test\x1Fname", false},
+		{"starts with control char", "\x05cpu", false},
+		{"ends with control char", "cpu\x05", false},
+
+		// Edge cases
+		{"empty string", "", false},
+		{"single letter", "a", true},
+		{"max length (128)", "a" + string(make([]byte, 127)), false}, // 128 'a's but make() creates zeros
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidMeasurementName(tt.input)
+			if result != tt.expected {
+				t.Errorf("isValidMeasurementName(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsValidMeasurementName_MaxLength(t *testing.T) {
+	// Test exactly at the 128 char boundary
+	validMaxLen := make([]byte, 128)
+	validMaxLen[0] = 'a'
+	for i := 1; i < 128; i++ {
+		validMaxLen[i] = 'b'
+	}
+
+	if !isValidMeasurementName(string(validMaxLen)) {
+		t.Error("expected 128 char name to be valid")
+	}
+
+	// Test 129 chars (should be invalid)
+	tooLong := make([]byte, 129)
+	tooLong[0] = 'a'
+	for i := 1; i < 129; i++ {
+		tooLong[i] = 'b'
+	}
+
+	if isValidMeasurementName(string(tooLong)) {
+		t.Error("expected 129 char name to be invalid")
+	}
+}


### PR DESCRIPTION
Measurement names containing ASCII control characters (0x01-0x08, 0x0B-0x0C, 0x0E-0x1F) corrupt S3 ListObjectsV2 XML responses, breaking all database/table listing for the entire bucket.

Add validation requiring measurement names to start with a letter and contain only alphanumeric characters, underscores, or hyphens. This matches the existing database name validation pattern.

Affected endpoints:
- POST /api/v1/write (line protocol)
- POST /api/v1/write/msgpack (msgpack)
- POST /api/v1/continuous-queries (create)
- PUT /api/v1/continuous-queries/:id (update)

Fixes #122