### PR TITLE
feat(tiering): implement 2-tier hot/cold storage system

### DIFF
--- a/internal/api/tiering.go
+++ b/internal/api/tiering.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/tiering"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// TieringHandler handles tiered storage API operations
+type TieringHandler struct {
+	manager *tiering.Manager
+	logger  zerolog.Logger
+}
+
+// NewTieringHandler creates a new tiering handler
+func NewTieringHandler(manager *tiering.Manager, logger zerolog.Logger) *TieringHandler {
+	return &TieringHandler{
+		manager: manager,
+		logger:  logger.With().Str("component", "tiering-api").Logger(),
+	}
+}
+
+// GetStatus returns the current tiering status
+// GET /api/v1/tiering/status
+func (h *TieringHandler) GetStatus(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	status, err := h.manager.GetStatus(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to get tiering status")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to get tiering status",
+		})
+	}
+
+	return c.JSON(status)
+}
+
+// GetFiles returns files by tier
+// GET /api/v1/tiering/files
+// Query params: tier (optional), database (optional), limit (optional)
+func (h *TieringHandler) GetFiles(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	tierParam := c.Query("tier")
+	database := c.Query("database")
+	limit := c.QueryInt("limit", 100)
+
+	var files []tiering.FileMetadata
+	var err error
+
+	if database != "" {
+		files, err = h.manager.GetMetadata().GetFilesByDatabase(ctx, database)
+	} else if tierParam != "" {
+		tier := tiering.TierFromString(tierParam)
+		files, err = h.manager.GetMetadata().GetFilesInTier(ctx, tier)
+	} else {
+		// Get all files - query each tier (2-tier system: hot and cold)
+		for _, t := range []tiering.Tier{tiering.TierHot, tiering.TierCold} {
+			tierFiles, tierErr := h.manager.GetMetadata().GetFilesInTier(ctx, t)
+			if tierErr != nil {
+				err = tierErr
+				break
+			}
+			files = append(files, tierFiles...)
+		}
+	}
+
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to get tiering files")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to get tiering files",
+		})
+	}
+
+	// Apply limit
+	if len(files) > limit {
+		files = files[:limit]
+	}
+
+	return c.JSON(fiber.Map{
+		"files": files,
+		"count": len(files),
+	})
+}
+
+// TriggerMigrationRequest represents a manual migration request
+type TriggerMigrationRequest struct {
+	FromTier    string `json:"from_tier,omitempty"`    // Optional: "hot" (2-tier system)
+	ToTier      string `json:"to_tier,omitempty"`      // Optional: "cold" (2-tier system)
+	Database    string `json:"database,omitempty"`     // Optional: filter by database
+	Measurement string `json:"measurement,omitempty"`  // Optional: filter by measurement
+	DryRun      bool   `json:"dry_run,omitempty"`      // If true, only report what would be migrated
+}
+
+// TriggerMigration triggers a manual migration
+// POST /api/v1/tiering/migrate
+func (h *TieringHandler) TriggerMigration(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 2*time.Hour)
+	defer cancel()
+
+	var req TriggerMigrationRequest
+	if err := c.BodyParser(&req); err != nil {
+		// Empty body is OK - run full migration cycle
+	}
+
+	// For now, just run a full migration cycle
+	// TODO: Support filtered migrations based on request params
+
+	h.logger.Info().
+		Str("from_tier", req.FromTier).
+		Str("to_tier", req.ToTier).
+		Str("database", req.Database).
+		Bool("dry_run", req.DryRun).
+		Msg("Manual migration triggered")
+
+	if err := h.manager.TriggerMigration(ctx); err != nil {
+		h.logger.Error().Err(err).Msg("Failed to trigger migration")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to trigger migration",
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"message": "Migration completed successfully",
+		"status":  "completed",
+	})
+}
+
+// GetStats returns migration statistics
+// GET /api/v1/tiering/stats
+func (h *TieringHandler) GetStats(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	// Get tier stats
+	tierStats, err := h.manager.GetMetadata().GetTierStats(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to get tier stats")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to get tier stats",
+		})
+	}
+
+	// Get recent migrations
+	recentMigrations, err := h.manager.GetMetadata().GetRecentMigrations(ctx, 10)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to get recent migrations")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to get recent migrations",
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"tier_stats":        tierStats,
+		"recent_migrations": recentMigrations,
+	})
+}
+
+// ScanFiles scans the hot tier storage and registers all existing files
+// POST /api/v1/tiering/scan
+func (h *TieringHandler) ScanFiles(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Minute)
+	defer cancel()
+
+	h.logger.Info().Msg("Starting file scan via API")
+
+	result, err := h.manager.ScanAndRegisterFiles(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to scan files")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.JSON(result)
+}
+
+// RegisterRoutes registers tiering API routes
+func (h *TieringHandler) RegisterRoutes(app fiber.Router) {
+	tiering := app.Group("/api/v1/tiering")
+
+	tiering.Get("/status", h.GetStatus)
+	tiering.Get("/files", h.GetFiles)
+	tiering.Post("/migrate", h.TriggerMigration)
+	tiering.Get("/stats", h.GetStats)
+	tiering.Post("/scan", h.ScanFiles)
+}

--- a/internal/api/tiering_policies.go
+++ b/internal/api/tiering_policies.go
@@ -1,0 +1,185 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/tiering"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// TieringPoliciesHandler handles tiering policy API operations
+type TieringPoliciesHandler struct {
+	manager *tiering.Manager
+	logger  zerolog.Logger
+}
+
+// NewTieringPoliciesHandler creates a new tiering policies handler
+func NewTieringPoliciesHandler(manager *tiering.Manager, logger zerolog.Logger) *TieringPoliciesHandler {
+	return &TieringPoliciesHandler{
+		manager: manager,
+		logger:  logger.With().Str("component", "tiering-policies-api").Logger(),
+	}
+}
+
+// PolicyRequest represents a request to create/update a tiering policy
+// 2-tier system: data older than HotMaxAgeDays moves from hot to cold
+type PolicyRequest struct {
+	HotOnly       bool `json:"hot_only,omitempty"`         // Exclude from tiering entirely
+	HotMaxAgeDays *int `json:"hot_max_age_days,omitempty"` // nil = use global default
+}
+
+// ListPolicies returns all custom tiering policies
+// GET /api/v1/tiering/policies
+func (h *TieringPoliciesHandler) ListPolicies(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	policies, err := h.manager.GetPolicies().List(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to list tiering policies")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to list tiering policies",
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"policies": policies,
+		"count":    len(policies),
+	})
+}
+
+// GetPolicy returns the policy for a specific database
+// GET /api/v1/tiering/policies/:database
+func (h *TieringPoliciesHandler) GetPolicy(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	database := c.Params("database")
+	if database == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name is required",
+		})
+	}
+
+	policy, err := h.manager.GetPolicies().Get(ctx, database)
+	if err != nil {
+		h.logger.Error().Err(err).Str("database", database).Msg("Failed to get tiering policy")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to get tiering policy",
+		})
+	}
+
+	if policy == nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error":   "No custom policy for this database",
+			"message": "Using global defaults",
+		})
+	}
+
+	return c.JSON(policy)
+}
+
+// SetPolicy creates or updates the policy for a database
+// PUT /api/v1/tiering/policies/:database
+func (h *TieringPoliciesHandler) SetPolicy(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	database := c.Params("database")
+	if database == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name is required",
+		})
+	}
+
+	var req PolicyRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	policy := &tiering.DatabasePolicy{
+		Database:      database,
+		HotOnly:       req.HotOnly,
+		HotMaxAgeDays: req.HotMaxAgeDays,
+	}
+
+	if err := h.manager.GetPolicies().Set(ctx, policy); err != nil {
+		h.logger.Error().Err(err).Str("database", database).Msg("Failed to set tiering policy")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to set tiering policy",
+		})
+	}
+
+	h.logger.Info().
+		Str("database", database).
+		Bool("hot_only", req.HotOnly).
+		Msg("Tiering policy updated")
+
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{
+		"message":  "Policy updated successfully",
+		"database": database,
+		"policy":   policy,
+	})
+}
+
+// DeletePolicy removes the custom policy for a database (reverts to global defaults)
+// DELETE /api/v1/tiering/policies/:database
+func (h *TieringPoliciesHandler) DeletePolicy(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	database := c.Params("database")
+	if database == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name is required",
+		})
+	}
+
+	if err := h.manager.GetPolicies().Delete(ctx, database); err != nil {
+		h.logger.Error().Err(err).Str("database", database).Msg("Failed to delete tiering policy")
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	h.logger.Info().
+		Str("database", database).
+		Msg("Tiering policy deleted, reverting to global defaults")
+
+	return c.JSON(fiber.Map{
+		"message":  "Policy deleted, database now uses global defaults",
+		"database": database,
+	})
+}
+
+// GetEffectivePolicy returns the effective policy for a database (resolved with global defaults)
+// GET /api/v1/tiering/policies/:database/effective
+func (h *TieringPoliciesHandler) GetEffectivePolicy(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	database := c.Params("database")
+	if database == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Database name is required",
+		})
+	}
+
+	effective := h.manager.GetEffectivePolicy(ctx, database)
+	return c.JSON(effective)
+}
+
+// RegisterRoutes registers tiering policy API routes
+func (h *TieringPoliciesHandler) RegisterRoutes(app fiber.Router) {
+	policies := app.Group("/api/v1/tiering/policies")
+
+	policies.Get("/", h.ListPolicies)
+	policies.Get("/:database", h.GetPolicy)
+	policies.Put("/:database", h.SetPolicy)
+	policies.Delete("/:database", h.DeletePolicy)
+	policies.Get("/:database/effective", h.GetEffectivePolicy)
+}

--- a/internal/license/client.go
+++ b/internal/license/client.go
@@ -350,6 +350,13 @@ func (c *Client) CanUseRetentionScheduler() bool {
 	return c.license != nil && c.license.CanUseRetentionScheduler()
 }
 
