### PR TITLE
fix(security): prevent SQL injection in DuckDB credential configuration

### DIFF
--- a/internal/database/duckdb_test.go
+++ b/internal/database/duckdb_test.go
@@ -1,0 +1,56 @@
+package database
+
+import "testing"
+
+func TestEscapeSQLString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no quotes",
+			input:    "simple_value",
+			expected: "simple_value",
+		},
+		{
+			name:     "single quote",
+			input:    "value'with'quotes",
+			expected: "value''with''quotes",
+		},
+		{
+			name:     "sql injection attempt",
+			input:    "test'; DROP TABLE data; --",
+			expected: "test''; DROP TABLE data; --",
+		},
+		{
+			name:     "multiple consecutive quotes",
+			input:    "a'''b",
+			expected: "a''''''b",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only quotes",
+			input:    "'''",
+			expected: "''''''",
+		},
+		{
+			name:     "realistic s3 secret key",
+			input:    "wJalrXUtnFEMI/K7MDENG/bPxRfiCY'EXAMPLE",
+			expected: "wJalrXUtnFEMI/K7MDENG/bPxRfiCY''EXAMPLE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := escapeSQLString(tt.input)
+			if result != tt.expected {
+				t.Errorf("escapeSQLString(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `escapeSQLString()` helper function to escape single quotes in SQL strings
- Fix SQL injection vulnerabilities in S3 credential configuration (`configureS3Access`)
- Fix SQL injection vulnerabilities in runtime S3 reconfiguration (`ConfigureS3`)
- Fix SQL injection vulnerabilities in Azure credential configuration (`configureAzureAccess`)
- Add unit tests for the escape function with 7 test cases including injection attempts

## Security Impact

**Severity:** Critical

**Attack Vector:** If S3/Azure credentials or configuration values contain single quotes (e.g., `test'; DROP TABLE data; --`), arbitrary DuckDB SQL could be executed.

**Risk:** Configuration tampering, potential data exfiltration via modified storage endpoints.

## Test plan

- [x] Unit tests pass for `escapeSQLString()` function
- [x] All existing database tests pass
- [x] Build succeeds
- [ ] Manual verification: test with credentials containing special characters

## Files Changed

| File | Change |
|------|--------|
| `internal/database/duckdb.go` | Added escape helper, applied to 10 SQL interpolation points |
| `internal/database/duckdb_test.go` | New test file with 7 test cases |

Security fix for release 26.02.1