### PR TITLE
refactor: sanitize query and compaction paths for 26.02.1 release

### DIFF
--- a/internal/compaction/hourly.go
+++ b/internal/compaction/hourly.go
@@ -175,10 +175,19 @@ func (t *HourlyTier) listHourPartitions(ctx context.Context, database, measureme
 			continue // Not a valid hour, skip
 		}
 
-		// Parse partition time
-		yearInt, _ := strconv.Atoi(year)
-		monthInt, _ := strconv.Atoi(month)
-		dayInt, _ := strconv.Atoi(day)
+		// Parse partition time with proper error handling
+		yearInt, err := strconv.Atoi(year)
+		if err != nil {
+			continue // Invalid year, skip
+		}
+		monthInt, err := strconv.Atoi(month)
+		if err != nil || monthInt < 1 || monthInt > 12 {
+			continue // Invalid month, skip
+		}
+		dayInt, err := strconv.Atoi(day)
+		if err != nil || dayInt < 1 || dayInt > 31 {
+			continue // Invalid day, skip
+		}
 
 		partitionTime := time.Date(yearInt, time.Month(monthInt), dayInt, hourInt, 0, 0, 0, time.UTC)
 

--- a/internal/compaction/tier.go
+++ b/internal/compaction/tier.go
@@ -2,7 +2,6 @@ package compaction
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -149,22 +148,6 @@ func (t *BaseTier) GetBaseStats(tierName string) map[string]interface{} {
 		"total_bytes_saved":     t.TotalBytesSaved,
 		"total_bytes_saved_mb":  float64(t.TotalBytesSaved) / 1024 / 1024,
 	}
-}
-
-// RecordCompaction records metrics for a completed compaction
-func (t *BaseTier) RecordCompaction(filesCompacted int, bytesSaved int64) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.TotalCompactions++
-	t.TotalFilesCompacted += filesCompacted
-	t.TotalBytesSaved += bytesSaved
-}
-
-// IsCompactedFile checks if a file is a compacted file from a specific tier
-func (t *BaseTier) IsCompactedFile(tierName, filename string) bool {
-	suffix := fmt.Sprintf("_%s.parquet", tierName)
-	return len(filename) >= len(suffix) && filename[len(filename)-len(suffix):] == suffix
 }
 
 // ShouldCompactByFileSuffix determines if compaction is needed based on file classification.


### PR DESCRIPTION
## Summary

Code sanitization for release 26.02.1 covering query and compaction paths:

### Query Path
- Extract shared `ValidateSQLRequest()` helper to consolidate duplicate validation across 3 endpoints
- **Bug fix**: Add missing max length check to `estimateQuery` endpoint
- Add error metrics (`IncQueryErrors`) to Arrow query endpoint for consistency

### Compaction Path  
- Move db/measurement listing outside tier loop to reduce storage API calls (~50% reduction)
- Remove unused `IsCompactedFile(tierName, filename)` method
- Remove unused `RecordCompaction()` method
- Add proper error checking to hourly partition date parsing (consistency with daily.go)

## Test plan
- [x] Unit tests pass: `go test ./internal/api/... ./internal/compaction/...`
- [x] Benchmarks verified - no regression
- [x] Query suite verified on production dataset

## Benchmark Results

No performance regression. Aggregation queries show slight improvement:

| Query | Baseline | After | Change |
|-------|----------|-------|--------|
| AVG/MIN/MAX (JSON) | 655ms | 550ms | -16% |
| GROUP BY (JSON) | 413ms | 403ms | -2% |