+// CanUseTieredStorage returns true if tiered storage is allowed
+func (c *Client) CanUseTieredStorage() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.license != nil && c.license.CanUseTieredStorage()
+}
+
 // GetFingerprint returns the machine fingerprint
 func (c *Client) GetFingerprint() string {
 	return c.fingerprint

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -20,7 +20,7 @@ const (
 	FeatureRetentionScheduler = "retention_scheduler"
 	FeatureClustering         = "clustering"
 	FeatureRBAC               = "rbac"
-	FeatureTieredStorage      = "tiered_storage"
+	FeatureTieredStorage      = "tiering"
 	FeatureAutoAggregation    = "auto_aggregation"
 )
 
@@ -93,6 +93,12 @@ func (l *License) CanUseCQScheduler() bool {
 // All valid license tiers (starter, professional, enterprise, unlimited) include this feature
 func (l *License) CanUseRetentionScheduler() bool {
 	return l.IsValid()
+}
+
+// CanUseTieredStorage returns true if the license allows tiered storage
+// Requires enterprise license with the tiered_storage feature
+func (l *License) CanUseTieredStorage() bool {
+	return l.HasFeature(FeatureTieredStorage)
 }
 
 // TierFromString converts a string to a Tier

--- a/internal/tiering/integration_test.go
+++ b/internal/tiering/integration_test.go
@@ -1,0 +1,520 @@
+package tiering
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/config"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+)
+
+// mockBackend implements storage.Backend for testing
+type mockBackend struct {
+	files map[string][]byte
+	typ   string
+	mu    sync.RWMutex
+}
+
+func newMockBackend(typ string) *mockBackend {
+	return &mockBackend{
+		files: make(map[string][]byte),
+		typ:   typ,
+	}
+}
+
+func (m *mockBackend) Type() string       { return m.typ }
+func (m *mockBackend) ConfigJSON() string { return "{}" }
+func (m *mockBackend) Read(_ context.Context, path string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if data, ok := m.files[path]; ok {
+		return data, nil
+	}
+	return nil, os.ErrNotExist
+}
+func (m *mockBackend) ReadTo(_ context.Context, path string, w io.Writer) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if data, ok := m.files[path]; ok {
+		_, err := w.Write(data)
+		return err
+	}
+	return os.ErrNotExist
+}
+func (m *mockBackend) Write(_ context.Context, path string, data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.files[path] = data
+	return nil
+}
+func (m *mockBackend) WriteReader(_ context.Context, path string, r io.Reader, _ int64) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.files[path] = data
+	return nil
+}
+func (m *mockBackend) Delete(_ context.Context, path string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.files, path)
+	return nil
+}
+func (m *mockBackend) Exists(_ context.Context, path string) (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.files[path]
+	return ok, nil
+}
+func (m *mockBackend) List(_ context.Context, prefix string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var paths []string
+	for p := range m.files {
+		if len(p) >= len(prefix) && p[:len(prefix)] == prefix {
+			paths = append(paths, p)
+		}
+	}
+	return paths, nil
+}
+func (m *mockBackend) Close() error { return nil }
+
+// mockLicenseClient implements enough of license.Client for testing
+type mockLicenseClient struct {
+	canUseTieredStorage bool
+}
+
+func (m *mockLicenseClient) CanUseTieredStorage() bool {
+	return m.canUseTieredStorage
+}
+
+// setupIntegrationTest creates a full tiering setup for integration testing
+// 2-tier system: Hot (local) -> Cold (S3/Azure)
+func setupIntegrationTest(t *testing.T, withColdBackend bool) (*Manager, *mockBackend, *mockBackend, func()) {
+	t.Helper()
+
+	// Create temp file for SQLite
+	tmpFile, err := os.CreateTemp("", "tiering_integration_test_*.db")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	db, err := sql.Open("sqlite3", tmpFile.Name())
+	if err != nil {
+		os.Remove(tmpFile.Name())
+		t.Fatalf("Failed to open SQLite: %v", err)
+	}
+
+	logger := zerolog.Nop()
+
+	hotBackend := newMockBackend("local")
+	var coldBackend *mockBackend
+	if withColdBackend {
+		coldBackend = newMockBackend("s3")
+	}
+
+	cfg := &config.TieredStorageConfig{
+		Enabled:                true,
+		MigrationSchedule:      "0 2 * * *",
+		MigrationMaxConcurrent: 2,
+		MigrationBatchSize:     10,
+		DefaultHotMaxAgeDays:   7,
+		Cold: config.ColdTierConfig{
+			Enabled:        withColdBackend,
+			Backend:        "s3",
+			S3Bucket:       "arc-archive-test",
+			S3Region:       "us-east-1",
+			S3StorageClass: "GLACIER",
+		},
+	}
+
+	// Create a wrapper that implements what Manager needs
+	type licenseWrapper interface {
+		CanUseTieredStorage() bool
+	}
+
+	mockLicense := &mockLicenseClient{canUseTieredStorage: true}
+
+	// Since we can't easily mock the full license.Client, we'll test the components
+	// directly without the manager for integration tests
+
+	// Create metadata store directly
+	metadata, err := NewMetadataStore(db, logger)
+	if err != nil {
+		db.Close()
+		os.Remove(tmpFile.Name())
+		t.Fatalf("Failed to create metadata store: %v", err)
+	}
+
+	// Create policy store directly
+	policies, err := NewPolicyStore(db, cfg, logger)
+	if err != nil {
+		db.Close()
+		os.Remove(tmpFile.Name())
+		t.Fatalf("Failed to create policy store: %v", err)
+	}
+
+	// Create a minimal manager-like struct for testing
+	// We can't use NewManager because it requires a real license.Client
+	m := &Manager{
+		hotBackend:  hotBackend,
+		coldBackend: coldBackend,
+		metadata:    metadata,
+		policies:    policies,
+		config:      cfg,
+		logger:      logger,
+		stopCh:      make(chan struct{}),
+	}
+
+	// Create migrator
+	m.migrator = NewMigrator(&MigratorConfig{
+		Manager:       m,
+		MaxConcurrent: cfg.MigrationMaxConcurrent,
+		BatchSize:     cfg.MigrationBatchSize,
+		Logger:        logger,
+	})
+
+	cleanup := func() {
+		db.Close()
+		os.Remove(tmpFile.Name())
+	}
+
+	// Need to assign mockLicense to a variable to avoid unused variable error
+	_ = mockLicense
+
+	return m, hotBackend, coldBackend, cleanup
+}
+
+func TestIntegration_RecordAndRetrieveFiles(t *testing.T) {
+	m, hotBackend, _, cleanup := setupIntegrationTest(t, false)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Write some test data to hot backend
+	testData := []byte("test parquet data")
+	testPath := "testdb/cpu/2025/01/15/data.parquet"
+	if err := hotBackend.Write(ctx, testPath, testData); err != nil {
+		t.Fatalf("Failed to write test data: %v", err)
+	}
+
+	// Record file in metadata
+	file := &FileMetadata{
+		Path:          testPath,
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+		SizeBytes:     int64(len(testData)),
+	}
+
+	if err := m.RecordNewFile(ctx, file); err != nil {
+		t.Fatalf("RecordNewFile failed: %v", err)
+	}
+
+	// Verify file is recorded in hot tier
+	retrieved, err := m.metadata.GetFile(ctx, testPath)
+	if err != nil {
+		t.Fatalf("GetFile failed: %v", err)
+	}
+
+	if retrieved.Tier != TierHot {
+		t.Errorf("Expected tier hot, got %s", retrieved.Tier)
+	}
+	if retrieved.Database != "testdb" {
+		t.Errorf("Expected database testdb, got %s", retrieved.Database)
+	}
+}
+
+func TestIntegration_PolicyBasedMigration(t *testing.T) {
+	m, hotBackend, _, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create test data for two databases
+	db1Data := []byte("database 1 data")
+	db2Data := []byte("database 2 data")
+
+	db1Path := "db1/cpu/2025/01/01/data.parquet"
+	db2Path := "db2/cpu/2025/01/01/data.parquet"
+
+	if err := hotBackend.Write(ctx, db1Path, db1Data); err != nil {
+		t.Fatalf("Failed to write db1 data: %v", err)
+	}
+	if err := hotBackend.Write(ctx, db2Path, db2Data); err != nil {
+		t.Fatalf("Failed to write db2 data: %v", err)
+	}
+
+	// Record files - both with old partition time (should be eligible for migration)
+	oldTime := time.Now().UTC().AddDate(0, 0, -30) // 30 days old
+
+	file1 := &FileMetadata{
+		Path:          db1Path,
+		Database:      "db1",
+		Measurement:   "cpu",
+		PartitionTime: oldTime,
+		SizeBytes:     int64(len(db1Data)),
+	}
+	file2 := &FileMetadata{
+		Path:          db2Path,
+		Database:      "db2",
+		Measurement:   "cpu",
+		PartitionTime: oldTime,
+		SizeBytes:     int64(len(db2Data)),
+	}
+
+	if err := m.RecordNewFile(ctx, file1); err != nil {
+		t.Fatalf("RecordNewFile failed: %v", err)
+	}
+	if err := m.RecordNewFile(ctx, file2); err != nil {
+		t.Fatalf("RecordNewFile failed: %v", err)
+	}
+
+	// Set db2 as hot_only (should not migrate)
+	policy := &DatabasePolicy{
+		Database: "db2",
+		HotOnly:  true,
+	}
+	if err := m.policies.Set(ctx, policy); err != nil {
+		t.Fatalf("Set policy failed: %v", err)
+	}
+
+	// Find migration candidates (hot -> cold in 2-tier system)
+	candidates, err := m.migrator.FindCandidates(ctx, TierHot, TierCold)
+	if err != nil {
+		t.Fatalf("FindCandidates failed: %v", err)
+	}
+
+	// Only db1 should be a candidate (db2 is hot_only)
+	if len(candidates) != 1 {
+		t.Fatalf("Expected 1 candidate, got %d", len(candidates))
+	}
+	if candidates[0].Database != "db1" {
+		t.Errorf("Expected candidate from db1, got %s", candidates[0].Database)
+	}
+
+	// Verify db2 is excluded
+	for _, c := range candidates {
+		if c.Database == "db2" {
+			t.Error("db2 should be excluded (hot_only)")
+		}
+	}
+}
+
+func TestIntegration_CustomPolicyOverridesDefaults(t *testing.T) {
+	m, _, coldBackend, cleanup := setupIntegrationTest(t, false)
+	_ = coldBackend // unused in this test
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Get effective policy for database without custom policy
+	effective := m.policies.GetEffective(ctx, "default_db")
+	if effective.Source != "global" {
+		t.Errorf("Expected source 'global', got '%s'", effective.Source)
+	}
+	if effective.HotMaxAgeDays != 7 {
+		t.Errorf("Expected HotMaxAgeDays 7, got %d", effective.HotMaxAgeDays)
+	}
+
+	// Set custom policy
+	customDays := 3
+	policy := &DatabasePolicy{
+		Database:      "custom_db",
+		HotMaxAgeDays: &customDays,
+	}
+	if err := m.policies.Set(ctx, policy); err != nil {
+		t.Fatalf("Set policy failed: %v", err)
+	}
+
+	// Verify effective policy uses custom value
+	effective = m.policies.GetEffective(ctx, "custom_db")
+	if effective.Source != "custom" {
+		t.Errorf("Expected source 'custom', got '%s'", effective.Source)
+	}
+	if effective.HotMaxAgeDays != 3 {
+		t.Errorf("Expected HotMaxAgeDays 3 (custom), got %d", effective.HotMaxAgeDays)
+	}
+}
+
+func TestIntegration_TierStats(t *testing.T) {
+	m, hotBackend, _, cleanup := setupIntegrationTest(t, false)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Record multiple files
+	for i := 0; i < 5; i++ {
+		path := "testdb/cpu/2025/01/01/data_" + string(rune('a'+i)) + ".parquet"
+		data := make([]byte, 1000*(i+1)) // Varying sizes
+
+		if err := hotBackend.Write(ctx, path, data); err != nil {
+			t.Fatalf("Failed to write data: %v", err)
+		}
+
+		file := &FileMetadata{
+			Path:          path,
+			Database:      "testdb",
+			Measurement:   "cpu",
+			PartitionTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			SizeBytes:     int64(len(data)),
+		}
+		if err := m.RecordNewFile(ctx, file); err != nil {
+			t.Fatalf("RecordNewFile failed: %v", err)
+		}
+	}
+
+	// Get tier stats
+	stats, err := m.metadata.GetTierStats(ctx)
+	if err != nil {
+		t.Fatalf("GetTierStats failed: %v", err)
+	}
+
+	hotStats := stats[TierHot]
+	if hotStats.FileCount != 5 {
+		t.Errorf("Expected 5 files in hot tier, got %d", hotStats.FileCount)
+	}
+
+	// TotalSizeMB is bytes / (1024*1024), so small files will show 0 MB
+	// Just verify the field is accessible and non-negative
+	if hotStats.TotalSizeMB < 0 {
+		t.Errorf("TotalSizeMB should be non-negative, got %d", hotStats.TotalSizeMB)
+	}
+}
+
+func TestIntegration_FileDeletion(t *testing.T) {
+	m, hotBackend, _, cleanup := setupIntegrationTest(t, false)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	testPath := "testdb/cpu/2025/01/15/data.parquet"
+	testData := []byte("test data")
+
+	if err := hotBackend.Write(ctx, testPath, testData); err != nil {
+		t.Fatalf("Failed to write data: %v", err)
+	}
+
+	file := &FileMetadata{
+		Path:          testPath,
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+		SizeBytes:     int64(len(testData)),
+	}
+
+	if err := m.RecordNewFile(ctx, file); err != nil {
+		t.Fatalf("RecordNewFile failed: %v", err)
+	}
+
+	// Verify file exists
+	retrieved, err := m.metadata.GetFile(ctx, testPath)
+	if err != nil {
+		t.Fatalf("GetFile failed: %v", err)
+	}
+	if retrieved == nil {
+		t.Fatal("File should exist")
+	}
+
+	// Delete file
+	if err := m.DeleteFile(ctx, testPath); err != nil {
+		t.Fatalf("DeleteFile failed: %v", err)
+	}
+
+	// Verify file is gone from metadata
+	retrieved, err = m.metadata.GetFile(ctx, testPath)
+	if err != nil {
+		t.Fatalf("GetFile failed: %v", err)
+	}
+	if retrieved != nil {
+		t.Error("File should not exist after deletion")
+	}
+}
+
+func TestIntegration_MigrateBatch(t *testing.T) {
+	m, hotBackend, coldBackend, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create test files
+	oldTime := time.Now().UTC().AddDate(0, 0, -30)
+	var files []MigrationCandidate
+
+	for i := 0; i < 3; i++ {
+		path := "testdb/cpu/2025/01/01/data_" + string(rune('a'+i)) + ".parquet"
+		data := []byte("test data for file " + string(rune('a'+i)))
+
+		if err := hotBackend.Write(ctx, path, data); err != nil {
+			t.Fatalf("Failed to write data: %v", err)
+		}
+
+		file := &FileMetadata{
+			Path:          path,
+			Database:      "testdb",
+			Measurement:   "cpu",
+			PartitionTime: oldTime,
+			SizeBytes:     int64(len(data)),
+		}
+
+		if err := m.RecordNewFile(ctx, file); err != nil {
+			t.Fatalf("RecordNewFile failed: %v", err)
+		}
+
+		files = append(files, MigrationCandidate{
+			Path:          path,
+			Database:      "testdb",
+			Measurement:   "cpu",
+			PartitionTime: oldTime,
+			SizeBytes:     int64(len(data)),
+			CurrentTier:   TierHot,
+			TargetTier:    TierCold,
+		})
+	}
+
+	// Migrate batch
+	migrated, errors := m.migrator.MigrateBatch(ctx, files)
+
+	if errors > 0 {
+		t.Errorf("Expected 0 errors, got %d", errors)
+	}
+	if migrated != 3 {
+		t.Errorf("Expected 3 migrated, got %d", migrated)
+	}
+
+	// Verify files are now in cold backend
+	for _, f := range files {
+		exists, err := coldBackend.Exists(ctx, f.Path)
+		if err != nil {
+			t.Fatalf("Exists check failed: %v", err)
+		}
+		if !exists {
+			t.Errorf("File %s should exist in cold backend", f.Path)
+		}
+
+		// File should be removed from hot backend
+		exists, _ = hotBackend.Exists(ctx, f.Path)
+		if exists {
+			t.Errorf("File %s should be removed from hot backend", f.Path)
+		}
+
+		// Metadata should show cold tier
+		retrieved, err := m.metadata.GetFile(ctx, f.Path)
+		if err != nil {
+			t.Fatalf("GetFile failed: %v", err)
+		}
+		if retrieved.Tier != TierCold {
+			t.Errorf("File %s tier should be cold, got %s", f.Path, retrieved.Tier)
+		}
+	}
+}

