### PR TITLE
fix(compaction): add manifest-based tracking to prevent data duplication

### DIFF
--- a/internal/compaction/manager.go
+++ b/internal/compaction/manager.go
@@ -18,8 +18,9 @@ var ErrCycleAlreadyRunning = errors.New("compaction cycle already running")
 
 // Manager orchestrates compaction jobs across all measurements
 type Manager struct {
-	StorageBackend storage.Backend
-	LockManager    *LockManager
+	StorageBackend  storage.Backend
+	LockManager     *LockManager
+	ManifestManager *ManifestManager
 
 	// Configuration
 	MinAgeHours   int
@@ -44,10 +45,11 @@ type Manager struct {
 	cycleID      atomic.Int64
 
 	// Metrics
-	TotalJobsCompleted  int
-	TotalJobsFailed     int
-	TotalFilesCompacted int
-	TotalBytesSaved     int64
+	TotalJobsCompleted   int
+	TotalJobsFailed      int
+	TotalFilesCompacted  int
+	TotalBytesSaved      int64
+	TotalManifestsRecov  int // Number of manifests recovered
 
 	logger zerolog.Logger
 	mu     sync.Mutex
@@ -99,9 +101,12 @@ func NewManager(cfg *ManagerConfig) *Manager {
 		defaultSortKeys = []string{"time"} // Default to time-only sorting
 	}
 
+	logger := cfg.Logger.With().Str("component", "compaction-manager").Logger()
+
 	m := &Manager{
 		StorageBackend:  cfg.StorageBackend,
 		LockManager:     cfg.LockManager,
+		ManifestManager: NewManifestManager(cfg.StorageBackend, logger),
 		MinAgeHours:     cfg.MinAgeHours,
 		MinFiles:        cfg.MinFiles,
 		TargetSizeMB:    cfg.TargetSizeMB,
@@ -112,7 +117,7 @@ func NewManager(cfg *ManagerConfig) *Manager {
 		DefaultSortKeys: defaultSortKeys,
 		Tiers:           cfg.Tiers,
 		jobHistory:      make([]map[string]interface{}, 0),
-		logger:          cfg.Logger.With().Str("component", "compaction-manager").Logger(),
+		logger:          logger,
 	}
 
 	// Log tier information
@@ -442,6 +447,21 @@ func (m *Manager) RunCompactionCycleForTiers(ctx context.Context, tierNames []st
 		Strs("tiers", tierNames).
 		Msg("Starting compaction cycle for specific tiers")
 
+	// Run manifest recovery before starting new compactions
+	// This ensures interrupted compactions from previous cycles are completed
+	if m.ManifestManager != nil {
+		recovered, err := m.ManifestManager.RecoverOrphanedManifests(ctx)
+		if err != nil {
+			m.logger.Warn().Err(err).Msg("Manifest recovery encountered errors")
+		}
+		if recovered > 0 {
+			m.mu.Lock()
+			m.TotalManifestsRecov += recovered
+			m.mu.Unlock()
+			m.logger.Info().Int("recovered", recovered).Msg("Recovered orphaned compaction manifests")
+		}
+	}
+
 	// Build tier filter map for quick lookup
 	tierFilter := make(map[string]bool)
 	for _, name := range tierNames {
@@ -524,13 +544,22 @@ func (m *Manager) RunCompactionCycleForTiers(ctx context.Context, tierNames []st
 
 				// Process this measurement's candidates immediately
 				for _, candidate := range candidates {
+					// Filter out files that are tracked by manifests (pending compaction)
+					filteredCandidate, shouldProcess := m.filterCandidateFiles(ctx, candidate)
+					if !shouldProcess {
+						m.logger.Debug().
+							Str("partition", candidate.PartitionPath).
+							Msg("Skipping candidate: all files are tracked by manifests")
+						continue
+					}
+
 					// Split large candidates into batches to prevent DuckDB segfaults
 					// when processing too many files in a single read_parquet() call
-					batches := SplitCandidateIntoBatches(candidate)
+					batches := SplitCandidateIntoBatches(filteredCandidate)
 					if len(batches) > 1 {
 						m.logger.Info().
-							Str("partition", candidate.PartitionPath).
-							Int("total_files", len(candidate.Files)).
+							Str("partition", filteredCandidate.PartitionPath).
+							Int("total_files", len(filteredCandidate.Files)).
 							Int("batches", len(batches)).
 							Msg("Splitting large candidate into batches")
 					}
@@ -728,19 +757,62 @@ func (m *Manager) GetSortKeys(measurement string) []string {
 	return m.DefaultSortKeys
 }
 
+// filterCandidateFiles removes files that are tracked by manifests from a candidate.
+// Returns the filtered candidate and whether it should still be processed.
+func (m *Manager) filterCandidateFiles(ctx context.Context, candidate Candidate) (Candidate, bool) {
+	if m.ManifestManager == nil {
+		return candidate, len(candidate.Files) > 0
+	}
+
+	filesInManifests, err := m.ManifestManager.GetFilesInManifests(ctx)
+	if err != nil {
+		m.logger.Warn().Err(err).Msg("Failed to get files in manifests, proceeding without filtering")
+		return candidate, len(candidate.Files) > 0
+	}
+
+	if len(filesInManifests) == 0 {
+		return candidate, len(candidate.Files) > 0
+	}
+
+	// Filter out files that are in manifests
+	filteredFiles := make([]string, 0, len(candidate.Files))
+	var skipped int
+	for _, f := range candidate.Files {
+		if _, inManifest := filesInManifests[f]; inManifest {
+			skipped++
+			continue
+		}
+		filteredFiles = append(filteredFiles, f)
+	}
+
+	if skipped > 0 {
+		m.logger.Debug().
+			Str("partition", candidate.PartitionPath).
+			Int("skipped", skipped).
+			Int("remaining", len(filteredFiles)).
+			Msg("Filtered files tracked by manifests")
+	}
+
+	candidate.Files = filteredFiles
+	candidate.FileCount = len(filteredFiles)
+
+	return candidate, len(filteredFiles) > 0
+}
+
 // Stats returns compaction statistics
 func (m *Manager) Stats() map[string]interface{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	stats := map[string]interface{}{
-		"total_jobs_completed":  m.TotalJobsCompleted,
-		"total_jobs_failed":     m.TotalJobsFailed,
-		"total_files_compacted": m.TotalFilesCompacted,
-		"total_bytes_saved":     m.TotalBytesSaved,
-		"total_bytes_saved_mb":  float64(m.TotalBytesSaved) / 1024 / 1024,
-		"cycle_running":         m.cycleRunning.Load(),
-		"current_cycle_id":      m.cycleID.Load(),
+		"total_jobs_completed":    m.TotalJobsCompleted,
+		"total_jobs_failed":       m.TotalJobsFailed,
+		"total_files_compacted":   m.TotalFilesCompacted,
+		"total_bytes_saved":       m.TotalBytesSaved,
+		"total_bytes_saved_mb":    float64(m.TotalBytesSaved) / 1024 / 1024,
+		"total_manifests_recover": m.TotalManifestsRecov,
+		"cycle_running":           m.cycleRunning.Load(),
+		"current_cycle_id":        m.cycleID.Load(),
 	}
 
 	// Add recent jobs (last 10)

--- a/internal/compaction/manifest.go
+++ b/internal/compaction/manifest.go
@@ -1,0 +1,352 @@
+package compaction
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// ManifestStatus represents the state of a compaction manifest
+type ManifestStatus string
+
+const (
+	// ManifestStatusPending indicates the compaction is in progress
+	ManifestStatusPending ManifestStatus = "pending"
+)
+
+// ManifestBasePath is the base directory for storing compaction manifests
+const ManifestBasePath = "_compaction_state"
+
+// Manifest tracks the state of a compaction operation for crash recovery.
+// If a pod crashes after uploading the compacted file but before deleting
+// source files, the manifest allows recovery to complete the deletion.
+type Manifest struct {
+	// Output file information
+	OutputPath string `json:"output_path"` // Full storage path of compacted file
+	OutputSize int64  `json:"output_size"` // Expected size of output file (for validation)
+
+	// Input files that were compacted
+	InputFiles []string `json:"input_files"`
+
+	// Metadata
+	Database      string         `json:"database"`
+	Measurement   string         `json:"measurement"`
+	PartitionPath string         `json:"partition_path"`
+	Tier          string         `json:"tier"`
+	Status        ManifestStatus `json:"status"`
+	CreatedAt     time.Time      `json:"created_at"`
+	JobID         string         `json:"job_id"`
+}
+
+// ManifestManager handles reading, writing, and recovering from compaction manifests
+type ManifestManager struct {
+	backend storage.Backend
+	logger  zerolog.Logger
+	mu      sync.Mutex
+
+	// Cache of manifest paths to input files for quick lookup during candidate filtering
+	// Key: manifest path, Value: set of input file paths
+	manifestCache     map[string]map[string]struct{}
+	manifestCacheMu   sync.RWMutex
+	manifestCacheTime time.Time
+	cacheTTL          time.Duration
+}
+
+// NewManifestManager creates a new manifest manager
+func NewManifestManager(backend storage.Backend, logger zerolog.Logger) *ManifestManager {
+	return &ManifestManager{
+		backend:       backend,
+		logger:        logger.With().Str("component", "manifest-manager").Logger(),
+		manifestCache: make(map[string]map[string]struct{}),
+		cacheTTL:      30 * time.Second,
+	}
+}
+
+// GenerateManifestPath generates a unique manifest path for a compaction job
+func (m *ManifestManager) GenerateManifestPath(tier, database, partitionPath, jobID string) string {
+	// Path format: _compaction_state/{tier}/{database}/{partition_path_sanitized}_{jobID}.json
+	sanitizedPartition := strings.ReplaceAll(partitionPath, "/", "_")
+	return filepath.Join(ManifestBasePath, tier, database, fmt.Sprintf("%s_%s.json", sanitizedPartition, jobID))
+}
+
+// WriteManifest writes a manifest to storage
+func (m *ManifestManager) WriteManifest(ctx context.Context, manifest *Manifest) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	manifestPath := m.GenerateManifestPath(manifest.Tier, manifest.Database, manifest.PartitionPath, manifest.JobID)
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	if err := m.backend.Write(ctx, manifestPath, data); err != nil {
+		return "", fmt.Errorf("failed to write manifest to %s: %w", manifestPath, err)
+	}
+
+	m.logger.Debug().
+		Str("path", manifestPath).
+		Str("output", manifest.OutputPath).
+		Int("input_count", len(manifest.InputFiles)).
+		Msg("Wrote compaction manifest")
+
+	// Invalidate cache
+	m.invalidateCache()
+
+	return manifestPath, nil
+}
+
+// DeleteManifest removes a manifest from storage
+func (m *ManifestManager) DeleteManifest(ctx context.Context, manifestPath string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := m.backend.Delete(ctx, manifestPath); err != nil {
+		return fmt.Errorf("failed to delete manifest %s: %w", manifestPath, err)
+	}
+
+	m.logger.Debug().Str("path", manifestPath).Msg("Deleted compaction manifest")
+
+	// Invalidate cache
+	m.invalidateCache()
+
+	return nil
+}
+
+// ReadManifest reads a manifest from storage
+func (m *ManifestManager) ReadManifest(ctx context.Context, manifestPath string) (*Manifest, error) {
+	data, err := m.backend.Read(ctx, manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest %s: %w", manifestPath, err)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal manifest %s: %w", manifestPath, err)
+	}
+
+	return &manifest, nil
+}
+
+// ListManifests lists all manifest files in storage
+func (m *ManifestManager) ListManifests(ctx context.Context) ([]string, error) {
+	objects, err := m.backend.List(ctx, ManifestBasePath+"/")
+	if err != nil {
+		// If the directory doesn't exist, return empty list
+		return []string{}, nil
+	}
+
+	var manifests []string
+	for _, obj := range objects {
+		if strings.HasSuffix(obj, ".json") {
+			manifests = append(manifests, obj)
+		}
+	}
+
+	return manifests, nil
+}
+
+// RecoverOrphanedManifests finds and processes orphaned manifests from interrupted compactions.
+// Returns the number of manifests recovered and any error encountered.
+func (m *ManifestManager) RecoverOrphanedManifests(ctx context.Context) (int, error) {
+	manifests, err := m.ListManifests(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list manifests: %w", err)
+	}
+
+	if len(manifests) == 0 {
+		return 0, nil
+	}
+
+	m.logger.Info().Int("count", len(manifests)).Msg("Found orphaned manifests, starting recovery")
+
+	var recovered int
+	for _, manifestPath := range manifests {
+		select {
+		case <-ctx.Done():
+			return recovered, ctx.Err()
+		default:
+		}
+
+		if err := m.recoverManifest(ctx, manifestPath); err != nil {
+			m.logger.Error().Err(err).Str("manifest", manifestPath).Msg("Failed to recover manifest")
+			continue
+		}
+		recovered++
+	}
+
+	m.logger.Info().Int("recovered", recovered).Int("total", len(manifests)).Msg("Manifest recovery complete")
+	return recovered, nil
+}
+
+// recoverManifest processes a single orphaned manifest
+func (m *ManifestManager) recoverManifest(ctx context.Context, manifestPath string) error {
+	manifest, err := m.ReadManifest(ctx, manifestPath)
+	if err != nil {
+		// If we can't read the manifest, delete it and let compaction retry
+		m.logger.Warn().Err(err).Str("manifest", manifestPath).Msg("Cannot read manifest, deleting")
+		return m.DeleteManifest(ctx, manifestPath)
+	}
+
+	m.logger.Info().
+		Str("manifest", manifestPath).
+		Str("output", manifest.OutputPath).
+		Int("inputs", len(manifest.InputFiles)).
+		Msg("Processing orphaned manifest")
+
+	// Check if output file exists
+	exists, err := m.backend.Exists(ctx, manifest.OutputPath)
+	if err != nil {
+		return fmt.Errorf("failed to check output file existence: %w", err)
+	}
+
+	if !exists {
+		// Output file doesn't exist - compaction was interrupted before upload completed
+		// Delete manifest and let compaction retry
+		m.logger.Info().
+			Str("manifest", manifestPath).
+			Str("output", manifest.OutputPath).
+			Msg("Output file missing, deleting manifest for retry")
+		return m.DeleteManifest(ctx, manifestPath)
+	}
+
+	// Output file exists - verify size if we have ObjectLister
+	if objectLister, ok := m.backend.(storage.ObjectLister); ok {
+		objects, err := objectLister.ListObjects(ctx, manifest.OutputPath)
+		if err == nil && len(objects) > 0 {
+			actualSize := objects[0].Size
+			if actualSize != manifest.OutputSize {
+				// Size mismatch - partial upload, delete output and manifest for retry
+				m.logger.Warn().
+					Str("manifest", manifestPath).
+					Int64("expected_size", manifest.OutputSize).
+					Int64("actual_size", actualSize).
+					Msg("Output file size mismatch, deleting for retry")
+
+				if err := m.backend.Delete(ctx, manifest.OutputPath); err != nil {
+					m.logger.Warn().Err(err).Str("output", manifest.OutputPath).Msg("Failed to delete partial output")
+				}
+				return m.DeleteManifest(ctx, manifestPath)
+			}
+		}
+	}
+
+	// Output file exists and is valid - complete the deletion of input files
+	m.logger.Info().
+		Str("manifest", manifestPath).
+		Int("inputs", len(manifest.InputFiles)).
+		Msg("Output file valid, completing input file deletion")
+
+	var deleteErrors int
+	for _, inputFile := range manifest.InputFiles {
+		if err := m.backend.Delete(ctx, inputFile); err != nil {
+			// Check if file already deleted
+			exists, checkErr := m.backend.Exists(ctx, inputFile)
+			if checkErr == nil && !exists {
+				// File already deleted, continue
+				continue
+			}
+			m.logger.Warn().Err(err).Str("file", inputFile).Msg("Failed to delete input file during recovery")
+			deleteErrors++
+		}
+	}
+
+	if deleteErrors > 0 {
+		m.logger.Warn().
+			Int("errors", deleteErrors).
+			Int("total", len(manifest.InputFiles)).
+			Msg("Some input files could not be deleted during recovery")
+	}
+
+	// Delete the manifest to complete recovery
+	return m.DeleteManifest(ctx, manifestPath)
+}
+
+// GetFilesInManifests returns a set of all input files currently tracked by manifests.
+// This is used to exclude files from compaction candidate scans.
+func (m *ManifestManager) GetFilesInManifests(ctx context.Context) (map[string]struct{}, error) {
+	m.manifestCacheMu.RLock()
+	if time.Since(m.manifestCacheTime) < m.cacheTTL && len(m.manifestCache) > 0 {
+		// Return cached result
+		result := make(map[string]struct{})
+		for _, files := range m.manifestCache {
+			for f := range files {
+				result[f] = struct{}{}
+			}
+		}
+		m.manifestCacheMu.RUnlock()
+		return result, nil
+	}
+	m.manifestCacheMu.RUnlock()
+
+	// Rebuild cache
+	m.manifestCacheMu.Lock()
+	defer m.manifestCacheMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if time.Since(m.manifestCacheTime) < m.cacheTTL && len(m.manifestCache) > 0 {
+		result := make(map[string]struct{})
+		for _, files := range m.manifestCache {
+			for f := range files {
+				result[f] = struct{}{}
+			}
+		}
+		return result, nil
+	}
+
+	manifests, err := m.ListManifests(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	newCache := make(map[string]map[string]struct{})
+	result := make(map[string]struct{})
+
+	for _, manifestPath := range manifests {
+		manifest, err := m.ReadManifest(ctx, manifestPath)
+		if err != nil {
+			m.logger.Warn().Err(err).Str("manifest", manifestPath).Msg("Failed to read manifest for cache")
+			continue
+		}
+
+		files := make(map[string]struct{})
+		for _, f := range manifest.InputFiles {
+			files[f] = struct{}{}
+			result[f] = struct{}{}
+		}
+		// Also add output file to prevent re-compaction
+		result[manifest.OutputPath] = struct{}{}
+		newCache[manifestPath] = files
+	}
+
+	m.manifestCache = newCache
+	m.manifestCacheTime = time.Now()
+
+	return result, nil
+}
+
+// invalidateCache clears the manifest cache
+func (m *ManifestManager) invalidateCache() {
+	m.manifestCacheMu.Lock()
+	defer m.manifestCacheMu.Unlock()
+	m.manifestCache = make(map[string]map[string]struct{})
+	m.manifestCacheTime = time.Time{}
+}
+
+// IsFileInManifest checks if a file is tracked by any manifest
+func (m *ManifestManager) IsFileInManifest(ctx context.Context, filePath string) (bool, error) {
+	files, err := m.GetFilesInManifests(ctx)
+	if err != nil {
+		return false, err
+	}
+	_, exists := files[filePath]
+	return exists, nil
+}

--- a/internal/compaction/manifest_test.go
+++ b/internal/compaction/manifest_test.go
@@ -1,0 +1,418 @@
+package compaction
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+func TestManifestManager_WriteAndRead(t *testing.T) {
+	// Create temp directory for test
+	tempDir, err := os.MkdirTemp("", "manifest_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create local storage backend
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	backend, err := storage.NewLocalBackend(tempDir, logger)
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+
+	// Create manifest manager
+	mm := NewManifestManager(backend, logger)
+
+	// Create a test manifest
+	manifest := &Manifest{
+		OutputPath:    "testdb/cpu/2025/01/15/10/cpu_20250115_100000_compacted.parquet",
+		OutputSize:    1024 * 1024,
+		InputFiles:    []string{"testdb/cpu/2025/01/15/10/file1.parquet", "testdb/cpu/2025/01/15/10/file2.parquet"},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu/2025/01/15/10",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "test_job_123",
+	}
+
+	ctx := context.Background()
+
+	// Write manifest
+	manifestPath, err := mm.WriteManifest(ctx, manifest)
+	if err != nil {
+		t.Fatalf("Failed to write manifest: %v", err)
+	}
+
+	// Verify path format
+	expectedPathPrefix := filepath.Join(ManifestBasePath, "hourly", "testdb")
+	if !manifestContains(manifestPath, expectedPathPrefix) {
+		t.Errorf("Manifest path %s doesn't contain expected prefix %s", manifestPath, expectedPathPrefix)
+	}
+
+	// Read manifest back
+	readManifest, err := mm.ReadManifest(ctx, manifestPath)
+	if err != nil {
+		t.Fatalf("Failed to read manifest: %v", err)
+	}
+
+	// Verify fields
+	if readManifest.OutputPath != manifest.OutputPath {
+		t.Errorf("OutputPath mismatch: got %s, want %s", readManifest.OutputPath, manifest.OutputPath)
+	}
+	if readManifest.OutputSize != manifest.OutputSize {
+		t.Errorf("OutputSize mismatch: got %d, want %d", readManifest.OutputSize, manifest.OutputSize)
+	}
+	if len(readManifest.InputFiles) != len(manifest.InputFiles) {
+		t.Errorf("InputFiles length mismatch: got %d, want %d", len(readManifest.InputFiles), len(manifest.InputFiles))
+	}
+	if readManifest.Database != manifest.Database {
+		t.Errorf("Database mismatch: got %s, want %s", readManifest.Database, manifest.Database)
+	}
+	if readManifest.Tier != manifest.Tier {
+		t.Errorf("Tier mismatch: got %s, want %s", readManifest.Tier, manifest.Tier)
+	}
+	if readManifest.Status != manifest.Status {
+		t.Errorf("Status mismatch: got %s, want %s", readManifest.Status, manifest.Status)
+	}
+
+	// Delete manifest
+	err = mm.DeleteManifest(ctx, manifestPath)
+	if err != nil {
+		t.Fatalf("Failed to delete manifest: %v", err)
+	}
+
+	// Verify deleted
+	_, err = mm.ReadManifest(ctx, manifestPath)
+	if err == nil {
+		t.Error("Expected error reading deleted manifest, got nil")
+	}
+}
+
+func TestManifestManager_ListManifests(t *testing.T) {
+	// Create temp directory for test
+	tempDir, err := os.MkdirTemp("", "manifest_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create local storage backend
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	backend, err := storage.NewLocalBackend(tempDir, logger)
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+
+	mm := NewManifestManager(backend, logger)
+	ctx := context.Background()
+
+	// Initially empty
+	manifests, err := mm.ListManifests(ctx)
+	if err != nil {
+		t.Fatalf("Failed to list manifests: %v", err)
+	}
+	if len(manifests) != 0 {
+		t.Errorf("Expected 0 manifests, got %d", len(manifests))
+	}
+
+	// Create multiple manifests
+	for i := 0; i < 3; i++ {
+		manifest := &Manifest{
+			OutputPath:    "testdb/cpu/2025/01/15/10/output.parquet",
+			OutputSize:    1024,
+			InputFiles:    []string{"input.parquet"},
+			Database:      "testdb",
+			Measurement:   "cpu",
+			PartitionPath: "testdb/cpu/2025/01/15/10",
+			Tier:          "hourly",
+			Status:        ManifestStatusPending,
+			CreatedAt:     time.Now().UTC(),
+			JobID:         "job_" + string(rune('0'+i)),
+		}
+		_, err := mm.WriteManifest(ctx, manifest)
+		if err != nil {
+			t.Fatalf("Failed to write manifest %d: %v", i, err)
+		}
+	}
+
+	// List again
+	manifests, err = mm.ListManifests(ctx)
+	if err != nil {
+		t.Fatalf("Failed to list manifests: %v", err)
+	}
+	if len(manifests) != 3 {
+		t.Errorf("Expected 3 manifests, got %d", len(manifests))
+	}
+}
+
+func TestManifestManager_GetFilesInManifests(t *testing.T) {
+	// Create temp directory for test
+	tempDir, err := os.MkdirTemp("", "manifest_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create local storage backend
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	backend, err := storage.NewLocalBackend(tempDir, logger)
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+
+	mm := NewManifestManager(backend, logger)
+	ctx := context.Background()
+
+	// Create manifest with input files
+	manifest := &Manifest{
+		OutputPath:    "testdb/cpu/output.parquet",
+		OutputSize:    1024,
+		InputFiles:    []string{"testdb/cpu/file1.parquet", "testdb/cpu/file2.parquet", "testdb/cpu/file3.parquet"},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "test_job",
+	}
+	_, err = mm.WriteManifest(ctx, manifest)
+	if err != nil {
+		t.Fatalf("Failed to write manifest: %v", err)
+	}
+
+	// Get files in manifests
+	files, err := mm.GetFilesInManifests(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get files in manifests: %v", err)
+	}
+
+	// Should contain all input files
+	for _, f := range manifest.InputFiles {
+		if _, exists := files[f]; !exists {
+			t.Errorf("Expected file %s to be in manifest files", f)
+		}
+	}
+
+	// Should also contain output file
+	if _, exists := files[manifest.OutputPath]; !exists {
+		t.Errorf("Expected output file %s to be in manifest files", manifest.OutputPath)
+	}
+
+	// Total should be inputs + output
+	expectedCount := len(manifest.InputFiles) + 1
+	if len(files) != expectedCount {
+		t.Errorf("Expected %d files, got %d", expectedCount, len(files))
+	}
+}
+
+func TestManifestManager_RecoverOrphanedManifests_OutputMissing(t *testing.T) {
+	// Create temp directory for test
+	tempDir, err := os.MkdirTemp("", "manifest_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create local storage backend
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	backend, err := storage.NewLocalBackend(tempDir, logger)
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+
+	mm := NewManifestManager(backend, logger)
+	ctx := context.Background()
+
+	// Create manifest (output file doesn't exist)
+	manifest := &Manifest{
+		OutputPath:    "testdb/cpu/output.parquet", // This file doesn't exist
+		OutputSize:    1024,
+		InputFiles:    []string{"testdb/cpu/file1.parquet"},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "orphan_job",
+	}
+	manifestPath, err := mm.WriteManifest(ctx, manifest)
+	if err != nil {
+		t.Fatalf("Failed to write manifest: %v", err)
+	}
+
+	// Verify manifest exists
+	manifests, _ := mm.ListManifests(ctx)
+	if len(manifests) != 1 {
+		t.Fatalf("Expected 1 manifest before recovery, got %d", len(manifests))
+	}
+
+	// Run recovery - should delete manifest because output doesn't exist
+	recovered, err := mm.RecoverOrphanedManifests(ctx)
+	if err != nil {
+		t.Fatalf("Recovery failed: %v", err)
+	}
+	if recovered != 1 {
+		t.Errorf("Expected 1 recovered, got %d", recovered)
+	}
+
+	// Verify manifest was deleted
+	_, err = mm.ReadManifest(ctx, manifestPath)
+	if err == nil {
+		t.Error("Expected manifest to be deleted after recovery")
+	}
+}
+
+func TestManifestManager_RecoverOrphanedManifests_OutputExists(t *testing.T) {
+	// Create temp directory for test
+	tempDir, err := os.MkdirTemp("", "manifest_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create local storage backend
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	backend, err := storage.NewLocalBackend(tempDir, logger)
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+
+	mm := NewManifestManager(backend, logger)
+	ctx := context.Background()
+
+	// Create output file (simulating successful upload)
+	outputPath := "testdb/cpu/output.parquet"
+	outputContent := []byte("fake parquet data")
+	err = backend.Write(ctx, outputPath, outputContent)
+	if err != nil {
+		t.Fatalf("Failed to write output file: %v", err)
+	}
+
+	// Create input files (these should be deleted by recovery)
+	inputFile := "testdb/cpu/input1.parquet"
+	err = backend.Write(ctx, inputFile, []byte("input data"))
+	if err != nil {
+		t.Fatalf("Failed to write input file: %v", err)
+	}
+
+	// Create manifest
+	manifest := &Manifest{
+		OutputPath:    outputPath,
+		OutputSize:    int64(len(outputContent)),
+		InputFiles:    []string{inputFile},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "orphan_job",
+	}
+	manifestPath, err := mm.WriteManifest(ctx, manifest)
+	if err != nil {
+		t.Fatalf("Failed to write manifest: %v", err)
+	}
+
+	// Run recovery - should delete input files and manifest
+	recovered, err := mm.RecoverOrphanedManifests(ctx)
+	if err != nil {
+		t.Fatalf("Recovery failed: %v", err)
+	}
+	if recovered != 1 {
+		t.Errorf("Expected 1 recovered, got %d", recovered)
+	}
+
+	// Verify manifest was deleted
+	_, err = mm.ReadManifest(ctx, manifestPath)
+	if err == nil {
+		t.Error("Expected manifest to be deleted after recovery")
+	}
+
+	// Verify input file was deleted
+	exists, _ := backend.Exists(ctx, inputFile)
+	if exists {
+		t.Error("Expected input file to be deleted after recovery")
+	}
+
+	// Verify output file still exists
+	exists, _ = backend.Exists(ctx, outputPath)
+	if !exists {
+		t.Error("Expected output file to still exist after recovery")
+	}
+}
+
+func TestManifestManager_IsFileInManifest(t *testing.T) {
+	// Create temp directory for test
+	tempDir, err := os.MkdirTemp("", "manifest_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create local storage backend
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	backend, err := storage.NewLocalBackend(tempDir, logger)
+	if err != nil {
+		t.Fatalf("Failed to create backend: %v", err)
+	}
+	defer backend.Close()
+
+	mm := NewManifestManager(backend, logger)
+	ctx := context.Background()
+
+	// Create manifest
+	manifest := &Manifest{
+		OutputPath:    "testdb/cpu/output.parquet",
+		OutputSize:    1024,
+		InputFiles:    []string{"testdb/cpu/tracked.parquet"},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "test_job",
+	}
+	_, err = mm.WriteManifest(ctx, manifest)
+	if err != nil {
+		t.Fatalf("Failed to write manifest: %v", err)
+	}
+
+	// Check tracked file
+	inManifest, err := mm.IsFileInManifest(ctx, "testdb/cpu/tracked.parquet")
+	if err != nil {
+		t.Fatalf("Failed to check file: %v", err)
+	}
+	if !inManifest {
+		t.Error("Expected tracked file to be in manifest")
+	}
+
+	// Check untracked file
+	inManifest, err = mm.IsFileInManifest(ctx, "testdb/cpu/untracked.parquet")
+	if err != nil {
+		t.Fatalf("Failed to check file: %v", err)
+	}
+	if inManifest {
+		t.Error("Expected untracked file to not be in manifest")
+	}
+}
+
+func manifestContains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/internal/compaction/subprocess.go
+++ b/internal/compaction/subprocess.go
@@ -95,19 +95,23 @@ func RunSubprocessJob(config *SubprocessJobConfig) (*SubprocessJobResult, error)
 		}
 	}
 
+	// Create manifest manager for crash recovery
+	manifestManager := NewManifestManager(backend, logger)
+
 	// Create and run job
 	job := NewJob(&JobConfig{
-		Database:       config.Database,
-		Measurement:    config.Measurement,
-		PartitionPath:  config.PartitionPath,
-		Files:          config.Files,
-		StorageBackend: backend,
-		TargetSizeMB:   config.TargetSizeMB,
-		Tier:           config.Tier,
-		TempDirectory:  config.TempDirectory,
-		SortKeys:       config.SortKeys,
-		Logger:         logger,
-		DB:             db,
+		Database:        config.Database,
+		Measurement:     config.Measurement,
+		PartitionPath:   config.PartitionPath,
+		Files:           config.Files,
+		StorageBackend:  backend,
+		TargetSizeMB:    config.TargetSizeMB,
+		Tier:            config.Tier,
+		TempDirectory:   config.TempDirectory,
+		SortKeys:        config.SortKeys,
+		Logger:          logger,
+		DB:              db,
+		ManifestManager: manifestManager,
 	})
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes #157 - Compaction causes data duplication when deletion fails or pod restarts.

This PR implements **manifest-based tracking** to ensure atomic compaction operations with crash recovery support.

## Problem

The compaction process was not atomic. When a pod crashed after uploading the compacted file but before deleting source files, both original and compacted files remained in storage, causing:

- **Data duplication** in query results (400k rows → 800k rows)
- **Storage waste** from duplicate files
- **Compounding duplication** in subsequent compaction cycles

## Solution

Implement a manifest file system that tracks compaction state and enables crash recovery:

```
_compaction_state/
├── hourly/
│   └── {database}/
│       └── {partition}_{job_id}.json
└── daily/
    └── {database}/
        └── {partition}_{job_id}.json
```

### Compaction Flow (Modified)

```
1. Download input files
2. Compact → create output file locally
3. Write manifest: { output_path, output_size, input_files[], status: "pending" }
4. Upload output file
5. Delete input files
6. Delete manifest (compaction complete)
```

### Recovery Flow (On Startup / Each Cycle)

```
1. Scan for orphaned manifests in _compaction_state/
2. For each manifest:
   - Output missing → delete manifest, retry compaction next cycle
   - Output exists + size matches → complete deletion of inputs, delete manifest
   - Output size mismatch → delete partial output, delete manifest, retry
3. Filter candidates to exclude files tracked by manifests
```

## Changes

| File | Changes |
|------|---------|
| `internal/compaction/manifest.go` | New ManifestManager for read/write/recovery |
| `internal/compaction/manifest_test.go` | Comprehensive tests for manifest operations |
| `internal/compaction/job.go` | Write manifest before upload, delete after success |
| `internal/compaction/manager.go` | Run recovery at cycle start, filter candidates |
| `internal/compaction/subprocess.go` | Create ManifestManager for subprocess jobs |

## Manifest File Format

```json
{
  "output_path": "metrics/cpu/2025/01/15/10/cpu_compacted.parquet",
  "output_size": 52428800,
  "input_files": [
    "metrics/cpu/2025/01/15/10/file1.parquet",
    "metrics/cpu/2025/01/15/10/file2.parquet"
  ],
  "database": "metrics",
  "measurement": "cpu",
  "partition_path": "metrics/cpu/2025/01/15/10",
  "tier": "hourly",
  "status": "pending",
  "created_at": "2025-01-15T10:30:00Z",
  "job_id": "metrics_cpu_..._1737834567890"
}
```

## Recovery Scenarios

| Crash Point | Output | Inputs | Recovery Action |
|-------------|--------|--------|-----------------|
| Before upload | Missing | Exist | Delete manifest, retry next cycle |
| During upload | Partial | Exist | Delete partial + manifest, retry |
| After upload | Valid | Exist | Delete inputs, delete manifest ✓ |
| After delete | Valid | Gone | Just delete manifest |

## Test plan

- [x] All existing compaction tests pass
- [x] New manifest tests pass:
  - `TestManifestManager_WriteAndRead`
  - `TestManifestManager_ListManifests`
  - `TestManifestManager_GetFilesInManifests`
  - `TestManifestManager_RecoverOrphanedManifests_OutputMissing`
  - `TestManifestManager_RecoverOrphanedManifests_OutputExists`
  - `TestManifestManager_IsFileInManifest`
- [x] Deployed to test cluster (`registry.gyoom.co/arc:manifest-fix`)
- [x] Health check passing
