### PR TITLE
fix(audit): SQLite vacuum to prevent file bloat

### DIFF
--- a/RELEASE_NOTES_2026.03.1.md
+++ b/RELEASE_NOTES_2026.03.1.md
@@ -154,7 +154,7 @@ The tiered storage migrator now only moves daily-compacted files to cold tier (S
 
 ## Improvements
 
-*None yet*
+- **Audit log SQLite storage**: Added `auto_vacuum = INCREMENTAL` to prevent database file bloat. Runs full `VACUUM` on startup and incremental vacuum after retention cleanup deletes old entries.
 
 ## Upgrade Notes
 


### PR DESCRIPTION
## Summary
- Enable `auto_vacuum = INCREMENTAL` on audit SQLite schema init
- Run full `VACUUM` on startup to reclaim space from previous runs
- Run `incremental_vacuum` after retention cleanup deletes old entries

## Test plan
- [x] All 7 audit tests pass
- [x] `go build ./cmd/... ./internal/...` succeeds
- [ ] Deploy, let audit accumulate, verify file size stabilizes after retention cleanup