### PR TITLE
fix(tiering): route X-Arc-Database queries to cold tier

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1047,6 +1047,10 @@ func main() {
 		queryHandler.SetTieringManager(tieringManager)
 		log.Info().Msg("Tiering manager wired to query handler for multi-tier queries")
 
+		// Wire tiering manager to databases handler for cold-tier database/measurement listing
+		databasesHandler.SetTieringManager(tieringManager)
+		log.Info().Msg("Tiering manager wired to databases handler for cold-tier listing")
+
 		// Wire tiering manager to arrow buffer for automatic file registration
 		arrowBuffer.SetTieringManager(tieringManager)
 		log.Info().Msg("Tiering manager wired to arrow buffer for auto-registration")


### PR DESCRIPTION
## Summary

Fixes #166 - Two bugs with tiered storage query routing:

1. **X-Arc-Database header queries now route to cold tier**
   - Queries using `X-Arc-Database: mydb` + `SELECT * FROM measurement` were failing for cold-only data
   - Root cause: fast path called `getStoragePath()` before checking tiering metadata

2. **Database/measurement listing includes cold-only data**
   - `GET /api/v1/databases` was only showing hot tier databases
   - Now merges results from hot tier and tiering metadata

## Changes

- **internal/api/query.go**: Added `buildReadParquetExprForMeasurement()` tiering-aware method
- **internal/tiering/metadata.go**: Added `GetAllDatabases()` and `GetMeasurementsByDatabase()`
- **internal/api/databases.go**: Added tiering manager integration for listing
- **cmd/arc/main.go**: Wired tiering manager to databases handler

## Test plan

- [x] Build passes
- [x] Existing tests pass
- [x] Manual test: Query with X-Arc-Database header returns cold tier data
- [x] Manual test: Database listing shows cold-only databases