### PR TITLE
feat(query-mgmt): add long-running query management (Enterprise)

### DIFF
--- a/arc.toml
+++ b/arc.toml
@@ -51,7 +51,7 @@ s3_path_style = true        # True for MinIO, false for AWS
 # -----------------------------------------------------------------------------
 [ingest]
 max_buffer_size = 2500000   # Records before flush (default: 50000)
-max_buffer_age_ms = 500    # Max buffer age before flush
+max_buffer_age_ms = 100   # Max buffer age before flush
 
 # Sort keys for compression/query performance: "measurement:col1,col2"
 # Time column is always appended automatically
@@ -169,6 +169,12 @@ include_reads = false           # Log GET/query requests (high volume)
 [backup]
 enabled = true
 local_path = "./data/backups"           # Directory for local backups
+
+# Query Management (Enterprise)
+# -----------------------------------------------------------------------------
+# [query_management]
+# enabled = false
+# history_size = 100              # Number of completed queries to keep in memory
 
 [wal]
 enabled = false

--- a/internal/api/query_management.go
+++ b/internal/api/query_management.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"strconv"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/license"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/queryregistry"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// QueryManagementHandler handles query management API operations.
+type QueryManagementHandler struct {
+	registry      *queryregistry.Registry
+	authManager   *auth.AuthManager
+	licenseClient *license.Client
+	logger        zerolog.Logger
+}
+
+// NewQueryManagementHandler creates a new query management handler.
+func NewQueryManagementHandler(registry *queryregistry.Registry, authManager *auth.AuthManager, licenseClient *license.Client, logger zerolog.Logger) *QueryManagementHandler {
+	return &QueryManagementHandler{
+		registry:      registry,
+		authManager:   authManager,
+		licenseClient: licenseClient,
+		logger:        logger.With().Str("component", "query-mgmt-api").Logger(),
+	}
+}
+
+// RegisterRoutes registers query management API routes.
+func (h *QueryManagementHandler) RegisterRoutes(app fiber.Router) {
+	group := app.Group("/api/v1/queries")
+	if h.authManager != nil {
+		group.Use(auth.RequireAdmin(h.authManager))
+	}
+	group.Use(h.requireQueryManagementLicense)
+
+	group.Get("/active", h.listActiveQueries)
+	group.Get("/history", h.listQueryHistory)
+	group.Get("/:id", h.getQuery)
+	group.Delete("/:id", h.cancelQuery)
+}
+
+// requireQueryManagementLicense checks that the license includes the query management feature.
+func (h *QueryManagementHandler) requireQueryManagementLicense(c *fiber.Ctx) error {
+	if h.licenseClient == nil || !h.licenseClient.CanUseQueryManagement() {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+			"success": false,
+			"error":   "Query management requires an enterprise license with the 'query_management' feature enabled",
+		})
+	}
+	return c.Next()
+}
+
+// listActiveQueries returns all currently running queries.
+func (h *QueryManagementHandler) listActiveQueries(c *fiber.Ctx) error {
+	active := h.registry.GetActive()
+
+	// Truncate SQL for listing view
+	type querySummary struct {
+		ID             string  `json:"id"`
+		SQL            string  `json:"sql"`
+		TokenID        int64   `json:"token_id,omitempty"`
+		TokenName      string  `json:"token_name,omitempty"`
+		RemoteAddr     string  `json:"remote_addr,omitempty"`
+		Status         string  `json:"status"`
+		StartTime      string  `json:"start_time"`
+		DurationMs     float64 `json:"duration_ms"`
+		IsParallel     bool    `json:"is_parallel"`
+		PartitionCount int     `json:"partition_count,omitempty"`
+	}
+
+	queries := make([]querySummary, 0, len(active))
+	for _, q := range active {
+		sql := q.SQL
+		if len(sql) > 200 {
+			sql = sql[:200] + "..."
+		}
+		queries = append(queries, querySummary{
+			ID:             q.ID,
+			SQL:            sql,
+			TokenID:        q.TokenID,
+			TokenName:      q.TokenName,
+			RemoteAddr:     q.RemoteAddr,
+			Status:         string(q.Status),
+			StartTime:      q.StartTime.UTC().Format("2006-01-02T15:04:05Z"),
+			DurationMs:     q.DurationMs,
+			IsParallel:     q.IsParallel,
+			PartitionCount: q.PartitionCount,
+		})
+	}
+
+	// Update metrics
+	metrics.Get().SetQueryMgmtActiveQueries(int64(len(active)))
+
+	return c.JSON(fiber.Map{
+		"success": true,
+		"queries": queries,
+		"count":   len(queries),
+	})
+}
+
+// listQueryHistory returns recently completed queries.
+func (h *QueryManagementHandler) listQueryHistory(c *fiber.Ctx) error {
+	limit := 50
+	if l := c.Query("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+			if limit > 1000 {
+				limit = 1000
+			}
+		}
+	}
+
+	history := h.registry.GetHistory(limit)
+
+	// Update metrics
+	metrics.Get().SetQueryMgmtHistorySize(int64(h.registry.HistoryLen()))
+
+	return c.JSON(fiber.Map{
+		"success": true,
+		"queries": history,
+		"count":   len(history),
+	})
+}
+
+// getQuery returns details for a specific query by ID.
+func (h *QueryManagementHandler) getQuery(c *fiber.Ctx) error {
+	queryID := c.Params("id")
+	if queryID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"error":   "Query ID is required",
+		})
+	}
+
+	q := h.registry.GetQuery(queryID)
+	if q == nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"success": false,
+			"error":   "Query not found",
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"success": true,
+		"query":   q,
+	})
+}
+
+// cancelQuery cancels a running query by ID.
+func (h *QueryManagementHandler) cancelQuery(c *fiber.Ctx) error {
+	queryID := c.Params("id")
+	if queryID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"error":   "Query ID is required",
+		})
+	}
+
+	ok := h.registry.Cancel(queryID)
+	if !ok {
+		// Check if query exists in history (already completed)
+		q := h.registry.GetQuery(queryID)
+		if q != nil {
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"success": false,
+				"error":   "Query already " + string(q.Status),
+			})
+		}
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"success": false,
+			"error":   "Query not found",
+		})
+	}
+
+	metrics.Get().IncQueryMgmtCancelled()
+
+	h.logger.Info().
+		Str("query_id", queryID).
+		Msg("Query cancelled via API")
+
+	return c.JSON(fiber.Map{
+		"success": true,
+		"message": "Query cancelled",
+	})
+}

