### PR TITLE
fix(compaction): cleanup orphaned temp directories on startup

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -477,6 +477,11 @@ func main() {
 			Logger:          logger.Get("compaction"),
 		})
 
+		// Cleanup orphaned temp directories from previous runs (e.g., pod crashes)
+		if err := compactionManager.CleanupOrphanedTempDirs(); err != nil {
+			log.Warn().Err(err).Msg("Failed to cleanup orphaned compaction temp directories")
+		}
+
 		// Create hourly scheduler (if hourly tier is enabled)
 		if cfg.Compaction.HourlyEnabled {
 			hourlyScheduler, err = compaction.NewScheduler(&compaction.SchedulerConfig{


### PR DESCRIPTION
## Summary

Fixes #164

When a pod crashes mid-compaction, the `defer` cleanup in `job.go:202` never runs and temp directories accumulate at `./data/compaction/{job_id}/`. This adds a `CleanupOrphanedTempDirs()` method that removes all orphaned temp directories on startup.

## Changes

| File | Change |
|------|--------|
| `internal/compaction/manager.go` | Add `CleanupOrphanedTempDirs()` method |
| `cmd/arc/main.go` | Call cleanup on startup before compaction schedulers |
| `internal/compaction/manager_test.go` | Add unit tests |

## Behavior

On startup, before compaction schedulers are started:
1. Read all entries in `TempDirectory` (default: `./data/compaction/`)
2. Remove any subdirectories (these are orphaned job temp dirs)
3. Log each removed directory and total count

## Test plan

- [x] Unit tests pass: `go test ./internal/compaction/... -run TestManager_CleanupOrphanedTempDirs -v`
- [x] All compaction tests pass
- [x] Build passes

Manual verification:
```bash
mkdir -p ./data/compaction/fake_orphan_job_123
# Start arc
# Check logs for "Cleaned up orphaned temp directory"
# Verify ./data/compaction/fake_orphan_job_123 is removed
```