### PR TITLE
fix(config): auto-sync HTTP write timeout with query timeout (#185)

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -749,6 +749,15 @@ func main() {
 			Msg("Node running with cluster role")
 	}
 
+	// Auto-sync: ensure HTTP write timeout can accommodate query timeout
+	if cfg.Query.Timeout > 0 && cfg.Server.WriteTimeout < cfg.Query.Timeout {
+		log.Warn().
+			Int("write_timeout", cfg.Server.WriteTimeout).
+			Int("query_timeout", cfg.Query.Timeout).
+			Msg("HTTP write_timeout is less than query timeout - adjusting to match")
+		cfg.Server.WriteTimeout = cfg.Query.Timeout
+	}
+
 	// Initialize HTTP server
 	serverConfig := &api.ServerConfig{
 		Port:            cfg.Server.Port,


### PR DESCRIPTION
HTTP WriteTimeout (30s default) was lower than query.timeout (300s default), causing long-running queries to fail with connection timeout before completing.

Now auto-adjusts WriteTimeout to match query timeout at startup with a warning log when the mismatch is detected.