--- a/internal/api/query_management_test.go
+++ b/internal/api/query_management_test.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/queryregistry"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// setupQueryManagementTest creates a Fiber app with the query management handler.
+// License middleware is bypassed for functional tests (tested separately).
+func setupQueryManagementTest(t *testing.T) (*fiber.App, *queryregistry.Registry) {
+	t.Helper()
+	metrics.Init(zerolog.Nop())
+
+	registry := queryregistry.NewRegistry(&queryregistry.RegistryConfig{HistorySize: 50}, zerolog.Nop())
+
+	app := fiber.New()
+	h := &QueryManagementHandler{
+		registry: registry,
+		logger:   zerolog.Nop(),
+	}
+
+	// Register routes without auth/license middleware for functional tests
+	group := app.Group("/api/v1/queries")
+	group.Get("/active", h.listActiveQueries)
+	group.Get("/history", h.listQueryHistory)
+	group.Get("/:id", h.getQuery)
+	group.Delete("/:id", h.cancelQuery)
+
+	return app, registry
+}
+
+func TestQueryManagement_ListActiveQueries_Empty(t *testing.T) {
+	app, _ := setupQueryManagementTest(t)
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/active", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) == "" {
+		t.Fatal("expected non-empty response body")
+	}
+}
+
+func TestQueryManagement_ListActiveQueries_WithRunning(t *testing.T) {
+	app, registry := setupQueryManagementTest(t)
+
+	// Register a query but don't complete it
+	registry.Register(context.Background(), "SELECT * FROM test", 1, "test-token", "127.0.0.1", false, 0)
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/active", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_ListHistory_Empty(t *testing.T) {
+	app, _ := setupQueryManagementTest(t)
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/history", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_ListHistory_WithCompleted(t *testing.T) {
+	app, registry := setupQueryManagementTest(t)
+
+	id, _ := registry.Register(context.Background(), "SELECT 1", 1, "test-token", "127.0.0.1", false, 0)
+	registry.Complete(id, 10)
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/history", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_ListHistory_WithLimit(t *testing.T) {
+	app, registry := setupQueryManagementTest(t)
+
+	for i := 0; i < 5; i++ {
+		id, _ := registry.Register(context.Background(), "SELECT 1", 1, "tok", "127.0.0.1", false, 0)
+		registry.Complete(id, i)
+	}
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/history?limit=2", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_GetQuery_Active(t *testing.T) {
+	app, registry := setupQueryManagementTest(t)
+
+	queryID, _ := registry.Register(context.Background(), "SELECT * FROM test", 1, "test-token", "127.0.0.1", false, 0)
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/"+queryID, nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_GetQuery_Completed(t *testing.T) {
+	app, registry := setupQueryManagementTest(t)
+
+	queryID, _ := registry.Register(context.Background(), "SELECT 1", 1, "test-token", "127.0.0.1", false, 0)
+	registry.Complete(queryID, 5)
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/"+queryID, nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_GetQuery_NotFound(t *testing.T) {
+	app, _ := setupQueryManagementTest(t)
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/nonexistent", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 404 {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_CancelQuery(t *testing.T) {
+	app, registry := setupQueryManagementTest(t)
+
+	queryID, ctx := registry.Register(context.Background(), "SELECT slow()", 1, "test-token", "127.0.0.1", false, 0)
+
+	req, _ := http.NewRequest("DELETE", "/api/v1/queries/"+queryID, nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Verify context was cancelled
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("expected context to be cancelled")
+	}
+
+	// Verify query moved to history
+	if registry.ActiveCount() != 0 {
+		t.Fatalf("expected 0 active queries, got %d", registry.ActiveCount())
+	}
+}
+
+func TestQueryManagement_CancelQuery_NotFound(t *testing.T) {
+	app, _ := setupQueryManagementTest(t)
+
+	req, _ := http.NewRequest("DELETE", "/api/v1/queries/nonexistent", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 404 {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_CancelQuery_AlreadyCompleted(t *testing.T) {
+	app, registry := setupQueryManagementTest(t)
+
+	queryID, _ := registry.Register(context.Background(), "SELECT 1", 1, "test-token", "127.0.0.1", false, 0)
+	registry.Complete(queryID, 1)
+
+	req, _ := http.NewRequest("DELETE", "/api/v1/queries/"+queryID, nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 409 {
+		t.Fatalf("expected 409, got %d", resp.StatusCode)
+	}
+}
+
+func TestQueryManagement_LicenseRequired(t *testing.T) {
+	metrics.Init(zerolog.Nop())
+	registry := queryregistry.NewRegistry(nil, zerolog.Nop())
+
+	// No license client — middleware should block
+	app := fiber.New()
+	handler := NewQueryManagementHandler(registry, nil, nil, zerolog.Nop())
+	handler.RegisterRoutes(app)
+
+	req, _ := http.NewRequest("GET", "/api/v1/queries/active", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 403 {
+		t.Fatalf("expected 403 without license, got %d", resp.StatusCode)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	AuditLog        AuditLogConfig
 	Backup          BackupConfig
 	Governance      GovernanceConfig
+	QueryManagement QueryManagementConfig
 }
 
 type ServerConfig struct {
@@ -256,6 +257,13 @@ type GovernanceConfig struct {
 	DefaultMaxQueriesPerHour int // Default max queries per hour per token (0 = unlimited)
 	DefaultMaxQueriesPerDay  int // Default max queries per day per token (0 = unlimited)
 	DefaultMaxRowsPerQuery   int // Default max rows returned per query (0 = unlimited)
+}
+
+// QueryManagementConfig holds configuration for long-running query management (Enterprise feature).
+// Provides active query tracking, cancellation, and history.
+type QueryManagementConfig struct {
+	Enabled     bool // Enable query management (requires enterprise license with query_management feature)
+	HistorySize int  // Ring buffer size for completed query history (default: 100)
 }
 
 type BackupConfig struct {
@@ -573,6 +581,10 @@ func Load() (*Config, error) {
 			DefaultMaxQueriesPerDay:  v.GetInt("governance.default_max_queries_per_day"),
 			DefaultMaxRowsPerQuery:   v.GetInt("governance.default_max_rows_per_query"),
 		},
+		QueryManagement: QueryManagementConfig{
+			Enabled:     v.GetBool("query_management.enabled"),
+			HistorySize: v.GetInt("query_management.history_size"),
+		},
 	}
 
 	return cfg, nil
@@ -784,6 +796,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("governance.default_max_queries_per_hour", 0)
 	v.SetDefault("governance.default_max_queries_per_day", 0)
 	v.SetDefault("governance.default_max_rows_per_query", 0)
+
+	// Query management defaults (Enterprise feature)
+	v.SetDefault("query_management.enabled", false)
+	v.SetDefault("query_management.history_size", 100)
 
 	// Backup defaults
 	v.SetDefault("backup.enabled", true)

--- a/internal/license/client.go
+++ b/internal/license/client.go
@@ -378,6 +378,13 @@ func (c *Client) CanUseQueryGovernance() bool {
 	return c.license != nil && c.license.CanUseQueryGovernance()
 }
 
+// CanUseQueryManagement returns true if query management is allowed
+func (c *Client) CanUseQueryManagement() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.license != nil && c.license.CanUseQueryManagement()
+}
+
 // GetFingerprint returns the machine fingerprint
 func (c *Client) GetFingerprint() string {
 	return c.fingerprint

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -25,6 +25,7 @@ const (
 	FeatureAuditLogging       = "audit_logging"
 	FeatureWriterFailover     = "writer_failover"
 	FeatureQueryGovernance    = "query_governance"
+	FeatureQueryManagement   = "query_management"
 )
 
 // License represents a validated license
@@ -118,6 +119,12 @@ func (l *License) CanUseWriterFailover() bool {
 // Requires enterprise license with the query_governance feature
 func (l *License) CanUseQueryGovernance() bool {
 	return l.HasFeature(FeatureQueryGovernance)
+}
+
+// CanUseQueryManagement returns true if the license allows query management
+// Requires enterprise license with the query_management feature
+func (l *License) CanUseQueryManagement() bool {
+	return l.HasFeature(FeatureQueryManagement)
 }
 
 // TierFromString converts a string to a Tier

--- a/internal/queryregistry/registry.go
+++ b/internal/queryregistry/registry.go
@@ -1,0 +1,277 @@
+package queryregistry
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// QueryStatus represents the lifecycle state of a tracked query.
+type QueryStatus string
+
+const (
+	StatusRunning   QueryStatus = "running"
+	StatusCompleted QueryStatus = "completed"
+	StatusCancelled QueryStatus = "cancelled"
+	StatusFailed    QueryStatus = "failed"
+	StatusTimedOut  QueryStatus = "timed_out"
+)
+
+// TrackedQuery holds all metadata about a tracked query.
+type TrackedQuery struct {
+	ID             string      `json:"id"`
+	SQL            string      `json:"sql"`
+	TokenID        int64       `json:"token_id,omitempty"`
+	TokenName      string      `json:"token_name,omitempty"`
+	RemoteAddr     string      `json:"remote_addr,omitempty"`
+	Status         QueryStatus `json:"status"`
+	StartTime      time.Time   `json:"start_time"`
+	EndTime        *time.Time  `json:"end_time,omitempty"`
+	DurationMs     float64     `json:"duration_ms,omitempty"`
+	RowCount       int         `json:"row_count,omitempty"`
+	Error          string      `json:"error,omitempty"`
+	IsParallel     bool        `json:"is_parallel"`
+	PartitionCount int         `json:"partition_count,omitempty"`
+}
+
+// activeEntry stores the tracked query plus its cancel func.
+type activeEntry struct {
+	query  *TrackedQuery
+	cancel context.CancelFunc
+}
+
+// RegistryConfig holds configuration for the query registry.
+type RegistryConfig struct {
+	HistorySize int // Ring buffer size for completed queries (default: 100)
+}
+
+// Registry tracks active and recently completed queries.
+type Registry struct {
+	mu       sync.RWMutex
+	active   map[string]*activeEntry
+	history  []*TrackedQuery // Ring buffer
+	histSize int             // Configured capacity
+	histHead int             // Next write position
+	histLen  int             // Current count (up to histSize)
+	logger   zerolog.Logger
+}
+
+// NewRegistry creates a new query registry.
+func NewRegistry(cfg *RegistryConfig, logger zerolog.Logger) *Registry {
+	histSize := 100
+	if cfg != nil && cfg.HistorySize > 0 {
+		histSize = cfg.HistorySize
+	}
+	return &Registry{
+		active:   make(map[string]*activeEntry),
+		history:  make([]*TrackedQuery, histSize),
+		histSize: histSize,
+		logger:   logger.With().Str("component", "query-registry").Logger(),
+	}
+}
+
+// Register registers a new active query. Returns the query ID and a
+// context derived from parentCtx that can be cancelled via Cancel().
+func (r *Registry) Register(parentCtx context.Context, sql string, tokenID int64, tokenName string, remoteAddr string, isParallel bool, partitionCount int) (string, context.Context) {
+	queryID := uuid.New().String()[:12]
+	ctx, cancel := context.WithCancel(parentCtx)
+
+	query := &TrackedQuery{
+		ID:             queryID,
+		SQL:            sql,
+		TokenID:        tokenID,
+		TokenName:      tokenName,
+		RemoteAddr:     remoteAddr,
+		Status:         StatusRunning,
+		StartTime:      time.Now(),
+		IsParallel:     isParallel,
+		PartitionCount: partitionCount,
+	}
+
+	r.mu.Lock()
+	r.active[queryID] = &activeEntry{query: query, cancel: cancel}
+	r.mu.Unlock()
+
+	r.logger.Debug().
+		Str("query_id", queryID).
+		Int64("token_id", tokenID).
+		Bool("parallel", isParallel).
+		Msg("Query registered")
+
+	return queryID, ctx
+}
+
+// Complete marks a query as completed and moves it to history.
+func (r *Registry) Complete(queryID string, rowCount int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.active[queryID]
+	if !ok {
+		return
+	}
+
+	now := time.Now()
+	entry.query.Status = StatusCompleted
+	entry.query.EndTime = &now
+	entry.query.DurationMs = float64(now.Sub(entry.query.StartTime).Milliseconds())
+	entry.query.RowCount = rowCount
+
+	r.addToHistory(entry.query)
+	delete(r.active, queryID)
+}
+
+// Fail marks a query as failed and moves it to history.
+func (r *Registry) Fail(queryID string, errMsg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.active[queryID]
+	if !ok {
+		return
+	}
+
+	now := time.Now()
+	entry.query.Status = StatusFailed
+	entry.query.EndTime = &now
+	entry.query.DurationMs = float64(now.Sub(entry.query.StartTime).Milliseconds())
+	entry.query.Error = errMsg
+
+	r.addToHistory(entry.query)
+	delete(r.active, queryID)
+}
+
+// TimedOut marks a query as timed out and moves it to history.
+func (r *Registry) TimedOut(queryID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.active[queryID]
+	if !ok {
+		return
+	}
+
+	now := time.Now()
+	entry.query.Status = StatusTimedOut
+	entry.query.EndTime = &now
+	entry.query.DurationMs = float64(now.Sub(entry.query.StartTime).Milliseconds())
+	entry.query.Error = "Query timed out"
+
+	r.addToHistory(entry.query)
+	delete(r.active, queryID)
+}
+
+// Cancel cancels a running query by ID. Returns true if the query was found and cancelled.
+func (r *Registry) Cancel(queryID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.active[queryID]
+	if !ok {
+		return false
+	}
+
+	now := time.Now()
+	entry.query.Status = StatusCancelled
+	entry.query.EndTime = &now
+	entry.query.DurationMs = float64(now.Sub(entry.query.StartTime).Milliseconds())
+
+	// Cancel the context — this propagates to DuckDB QueryContext
+	entry.cancel()
+
+	r.logger.Info().
+		Str("query_id", queryID).
+		Int64("token_id", entry.query.TokenID).
+		Float64("duration_ms", entry.query.DurationMs).
+		Msg("Query cancelled via API")
+
+	r.addToHistory(entry.query)
+	delete(r.active, queryID)
+	return true
+}
+
+// GetActive returns a snapshot of all active queries.
+func (r *Registry) GetActive() []*TrackedQuery {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*TrackedQuery, 0, len(r.active))
+	now := time.Now()
+	for _, entry := range r.active {
+		q := *entry.query // copy
+		q.DurationMs = float64(now.Sub(q.StartTime).Milliseconds())
+		result = append(result, &q)
+	}
+	return result
+}
+
+// GetHistory returns a snapshot of the most recent completed queries (newest first).
+func (r *Registry) GetHistory(limit int) []*TrackedQuery {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	count := r.histLen
+	if limit > 0 && limit < count {
+		count = limit
+	}
+
+	result := make([]*TrackedQuery, 0, count)
+	for i := 0; i < count; i++ {
+		// Walk backwards from most recent
+		idx := (r.histHead - 1 - i + r.histSize) % r.histSize
+		if r.history[idx] != nil {
+			q := *r.history[idx] // copy
+			result = append(result, &q)
+		}
+	}
+	return result
+}
+
+// GetQuery returns a specific query by ID (checks active then history).
+func (r *Registry) GetQuery(queryID string) *TrackedQuery {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// Check active first
+	if entry, ok := r.active[queryID]; ok {
+		q := *entry.query
+		q.DurationMs = float64(time.Since(q.StartTime).Milliseconds())
+		return &q
+	}
+
+	// Check history
+	for i := 0; i < r.histLen; i++ {
+		idx := (r.histHead - 1 - i + r.histSize) % r.histSize
+		if r.history[idx] != nil && r.history[idx].ID == queryID {
+			q := *r.history[idx]
+			return &q
+		}
+	}
+	return nil
+}
+
+// ActiveCount returns the number of currently running queries.
+func (r *Registry) ActiveCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.active)
+}
+
+// HistoryLen returns the number of queries in the history buffer.
+func (r *Registry) HistoryLen() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.histLen
+}
+
+// addToHistory appends a query to the ring buffer. Must be called with mu held.
+func (r *Registry) addToHistory(q *TrackedQuery) {
+	r.history[r.histHead] = q
+	r.histHead = (r.histHead + 1) % r.histSize
+	if r.histLen < r.histSize {
+		r.histLen++
+	}
+}

--- a/internal/queryregistry/registry_test.go
+++ b/internal/queryregistry/registry_test.go
@@ -1,0 +1,320 @@
+package queryregistry
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func newTestRegistry(historySize int) *Registry {
+	return NewRegistry(&RegistryConfig{HistorySize: historySize}, zerolog.Nop())
+}
+
+func TestRegistry_RegisterAndGetActive(t *testing.T) {
+	r := newTestRegistry(10)
+
+	queryID, ctx := r.Register(context.Background(), "SELECT 1", 1, "test-token", "127.0.0.1", false, 0)
+	if queryID == "" {
+		t.Fatal("expected non-empty query ID")
+	}
+	if ctx == nil {
+		t.Fatal("expected non-nil context")
+	}
+
+	active := r.GetActive()
+	if len(active) != 1 {
+		t.Fatalf("expected 1 active query, got %d", len(active))
+	}
+	if active[0].ID != queryID {
+		t.Fatalf("expected query ID %s, got %s", queryID, active[0].ID)
+	}
+	if active[0].Status != StatusRunning {
+		t.Fatalf("expected status running, got %s", active[0].Status)
+	}
+	if active[0].SQL != "SELECT 1" {
+		t.Fatalf("expected SQL 'SELECT 1', got %s", active[0].SQL)
+	}
+
+	if r.ActiveCount() != 1 {
+		t.Fatalf("expected ActiveCount=1, got %d", r.ActiveCount())
+	}
+}
+
+func TestRegistry_Complete(t *testing.T) {
+	r := newTestRegistry(10)
+
+	queryID, _ := r.Register(context.Background(), "SELECT 1", 1, "test-token", "127.0.0.1", false, 0)
+	r.Complete(queryID, 42)
+
+	if r.ActiveCount() != 0 {
+		t.Fatalf("expected 0 active queries after complete, got %d", r.ActiveCount())
+	}
+
+	history := r.GetHistory(0)
+	if len(history) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(history))
+	}
+	if history[0].Status != StatusCompleted {
+		t.Fatalf("expected status completed, got %s", history[0].Status)
+	}
+	if history[0].RowCount != 42 {
+		t.Fatalf("expected RowCount=42, got %d", history[0].RowCount)
+	}
+	if history[0].EndTime == nil {
+		t.Fatal("expected non-nil EndTime")
+	}
+}
+
+func TestRegistry_Fail(t *testing.T) {
+	r := newTestRegistry(10)
+
+	queryID, _ := r.Register(context.Background(), "SELECT bad", 1, "test-token", "127.0.0.1", false, 0)
+	r.Fail(queryID, "syntax error")
+
+	if r.ActiveCount() != 0 {
+		t.Fatalf("expected 0 active queries after fail, got %d", r.ActiveCount())
+	}
+
+	history := r.GetHistory(0)
+	if len(history) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(history))
+	}
+	if history[0].Status != StatusFailed {
+		t.Fatalf("expected status failed, got %s", history[0].Status)
+	}
+	if history[0].Error != "syntax error" {
+		t.Fatalf("expected error 'syntax error', got %s", history[0].Error)
+	}
+}
+
+func TestRegistry_TimedOut(t *testing.T) {
+	r := newTestRegistry(10)
+
+	queryID, _ := r.Register(context.Background(), "SELECT slow()", 1, "test-token", "127.0.0.1", false, 0)
+	r.TimedOut(queryID)
+
+	history := r.GetHistory(0)
+	if len(history) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(history))
+	}
+	if history[0].Status != StatusTimedOut {
+		t.Fatalf("expected status timed_out, got %s", history[0].Status)
+	}
+}
+
+func TestRegistry_Cancel(t *testing.T) {
+	r := newTestRegistry(10)
+
+	queryID, ctx := r.Register(context.Background(), "SELECT slow()", 1, "test-token", "127.0.0.1", false, 0)
+
+	// Cancel the query
+	ok := r.Cancel(queryID)
+	if !ok {
+		t.Fatal("expected Cancel to return true")
+	}
+
+	// Context should be cancelled
+	select {
+	case <-ctx.Done():
+		// expected
+	default:
+		t.Fatal("expected context to be cancelled")
+	}
+
+	if r.ActiveCount() != 0 {
+		t.Fatalf("expected 0 active after cancel, got %d", r.ActiveCount())
+	}
+
+	history := r.GetHistory(0)
+	if len(history) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(history))
+	}
+	if history[0].Status != StatusCancelled {
+		t.Fatalf("expected status cancelled, got %s", history[0].Status)
+	}
+}
+
+func TestRegistry_Cancel_NotFound(t *testing.T) {
+	r := newTestRegistry(10)
+
+	ok := r.Cancel("nonexistent")
+	if ok {
+		t.Fatal("expected Cancel to return false for nonexistent query")
+	}
+}
+
+func TestRegistry_GetQuery_Active(t *testing.T) {
+	r := newTestRegistry(10)
+
+	queryID, _ := r.Register(context.Background(), "SELECT 1", 1, "test-token", "127.0.0.1", false, 0)
+
+	q := r.GetQuery(queryID)
+	if q == nil {
+		t.Fatal("expected to find active query")
+	}
+	if q.Status != StatusRunning {
+		t.Fatalf("expected status running, got %s", q.Status)
+	}
+}
+
+func TestRegistry_GetQuery_History(t *testing.T) {
+	r := newTestRegistry(10)
+
+	queryID, _ := r.Register(context.Background(), "SELECT 1", 1, "test-token", "127.0.0.1", false, 0)
+	r.Complete(queryID, 5)
+
+	q := r.GetQuery(queryID)
+	if q == nil {
+		t.Fatal("expected to find query in history")
+	}
+	if q.Status != StatusCompleted {
+		t.Fatalf("expected status completed, got %s", q.Status)
+	}
+}
+
+func TestRegistry_GetQuery_NotFound(t *testing.T) {
+	r := newTestRegistry(10)
+
+	q := r.GetQuery("nonexistent")
+	if q != nil {
+		t.Fatal("expected nil for nonexistent query")
+	}
+}
+
+func TestRegistry_HistoryRingBuffer_Overflow(t *testing.T) {
+	r := newTestRegistry(3) // Small buffer
+
+	// Register and complete 5 queries
+	for i := 0; i < 5; i++ {
+		id, _ := r.Register(context.Background(), "SELECT 1", 1, "tok", "127.0.0.1", false, 0)
+		r.Complete(id, i)
+	}
+
+	// Should only keep the last 3
+	if r.HistoryLen() != 3 {
+		t.Fatalf("expected HistoryLen=3, got %d", r.HistoryLen())
+	}
+
+	history := r.GetHistory(0)
+	if len(history) != 3 {
+		t.Fatalf("expected 3 history entries, got %d", len(history))
+	}
+
+	// Should be newest first: row counts 4, 3, 2
+	if history[0].RowCount != 4 {
+		t.Fatalf("expected newest entry RowCount=4, got %d", history[0].RowCount)
+	}
+	if history[2].RowCount != 2 {
+		t.Fatalf("expected oldest entry RowCount=2, got %d", history[2].RowCount)
+	}
+}
+
+func TestRegistry_HistoryLimit(t *testing.T) {
+	r := newTestRegistry(10)
+
+	for i := 0; i < 5; i++ {
+		id, _ := r.Register(context.Background(), "SELECT 1", 1, "tok", "127.0.0.1", false, 0)
+		r.Complete(id, i)
+	}
+
+	// Request only 2
+	history := r.GetHistory(2)
+	if len(history) != 2 {
+		t.Fatalf("expected 2 history entries with limit, got %d", len(history))
+	}
+}
+
+func TestRegistry_ParallelQuery(t *testing.T) {
+	r := newTestRegistry(10)
+
+	queryID, _ := r.Register(context.Background(), "SELECT * FROM db.measurement", 1, "tok", "127.0.0.1", true, 24)
+
+	q := r.GetQuery(queryID)
+	if !q.IsParallel {
+		t.Fatal("expected IsParallel=true")
+	}
+	if q.PartitionCount != 24 {
+		t.Fatalf("expected PartitionCount=24, got %d", q.PartitionCount)
+	}
+}
+
+func TestRegistry_DefaultHistorySize(t *testing.T) {
+	r := NewRegistry(nil, zerolog.Nop())
+	if r.histSize != 100 {
+		t.Fatalf("expected default histSize=100, got %d", r.histSize)
+	}
+}
+
+func TestRegistry_ActiveDurationMs(t *testing.T) {
+	r := newTestRegistry(10)
+
+	r.Register(context.Background(), "SELECT 1", 1, "tok", "127.0.0.1", false, 0)
+	time.Sleep(10 * time.Millisecond)
+
+	active := r.GetActive()
+	if len(active) != 1 {
+		t.Fatalf("expected 1 active query, got %d", len(active))
+	}
+	if active[0].DurationMs < 10 {
+		t.Fatalf("expected DurationMs >= 10, got %f", active[0].DurationMs)
+	}
+}
+
+func TestRegistry_Concurrent(t *testing.T) {
+	r := newTestRegistry(100)
+	var wg sync.WaitGroup
+
+	// Concurrent registers and completes
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id, _ := r.Register(context.Background(), "SELECT 1", 1, "tok", "127.0.0.1", false, 0)
+			r.Complete(id, 1)
+		}()
+	}
+
+	// Concurrent cancels
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id, _ := r.Register(context.Background(), "SELECT 1", 1, "tok", "127.0.0.1", false, 0)
+			r.Cancel(id)
+		}()
+	}
+
+	// Concurrent reads
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.GetActive()
+			r.GetHistory(0)
+			r.ActiveCount()
+		}()
+	}
+
+	wg.Wait()
+
+	// All queries should be completed or cancelled
+	if r.ActiveCount() != 0 {
+		t.Fatalf("expected 0 active queries after concurrent test, got %d", r.ActiveCount())
+	}
+}
+
+func TestRegistry_CompleteNonexistent(t *testing.T) {
+	r := newTestRegistry(10)
+
+	// Should not panic
+	r.Complete("nonexistent", 0)
+	r.Fail("nonexistent", "error")
+	r.TimedOut("nonexistent")
+
+	if r.HistoryLen() != 0 {
+		t.Fatalf("expected 0 history entries, got %d", r.HistoryLen())
+	}
+}


### PR DESCRIPTION
## Summary
- Add real-time query tracking, cancellation, and history as an enterprise feature (`query_management` license)
- Query registry tracks active queries with unique IDs, SQL text, token info, and execution status in-memory
- Cancel running queries via `DELETE /api/v1/queries/:id` using Go context cancellation propagated to DuckDB
- Ring buffer history (default 100) of completed/cancelled/failed queries
- `X-Arc-Query-ID` response header for client-side correlation
- Bug fix: parallel executor now uses proper timeout context instead of `context.Background()`
- 3 new Prometheus metrics: `arc_query_mgmt_active_queries`, `arc_query_mgmt_cancelled_total`, `arc_query_mgmt_history_size`

## Test plan
- [x] 16 registry unit tests (register, complete, fail, timeout, cancel, ring buffer, concurrency)
- [x] 12 API handler tests (list active, history, get query, cancel, 404, 409, license gating)
- [x] Full build passes (`go build ./cmd/... ./internal/...`)
- [x] All existing license tests pass
- [x] Post-implementation review: security, license gating, code quality (3 parallel agents)
- [ ] Manual test: start with `query_management.enabled=true`, run slow query, cancel via API