### PR TITLE
fix: Ensure UTC dates for compaction filenames

### DIFF
--- a/internal/compaction/daily.go
+++ b/internal/compaction/daily.go
@@ -130,12 +130,6 @@ func (t *DailyTier) ShouldCompact(files []string, partitionTime time.Time) bool 
 	)
 }
 
-// GetCompactedFilename generates the filename for a compacted file
-func (t *DailyTier) GetCompactedFilename(measurement string, partitionTime time.Time) string {
-	timestamp := partitionTime.Format("20060102")
-	return measurement + "_" + timestamp + "_daily.parquet"
-}
-
 // IsCompactedFile checks if a file is a compacted daily file
 func (t *DailyTier) IsCompactedFile(filename string) bool {
 	return strings.HasSuffix(filename, "_daily.parquet")
@@ -263,18 +257,18 @@ func extractNewestFileTime(files []string) time.Time {
 		// Remove .parquet extension
 		filename = strings.TrimSuffix(filename, ".parquet")
 
-		// Check if it's a daily compacted file: measurement_YYYYMMDD_daily
+		// Check if it's a daily compacted file: measurement_YYYYMMDD_HHMMSS_daily
 		if strings.HasSuffix(filename, "_daily") {
 			// Remove _daily suffix
 			filename = strings.TrimSuffix(filename, "_daily")
 			fileParts := strings.Split(filename, "_")
-			if len(fileParts) < 2 {
+			if len(fileParts) < 3 {
 				continue
 			}
-			// Last part is the date
-			datePart := fileParts[len(fileParts)-1]
-			// Parse date: YYYYMMDD (daily files created at midnight UTC)
-			fileTime, err := time.Parse("20060102", datePart)
+			// Last two parts are date and time: YYYYMMDD_HHMMSS
+			dateTimePart := fileParts[len(fileParts)-2] + "_" + fileParts[len(fileParts)-1]
+			// Parse timestamp: YYYYMMDD_HHMMSS
+			fileTime, err := time.Parse("20060102_150405", dateTimePart)
 			if err != nil {
 				continue
 			}

--- a/internal/compaction/daily_test.go
+++ b/internal/compaction/daily_test.go
@@ -53,7 +53,7 @@ func TestExtractNewestFileTime(t *testing.T) {
 		{
 			name: "daily compacted file",
 			files: []string{
-				"default/metrics/2026/01/01/metrics_20260102_daily.parquet",
+				"default/metrics/2026/01/01/metrics_20260102_000000_daily.parquet",
 			},
 			expected: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
 		},
@@ -62,7 +62,7 @@ func TestExtractNewestFileTime(t *testing.T) {
 			files: []string{
 				"default/metrics/2026/01/01/00/metrics_20260101_120000_123456789.parquet",
 				"default/metrics/2026/01/01/01/metrics_20260101_130000_987654321.parquet",
-				"default/metrics/2026/01/01/metrics_20260102_daily.parquet",
+				"default/metrics/2026/01/01/metrics_20260102_000000_daily.parquet",
 			},
 			expected: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
 		},

--- a/internal/compaction/hourly.go
+++ b/internal/compaction/hourly.go
@@ -127,12 +127,6 @@ func (t *HourlyTier) ShouldCompact(files []string, partitionTime time.Time) bool
 	)
 }
 
-// GetCompactedFilename generates the filename for a compacted file
-func (t *HourlyTier) GetCompactedFilename(measurement string, partitionTime time.Time) string {
-	timestamp := partitionTime.Format("20060102_150405")
-	return measurement + "_" + timestamp + "_compacted.parquet"
-}
-
 // IsCompactedFile checks if a file is a compacted hourly file
 func (t *HourlyTier) IsCompactedFile(filename string) bool {
 	return strings.HasSuffix(filename, "_compacted.parquet")

--- a/internal/compaction/job.go
+++ b/internal/compaction/job.go
@@ -428,8 +428,8 @@ func (j *Job) downloadSingleFile(ctx context.Context, tempDir string, index int,
 // It validates each file and only compacts valid ones, storing the list of
 // successfully compacted files' storage keys in j.compactedFiles.
 func (j *Job) compactFiles(ctx context.Context, files []downloadedFile, tempDir string) (string, error) {
-	// Generate output filename with tier-specific suffix
-	timestamp := time.Now().Format("20060102_150405")
+	// Generate output filename with tier-specific suffix (use UTC for consistency)
+	timestamp := time.Now().UTC().Format("20060102_150405")
 	suffix := "compacted"
 	if j.Tier != "hourly" {
 		suffix = j.Tier

--- a/internal/compaction/tier.go
+++ b/internal/compaction/tier.go
@@ -79,9 +79,6 @@ type Tier interface {
 	// ShouldCompact determines if a partition should be compacted based on tier-specific criteria
 	ShouldCompact(files []string, partitionTime time.Time) bool
 
-	// GetCompactedFilename generates the filename for a compacted file
-	GetCompactedFilename(measurement string, partitionTime time.Time) string
-
 	// IsCompactedFile checks if a file is already a compacted file from this tier
 	IsCompactedFile(filename string) bool
 
@@ -162,12 +159,6 @@ func (t *BaseTier) RecordCompaction(filesCompacted int, bytesSaved int64) {
 	t.TotalCompactions++
 	t.TotalFilesCompacted += filesCompacted
 	t.TotalBytesSaved += bytesSaved
-}
-
-// GetCompactedFilename generates a filename for a compacted file
-func (t *BaseTier) GetCompactedFilename(tierName, measurement string, partitionTime time.Time) string {
-	timestamp := partitionTime.Format("20060102")
-	return fmt.Sprintf("%s_%s_%s.parquet", measurement, timestamp, tierName)
 }
 
 // IsCompactedFile checks if a file is a compacted file from a specific tier


### PR DESCRIPTION
Dates in the filenames were not using UTC when compacting. I've also removed the unused method GetCompactedFilename as this happens in CompactFiles in job.go.