--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -1,0 +1,468 @@
+package tiering
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/license"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// Manager orchestrates tiered storage operations
+type Manager struct {
+	// Storage backends
+	hotBackend  storage.Backend
+	coldBackend storage.Backend
+
+	// Data stores
+	metadata *MetadataStore
+	policies *PolicyStore
+
+	// Configuration
+	config *config.TieredStorageConfig
+
+	// License client for feature gating
+	licenseClient *license.Client
+
+	// Components
+	migrator  *Migrator
+	scheduler *Scheduler
+	router    *Router
+
+	// State
+	running atomic.Bool
+	stopCh  chan struct{}
+
+	logger zerolog.Logger
+	mu     sync.RWMutex
+}
+
+// ManagerConfig holds configuration for creating a tiering manager
+type ManagerConfig struct {
+	// Storage backends
+	HotBackend  storage.Backend // Required: local storage for hot tier
+	ColdBackend storage.Backend // Optional: S3/Azure for cold tier
+
+	// Database connection for metadata
+	DB *sql.DB
+
+	// Configuration
+	Config *config.TieredStorageConfig
+
+	// License client
+	LicenseClient *license.Client
+
+	// Logger
+	Logger zerolog.Logger
+}
+
+// NewManager creates a new tiering manager
+func NewManager(cfg *ManagerConfig) (*Manager, error) {
+	logger := cfg.Logger.With().Str("component", "tiering-manager").Logger()
+
+	// Validate configuration
+	if cfg.HotBackend == nil {
+		return nil, fmt.Errorf("hot backend is required")
+	}
+	if cfg.DB == nil {
+		return nil, fmt.Errorf("database connection is required")
+	}
+	if cfg.Config == nil {
+		return nil, fmt.Errorf("configuration is required")
+	}
+
+	// Validate license
+	if cfg.LicenseClient == nil {
+		return nil, fmt.Errorf("license client is required for tiered storage")
+	}
+	if !cfg.LicenseClient.CanUseTieredStorage() {
+		return nil, fmt.Errorf("valid license with tiered_storage feature required")
+	}
+
+	// Create metadata store
+	metadata, err := NewMetadataStore(cfg.DB, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metadata store: %w", err)
+	}
+
+	// Create policy store
+	policies, err := NewPolicyStore(cfg.DB, cfg.Config, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create policy store: %w", err)
+	}
+
+	m := &Manager{
+		hotBackend:    cfg.HotBackend,
+		coldBackend:   cfg.ColdBackend,
+		metadata:      metadata,
+		policies:      policies,
+		config:        cfg.Config,
+		licenseClient: cfg.LicenseClient,
+		stopCh:        make(chan struct{}),
+		logger:        logger,
+	}
+
+	// Create migrator
+	m.migrator = NewMigrator(&MigratorConfig{
+		Manager:       m,
+		MaxConcurrent: cfg.Config.MigrationMaxConcurrent,
+		BatchSize:     cfg.Config.MigrationBatchSize,
+		Logger:        logger,
+	})
+
+	// Create scheduler
+	m.scheduler = NewScheduler(&SchedulerConfig{
+		Manager:  m,
+		Schedule: cfg.Config.MigrationSchedule,
+		Logger:   logger,
+	})
+
+	// Create router for query routing across tiers
+	m.router = NewRouter(m, logger)
+
+	logger.Info().
+		Bool("cold_enabled", cfg.ColdBackend != nil && cfg.Config.Cold.Enabled).
+		Str("schedule", cfg.Config.MigrationSchedule).
+		Msg("Tiering manager created")
+
+	return m, nil
+}
+
+// Start starts the tiering manager and scheduler
+func (m *Manager) Start() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.running.Load() {
+		return fmt.Errorf("tiering manager already running")
+	}
+
+	// Verify license before starting
+	if !m.licenseClient.CanUseTieredStorage() {
+		m.logger.Warn().Msg("Valid license required for tiered storage - not starting scheduler")
+		return nil
+	}
+
+	// Start scheduler
+	if err := m.scheduler.Start(); err != nil {
+		return fmt.Errorf("failed to start scheduler: %w", err)
+	}
+
+	m.running.Store(true)
+	m.logger.Info().Msg("Tiering manager started")
+	return nil
+}
+
+// Stop stops the tiering manager and scheduler
+func (m *Manager) Stop() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running.Load() {
+		return nil
+	}
+
+	close(m.stopCh)
+	m.scheduler.Stop()
+	m.running.Store(false)
+
+	m.logger.Info().Msg("Tiering manager stopped")
+	return nil
+}
+
+// IsRunning returns true if the manager is running
+func (m *Manager) IsRunning() bool {
+	return m.running.Load()
+}
+
+// RunMigrationCycle runs a single migration cycle
+func (m *Manager) RunMigrationCycle(ctx context.Context) error {
+	// Check license before each cycle
+	if !m.licenseClient.CanUseTieredStorage() {
+		m.logger.Warn().Msg("Valid license required - skipping migration cycle")
+		return nil
+	}
+
+	m.logger.Info().Msg("Starting migration cycle")
+	startTime := time.Now()
+
+	// Scan and register any new files before migration
+	scanResult, err := m.ScanAndRegisterFiles(ctx)
+	if err != nil {
+		m.logger.Warn().Err(err).Msg("File scan failed, continuing with existing metadata")
+	} else {
+		m.logger.Info().
+			Int("scanned", scanResult.FilesScanned).
+			Int("registered", scanResult.FilesRegistered).
+			Msg("Pre-migration scan completed")
+	}
+
+	var totalMigrated int
+	var totalErrors int
+
+	// Hot -> Cold migrations (2-tier system)
+	if m.coldBackend != nil && m.config.Cold.Enabled {
+		migrated, errors := m.migrator.MigrateTier(ctx, TierHot, TierCold)
+		totalMigrated += migrated
+		totalErrors += errors
+	}
+
+	duration := time.Since(startTime)
+	m.logger.Info().
+		Int("migrated", totalMigrated).
+		Int("errors", totalErrors).
+		Dur("duration", duration).
+		Msg("Migration cycle completed")
+
+	return nil
+}
+
+// TriggerMigration triggers a manual migration cycle
+func (m *Manager) TriggerMigration(ctx context.Context) error {
+	return m.RunMigrationCycle(ctx)
+}
+
+// GetBackendForTier returns the storage backend for a tier
+func (m *Manager) GetBackendForTier(tier Tier) storage.Backend {
+	switch tier {
+	case TierHot:
+		return m.hotBackend
+	case TierCold:
+		return m.coldBackend
+	default:
+		return m.hotBackend
+	}
+}
+
+// GetMetadata returns the metadata store
+func (m *Manager) GetMetadata() *MetadataStore {
+	return m.metadata
+}
+
+// GetPolicies returns the policy store
+func (m *Manager) GetPolicies() *PolicyStore {
+	return m.policies
+}
+
+// GetConfig returns the tiered storage configuration
+func (m *Manager) GetConfig() *config.TieredStorageConfig {
+	return m.config
+}
+
+// GetRouter returns the tier router for query routing
+func (m *Manager) GetRouter() *Router {
+	return m.router
+}
+
+// RecordNewFile records a newly ingested file in the hot tier
+func (m *Manager) RecordNewFile(ctx context.Context, file *FileMetadata) error {
+	file.Tier = TierHot
+	if file.CreatedAt.IsZero() {
+		file.CreatedAt = time.Now().UTC()
+	}
+	return m.metadata.RecordFile(ctx, file)
+}
+
+// DeleteFile removes a file from tier metadata (called when file is deleted)
+func (m *Manager) DeleteFile(ctx context.Context, path string) error {
+	return m.metadata.DeleteFile(ctx, path)
+}
+
+// GetStatus returns the current tiering status
+func (m *Manager) GetStatus(ctx context.Context) (*StatusResponse, error) {
+	status := &StatusResponse{
+		Enabled:      m.config.Enabled,
+		LicenseValid: m.licenseClient.CanUseTieredStorage(),
+	}
+
+	if !status.LicenseValid {
+		status.Reason = "license required"
+		return status, nil
+	}
+
+	// Get tier stats
+	tierStats, err := m.metadata.GetTierStats(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tier stats: %w", err)
+	}
+
+	status.Tiers = make(map[string]TierStats)
+
+	// Hot tier
+	hotStats := tierStats[TierHot]
+	hotStats.Enabled = true
+	hotStats.Backend = "local"
+	status.Tiers["hot"] = hotStats
+
+	// Cold tier
+	coldStats := tierStats[TierCold]
+	coldStats.Enabled = m.config.Cold.Enabled && m.coldBackend != nil
+	coldStats.Backend = m.config.Cold.Backend
+	status.Tiers["cold"] = coldStats
+
+	// Scheduler status
+	status.Scheduler = m.scheduler.Status()
+
+	return status, nil
+}
+
+// GetEffectivePolicy returns the effective policy for a database
+func (m *Manager) GetEffectivePolicy(ctx context.Context, database string) *EffectivePolicy {
+	return m.policies.GetEffective(ctx, database)
+}
+
+// IsHotOnly returns true if the database should stay in hot tier only
+func (m *Manager) IsHotOnly(ctx context.Context, database string) bool {
+	return m.policies.IsHotOnly(ctx, database)
+}
+
+// ScanResult holds the results of a file scan operation
+type ScanResult struct {
+	FilesScanned    int `json:"files_scanned"`
+	FilesRegistered int `json:"files_registered"`
+	FilesSkipped    int `json:"files_skipped"`
+	Errors          int `json:"errors"`
+}
+
+// ScanAndRegisterFiles scans the hot tier storage and registers all existing parquet files
+// Path format: {database}/{measurement}/{year}/{month}/{day}/{hour}/{filename}.parquet
+func (m *Manager) ScanAndRegisterFiles(ctx context.Context) (*ScanResult, error) {
+	result := &ScanResult{}
+
+	// Check if hot backend supports ListObjects
+	objectLister, ok := m.hotBackend.(storage.ObjectLister)
+	if !ok {
+		return nil, fmt.Errorf("hot backend does not support ListObjects")
+	}
+
+	m.logger.Info().Msg("Starting file scan for tiering registration")
+
+	// List all objects in the storage root
+	objects, err := objectLister.ListObjects(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list objects: %w", err)
+	}
+
+	for _, obj := range objects {
+		// Only process parquet files
+		if !strings.HasSuffix(obj.Path, ".parquet") {
+			continue
+		}
+
+		result.FilesScanned++
+
+		// Parse the path to extract database, measurement, and partition time
+		// Format: {database}/{measurement}/{year}/{month}/{day}/{hour}/{filename}.parquet
+		fileInfo, err := m.parseFilePath(obj.Path)
+		if err != nil {
+			m.logger.Warn().
+				Str("path", obj.Path).
+				Err(err).
+				Msg("Failed to parse file path, skipping")
+			result.Errors++
+			continue
+		}
+
+		// Create file metadata
+		file := &FileMetadata{
+			Path:          obj.Path,
+			Database:      fileInfo.Database,
+			Measurement:   fileInfo.Measurement,
+			PartitionTime: fileInfo.PartitionTime,
+			Tier:          TierHot,
+			SizeBytes:     obj.Size,
+			CreatedAt:     obj.LastModified,
+		}
+
+		// Record the file (uses UPSERT, so safe to re-run)
+		if err := m.metadata.RecordFile(ctx, file); err != nil {
+			m.logger.Warn().
+				Str("path", obj.Path).
+				Err(err).
+				Msg("Failed to record file, skipping")
+			result.Errors++
+			continue
+		}
+
+		result.FilesRegistered++
+
+		// Log progress every 100 files
+		if result.FilesScanned%100 == 0 {
+			m.logger.Info().
+				Int("scanned", result.FilesScanned).
+				Int("registered", result.FilesRegistered).
+				Msg("Scan progress")
+		}
+	}
+
+	m.logger.Info().
+		Int("scanned", result.FilesScanned).
+		Int("registered", result.FilesRegistered).
+		Int("skipped", result.FilesSkipped).
+		Int("errors", result.Errors).
+		Msg("File scan completed")
+
+	return result, nil
+}
+
+// filePathInfo holds parsed information from a file path
+type filePathInfo struct {
+	Database      string
+	Measurement   string
+	PartitionTime time.Time
+}
+
+// parseFilePath parses a storage path to extract database, measurement, and partition time
+// Expected format: {database}/{measurement}/{year}/{month}/{day}/{hour}/{filename}.parquet
+func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
+	// Normalize path separators
+	path = filepath.ToSlash(path)
+	parts := strings.Split(path, "/")
+
+	// Need at least: database/measurement/year/month/day/hour/filename.parquet
+	if len(parts) < 7 {
+		return nil, fmt.Errorf("path too short: %s", path)
+	}
+
+	database := parts[0]
+	measurement := parts[1]
+
+	// Parse year, month, day, hour
+	year, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid year in path: %s", parts[2])
+	}
+
+	month, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return nil, fmt.Errorf("invalid month in path: %s", parts[3])
+	}
+
+	day, err := strconv.Atoi(parts[4])
+	if err != nil {
+		return nil, fmt.Errorf("invalid day in path: %s", parts[4])
+	}
+
+	hour, err := strconv.Atoi(parts[5])
+	if err != nil {
+		return nil, fmt.Errorf("invalid hour in path: %s", parts[5])
+	}
+
+	// Construct partition time (UTC)
+	partitionTime := time.Date(year, time.Month(month), day, hour, 0, 0, 0, time.UTC)
+
+	return &filePathInfo{
+		Database:      database,
+		Measurement:   measurement,
+		PartitionTime: partitionTime,
+	}, nil
+}

