### PR TITLE
fix(compaction): bypass file age check for old partitions (#187)

### DIFF
--- a/RELEASE_NOTES_2026.03.1.md
+++ b/RELEASE_NOTES_2026.03.1.md
@@ -198,7 +198,19 @@ The tiered storage migrator now only moves daily-compacted files to cold tier (S
 
 ## Bug Fixes
 
-*None yet*
+### Daily Compaction Blocked for Backfilled Data (#187)
+
+Daily compaction previously checked the **file creation timestamp** (extracted from filename) against a 24-hour cutoff for all partitions. This blocked compaction of backfilled historical data — files created today for data from years ago would be skipped because the files were "too new."
+
+**Fix:** Partitions older than 7 days now bypass the file creation time check entirely, since no late-arriving data is expected for old partitions. Recent partitions (≤7 days) retain the check to protect IoT late-sync scenarios.
+
+**Configuration:**
+```toml
+[compaction]
+daily_skip_file_age_check_days = 7  # default: 7 (0 = disabled)
+```
+
+**Env var:** `ARC_COMPACTION_DAILY_SKIP_FILE_AGE_CHECK_DAYS`
 
 ## Improvements
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -526,11 +526,12 @@ func main() {
 
 		if cfg.Compaction.DailyEnabled {
 			dailyTier := compaction.NewDailyTier(&compaction.DailyTierConfig{
-				StorageBackend: storageBackend,
-				MinAgeHours:    cfg.Compaction.DailyMinAgeHours,
-				MinFiles:       cfg.Compaction.DailyMinFiles,
-				Enabled:        true,
-				Logger:         logger.Get("compaction"),
+				StorageBackend:       storageBackend,
+				MinAgeHours:          cfg.Compaction.DailyMinAgeHours,
+				MinFiles:             cfg.Compaction.DailyMinFiles,
+				SkipFileAgeCheckDays: cfg.Compaction.DailySkipFileAgeCheckDays,
+				Enabled:              true,
+				Logger:               logger.Get("compaction"),
 			})
 			tiers = append(tiers, dailyTier)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,8 +118,9 @@ type CompactionConfig struct {
 	HourlyMinAgeHours int    // Minimum age for hourly compaction (default: 1)
 	HourlyMinFiles    int    // Minimum files for hourly compaction (default: 10)
 	DailyMinAgeHours  int    // Minimum age for daily compaction (default: 24)
-	DailyMinFiles     int    // Minimum files for daily compaction (default: 12)
-	MaxConcurrent     int    // Max concurrent compaction jobs (default: 2)
+	DailyMinFiles             int // Minimum files for daily compaction (default: 12)
+	DailySkipFileAgeCheckDays int // Skip file creation time check for partitions older than N days (default: 7)
+	MaxConcurrent             int // Max concurrent compaction jobs (default: 2)
 	TempDirectory     string // Temporary directory for compaction files (default: ./data/compaction)
 }
 
@@ -426,8 +427,9 @@ func Load() (*Config, error) {
 			HourlyMinAgeHours: v.GetInt("compaction.hourly_min_age_hours"),
 			HourlyMinFiles:    v.GetInt("compaction.hourly_min_files"),
 			DailyMinAgeHours:  v.GetInt("compaction.daily_min_age_hours"),
-			DailyMinFiles:     v.GetInt("compaction.daily_min_files"),
-			MaxConcurrent:     v.GetInt("compaction.max_concurrent"),
+			DailyMinFiles:             v.GetInt("compaction.daily_min_files"),
+			DailySkipFileAgeCheckDays: v.GetInt("compaction.daily_skip_file_age_check_days"),
+			MaxConcurrent:             v.GetInt("compaction.max_concurrent"),
 			TempDirectory:     v.GetString("compaction.temp_directory"),
 		},
 		WAL: WALConfig{
@@ -622,6 +624,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("compaction.hourly_min_files", 10)           // 10 files minimum
 	v.SetDefault("compaction.daily_min_age_hours", 24)        // 24 hours min age
 	v.SetDefault("compaction.daily_min_files", 12)            // 12 files minimum
+	v.SetDefault("compaction.daily_skip_file_age_check_days", 7) // Skip file age check for partitions older than 7 days
 	v.SetDefault("compaction.max_concurrent", 2)              // 2 concurrent jobs
 	v.SetDefault("compaction.temp_directory", "./data/compaction") // Temp directory for compaction files
 


### PR DESCRIPTION
Daily compaction was blocking backfilled historical data because it checked file creation timestamps (from filenames) against a 24h cutoff. Files created today for data from years ago were skipped.

Add configurable SkipFileAgeCheckDays (default: 7). Partitions older than this threshold bypass the file creation time check. Recent partitions retain the check to protect IoT late-sync scenarios.