### PR TITLE
fix(pruning): Filter non-existent S3/Azure partitions before query ex…

### DIFF
--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -661,10 +661,12 @@ func validateWhereClauseQuery(where string) error {
 // NewQueryHandler creates a new query handler
 func NewQueryHandler(db *database.DuckDB, storage storage.Backend, logger zerolog.Logger) *QueryHandler {
 	handlerLogger := logger.With().Str("component", "query-handler").Logger()
+	pruner := pruning.NewPartitionPruner(logger)
+	pruner.SetStorageBackend(storage) // Enable S3/Azure partition filtering
 	return &QueryHandler{
 		db:               db,
 		storage:          storage,
-		pruner:           pruning.NewPartitionPruner(logger),
+		pruner:           pruner,
 		queryCache:       database.NewQueryCache(database.QueryCacheTTL, database.DefaultQueryCacheMaxSize),
 		logger:           handlerLogger,
 		authManager:      nil,


### PR DESCRIPTION
…ecution

Time-filtered queries were failing when the requested range included partitions that don't exist in S3. The partition pruner was generating paths for all hours in the range without checking existence for remote storage (it only checked for local storage).

Changes:
- Add SetStorageBackend() to PartitionPruner for remote path validation
- Implement filterExistingRemotePaths() using ListDirectories() to check which S3/Azure partition directories actually exist
- Fix GeneratePartitionPaths() to preserve s3:// and azure:// URL scheme (was using filepath.Join which mangles URLs)
- Wire up storage backend in QueryHandler

When partitions are missing, queries now return partial results from existing partitions instead of failing entirely. This is critical for Grafana dashboards with "Last 30 days" time ranges where historical data may have gaps.

Fixes #125