--- a/internal/tiering/metadata.go
+++ b/internal/tiering/metadata.go
@@ -1,0 +1,565 @@
+package tiering
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// tierCacheEntry holds cached tier information with expiration
+type tierCacheEntry struct {
+	tiers     map[Tier]bool
+	expiresAt time.Time
+}
+
+// tierCacheTTL is how long tier lookups are cached (30 seconds)
+const tierCacheTTL = 30 * time.Second
+
+// MetadataStore manages tier file metadata in SQLite
+type MetadataStore struct {
+	db     *sql.DB
+	logger zerolog.Logger
+	mu     sync.RWMutex
+
+	// Cache for GetTiersForMeasurement - keyed by "database/measurement"
+	tierCache   map[string]*tierCacheEntry
+	tierCacheMu sync.RWMutex
+}
+
+// NewMetadataStore creates a new metadata store using the provided SQLite connection
+func NewMetadataStore(db *sql.DB, logger zerolog.Logger) (*MetadataStore, error) {
+	store := &MetadataStore{
+		db:        db,
+		logger:    logger.With().Str("component", "tiering-metadata").Logger(),
+		tierCache: make(map[string]*tierCacheEntry),
+	}
+
+	if err := store.initSchema(); err != nil {
+		return nil, fmt.Errorf("failed to initialize tiering schema: %w", err)
+	}
+
+	return store, nil
+}
+
+// initSchema creates the required tables if they don't exist
+func (s *MetadataStore) initSchema() error {
+	schema := `
+	-- File tier tracking
+	CREATE TABLE IF NOT EXISTS tier_files (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		path TEXT UNIQUE NOT NULL,
+		database TEXT NOT NULL,
+		measurement TEXT NOT NULL,
+		partition_time TIMESTAMP NOT NULL,
+		tier TEXT NOT NULL DEFAULT 'hot',
+		size_bytes INTEGER NOT NULL,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		migrated_at TIMESTAMP
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_tier_files_database ON tier_files(database);
+	CREATE INDEX IF NOT EXISTS idx_tier_files_tier ON tier_files(tier);
+	CREATE INDEX IF NOT EXISTS idx_tier_files_partition ON tier_files(partition_time);
+	CREATE INDEX IF NOT EXISTS idx_tier_files_database_tier ON tier_files(database, tier);
+
+	-- Migration history
+	CREATE TABLE IF NOT EXISTS tier_migrations (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		file_path TEXT NOT NULL,
+		database TEXT NOT NULL,
+		from_tier TEXT NOT NULL,
+		to_tier TEXT NOT NULL,
+		size_bytes INTEGER,
+		started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		completed_at TIMESTAMP,
+		error TEXT
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_tier_migrations_database ON tier_migrations(database);
+	CREATE INDEX IF NOT EXISTS idx_tier_migrations_started ON tier_migrations(started_at);
+	`
+
+	_, err := s.db.Exec(schema)
+	if err != nil {
+		return fmt.Errorf("failed to create tiering tables: %w", err)
+	}
+
+	s.logger.Info().Msg("Tiering metadata schema initialized")
+	return nil
+}
+
+// invalidateTierCache removes the cache entry for a database/measurement pair.
+// Call this after any operation that might change which tiers have data.
+func (s *MetadataStore) invalidateTierCache(database, measurement string) {
+	cacheKey := database + "/" + measurement
+	s.tierCacheMu.Lock()
+	delete(s.tierCache, cacheKey)
+	s.tierCacheMu.Unlock()
+}
+
+// RecordFile records a new file in the metadata store
+func (s *MetadataStore) RecordFile(ctx context.Context, file *FileMetadata) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	query := `
+		INSERT INTO tier_files (path, database, measurement, partition_time, tier, size_bytes, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(path) DO UPDATE SET
+			tier = excluded.tier,
+			size_bytes = excluded.size_bytes,
+			migrated_at = CASE WHEN tier_files.tier != excluded.tier THEN CURRENT_TIMESTAMP ELSE tier_files.migrated_at END
+	`
+
+	createdAt := file.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+
+	_, err := s.db.ExecContext(ctx, query,
+		file.Path,
+		file.Database,
+		file.Measurement,
+		file.PartitionTime.UTC(),
+		string(file.Tier),
+		file.SizeBytes,
+		createdAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to record file: %w", err)
+	}
+
+	// Invalidate tier cache for this database/measurement
+	s.invalidateTierCache(file.Database, file.Measurement)
+
+	return nil
+}
+
+// GetFile retrieves file metadata by path
+func (s *MetadataStore) GetFile(ctx context.Context, path string) (*FileMetadata, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	query := `
+		SELECT id, path, database, measurement, partition_time, tier, size_bytes, created_at, migrated_at
+		FROM tier_files
+		WHERE path = ?
+	`
+
+	row := s.db.QueryRowContext(ctx, query, path)
+	return s.scanFile(row)
+}
+
+// GetFilesInTier retrieves all files in a specific tier
+func (s *MetadataStore) GetFilesInTier(ctx context.Context, tier Tier) ([]FileMetadata, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	query := `
+		SELECT id, path, database, measurement, partition_time, tier, size_bytes, created_at, migrated_at
+		FROM tier_files
+		WHERE tier = ?
+		ORDER BY partition_time ASC
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, string(tier))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query files in tier: %w", err)
+	}
+	defer rows.Close()
+
+	return s.scanFiles(rows)
+}
+
+// GetFilesOlderThan retrieves files in a tier older than the specified age
+func (s *MetadataStore) GetFilesOlderThan(ctx context.Context, tier Tier, maxAge time.Duration) ([]FileMetadata, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cutoff := time.Now().UTC().Add(-maxAge)
+
+	query := `
+		SELECT id, path, database, measurement, partition_time, tier, size_bytes, created_at, migrated_at
+		FROM tier_files
+		WHERE tier = ? AND partition_time < ?
+		ORDER BY partition_time ASC
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, string(tier), cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query old files: %w", err)
+	}
+	defer rows.Close()
+
+	return s.scanFiles(rows)
+}
+
+// GetFilesByDatabase retrieves all files for a specific database
+func (s *MetadataStore) GetFilesByDatabase(ctx context.Context, database string) ([]FileMetadata, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	query := `
+		SELECT id, path, database, measurement, partition_time, tier, size_bytes, created_at, migrated_at
+		FROM tier_files
+		WHERE database = ?
+		ORDER BY partition_time DESC
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, database)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query files by database: %w", err)
+	}
+	defer rows.Close()
+
+	return s.scanFiles(rows)
+}
+
+// UpdateTier updates the tier for a file
+func (s *MetadataStore) UpdateTier(ctx context.Context, path string, newTier Tier) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Get database/measurement for cache invalidation
+	var database, measurement string
+	lookupQuery := `SELECT database, measurement FROM tier_files WHERE path = ?`
+	_ = s.db.QueryRowContext(ctx, lookupQuery, path).Scan(&database, &measurement)
+
+	query := `
+		UPDATE tier_files
+		SET tier = ?, migrated_at = CURRENT_TIMESTAMP
+		WHERE path = ?
+	`
+
+	result, err := s.db.ExecContext(ctx, query, string(newTier), path)
+	if err != nil {
+		return fmt.Errorf("failed to update tier: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("file not found: %s", path)
+	}
+
+	// Invalidate tier cache if we found the database/measurement
+	if database != "" && measurement != "" {
+		s.invalidateTierCache(database, measurement)
+	}
+
+	return nil
+}
+
+// DeleteFile removes a file from the metadata store
+func (s *MetadataStore) DeleteFile(ctx context.Context, path string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Get database/measurement for cache invalidation before delete
+	var database, measurement string
+	lookupQuery := `SELECT database, measurement FROM tier_files WHERE path = ?`
+	_ = s.db.QueryRowContext(ctx, lookupQuery, path).Scan(&database, &measurement)
+
+	query := `DELETE FROM tier_files WHERE path = ?`
+	_, err := s.db.ExecContext(ctx, query, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete file: %w", err)
+	}
+
+	// Invalidate tier cache if we found the database/measurement
+	if database != "" && measurement != "" {
+		s.invalidateTierCache(database, measurement)
+	}
+
+	return nil
+}
+
+// RecordMigration records a migration attempt
+func (s *MetadataStore) RecordMigration(ctx context.Context, record *MigrationRecord) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	query := `
+		INSERT INTO tier_migrations (file_path, database, from_tier, to_tier, size_bytes, started_at, completed_at, error)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`
+
+	result, err := s.db.ExecContext(ctx, query,
+		record.FilePath,
+		record.Database,
+		string(record.FromTier),
+		string(record.ToTier),
+		record.SizeBytes,
+		record.StartedAt,
+		record.CompletedAt,
+		record.Error,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to record migration: %w", err)
+	}
+
+	return result.LastInsertId()
+}
+
+// CompleteMigration marks a migration as completed
+func (s *MetadataStore) CompleteMigration(ctx context.Context, migrationID int64, err error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var errorMsg *string
+	if err != nil {
+		msg := err.Error()
+		errorMsg = &msg
+	}
+
+	query := `
+		UPDATE tier_migrations
+		SET completed_at = CURRENT_TIMESTAMP, error = ?
+		WHERE id = ?
+	`
+
+	_, execErr := s.db.ExecContext(ctx, query, errorMsg, migrationID)
+	if execErr != nil {
+		return fmt.Errorf("failed to complete migration: %w", execErr)
+	}
+
+	return nil
+}
+
+// GetTierStats returns statistics for each tier
+func (s *MetadataStore) GetTierStats(ctx context.Context) (map[Tier]TierStats, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	query := `
+		SELECT tier, COUNT(*) as file_count, COALESCE(SUM(size_bytes), 0) as total_bytes
+		FROM tier_files
+		GROUP BY tier
+	`
+
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tier stats: %w", err)
+	}
+	defer rows.Close()
+
+	stats := make(map[Tier]TierStats)
+	for rows.Next() {
+		var tierStr string
+		var fileCount int64
+		var totalBytes int64
+
+		if err := rows.Scan(&tierStr, &fileCount, &totalBytes); err != nil {
+			return nil, fmt.Errorf("failed to scan tier stats: %w", err)
+		}
+
+		tier := TierFromString(tierStr)
+		stats[tier] = TierStats{
+			Tier:        tier,
+			FileCount:   fileCount,
+			TotalSizeMB: totalBytes / (1024 * 1024),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating tier stats: %w", err)
+	}
+
+	return stats, nil
+}
+
+// GetTiersForMeasurement returns which tiers have data for a specific database/measurement.
+// Returns a map of tier -> bool indicating presence of data in that tier.
+// Results are cached for 30 seconds to reduce SQLite query overhead during query execution.
+func (s *MetadataStore) GetTiersForMeasurement(ctx context.Context, database, measurement string) (map[Tier]bool, error) {
+	cacheKey := database + "/" + measurement
+
+	// Check cache first (with separate lock to avoid blocking other operations)
+	s.tierCacheMu.RLock()
+	if entry, ok := s.tierCache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+		// Cache hit - return a copy to avoid mutation
+		result := make(map[Tier]bool, len(entry.tiers))
+		for k, v := range entry.tiers {
+			result[k] = v
+		}
+		s.tierCacheMu.RUnlock()
+		return result, nil
+	}
+	s.tierCacheMu.RUnlock()
+
+	// Cache miss - query database
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	query := `
+		SELECT DISTINCT tier
+		FROM tier_files
+		WHERE database = ? AND measurement = ?
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, database, measurement)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tiers for measurement: %w", err)
+	}
+	defer rows.Close()
+
+	tiers := make(map[Tier]bool)
+	for rows.Next() {
+		var tierStr string
+		if err := rows.Scan(&tierStr); err != nil {
+			return nil, fmt.Errorf("failed to scan tier: %w", err)
+		}
+		tiers[TierFromString(tierStr)] = true
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating tiers: %w", err)
+	}
+
+	// Update cache
+	s.tierCacheMu.Lock()
+	s.tierCache[cacheKey] = &tierCacheEntry{
+		tiers:     tiers,
+		expiresAt: time.Now().Add(tierCacheTTL),
+	}
+	s.tierCacheMu.Unlock()
+
+	// Return a copy
+	result := make(map[Tier]bool, len(tiers))
+	for k, v := range tiers {
+		result[k] = v
+	}
+	return result, nil
+}
+
+// GetRecentMigrations returns recent migration records
+func (s *MetadataStore) GetRecentMigrations(ctx context.Context, limit int) ([]MigrationRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	query := `
+		SELECT id, file_path, database, from_tier, to_tier, size_bytes, started_at, completed_at, error
+		FROM tier_migrations
+		ORDER BY started_at DESC
+		LIMIT ?
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recent migrations: %w", err)
+	}
+	defer rows.Close()
+
+	var records []MigrationRecord
+	for rows.Next() {
+		var record MigrationRecord
+		var fromTier, toTier string
+		var completedAt sql.NullTime
+		var errorMsg sql.NullString
+
+		if err := rows.Scan(
+			&record.ID,
+			&record.FilePath,
+			&record.Database,
+			&fromTier,
+			&toTier,
+			&record.SizeBytes,
+			&record.StartedAt,
+			&completedAt,
+			&errorMsg,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan migration record: %w", err)
+		}
+
+		record.FromTier = TierFromString(fromTier)
+		record.ToTier = TierFromString(toTier)
+		if completedAt.Valid {
+			record.CompletedAt = &completedAt.Time
+		}
+		if errorMsg.Valid {
+			record.Error = errorMsg.String
+		}
+
+		records = append(records, record)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating migrations: %w", err)
+	}
+
+	return records, nil
+}
+
+// helper functions
+
+func (s *MetadataStore) scanFile(row *sql.Row) (*FileMetadata, error) {
+	var file FileMetadata
+	var tierStr string
+	var migratedAt sql.NullTime
+
+	err := row.Scan(
+		&file.ID,
+		&file.Path,
+		&file.Database,
+		&file.Measurement,
+		&file.PartitionTime,
+		&tierStr,
+		&file.SizeBytes,
+		&file.CreatedAt,
+		&migratedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan file: %w", err)
+	}
+
+	file.Tier = TierFromString(tierStr)
+	if migratedAt.Valid {
+		file.MigratedAt = &migratedAt.Time
+	}
+
+	return &file, nil
+}
+
+func (s *MetadataStore) scanFiles(rows *sql.Rows) ([]FileMetadata, error) {
+	var files []FileMetadata
+
+	for rows.Next() {
+		var file FileMetadata
+		var tierStr string
+		var migratedAt sql.NullTime
+
+		err := rows.Scan(
+			&file.ID,
+			&file.Path,
+			&file.Database,
+			&file.Measurement,
+			&file.PartitionTime,
+			&tierStr,
+			&file.SizeBytes,
+			&file.CreatedAt,
+			&migratedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan file: %w", err)
+		}
+
+		file.Tier = TierFromString(tierStr)
+		if migratedAt.Valid {
+			file.MigratedAt = &migratedAt.Time
+		}
+
+		files = append(files, file)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating files: %w", err)
+	}
+
+	return files, nil
+}

--- a/internal/tiering/metadata_test.go
+++ b/internal/tiering/metadata_test.go
@@ -1,0 +1,287 @@
+package tiering
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+)
+
+func setupTestMetadataStore(t *testing.T) (*MetadataStore, func()) {
+	t.Helper()
+
+	// Create temp file for SQLite
+	tmpFile, err := os.CreateTemp("", "tiering_metadata_test_*.db")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	db, err := sql.Open("sqlite3", tmpFile.Name())
+	if err != nil {
+		os.Remove(tmpFile.Name())
+		t.Fatalf("Failed to open SQLite: %v", err)
+	}
+
+	logger := zerolog.Nop()
+	store, err := NewMetadataStore(db, logger)
+	if err != nil {
+		db.Close()
+		os.Remove(tmpFile.Name())
+		t.Fatalf("Failed to create metadata store: %v", err)
+	}
+
+	cleanup := func() {
+		db.Close()
+		os.Remove(tmpFile.Name())
+	}
+
+	return store, cleanup
+}
+
+func TestMetadataStore_RecordFile(t *testing.T) {
+	store, cleanup := setupTestMetadataStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	file := &FileMetadata{
+		Path:          "test/db/measurement/2025/01/01/00/file.parquet",
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Tier:          TierHot,
+		SizeBytes:     1024,
+		CreatedAt:     time.Now().UTC(),
+	}
+
+	// Record file
+	err := store.RecordFile(ctx, file)
+	if err != nil {
+		t.Fatalf("RecordFile() error = %v", err)
+	}
+
+	// Retrieve file
+	retrieved, err := store.GetFile(ctx, file.Path)
+	if err != nil {
+		t.Fatalf("GetFile() error = %v", err)
+	}
+
+	if retrieved == nil {
+		t.Fatal("GetFile() returned nil")
+	}
+
+	if retrieved.Database != file.Database {
+		t.Errorf("Database = %v, want %v", retrieved.Database, file.Database)
+	}
+	if retrieved.Measurement != file.Measurement {
+		t.Errorf("Measurement = %v, want %v", retrieved.Measurement, file.Measurement)
+	}
+	if retrieved.Tier != file.Tier {
+		t.Errorf("Tier = %v, want %v", retrieved.Tier, file.Tier)
+	}
+	if retrieved.SizeBytes != file.SizeBytes {
+		t.Errorf("SizeBytes = %v, want %v", retrieved.SizeBytes, file.SizeBytes)
+	}
+}
+
+func TestMetadataStore_UpdateTier(t *testing.T) {
+	store, cleanup := setupTestMetadataStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	file := &FileMetadata{
+		Path:          "test/db/measurement/2025/01/01/00/file.parquet",
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Tier:          TierHot,
+		SizeBytes:     1024,
+	}
+
+	// Record file
+	err := store.RecordFile(ctx, file)
+	if err != nil {
+		t.Fatalf("RecordFile() error = %v", err)
+	}
+
+	// Update tier
+	err = store.UpdateTier(ctx, file.Path, TierCold)
+	if err != nil {
+		t.Fatalf("UpdateTier() error = %v", err)
+	}
+
+	// Verify tier changed
+	retrieved, err := store.GetFile(ctx, file.Path)
+	if err != nil {
+		t.Fatalf("GetFile() error = %v", err)
+	}
+
+	if retrieved.Tier != TierCold {
+		t.Errorf("Tier = %v, want %v", retrieved.Tier, TierCold)
+	}
+
+	if retrieved.MigratedAt == nil {
+		t.Error("MigratedAt should not be nil after tier update")
+	}
+}
+
+func TestMetadataStore_GetFilesInTier(t *testing.T) {
+	store, cleanup := setupTestMetadataStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Add files in different tiers (2-tier system: hot and cold)
+	files := []FileMetadata{
+		{Path: "hot1.parquet", Database: "db1", Measurement: "m1", PartitionTime: time.Now().UTC(), Tier: TierHot, SizeBytes: 100},
+		{Path: "hot2.parquet", Database: "db1", Measurement: "m1", PartitionTime: time.Now().UTC(), Tier: TierHot, SizeBytes: 200},
+		{Path: "cold1.parquet", Database: "db1", Measurement: "m1", PartitionTime: time.Now().UTC(), Tier: TierCold, SizeBytes: 300},
+	}
+
+	for _, f := range files {
+		file := f
+		err := store.RecordFile(ctx, &file)
+		if err != nil {
+			t.Fatalf("RecordFile() error = %v", err)
+		}
+	}
+
+	// Get hot tier files
+	hotFiles, err := store.GetFilesInTier(ctx, TierHot)
+	if err != nil {
+		t.Fatalf("GetFilesInTier() error = %v", err)
+	}
+
+	if len(hotFiles) != 2 {
+		t.Errorf("GetFilesInTier(hot) returned %d files, want 2", len(hotFiles))
+	}
+
+	// Get cold tier files
+	coldFiles, err := store.GetFilesInTier(ctx, TierCold)
+	if err != nil {
+		t.Fatalf("GetFilesInTier() error = %v", err)
+	}
+
+	if len(coldFiles) != 1 {
+		t.Errorf("GetFilesInTier(cold) returned %d files, want 1", len(coldFiles))
+	}
+}
+
+func TestMetadataStore_GetFilesOlderThan(t *testing.T) {
+	store, cleanup := setupTestMetadataStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+
+	// Add files with different ages
+	files := []FileMetadata{
+		{Path: "recent.parquet", Database: "db1", Measurement: "m1", PartitionTime: now.Add(-1 * time.Hour), Tier: TierHot, SizeBytes: 100},
+		{Path: "old.parquet", Database: "db1", Measurement: "m1", PartitionTime: now.Add(-10 * 24 * time.Hour), Tier: TierHot, SizeBytes: 200},
+		{Path: "very_old.parquet", Database: "db1", Measurement: "m1", PartitionTime: now.Add(-30 * 24 * time.Hour), Tier: TierHot, SizeBytes: 300},
+	}
+
+	for _, f := range files {
+		file := f
+		err := store.RecordFile(ctx, &file)
+		if err != nil {
+			t.Fatalf("RecordFile() error = %v", err)
+		}
+	}
+
+	// Get files older than 7 days
+	oldFiles, err := store.GetFilesOlderThan(ctx, TierHot, 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("GetFilesOlderThan() error = %v", err)
+	}
+
+	if len(oldFiles) != 2 {
+		t.Errorf("GetFilesOlderThan(7d) returned %d files, want 2", len(oldFiles))
+	}
+}
+
+func TestMetadataStore_DeleteFile(t *testing.T) {
+	store, cleanup := setupTestMetadataStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	file := &FileMetadata{
+		Path:          "test.parquet",
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionTime: time.Now().UTC(),
+		Tier:          TierHot,
+		SizeBytes:     1024,
+	}
+
+	// Record file
+	err := store.RecordFile(ctx, file)
+	if err != nil {
+		t.Fatalf("RecordFile() error = %v", err)
+	}
+
+	// Delete file
+	err = store.DeleteFile(ctx, file.Path)
+	if err != nil {
+		t.Fatalf("DeleteFile() error = %v", err)
+	}
+
+	// Verify file is gone
+	retrieved, err := store.GetFile(ctx, file.Path)
+	if err != nil {
+		t.Fatalf("GetFile() error = %v", err)
+	}
+
+	if retrieved != nil {
+		t.Error("GetFile() should return nil after delete")
+	}
+}
+
+func TestMetadataStore_GetTierStats(t *testing.T) {
+	store, cleanup := setupTestMetadataStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Add files (2-tier system: hot and cold)
+	files := []FileMetadata{
+		{Path: "hot1.parquet", Database: "db1", Measurement: "m1", PartitionTime: time.Now().UTC(), Tier: TierHot, SizeBytes: 1024 * 1024},       // 1MB
+		{Path: "hot2.parquet", Database: "db1", Measurement: "m1", PartitionTime: time.Now().UTC(), Tier: TierHot, SizeBytes: 2 * 1024 * 1024},   // 2MB
+		{Path: "cold1.parquet", Database: "db1", Measurement: "m1", PartitionTime: time.Now().UTC(), Tier: TierCold, SizeBytes: 5 * 1024 * 1024}, // 5MB
+	}
+
+	for _, f := range files {
+		file := f
+		err := store.RecordFile(ctx, &file)
+		if err != nil {
+			t.Fatalf("RecordFile() error = %v", err)
+		}
+	}
+
+	stats, err := store.GetTierStats(ctx)
+	if err != nil {
+		t.Fatalf("GetTierStats() error = %v", err)
+	}
+
+	if stats[TierHot].FileCount != 2 {
+		t.Errorf("Hot tier file count = %d, want 2", stats[TierHot].FileCount)
+	}
+	if stats[TierHot].TotalSizeMB != 3 {
+		t.Errorf("Hot tier size = %d MB, want 3 MB", stats[TierHot].TotalSizeMB)
+	}
+
+	if stats[TierCold].FileCount != 1 {
+		t.Errorf("Cold tier file count = %d, want 1", stats[TierCold].FileCount)
+	}
+	if stats[TierCold].TotalSizeMB != 5 {
+		t.Errorf("Cold tier size = %d MB, want 5 MB", stats[TierCold].TotalSizeMB)
+	}
+}

--- a/internal/tiering/migrator.go
+++ b/internal/tiering/migrator.go
@@ -1,0 +1,373 @@
+package tiering
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/semaphore"
+)
+
+// Migrator handles file migration between tiers
+type Migrator struct {
+	manager       *Manager
+	maxConcurrent int
+	batchSize     int
+	logger        zerolog.Logger
+}
+
+// MigratorConfig holds configuration for creating a migrator
+type MigratorConfig struct {
+	Manager       *Manager
+	MaxConcurrent int
+	BatchSize     int
+	Logger        zerolog.Logger
+}
+
+// NewMigrator creates a new migrator
+func NewMigrator(cfg *MigratorConfig) *Migrator {
+	maxConcurrent := cfg.MaxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = 4
+	}
+
+	batchSize := cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	return &Migrator{
+		manager:       cfg.Manager,
+		maxConcurrent: maxConcurrent,
+		batchSize:     batchSize,
+		logger:        cfg.Logger.With().Str("component", "tiering-migrator").Logger(),
+	}
+}
+
+// MigrateTier migrates eligible files from one tier to another
+// Returns the number of files migrated and the number of errors
+func (m *Migrator) MigrateTier(ctx context.Context, fromTier, toTier Tier) (int, int) {
+	m.logger.Info().
+		Str("from_tier", string(fromTier)).
+		Str("to_tier", string(toTier)).
+		Msg("Starting tier migration")
+
+	// Find candidates for migration
+	candidates, err := m.FindCandidates(ctx, fromTier, toTier)
+	if err != nil {
+		m.logger.Error().Err(err).Msg("Failed to find migration candidates")
+		return 0, 1
+	}
+
+	if len(candidates) == 0 {
+		m.logger.Info().Msg("No candidates for migration")
+		return 0, 0
+	}
+
+	m.logger.Info().Int("candidates", len(candidates)).Msg("Found migration candidates")
+
+	// Process in batches
+	migrated := 0
+	errors := 0
+
+	for i := 0; i < len(candidates); i += m.batchSize {
+		end := i + m.batchSize
+		if end > len(candidates) {
+			end = len(candidates)
+		}
+
+		batch := candidates[i:end]
+		batchMigrated, batchErrors := m.MigrateBatch(ctx, batch)
+		migrated += batchMigrated
+		errors += batchErrors
+	}
+
+	return migrated, errors
+}
+
+// FindCandidates finds files eligible for migration from one tier to another
+func (m *Migrator) FindCandidates(ctx context.Context, fromTier, toTier Tier) ([]MigrationCandidate, error) {
+	// Only support Hot -> Cold migration in 2-tier system
+	if fromTier != TierHot || toTier != TierCold {
+		return nil, fmt.Errorf("unsupported migration: %s -> %s (only hot -> cold supported)", fromTier, toTier)
+	}
+
+	// Hot -> Cold: files older than hot_max_age_days
+	maxAge := time.Duration(m.manager.config.DefaultHotMaxAgeDays) * 24 * time.Hour
+
+	// Get files older than max age in the source tier
+	files, err := m.manager.metadata.GetFilesOlderThan(ctx, fromTier, maxAge)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get old files: %w", err)
+	}
+
+	// Filter by per-database policies
+	var candidates []MigrationCandidate
+	now := time.Now().UTC()
+
+	for _, file := range files {
+		// Check if database is excluded from tiering
+		if m.manager.IsHotOnly(ctx, file.Database) {
+			continue
+		}
+
+		// Get effective policy for this database
+		policy := m.manager.GetEffectivePolicy(ctx, file.Database)
+
+		// Calculate age threshold based on policy
+		ageThreshold := time.Duration(policy.HotMaxAgeDays) * 24 * time.Hour
+
+		// Check if file is old enough based on its policy
+		fileAge := now.Sub(file.PartitionTime)
+		if fileAge < ageThreshold {
+			continue
+		}
+
+		candidates = append(candidates, MigrationCandidate{
+			Path:          file.Path,
+			Database:      file.Database,
+			Measurement:   file.Measurement,
+			PartitionTime: file.PartitionTime,
+			SizeBytes:     file.SizeBytes,
+			CurrentTier:   fromTier,
+			TargetTier:    toTier,
+			Age:           fileAge,
+		})
+	}
+
+	return candidates, nil
+}
+
+// MigrateBatch migrates a batch of files concurrently
+func (m *Migrator) MigrateBatch(ctx context.Context, candidates []MigrationCandidate) (int, int) {
+	if len(candidates) == 0 {
+		return 0, 0
+	}
+
+	sem := semaphore.NewWeighted(int64(m.maxConcurrent))
+	var wg sync.WaitGroup
+	var migrated, errors int64
+	var mu sync.Mutex
+
+	for _, candidate := range candidates {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			m.logger.Error().Err(err).Msg("Failed to acquire semaphore")
+			break
+		}
+
+		wg.Add(1)
+		go func(c MigrationCandidate) {
+			defer wg.Done()
+			defer sem.Release(1)
+
+			if err := m.MigrateFile(ctx, c); err != nil {
+				m.logger.Error().
+					Err(err).
+					Str("path", c.Path).
+					Str("from", string(c.CurrentTier)).
+					Str("to", string(c.TargetTier)).
+					Msg("Failed to migrate file")
+
+				mu.Lock()
+				errors++
+				mu.Unlock()
+			} else {
+				mu.Lock()
+				migrated++
+				mu.Unlock()
+			}
+		}(candidate)
+	}
+
+	wg.Wait()
+	return int(migrated), int(errors)
+}
+
+// MigrateFile migrates a single file from one tier to another
+func (m *Migrator) MigrateFile(ctx context.Context, candidate MigrationCandidate) error {
+	startTime := time.Now()
+
+	// Get source and destination backends
+	srcBackend := m.manager.GetBackendForTier(candidate.CurrentTier)
+	dstBackend := m.manager.GetBackendForTier(candidate.TargetTier)
+
+	if srcBackend == nil {
+		return fmt.Errorf("source backend not available for tier: %s", candidate.CurrentTier)
+	}
+	if dstBackend == nil {
+		return fmt.Errorf("destination backend not available for tier: %s", candidate.TargetTier)
+	}
+
+	// Record migration start
+	record := &MigrationRecord{
+		FilePath:  candidate.Path,
+		Database:  candidate.Database,
+		FromTier:  candidate.CurrentTier,
+		ToTier:    candidate.TargetTier,
+		SizeBytes: candidate.SizeBytes,
+		StartedAt: startTime,
+	}
+	migrationID, err := m.manager.metadata.RecordMigration(ctx, record)
+	if err != nil {
+		m.logger.Warn().Err(err).Msg("Failed to record migration start")
+	}
+
+	// Perform the migration
+	migrationErr := m.copyFile(ctx, srcBackend, dstBackend, candidate.Path, candidate.SizeBytes)
+
+	if migrationErr != nil {
+		// Record failure
+		if migrationID > 0 {
+			m.manager.metadata.CompleteMigration(ctx, migrationID, migrationErr)
+		}
+		return migrationErr
+	}
+
+	// Update tier metadata
+	if err := m.manager.metadata.UpdateTier(ctx, candidate.Path, candidate.TargetTier); err != nil {
+		// Rollback: delete from destination
+		if delErr := dstBackend.Delete(ctx, candidate.Path); delErr != nil {
+			m.logger.Error().Err(delErr).Str("path", candidate.Path).Msg("Failed to rollback destination file")
+		}
+		return fmt.Errorf("failed to update tier metadata: %w", err)
+	}
+
+	// Delete from source tier
+	if err := srcBackend.Delete(ctx, candidate.Path); err != nil {
+		m.logger.Warn().Err(err).Str("path", candidate.Path).Msg("Failed to delete source file after migration")
+		// Don't fail the migration - file is in destination, just source cleanup failed
+	} else {
+		// Clean up empty parent directories after successful delete
+		m.CleanupEmptyDirectories(ctx, candidate.Path)
+	}
+
+	// Record success
+	if migrationID > 0 {
+		m.manager.metadata.CompleteMigration(ctx, migrationID, nil)
+	}
+
+	duration := time.Since(startTime)
+	m.logger.Debug().
+		Str("path", candidate.Path).
+		Str("from", string(candidate.CurrentTier)).
+		Str("to", string(candidate.TargetTier)).
+		Int64("size_bytes", candidate.SizeBytes).
+		Dur("duration", duration).
+		Msg("File migrated successfully")
+
+	return nil
+}
+
+// copyFile copies a file from source to destination backend
+func (m *Migrator) copyFile(ctx context.Context, src, dst interface {
+	Read(ctx context.Context, path string) ([]byte, error)
+	Write(ctx context.Context, path string, data []byte) error
+}, path string, expectedSize int64) error {
+
+	// For now, use simple read/write
+	// TODO: Use streaming (ReadTo/WriteReader) for large files
+
+	data, err := src.Read(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to read from source: %w", err)
+	}
+
+	// Verify size matches
+	if int64(len(data)) != expectedSize && expectedSize > 0 {
+		return fmt.Errorf("size mismatch: expected %d, got %d", expectedSize, len(data))
+	}
+
+	if err := dst.Write(ctx, path, data); err != nil {
+		return fmt.Errorf("failed to write to destination: %w", err)
+	}
+
+	return nil
+}
+
+// StreamingBackend is an interface for backends that support streaming
+type StreamingBackend interface {
+	ReadTo(ctx context.Context, path string, w io.Writer) error
+	WriteReader(ctx context.Context, path string, r io.Reader, size int64) error
+}
+
+// copyFileStreaming copies a file using streaming for memory efficiency
+// This is used for large files to avoid loading them entirely into memory
+func (m *Migrator) copyFileStreaming(ctx context.Context, src, dst StreamingBackend, path string, size int64) error {
+	// Create a pipe to stream data from source to destination
+	pr, pw := io.Pipe()
+
+	errCh := make(chan error, 2)
+
+	// Read from source in a goroutine
+	go func() {
+		err := src.ReadTo(ctx, path, pw)
+		pw.CloseWithError(err)
+		errCh <- err
+	}()
+
+	// Write to destination in main goroutine
+	go func() {
+		err := dst.WriteReader(ctx, path, pr, size)
+		pr.CloseWithError(err)
+		errCh <- err
+	}()
+
+	// Wait for both operations to complete
+	var readErr, writeErr error
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			if readErr == nil {
+				readErr = err
+			} else {
+				writeErr = err
+			}
+		}
+	}
+
+	if readErr != nil {
+		return fmt.Errorf("streaming read failed: %w", readErr)
+	}
+	if writeErr != nil {
+		return fmt.Errorf("streaming write failed: %w", writeErr)
+	}
+
+	return nil
+}
+
+// CleanupEmptyDirectories removes empty directories after file migration
+// Walks up from the file's hour directory, removing empty dirs until hitting a non-empty one
+// Path format: {database}/{measurement}/{year}/{month}/{day}/{hour}/
+func (m *Migrator) CleanupEmptyDirectories(ctx context.Context, filePath string) {
+	// Get DirectoryRemover interface from hot backend
+	dirRemover, ok := m.manager.hotBackend.(storage.DirectoryRemover)
+	if !ok {
+		return // Backend doesn't support directory removal
+	}
+
+	// Extract directory path from file path
+	dir := filepath.Dir(filePath)
+
+	// Walk up the tree: hour -> day -> month -> year -> measurement -> database
+	// Stop when we hit a non-empty directory or reach the root
+	// Maximum depth of 6 prevents accidentally climbing too far
+	for depth := 0; depth < 6; depth++ {
+		if dir == "" || dir == "." {
+			break
+		}
+
+		// Try to remove - will fail silently if not empty (os.Remove only removes empty dirs)
+		err := dirRemover.RemoveDirectory(ctx, dir)
+		if err != nil {
+			// Directory not empty or other error - stop climbing
+			break
+		}
+
+		m.logger.Debug().Str("dir", dir).Msg("Removed empty directory")
+		dir = filepath.Dir(dir)
+	}
+}

--- a/internal/tiering/policy.go
+++ b/internal/tiering/policy.go
@@ -1,0 +1,326 @@
+package tiering
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/rs/zerolog"
+)
+
+// DatabasePolicy represents per-database tiering policy overrides
+type DatabasePolicy struct {
+	ID            int64     `json:"id"`
+	Database      string    `json:"database"`
+	HotOnly       bool      `json:"hot_only"`         // Exclude from tiering entirely
+	HotMaxAgeDays *int      `json:"hot_max_age_days"` // nil = use global default
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// EffectivePolicy represents the resolved policy for a database
+type EffectivePolicy struct {
+	Database      string `json:"database"`
+	HotOnly       bool   `json:"hot_only"`
+	HotMaxAgeDays int    `json:"hot_max_age_days"`
+	Source        string `json:"source"` // "custom" or "global"
+}
+
+// PolicyStore manages per-database tiering policies in SQLite
+type PolicyStore struct {
+	db       *sql.DB
+	defaults *config.TieredStorageConfig
+	cache    map[string]*DatabasePolicy
+	logger   zerolog.Logger
+	mu       sync.RWMutex
+}
+
+// NewPolicyStore creates a new policy store
+func NewPolicyStore(db *sql.DB, defaults *config.TieredStorageConfig, logger zerolog.Logger) (*PolicyStore, error) {
+	store := &PolicyStore{
+		db:       db,
+		defaults: defaults,
+		cache:    make(map[string]*DatabasePolicy),
+		logger:   logger.With().Str("component", "tiering-policy").Logger(),
+	}
+
+	if err := store.initSchema(); err != nil {
+		return nil, fmt.Errorf("failed to initialize policy schema: %w", err)
+	}
+
+	// Load existing policies into cache
+	if err := store.loadCache(); err != nil {
+		return nil, fmt.Errorf("failed to load policy cache: %w", err)
+	}
+
+	return store, nil
+}
+
+// initSchema creates the tiering_policies table if it doesn't exist
+func (s *PolicyStore) initSchema() error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS tiering_policies (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		database TEXT UNIQUE NOT NULL,
+		hot_only BOOLEAN DEFAULT FALSE,
+		hot_max_age_days INTEGER,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_tiering_policies_database ON tiering_policies(database);
+	`
+
+	_, err := s.db.Exec(schema)
+	if err != nil {
+		return fmt.Errorf("failed to create tiering_policies table: %w", err)
+	}
+
+	s.logger.Info().Msg("Tiering policy schema initialized")
+	return nil
+}
+
+// loadCache loads all policies from the database into the in-memory cache
+func (s *PolicyStore) loadCache() error {
+	policies, err := s.listFromDB(context.Background())
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.cache = make(map[string]*DatabasePolicy)
+	for i := range policies {
+		s.cache[policies[i].Database] = &policies[i]
+	}
+
+	s.logger.Info().Int("count", len(policies)).Msg("Loaded tiering policies into cache")
+	return nil
+}
+
+// Get retrieves a policy for a specific database
+func (s *PolicyStore) Get(ctx context.Context, database string) (*DatabasePolicy, error) {
+	s.mu.RLock()
+	policy, exists := s.cache[database]
+	s.mu.RUnlock()
+
+	if exists {
+		return policy, nil
+	}
+
+	// Not in cache, check database and cache the result
+	policy, err := s.getFromDB(ctx, database)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result (even if nil, we cache to avoid repeated DB lookups)
+	if policy != nil {
+		s.mu.Lock()
+		s.cache[database] = policy
+		s.mu.Unlock()
+	}
+
+	return policy, nil
+}
+
+// getFromDB retrieves a policy from the database
+func (s *PolicyStore) getFromDB(ctx context.Context, database string) (*DatabasePolicy, error) {
+	query := `
+		SELECT id, database, hot_only, hot_max_age_days, created_at, updated_at
+		FROM tiering_policies
+		WHERE database = ?
+	`
+
+	row := s.db.QueryRowContext(ctx, query, database)
+	return s.scanPolicy(row)
+}
+
+// Set creates or updates a policy for a database
+func (s *PolicyStore) Set(ctx context.Context, policy *DatabasePolicy) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	query := `
+		INSERT INTO tiering_policies (database, hot_only, hot_max_age_days, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(database) DO UPDATE SET
+			hot_only = excluded.hot_only,
+			hot_max_age_days = excluded.hot_max_age_days,
+			updated_at = CURRENT_TIMESTAMP
+	`
+
+	_, err := s.db.ExecContext(ctx, query,
+		policy.Database,
+		policy.HotOnly,
+		policy.HotMaxAgeDays,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set policy: %w", err)
+	}
+
+	// Update cache
+	s.cache[policy.Database] = policy
+
+	s.logger.Info().
+		Str("database", policy.Database).
+		Bool("hot_only", policy.HotOnly).
+		Msg("Tiering policy updated")
+
+	return nil
+}
+
+// Delete removes a policy for a database (reverts to global defaults)
+func (s *PolicyStore) Delete(ctx context.Context, database string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	query := `DELETE FROM tiering_policies WHERE database = ?`
+	result, err := s.db.ExecContext(ctx, query, database)
+	if err != nil {
+		return fmt.Errorf("failed to delete policy: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("policy not found for database: %s", database)
+	}
+
+	// Remove from cache
+	delete(s.cache, database)
+
+	s.logger.Info().
+		Str("database", database).
+		Msg("Tiering policy deleted, reverting to global defaults")
+
+	return nil
+}
+
+// List returns all custom policies
+func (s *PolicyStore) List(ctx context.Context) ([]DatabasePolicy, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	policies := make([]DatabasePolicy, 0, len(s.cache))
+	for _, policy := range s.cache {
+		policies = append(policies, *policy)
+	}
+	return policies, nil
+}
+
+// listFromDB retrieves all policies from the database
+func (s *PolicyStore) listFromDB(ctx context.Context) ([]DatabasePolicy, error) {
+	query := `
+		SELECT id, database, hot_only, hot_max_age_days, created_at, updated_at
+		FROM tiering_policies
+		ORDER BY database
+	`
+
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list policies: %w", err)
+	}
+	defer rows.Close()
+
+	var policies []DatabasePolicy
+	for rows.Next() {
+		var policy DatabasePolicy
+		var hotMaxAge sql.NullInt64
+
+		err := rows.Scan(
+			&policy.ID,
+			&policy.Database,
+			&policy.HotOnly,
+			&hotMaxAge,
+			&policy.CreatedAt,
+			&policy.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan policy: %w", err)
+		}
+
+		if hotMaxAge.Valid {
+			val := int(hotMaxAge.Int64)
+			policy.HotMaxAgeDays = &val
+		}
+
+		policies = append(policies, policy)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating policies: %w", err)
+	}
+
+	return policies, nil
+}
+
+// GetEffective returns the effective policy for a database
+// This resolves custom policies with global defaults
+func (s *PolicyStore) GetEffective(ctx context.Context, database string) *EffectivePolicy {
+	policy, _ := s.Get(ctx, database)
+
+	effective := &EffectivePolicy{
+		Database:      database,
+		HotMaxAgeDays: s.defaults.DefaultHotMaxAgeDays,
+		Source:        "global",
+	}
+
+	if policy != nil {
+		effective.Source = "custom"
+		effective.HotOnly = policy.HotOnly
+
+		if policy.HotMaxAgeDays != nil {
+			effective.HotMaxAgeDays = *policy.HotMaxAgeDays
+		}
+	}
+
+	return effective
+}
+
+// IsHotOnly returns true if the database is excluded from tiering
+func (s *PolicyStore) IsHotOnly(ctx context.Context, database string) bool {
+	policy, err := s.Get(ctx, database)
+	if err != nil || policy == nil {
+		return false
+	}
+	return policy.HotOnly
+}
+
+// GetHotMaxAge returns the hot tier max age for a database in days
+func (s *PolicyStore) GetHotMaxAge(ctx context.Context, database string) int {
+	effective := s.GetEffective(ctx, database)
+	return effective.HotMaxAgeDays
+}
+
+// helper functions
+
+func (s *PolicyStore) scanPolicy(row *sql.Row) (*DatabasePolicy, error) {
+	var policy DatabasePolicy
+	var hotMaxAge sql.NullInt64
+
+	err := row.Scan(
+		&policy.ID,
+		&policy.Database,
+		&policy.HotOnly,
+		&hotMaxAge,
+		&policy.CreatedAt,
+		&policy.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan policy: %w", err)
+	}
+
+	if hotMaxAge.Valid {
+		val := int(hotMaxAge.Int64)
+		policy.HotMaxAgeDays = &val
+	}
+
+	return &policy, nil
+}

