### PR TITLE
fix(compaction): invalidate caches after compaction to prevent 404 er…

### DIFF
--- a/RELEASE_NOTES_2026.03.1.md
+++ b/RELEASE_NOTES_2026.03.1.md
@@ -12,6 +12,16 @@ Fixed a bug where missing fields in line protocol ingestion were stored as `0` i
 
 *Reported by [@bjarneksat](https://github.com/bjarneksat) — thank you!*
 
+### Stale Cache After Compaction Causes 404 Errors (#204)
+
+Fixed a bug where queries would intermittently fail with HTTP 404 errors after compaction deleted old parquet files from S3. DuckDB's `cache_httpfs` extension was caching glob results (directory listings) that still referenced deleted files, causing queries to attempt reading non-existent objects.
+
+**Root cause:** After compaction merged and deleted old parquet files, no cache invalidation was performed. DuckDB's `cache_httpfs` glob cache, `parquet_metadata_cache`, and Arc's partition pruner caches all retained stale references until their TTLs expired (~1 hour).
+
+**Fix:** Added post-compaction cache invalidation that clears all relevant caches (DuckDB `cache_httpfs`, `parquet_metadata_cache`, partition pruner, and SQL transform cache) immediately after each successful compaction job completes.
+
+*Reported by [@khalid244](https://github.com/khalid244) — thank you!*
+
 ## New Features
 
 ### Backup & Restore API

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -655,6 +655,14 @@ func (h *QueryHandler) SetQueryRegistry(registry *queryregistry.Registry) {
 	h.queryRegistry = registry
 }
 
+// InvalidateCaches clears all internal caches (partition pruner and SQL transform cache).
+// This should be called after compaction to prevent stale file references.
+func (h *QueryHandler) InvalidateCaches() {
+	h.pruner.InvalidateAllCaches()
+	h.queryCache.Invalidate()
+	h.logger.Info().Msg("Query caches invalidated after compaction")
+}
+
 // extractTableReferences extracts all database.measurement references from SQL
 // Returns a slice of TableReference structs for permission checking
 func extractTableReferences(sql string) []TableReference {


### PR DESCRIPTION
…rors (#204)

After compaction deletes old parquet files, DuckDB's cache_httpfs extension retains cached glob results (directory listings) pointing to deleted files, causing intermittent HTTP 404 errors on subsequent queries.

Added post-compaction cache invalidation that clears:
- DuckDB cache_httpfs (glob results, data blocks, file metadata)
- DuckDB parquet_metadata_cache (cached schema for deleted files)
- Partition pruner glob and path caches
- SQL transform cache

Uses a callback pattern to avoid circular imports between compaction and database/api packages. The callback fires outside the compaction mutex to avoid holding the lock during DuckDB IO.