### PR TITLE
perf(pruning): remove unused code and add day-level file caching

### DIFF
--- a/internal/pruning/partition_pruner_test.go
+++ b/internal/pruning/partition_pruner_test.go
@@ -849,26 +849,6 @@ func TestGlobCacheConcurrency(t *testing.T) {
 	// Should not panic
 }
 
-// TestMinFunction tests the min helper function
-func TestMinFunction(t *testing.T) {
-	tests := []struct {
-		a, b, want int
-	}{
-		{1, 2, 1},
-		{2, 1, 1},
-		{5, 5, 5},
-		{0, 10, 0},
-		{-1, 1, -1},
-	}
-
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("min(%d,%d)", tt.a, tt.b), func(t *testing.T) {
-			if got := min(tt.a, tt.b); got != tt.want {
-				t.Errorf("min(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
-			}
-		})
-	}
-}
 
 // Helper function
 func contains(s, substr string) bool {


### PR DESCRIPTION
## Summary

- Remove unused `FilesPruned`/`FilesScanned` stats counters (defined but never incremented)
- Add caching for day-level file existence checks (reduces S3/Azure API calls from O(N) to O(1) for repeated queries)
- Add `CleanupPartitionCache()` public method for cache maintenance (matches existing `CleanupGlobCache()`)
- Remove redundant `TrimSuffix` operation (duplicate call)
- Remove unused `min()` helper function (Go 1.21+ has builtin)

## Test plan

- [x] All pruning unit tests pass (`go test ./internal/pruning/... -v`)
- [x] Build passes (`go build ./...`)
- [x] Go vet passes (`go vet ./internal/pruning/...`)