--- a/internal/tiering/policy_test.go
+++ b/internal/tiering/policy_test.go
@@ -1,0 +1,266 @@
+package tiering
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/config"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+)
+
+func setupTestPolicyStore(t *testing.T) (*PolicyStore, func()) {
+	t.Helper()
+
+	// Create temp file for SQLite
+	tmpFile, err := os.CreateTemp("", "tiering_policy_test_*.db")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	db, err := sql.Open("sqlite3", tmpFile.Name())
+	if err != nil {
+		os.Remove(tmpFile.Name())
+		t.Fatalf("Failed to open SQLite: %v", err)
+	}
+
+	// 2-tier system: only hot max age is needed
+	defaults := &config.TieredStorageConfig{
+		DefaultHotMaxAgeDays: 7,
+	}
+
+	logger := zerolog.Nop()
+	store, err := NewPolicyStore(db, defaults, logger)
+	if err != nil {
+		db.Close()
+		os.Remove(tmpFile.Name())
+		t.Fatalf("Failed to create policy store: %v", err)
+	}
+
+	cleanup := func() {
+		db.Close()
+		os.Remove(tmpFile.Name())
+	}
+
+	return store, cleanup
+}
+
+func TestPolicyStore_SetAndGet(t *testing.T) {
+	store, cleanup := setupTestPolicyStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// 2-tier system: only hot max age is needed
+	hotDays := 3
+
+	policy := &DatabasePolicy{
+		Database:      "testdb",
+		HotOnly:       false,
+		HotMaxAgeDays: &hotDays,
+	}
+
+	// Set policy
+	err := store.Set(ctx, policy)
+	if err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	// Get policy
+	retrieved, err := store.Get(ctx, "testdb")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if retrieved == nil {
+		t.Fatal("Get() returned nil")
+	}
+
+	if retrieved.Database != "testdb" {
+		t.Errorf("Database = %v, want testdb", retrieved.Database)
+	}
+	if *retrieved.HotMaxAgeDays != 3 {
+		t.Errorf("HotMaxAgeDays = %v, want 3", *retrieved.HotMaxAgeDays)
+	}
+}
+
+func TestPolicyStore_HotOnly(t *testing.T) {
+	store, cleanup := setupTestPolicyStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	policy := &DatabasePolicy{
+		Database: "realtime",
+		HotOnly:  true,
+	}
+
+	// Set policy
+	err := store.Set(ctx, policy)
+	if err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	// Check IsHotOnly
+	if !store.IsHotOnly(ctx, "realtime") {
+		t.Error("IsHotOnly() = false, want true")
+	}
+
+	// Non-existent database should not be hot-only
+	if store.IsHotOnly(ctx, "nonexistent") {
+		t.Error("IsHotOnly() for nonexistent = true, want false")
+	}
+}
+
+func TestPolicyStore_GetEffective(t *testing.T) {
+	store, cleanup := setupTestPolicyStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Test 1: No custom policy - should use global defaults (2-tier system)
+	effective := store.GetEffective(ctx, "db_without_policy")
+	if effective.Source != "global" {
+		t.Errorf("Source = %v, want global", effective.Source)
+	}
+	if effective.HotMaxAgeDays != 7 {
+		t.Errorf("HotMaxAgeDays = %v, want 7 (global default)", effective.HotMaxAgeDays)
+	}
+
+	// Test 2: Custom policy with overrides
+	hotDays := 3
+	policy := &DatabasePolicy{
+		Database:      "custom_db",
+		HotMaxAgeDays: &hotDays,
+	}
+	err := store.Set(ctx, policy)
+	if err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	effective = store.GetEffective(ctx, "custom_db")
+	if effective.Source != "custom" {
+		t.Errorf("Source = %v, want custom", effective.Source)
+	}
+	if effective.HotMaxAgeDays != 3 {
+		t.Errorf("HotMaxAgeDays = %v, want 3 (custom)", effective.HotMaxAgeDays)
+	}
+}
+
+func TestPolicyStore_Delete(t *testing.T) {
+	store, cleanup := setupTestPolicyStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	hotDays := 3
+	policy := &DatabasePolicy{
+		Database:      "testdb",
+		HotMaxAgeDays: &hotDays,
+	}
+
+	// Set policy
+	err := store.Set(ctx, policy)
+	if err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	// Delete policy
+	err = store.Delete(ctx, "testdb")
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	// Get should return nil
+	retrieved, err := store.Get(ctx, "testdb")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if retrieved != nil {
+		t.Error("Get() should return nil after delete")
+	}
+
+	// Effective policy should now be global
+	effective := store.GetEffective(ctx, "testdb")
+	if effective.Source != "global" {
+		t.Errorf("Source = %v, want global after delete", effective.Source)
+	}
+}
+
+func TestPolicyStore_List(t *testing.T) {
+	store, cleanup := setupTestPolicyStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Add multiple policies
+	policies := []DatabasePolicy{
+		{Database: "db1", HotOnly: true},
+		{Database: "db2", HotOnly: false},
+		{Database: "db3", HotOnly: false},
+	}
+
+	for _, p := range policies {
+		policy := p
+		err := store.Set(ctx, &policy)
+		if err != nil {
+			t.Fatalf("Set() error = %v", err)
+		}
+	}
+
+	// List policies
+	listed, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	if len(listed) != 3 {
+		t.Errorf("List() returned %d policies, want 3", len(listed))
+	}
+}
+
+func TestPolicyStore_Update(t *testing.T) {
+	store, cleanup := setupTestPolicyStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	hotDays := 3
+	policy := &DatabasePolicy{
+		Database:      "testdb",
+		HotOnly:       false,
+		HotMaxAgeDays: &hotDays,
+	}
+
+	// Set initial policy
+	err := store.Set(ctx, policy)
+	if err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	// Update policy
+	newHotDays := 5
+	policy.HotMaxAgeDays = &newHotDays
+	policy.HotOnly = true
+
+	err = store.Set(ctx, policy)
+	if err != nil {
+		t.Fatalf("Set() (update) error = %v", err)
+	}
+
+	// Verify update
+	retrieved, err := store.Get(ctx, "testdb")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if *retrieved.HotMaxAgeDays != 5 {
+		t.Errorf("HotMaxAgeDays = %v, want 5", *retrieved.HotMaxAgeDays)
+	}
+	if !retrieved.HotOnly {
+		t.Error("HotOnly = false, want true")
+	}
+}

