### PR TITLE
fix(ingest): sanitize non-UTF8 strings to prevent query failures (Iss…

### DIFF
--- a/internal/ingest/utf8.go
+++ b/internal/ingest/utf8.go
@@ -1,0 +1,34 @@
+package ingest
+
+import "unicode/utf8"
+
+// SanitizeUTF8 replaces invalid UTF-8 sequences with the Unicode replacement character (U+FFFD).
+// This function is optimized for the common case where strings are already valid UTF-8:
+// - Fast path: utf8.ValidString() check (~3-25ns for typical strings), returns original string unchanged
+// - Slow path: Only allocates and copies when invalid bytes are found (rare case)
+//
+// This is used during ingestion to prevent DuckDB query failures caused by non-UTF-8 data
+// in Parquet files. Common sources of invalid UTF-8 include rsyslog messages, binary protocols,
+// and data from non-UTF-8 encodings (Latin-1, Windows-1252).
+func SanitizeUTF8(s string) (string, bool) {
+	// Fast path: ~3-25ns for typical strings, no allocation
+	if utf8.ValidString(s) {
+		return s, false
+	}
+
+	// Slow path: only executed for invalid UTF-8 (rare)
+	// Pre-allocate with some growth room for replacement characters
+	result := make([]byte, 0, len(s)+len(s)/8)
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			// Invalid UTF-8 byte - replace with U+FFFD (replacement character)
+			result = append(result, '\xef', '\xbf', '\xbd')
+			i++
+		} else {
+			result = append(result, s[i:i+size]...)
+			i += size
+		}
+	}
+	return string(result), true
+}

--- a/internal/ingest/utf8_test.go
+++ b/internal/ingest/utf8_test.go
@@ -1,0 +1,162 @@
+package ingest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeUTF8_ValidString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty string", ""},
+		{"ascii only", "Hello World"},
+		{"with unicode", "Hello, 世界! Привет мир!"},
+		{"with emojis", "Log message with emojis 🎉🚀💻"},
+		{"mixed content", "user=admin action=login status=success café résumé naïve"},
+		{"typical log", "2026-01-19T10:30:00Z INFO [server] Request processed in 42ms"},
+		{"json content", `{"level":"info","msg":"test","value":123}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, modified := SanitizeUTF8(tt.input)
+			if modified {
+				t.Errorf("Expected no modification for valid UTF-8, got modified=true")
+			}
+			if result != tt.input {
+				t.Errorf("Expected %q, got %q", tt.input, result)
+			}
+		})
+	}
+}
+
+func TestSanitizeUTF8_InvalidBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single invalid byte",
+			input:    "Hello\x80World",
+			expected: "Hello\ufffdWorld",
+		},
+		{
+			name:     "multiple invalid bytes",
+			input:    "\x80\x81\x82",
+			expected: "\ufffd\ufffd\ufffd",
+		},
+		{
+			name:     "invalid at start",
+			input:    "\x80Hello",
+			expected: "\ufffdHello",
+		},
+		{
+			name:     "invalid at end",
+			input:    "Hello\x80",
+			expected: "Hello\ufffd",
+		},
+		{
+			name:     "mixed valid and invalid",
+			input:    "Hello\x80世界\x81Test",
+			expected: "Hello\ufffd世界\ufffdTest",
+		},
+		{
+			name:     "invalid in JSON-like content",
+			input:    "{\"msg\":\"test\x80value\"}",
+			expected: "{\"msg\":\"test\ufffdvalue\"}",
+		},
+		{
+			name:     "latin1 high bytes",
+			input:    "caf\xe9 r\xe9sum\xe9", // café résumé in Latin-1
+			expected: "caf\ufffd r\ufffdsum\ufffd",
+		},
+		{
+			name:     "truncated utf8 sequence",
+			input:    "test\xc3", // incomplete 2-byte sequence
+			expected: "test\ufffd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, modified := SanitizeUTF8(tt.input)
+			if !modified {
+				t.Errorf("Expected modification for invalid UTF-8, got modified=false")
+			}
+			if result != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSanitizeUTF8_EdgeCases(t *testing.T) {
+	// Ensure we don't break valid edge cases
+	tests := []struct {
+		name     string
+		input    string
+		modified bool
+	}{
+		{"null byte in string", "hello\x00world", false}, // \x00 is valid UTF-8
+		{"replacement char already present", "test\ufffdvalue", false},
+		{"BOM", "\xef\xbb\xbfHello", false}, // UTF-8 BOM is valid
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, modified := SanitizeUTF8(tt.input)
+			if modified != tt.modified {
+				t.Errorf("Expected modified=%v, got modified=%v", tt.modified, modified)
+			}
+			if !tt.modified && result != tt.input {
+				t.Errorf("Expected unchanged string, got %q instead of %q", result, tt.input)
+			}
+		})
+	}
+}
+
+// Benchmarks to verify fast path performance
+func BenchmarkSanitizeUTF8_ValidShort(b *testing.B) {
+	input := "user=admin action=login"
+	for i := 0; i < b.N; i++ {
+		SanitizeUTF8(input)
+	}
+}
+
+func BenchmarkSanitizeUTF8_ValidMedium(b *testing.B) {
+	input := "Normal log message with some data: user=admin action=login status=success timestamp=2026-01-19T10:30:00Z"
+	for i := 0; i < b.N; i++ {
+		SanitizeUTF8(input)
+	}
+}
+
+func BenchmarkSanitizeUTF8_ValidLong(b *testing.B) {
+	input := strings.Repeat("This is a typical log message with various content. ", 20)
+	for i := 0; i < b.N; i++ {
+		SanitizeUTF8(input)
+	}
+}
+
+func BenchmarkSanitizeUTF8_ValidUnicode(b *testing.B) {
+	input := "日志消息 with mixed 内容 and émojis 🎉"
+	for i := 0; i < b.N; i++ {
+		SanitizeUTF8(input)
+	}
+}
+
+func BenchmarkSanitizeUTF8_InvalidSingle(b *testing.B) {
+	input := "Log with \x80 single invalid byte"
+	for i := 0; i < b.N; i++ {
+		SanitizeUTF8(input)
+	}
+}
+
+func BenchmarkSanitizeUTF8_InvalidMultiple(b *testing.B) {
+	input := "Log \x80 with \x81 multiple \x82 invalid \x83 bytes"
+	for i := 0; i < b.N; i++ {
+		SanitizeUTF8(input)
+	}
+}


### PR DESCRIPTION
…ue #136)

Users ingesting rsyslog messages or data with non-UTF-8 characters experienced DuckDB query errors. This adds automatic UTF-8 sanitization during ingestion.

Changes:
- Add SanitizeUTF8() function that replaces invalid UTF-8 bytes with U+FFFD
- Apply sanitization to MessagePack string fields (columnar and row formats)
- Apply sanitization to Line Protocol string field values
- Batch-level warning logs when sanitization occurs

Performance:
- Valid UTF-8 (99%+ of data): ~6-25ns overhead, zero allocations
- Invalid UTF-8 (rare): ~150-230ns with minimal allocations