### PR TITLE
Add S3 file caching via cache_httpfs extension

### DIFF
--- a/arc.toml
+++ b/arc.toml
@@ -269,12 +269,24 @@ enabled = false
 #   - Subqueries accessing the same data
 #   - Grafana dashboards with multiple panels querying similar time ranges
 #
-# Trade-off: Increases memory usage (default ~128MB for cache)
+# Trade-off: Increases memory usage based on cache size settings below
 # Only effective when storage.backend = "s3"
 #
 # Environment variable: ARC_QUERY_ENABLE_S3_CACHE
 # Default: false
 enable_s3_cache = false
+
+# Maximum size for in-memory S3 cache
+# Supports: KB, MB, GB (e.g., "128MB", "256MB", "1GB")
+# Environment variable: ARC_QUERY_S3_CACHE_SIZE
+# Default: "128MB"
+s3_cache_size = "128MB"
+
+# Cache entry TTL (time-to-live) in seconds
+# Cached blocks are evicted after this duration
+# Environment variable: ARC_QUERY_S3_CACHE_TTL_SECONDS
+# Default: 3600 (1 hour)
+s3_cache_ttl_seconds = 3600
 
 [telemetry]
 enabled = true

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -166,6 +166,10 @@ func main() {
 		AzureAccountName: cfg.Storage.AzureAccountName,
 		AzureAccountKey:  cfg.Storage.AzureAccountKey,
 		AzureEndpoint:    cfg.Storage.AzureEndpoint,
+		// Query optimization
+		EnableS3Cache:     cfg.Query.EnableS3Cache,
+		S3CacheSize:       cfg.Query.S3CacheSize,
+		S3CacheTTLSeconds: cfg.Query.S3CacheTTLSeconds,
 	}
 
 	db, err := database.New(dbConfig, logger.Get("database"))

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -50,7 +50,9 @@ type Config struct {
 	AzureAccountKey  string
 	AzureEndpoint    string // Custom endpoint (optional)
 	// Query optimization configuration
-	EnableS3Cache bool // Enable S3 file caching via cache_httpfs extension
+	EnableS3Cache     bool  // Enable S3 file caching via cache_httpfs extension
+	S3CacheSize       int64 // Cache size in bytes
+	S3CacheTTLSeconds int   // Cache entry TTL in seconds (default: 3600)
 }
 
 // New creates a new DuckDB instance
@@ -90,6 +92,7 @@ func New(cfg *Config, logger zerolog.Logger) (*DuckDB, error) {
 		Bool("wal_enabled", cfg.EnableWAL).
 		Bool("s3_enabled", s3Enabled).
 		Str("s3_region", cfg.S3Region).
+		Bool("s3_cache_enabled", cfg.EnableS3Cache).
 		Bool("azure_enabled", azureEnabled).
 		Str("azure_account", cfg.AzureAccountName).
 		Msg("DuckDB initialized")
@@ -137,7 +140,7 @@ func configureDatabase(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 
 	// Configure httpfs extension for S3 access if credentials are provided
 	if cfg.S3AccessKey != "" && cfg.S3SecretKey != "" {
-		if err := configureS3Access(db, cfg); err != nil {
+		if err := configureS3Access(db, cfg, logger); err != nil {
 			return fmt.Errorf("failed to configure S3 access: %w", err)
 		}
 	}
@@ -154,7 +157,7 @@ func configureDatabase(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 
 // configureS3Access sets up the httpfs extension for S3 access
 // Note: We use SET GLOBAL to ensure settings persist across all connections in the pool
-func configureS3Access(db *sql.DB, cfg *Config) error {
+func configureS3Access(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 	// Install and load the httpfs extension
 	if _, err := db.Exec("INSTALL httpfs"); err != nil {
 		return fmt.Errorf("failed to install httpfs: %w", err)
@@ -205,10 +208,31 @@ func configureS3Access(db *sql.DB, cfg *Config) error {
 
 	// Configure cache_httpfs extension for S3 file caching if enabled
 	if cfg.EnableS3Cache {
-		if _, err := db.Exec("INSTALL cache_httpfs FROM community"); err == nil {
-			if _, err := db.Exec("LOAD cache_httpfs"); err == nil {
-				db.Exec("SET cache_httpfs_type='in_memory'")
+		logger.Info().Msg("Enabling S3 file caching via cache_httpfs extension")
+		if _, err := db.Exec("INSTALL cache_httpfs FROM community"); err != nil {
+			logger.Warn().Err(err).Msg("Failed to install cache_httpfs extension, continuing without cache")
+		} else if _, err := db.Exec("LOAD cache_httpfs"); err != nil {
+			logger.Warn().Err(err).Msg("Failed to load cache_httpfs extension, continuing without cache")
+		} else {
+			db.Exec("SET cache_httpfs_type='in_memory'")
+			// Calculate max blocks from cache size (each block is 512KB)
+			if cfg.S3CacheSize > 0 {
+				maxBlocks := cfg.S3CacheSize / (512 * 1024) // 512KB per block
+				if maxBlocks > 0 {
+					db.Exec(fmt.Sprintf("SET cache_httpfs_max_in_mem_cache_block_count=%d", maxBlocks))
+				} else {
+					logger.Warn().
+						Int64("configured_bytes", cfg.S3CacheSize).
+						Msg("S3 cache size too small (minimum 512KB), increase s3_cache_size for caching to take effect")
+				}
 			}
+			if cfg.S3CacheTTLSeconds > 0 {
+				db.Exec(fmt.Sprintf("SET cache_httpfs_in_mem_cache_block_timeout_millisec=%d", cfg.S3CacheTTLSeconds*1000))
+			}
+			logger.Info().
+				Int64("cache_size_bytes", cfg.S3CacheSize).
+				Int("ttl_seconds", cfg.S3CacheTTLSeconds).
+				Msg("cache_httpfs extension loaded with in_memory mode")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `cache_httpfs` extension support for faster S3 reads
- Add `[query]` config section with `enable_s3_cache`, `s3_cache_size`, and `s3_cache_ttl_seconds` options
- Add logging for cache setup (info on success, warn on failure)
- Add config tests for defaults and environment variable overrides

## Test plan
- [x] Config tests pass (`TestQueryConfig_Defaults`, `TestQueryConfig_EnvOverride`)
- [x] Build succeeds