### PR TITLE
fix(security): harden tiering API auth, license gating, and path traversal

### DIFF
--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -436,6 +436,14 @@ func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
 	database := parts[0]
 	measurement := parts[1]
 
+	// Validate no path traversal in database or measurement names
+	if strings.Contains(database, "..") || strings.ContainsAny(database, "/\\") {
+		return nil, fmt.Errorf("invalid database name in path: %s", database)
+	}
+	if strings.Contains(measurement, "..") || strings.ContainsAny(measurement, "/\\") {
+		return nil, fmt.Errorf("invalid measurement name in path: %s", measurement)
+	}
+
 	// Parse year, month, day, hour
 	year, err := strconv.Atoi(parts[2])
 	if err != nil {


### PR DESCRIPTION
## Summary
- **Path traversal fix** in `parseFilePath()`: rejects database/measurement names containing `..` or path separators — prevents directory traversal via crafted storage paths
- **Admin auth + license middleware** on all tiering and tiering policies API routes (`RequireAdmin` + runtime license re-validation)
- **SQLite file permissions** restricted to `0600` after auth DB init (file contains auth tokens, audit logs, tiering metadata)

## Test plan
- [x] `go build ./cmd/... ./internal/...` passes
- [x] `go test ./internal/tiering/...` passes
- [x] `go test ./internal/audit/...` passes
- [x] `go test ./internal/api/...` passes