--- a/internal/tiering/router.go
+++ b/internal/tiering/router.go
@@ -1,0 +1,201 @@
+package tiering
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Router routes queries to the correct storage tier(s)
+type Router struct {
+	manager *Manager
+	logger  zerolog.Logger
+}
+
+// NewRouter creates a new tier router
+func NewRouter(manager *Manager, logger zerolog.Logger) *Router {
+	return &Router{
+		manager: manager,
+		logger:  logger.With().Str("component", "tiering-router").Logger(),
+	}
+}
+
+// GetStoragePathsForQuery returns storage paths across all tiers for a query
+// This is the primary integration point with the query handler
+func (r *Router) GetStoragePathsForQuery(ctx context.Context, database, measurement string, startTime, endTime *time.Time) ([]TieredPath, error) {
+	var paths []TieredPath
+
+	// Get all files for this database/measurement from metadata
+	files, err := r.manager.metadata.GetFilesByDatabase(ctx, database)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get files: %w", err)
+	}
+
+	// Filter by measurement and time range, group by tier
+	tierFiles := make(map[Tier][]string)
+
+	for _, file := range files {
+		// Filter by measurement if specified
+		if measurement != "" && file.Measurement != measurement {
+			continue
+		}
+
+		// Filter by time range if specified
+		if startTime != nil && file.PartitionTime.Before(*startTime) {
+			continue
+		}
+		if endTime != nil && file.PartitionTime.After(*endTime) {
+			continue
+		}
+
+		tierFiles[file.Tier] = append(tierFiles[file.Tier], file.Path)
+	}
+
+	// Convert to TieredPath list
+	for tier, filePaths := range tierFiles {
+		backend := r.getBackendName(tier)
+		for _, path := range filePaths {
+			paths = append(paths, TieredPath{
+				Path:    path,
+				Tier:    tier,
+				Backend: backend,
+			})
+		}
+	}
+
+	return paths, nil
+}
+
+// GetGlobPathsForQuery returns glob patterns for each tier
+// This is useful when we don't have metadata and need to scan all files
+func (r *Router) GetGlobPathsForQuery(database, measurement string) map[Tier]string {
+	paths := make(map[Tier]string)
+
+	// Hot tier (local)
+	paths[TierHot] = fmt.Sprintf("%s/%s/**/*.parquet", database, measurement)
+
+	// Cold tier (S3/Azure archive) - if enabled
+	if r.manager.coldBackend != nil && r.manager.config.Cold.Enabled {
+		paths[TierCold] = fmt.Sprintf("%s/%s/**/*.parquet", database, measurement)
+	}
+
+	return paths
+}
+
+// BuildReadParquetExpr builds a DuckDB read_parquet expression for tiered paths
+// This generates a UNION ALL query to read from multiple tiers
+func (r *Router) BuildReadParquetExpr(paths []TieredPath) string {
+	if len(paths) == 0 {
+		return ""
+	}
+
+	// Group paths by tier
+	tierPaths := make(map[Tier][]string)
+	for _, p := range paths {
+		tierPaths[p.Tier] = append(tierPaths[p.Tier], p.Path)
+	}
+
+	// If only one tier, return simple expression
+	if len(tierPaths) == 1 {
+		for _, filePaths := range tierPaths {
+			return r.buildReadParquet(filePaths)
+		}
+	}
+
+	// Multiple tiers: build UNION ALL expression
+	var parts []string
+
+	// Process tiers in order: hot, cold (2-tier system)
+	for _, tier := range []Tier{TierHot, TierCold} {
+		if filePaths, ok := tierPaths[tier]; ok && len(filePaths) > 0 {
+			parts = append(parts, fmt.Sprintf("SELECT * FROM %s", r.buildReadParquet(filePaths)))
+		}
+	}
+
+	if len(parts) == 1 {
+		return r.buildReadParquet(tierPaths[TierHot])
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(parts, " UNION ALL "))
+}
+
+// BuildMultiTierQuery builds a complete DuckDB query that reads from all tiers
+func (r *Router) BuildMultiTierQuery(database, measurement string, whereClause string) string {
+	globPaths := r.GetGlobPathsForQuery(database, measurement)
+
+	var parts []string
+
+	// Hot tier
+	if hotPath, ok := globPaths[TierHot]; ok {
+		hotBackend := r.manager.hotBackend
+		fullPath := r.buildFullPath(hotBackend.Type(), hotPath)
+		parts = append(parts, fmt.Sprintf("SELECT * FROM read_parquet('%s')", fullPath))
+	}
+
+	// Cold tier
+	if coldPath, ok := globPaths[TierCold]; ok && r.manager.coldBackend != nil {
+		fullPath := r.buildFullPath(r.manager.coldBackend.Type(), coldPath)
+		parts = append(parts, fmt.Sprintf("SELECT * FROM read_parquet('%s')", fullPath))
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	query := strings.Join(parts, " UNION ALL ")
+
+	if whereClause != "" {
+		query = fmt.Sprintf("SELECT * FROM (%s) WHERE %s", query, whereClause)
+	}
+
+	return query
+}
+
+// helper functions
+
+func (r *Router) getBackendName(tier Tier) string {
+	switch tier {
+	case TierHot:
+		return "local"
+	case TierCold:
+		return r.manager.config.Cold.Backend
+	default:
+		return "local"
+	}
+}
+
+func (r *Router) buildReadParquet(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+
+	if len(paths) == 1 {
+		return fmt.Sprintf("read_parquet('%s')", paths[0])
+	}
+
+	// Multiple paths: use list
+	quotedPaths := make([]string, len(paths))
+	for i, p := range paths {
+		quotedPaths[i] = fmt.Sprintf("'%s'", p)
+	}
+	return fmt.Sprintf("read_parquet([%s], union_by_name=true)", strings.Join(quotedPaths, ", "))
+}
+
+func (r *Router) buildFullPath(backendType, path string) string {
+	switch backendType {
+	case "s3":
+		bucket := r.manager.config.Cold.S3Bucket
+		return fmt.Sprintf("s3://%s/%s", bucket, path)
+	case "azure":
+		container := r.manager.config.Cold.AzureContainer
+		return fmt.Sprintf("azure://%s/%s", container, path)
+	case "local":
+		// For local, the path is already relative to storage root
+		return path
+	default:
+		return path
+	}
+}

--- a/internal/tiering/scheduler.go
+++ b/internal/tiering/scheduler.go
@@ -1,0 +1,158 @@
+package tiering
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/rs/zerolog"
+)
+
+// Scheduler manages scheduled tier migrations
+type Scheduler struct {
+	manager  *Manager
+	schedule string
+	cron     *cron.Cron
+	entryID  cron.EntryID
+	running  bool
+	lastRun  *time.Time
+	logger   zerolog.Logger
+	mu       sync.RWMutex
+}
+
+// SchedulerConfig holds configuration for creating a scheduler
+type SchedulerConfig struct {
+	Manager  *Manager
+	Schedule string // Cron schedule (default: "0 2 * * *" = 2am daily)
+	Logger   zerolog.Logger
+}
+
+// NewScheduler creates a new migration scheduler
+func NewScheduler(cfg *SchedulerConfig) *Scheduler {
+	schedule := cfg.Schedule
+	if schedule == "" {
+		schedule = "0 2 * * *" // Default: 2am daily
+	}
+
+	return &Scheduler{
+		manager:  cfg.Manager,
+		schedule: schedule,
+		logger:   cfg.Logger.With().Str("component", "tiering-scheduler").Logger(),
+	}
+}
+
+// Start starts the scheduler
+func (s *Scheduler) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		return nil
+	}
+
+	// Create cron scheduler with seconds support
+	s.cron = cron.New(cron.WithLocation(time.UTC))
+
+	// Add the migration job
+	entryID, err := s.cron.AddFunc(s.schedule, func() {
+		s.runMigration()
+	})
+	if err != nil {
+		return err
+	}
+
+	s.entryID = entryID
+	s.cron.Start()
+	s.running = true
+
+	logEvent := s.logger.Info().Str("schedule", s.schedule)
+	if nextRun := s.getNextRun(); nextRun != nil {
+		logEvent = logEvent.Time("next_run", *nextRun)
+	}
+	logEvent.Msg("Tiering scheduler started")
+
+	return nil
+}
+
+// Stop stops the scheduler
+func (s *Scheduler) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running {
+		return
+	}
+
+	if s.cron != nil {
+		ctx := s.cron.Stop()
+		<-ctx.Done()
+		s.cron = nil
+	}
+
+	s.running = false
+	s.logger.Info().Msg("Tiering scheduler stopped")
+}
+
+// IsRunning returns true if the scheduler is running
+func (s *Scheduler) IsRunning() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.running
+}
+
+// Status returns the current scheduler status
+func (s *Scheduler) Status() *SchedulerStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	status := &SchedulerStatus{
+		Running:  s.running,
+		Schedule: s.schedule,
+		LastRun:  s.lastRun,
+	}
+
+	if s.running {
+		status.NextRun = s.getNextRun()
+	}
+
+	return status
+}
+
+// TriggerNow triggers an immediate migration cycle
+func (s *Scheduler) TriggerNow(ctx context.Context) error {
+	s.logger.Info().Msg("Manual migration triggered")
+	return s.manager.RunMigrationCycle(ctx)
+}
+
+// runMigration runs a migration cycle (called by cron)
+func (s *Scheduler) runMigration() {
+	s.mu.Lock()
+	now := time.Now().UTC()
+	s.lastRun = &now
+	s.mu.Unlock()
+
+	s.logger.Info().Msg("Scheduled migration cycle starting")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
+	defer cancel()
+
+	if err := s.manager.RunMigrationCycle(ctx); err != nil {
+		s.logger.Error().Err(err).Msg("Scheduled migration cycle failed")
+	}
+}
+
+// getNextRun returns the next scheduled run time
+func (s *Scheduler) getNextRun() *time.Time {
+	if s.cron == nil {
+		return nil
+	}
+
+	entry := s.cron.Entry(s.entryID)
+	if entry.ID == 0 {
+		return nil
+	}
+
+	next := entry.Next
+	return &next
+}

