### PR TITLE
fix: prevent data loss during S3 outages with WAL-based recovery

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -725,3 +725,59 @@ func TestQueryConfig_EnvOverride(t *testing.T) {
 		t.Errorf("Query.S3CacheTTLSeconds = %d, want 7200", cfg.Query.S3CacheTTLSeconds)
 	}
 }
+
+func TestWALConfig_Defaults(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "arc-config-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldWd)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Test WAL defaults
+	if cfg.WAL.RecoveryIntervalSeconds != 300 {
+		t.Errorf("WAL.RecoveryIntervalSeconds default = %d, want 300", cfg.WAL.RecoveryIntervalSeconds)
+	}
+	if cfg.WAL.RecoveryBatchSize != 10000 {
+		t.Errorf("WAL.RecoveryBatchSize default = %d, want 10000", cfg.WAL.RecoveryBatchSize)
+	}
+}
+
+func TestWALConfig_EnvOverride(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "arc-config-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldWd)
+
+	os.Setenv("ARC_WAL_RECOVERY_INTERVAL_SECONDS", "600")
+	os.Setenv("ARC_WAL_RECOVERY_BATCH_SIZE", "5000")
+	defer func() {
+		os.Unsetenv("ARC_WAL_RECOVERY_INTERVAL_SECONDS")
+		os.Unsetenv("ARC_WAL_RECOVERY_BATCH_SIZE")
+	}()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.WAL.RecoveryIntervalSeconds != 600 {
+		t.Errorf("WAL.RecoveryIntervalSeconds = %d, want 600", cfg.WAL.RecoveryIntervalSeconds)
+	}
+	if cfg.WAL.RecoveryBatchSize != 5000 {
+		t.Errorf("WAL.RecoveryBatchSize = %d, want 5000", cfg.WAL.RecoveryBatchSize)
+	}
+}

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/compress"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/basekick-labs/arc/internal/tiering"
 	"github.com/basekick-labs/arc/pkg/models"
@@ -1175,6 +1176,8 @@ func (b *ArrowBuffer) writeColumnar(ctx context.Context, database string, record
 				Int64("queue_depth", b.queueDepth.Load()).
 				Msg("Flush queue full - data preserved in WAL for recovery")
 			b.totalErrors.Add(1)
+			// Track records preserved in WAL for operator visibility
+			metrics.Get().IncWALRecordsPreserved(int64(totalBuffered))
 			// Data is already in WAL (written at ingest time) - no memory growth
 			// WAL will be replayed on restart or via periodic recovery
 		}


### PR DESCRIPTION
## Summary

Fixes critical data loss bugs when S3 becomes unavailable. Data is preserved in WAL and automatically recovered when S3 is healthy again.

## Key Changes

    WAL Recovery - Data stays in WAL if flush fails, recovered on restart or via periodic recovery
    No Memory Growth - Buffer cleared on flush failure (data safe in WAL)
    Periodic Recovery - Background goroutine replays WAL every 5 minutes
    WAL File Deletion - Files deleted after successful recovery (not renamed to .recovered)

## Flow During S3 Outage
```
Data In -> WAL (disk) -> Buffer (memory) -> Flush -> S3 FAIL
                                                        |
Buffer cleared (memory freed) <-------------------------+
Data preserved in WAL
Periodic recovery replays when S3 recovers
WAL file deleted after successful recovery
````

---

## Changes by File

### cmd/arc/main.go

| Scenario | Before | After |
|----------|--------|-------|
| WAL Recovery Timing | Runs before ArrowBuffer exists | Runs after ArrowBuffer is ready |
| Recovery Callback | Just logs, doesn't replay data | Actually replays to ArrowBuffer |
| S3 Outage Recovery | Requires restart | Periodic recovery every 5 minutes |

### internal/ingest/arrow_writer.go

| Scenario | Before | After |
|----------|--------|-------|
| Flush Queue Full | dropping task - unclear fate | preserved in WAL - data safe |
| Async Flush Failure | Silent error, no record count | Logs record count, WAL safety note |
| Sync Flush Failure | No logging at all | Warns with record count |
| Memory During Outage | Could grow indefinitely | Bounded - data stays in WAL only |

### internal/wal/recovery.go

| Scenario | Before | After |
|----------|--------|-------|
| Entry Failure | continue - processes remaining | break - stops, retries later |
| After Recovery | Rename to .recovered | Delete file |
| Partial Failure | File renamed anyway (data lost) | File kept for retry |
| Stats Tracking | Always counts as recovered | Only counts if ALL succeed |
| Logging | No entry count | Shows entry count |

---

## End-to-End Scenarios

| Scenario | Before | After |
|----------|--------|-------|
| S3 goes down during flush | Data lost or memory grows | Data safe in WAL, memory bounded |
| S3 recovers | Must restart to recover | Auto-recovers within 5 minutes |
| Recovery succeeds | .recovered files pile up | Files deleted, disk freed |
| Recovery partially fails | Lost entries, file archived | File kept, retry on next cycle |
| Startup recovery | Logs only, data lost | Actually replays all data |

---

## Test Plan

- [x] Deploy to Kubernetes (arc namespace)
- [x] Ingest data during S3 outage (503 errors)
- [x] Verify data preserved in WAL log message
- [x] Restart pod, verify WAL recovery runs
- [x] Verify WAL file recovered and deleted log message
- [x] Confirm WAL directory only has new empty file