### PR TITLE
feat(tiering): only migrate daily-compacted files to cold tier

### DIFF
--- a/RELEASE_NOTES_2026.03.1.md
+++ b/RELEASE_NOTES_2026.03.1.md
@@ -1,5 +1,69 @@
 # Arc 2026.03.1 Release Notes
 
+## New Features
+
+### Bulk Import API (CSV & Parquet)
+
+Arc now supports bulk importing data from CSV and Parquet files via dedicated API endpoints. Files are uploaded via multipart form data, processed by DuckDB, and written directly into Arc's partitioned Parquet storage layout — bypassing the ingestion buffer for maximum throughput on large imports.
+
+**Endpoints:**
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/api/v1/import/csv` | Import a CSV file |
+| `POST` | `/api/v1/import/parquet` | Import a Parquet file |
+| `GET` | `/api/v1/import/stats` | Import handler statistics |
+
+**CSV import example:**
+```bash
+curl -X POST "http://localhost:8000/api/v1/import/csv?measurement=cpu" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-arc-database: production" \
+  -F "file=@cpu_metrics.csv"
+```
+
+**Parquet import example:**
+```bash
+curl -X POST "http://localhost:8000/api/v1/import/parquet?measurement=events" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-arc-database: analytics" \
+  -F "file=@events_export.parquet"
+```
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "result": {
+    "database": "production",
+    "measurement": "cpu",
+    "rows_imported": 1500000,
+    "partitions_created": 24,
+    "time_range_min": "2025-01-01 00:00:00",
+    "time_range_max": "2025-01-01 23:59:59",
+    "columns": ["time", "host", "usage_idle", "usage_system"],
+    "duration_ms": 3400
+  }
+}
+```
+
+**CSV options:**
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `measurement` | *(required)* | Target measurement name |
+| `time_column` | `time` | Column containing timestamps |
+| `time_format` | auto-detect | `epoch_s`, `epoch_ms`, `epoch_us`, `epoch_ns` |
+| `delimiter` | `,` | CSV field delimiter |
+| `skip_rows` | `0` | Rows to skip before header |
+
+**Key features:**
+- **DuckDB-powered** — leverages DuckDB's native CSV/Parquet parsing with automatic type inference
+- **Automatic hourly partitioning** — data is split into Arc's standard `YYYY/MM/DD/HH/` layout
+- **Time column renaming** — non-standard time column names are automatically mapped to `time`
+- **All storage backends** — works with local filesystem, S3, and Azure Blob Storage
+- **Auth & RBAC** — same authentication and permission model as write endpoints
+
+**Documentation:** See [docs/bulk-import.md](docs/bulk-import.md) for full usage guide.
+
 ## Enterprise Features
 
 ### Audit Logging
@@ -69,11 +133,13 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 **Requires:** Enterprise license with `audit_logging` feature.
 
-### Tiered Storage: Daily Compaction Gate
+### Tiered Storage: Daily-Compacted-Only Migration Gate
 
-Tiered storage migration now only moves daily-compacted files (`*_daily.parquet`) to cold tier. This prevents migrating raw or hourly-compacted files that haven't been fully consolidated, ensuring optimal storage efficiency and query performance on cold tier.
+The tiered storage migrator now only moves daily-compacted files to cold tier (S3 GLACIER / Azure Archive). Raw ingestion files and hourly-compacted files are skipped, ensuring fewer, larger objects land in archive storage.
 
-**Impact:** Files must complete daily compaction before becoming eligible for cold tier migration. This guarantees that cold tier contains only fully compacted data, reducing file count and improving query performance on S3/Azure.
+**Before:** All files exceeding `hot_max_age_days` were migrated regardless of compaction status, resulting in many small files in cold storage — increasing object count, S3 costs, and cold-tier query latency.
+
+**After:** Only files with the `_daily.parquet` suffix are eligible for cold migration. Since the daily compaction schedule runs well within the `hot_max_age_days` window, data is guaranteed to be fully compacted before moving to archive.
 
 ## New Metrics
 
@@ -81,3 +147,19 @@ Tiered storage migration now only moves daily-compacted files (`*_daily.parquet`
 |--------|-------------|
 | `arc_audit_events_total` | Total audit events logged |
 | `arc_audit_write_errors` | Audit log write failures |
+
+## Bug Fixes
+
+*None yet*
+
+## Improvements
+
+*None yet*
+
+## Upgrade Notes
+
+1. **Bulk import** is available immediately with no configuration required. The endpoints respect the existing `server.max_payload_size` setting (default: 1GB) for upload size limits.
+
+## Dependencies
+
+*No new dependencies*

--- a/internal/tiering/migrator.go
+++ b/internal/tiering/migrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -125,6 +126,11 @@ func (m *Migrator) FindCandidates(ctx context.Context, fromTier, toTier Tier) ([
 		// Check if file is old enough based on its policy
 		fileAge := now.Sub(file.PartitionTime)
 		if fileAge < ageThreshold {
+			continue
+		}
+
+		// Only migrate daily-compacted files to cold tier
+		if !strings.HasSuffix(file.Path, "_daily.parquet") {
 			continue
 		}
 


### PR DESCRIPTION
Raw ingestion files and hourly-compacted files are now skipped during hot-to-cold migration. Only files with _daily.parquet suffix are eligible, ensuring fewer, larger objects land in archive storage.