--- a/internal/tiering/tier.go
+++ b/internal/tiering/tier.go
@@ -1,0 +1,111 @@
+package tiering
+
+import "time"
+
+// Tier represents a storage tier
+type Tier string
+
+const (
+	// TierHot represents local/fast storage for recent data
+	TierHot Tier = "hot"
+	// TierCold represents S3/Azure archive storage for historical data
+	TierCold Tier = "cold"
+)
+
+// String returns the string representation of a Tier
+func (t Tier) String() string {
+	return string(t)
+}
+
+// IsValid returns true if the tier is a valid tier value
+func (t Tier) IsValid() bool {
+	switch t {
+	case TierHot, TierCold:
+		return true
+	default:
+		return false
+	}
+}
+
+// TierFromString converts a string to a Tier
+func TierFromString(s string) Tier {
+	switch s {
+	case "hot":
+		return TierHot
+	case "cold":
+		return TierCold
+	default:
+		return TierHot // Default to hot tier
+	}
+}
+
+// FileMetadata represents metadata about a file in the tiering system
+type FileMetadata struct {
+	ID            int64     `json:"id"`
+	Path          string    `json:"path"`
+	Database      string    `json:"database"`
+	Measurement   string    `json:"measurement"`
+	PartitionTime time.Time `json:"partition_time"`
+	Tier          Tier      `json:"tier"`
+	SizeBytes     int64     `json:"size_bytes"`
+	CreatedAt     time.Time `json:"created_at"`
+	MigratedAt    *time.Time `json:"migrated_at,omitempty"`
+}
+
+// MigrationCandidate represents a file that is eligible for tier migration
+type MigrationCandidate struct {
+	Path          string    `json:"path"`
+	Database      string    `json:"database"`
+	Measurement   string    `json:"measurement"`
+	PartitionTime time.Time `json:"partition_time"`
+	SizeBytes     int64     `json:"size_bytes"`
+	CurrentTier   Tier      `json:"current_tier"`
+	TargetTier    Tier      `json:"target_tier"`
+	Age           time.Duration `json:"age"`
+}
+
+// MigrationRecord represents a completed or failed migration
+type MigrationRecord struct {
+	ID          int64      `json:"id"`
+	FilePath    string     `json:"file_path"`
+	Database    string     `json:"database"`
+	FromTier    Tier       `json:"from_tier"`
+	ToTier      Tier       `json:"to_tier"`
+	SizeBytes   int64      `json:"size_bytes"`
+	StartedAt   time.Time  `json:"started_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	Error       string     `json:"error,omitempty"`
+}
+
+// TieredPath represents a storage path with its tier information
+type TieredPath struct {
+	Path    string `json:"path"`
+	Tier    Tier   `json:"tier"`
+	Backend string `json:"backend"` // "local", "s3", "azure"
+}
+
+// TierStats holds statistics for a single tier
+type TierStats struct {
+	Tier        Tier   `json:"tier"`
+	Enabled     bool   `json:"enabled"`
+	Backend     string `json:"backend"`
+	FileCount   int64  `json:"file_count"`
+	TotalSizeMB int64  `json:"total_size_mb"`
+}
+
+// StatusResponse represents the tiering status API response
+type StatusResponse struct {
+	Enabled      bool                  `json:"enabled"`
+	LicenseValid bool                  `json:"license_valid"`
+	Reason       string                `json:"reason,omitempty"`
+	Tiers        map[string]TierStats  `json:"tiers,omitempty"`
+	Scheduler    *SchedulerStatus      `json:"scheduler,omitempty"`
+}
+
+// SchedulerStatus represents the migration scheduler status
+type SchedulerStatus struct {
+	Running  bool       `json:"running"`
+	Schedule string     `json:"schedule"`
+	NextRun  *time.Time `json:"next_run,omitempty"`
+	LastRun  *time.Time `json:"last_run,omitempty"`
+}

--- a/internal/tiering/tier_test.go
+++ b/internal/tiering/tier_test.go
@@ -1,0 +1,69 @@
+package tiering
+
+import (
+	"testing"
+)
+
+func TestTier_String(t *testing.T) {
+	// 2-tier system: hot and cold only
+	tests := []struct {
+		tier     Tier
+		expected string
+	}{
+		{TierHot, "hot"},
+		{TierCold, "cold"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.tier.String(); got != tt.expected {
+				t.Errorf("Tier.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTier_IsValid(t *testing.T) {
+	// 2-tier system: hot and cold only
+	tests := []struct {
+		tier     Tier
+		expected bool
+	}{
+		{TierHot, true},
+		{TierCold, true},
+		{Tier("warm"), false},    // Warm tier removed in 2-tier system
+		{Tier("invalid"), false},
+		{Tier(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.tier), func(t *testing.T) {
+			if got := tt.tier.IsValid(); got != tt.expected {
+				t.Errorf("Tier.IsValid() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTierFromString(t *testing.T) {
+	// 2-tier system: hot and cold only
+	tests := []struct {
+		input    string
+		expected Tier
+	}{
+		{"hot", TierHot},
+		{"cold", TierCold},
+		{"warm", TierHot},    // Warm tier removed - defaults to hot
+		{"invalid", TierHot}, // Default to hot
+		{"", TierHot},        // Default to hot
+		{"HOT", TierHot},     // Case sensitivity - defaults to hot
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := TierFromString(tt.input); got != tt.expected {
+				t.Errorf("TierFromString(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enterprise feature for automatic data lifecycle management with hot (local) and cold (S3/Azure) storage tiers.

Key features:
- Automatic migration of data older than configurable threshold to cold tier
- Multi-tier query routing with UNION ALL across tiers
- Per-database tiering policies via API
- Tier metadata caching (30s TTL) to reduce query overhead
- Auto-registration of new files on ingest
- DuckDB S3 credentials configuration for cold tier queries
- Folder cleanup after migration

API endpoints:
- GET/POST /api/v1/tiering/status - Tier status and stats
- POST /api/v1/tiering/migrate - Trigger manual migration
- POST /api/v1/tiering/scan - Scan and register files
- CRUD /api/v1/tiering/policies/:database - Per-database policies

Configuration:
- tiered_storage.enabled - Enable/disable feature
- tiered_storage.default_hot_max_age_days - Migration threshold
- tiered_storage.cold.* - S3/Azure cold tier settings

Requires enterprise license with 'tiering' feature.