### PR TITLE
fix(api): return detailed DuckDB error messages in query responses

### DIFF
--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1138,7 +1138,7 @@ localProcessing:
 			h.logger.Error().Err(err).Str("sql", req.SQL).Msg("Parallel query execution failed")
 			return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 				Success:         false,
-				Error:           "Query execution failed",
+				Error:           err.Error(),
 				ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 				Timestamp:       timestamp,
 			})
@@ -1160,7 +1160,7 @@ localProcessing:
 			h.logger.Error().Err(err).Msg("Failed to create merged iterator")
 			return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 				Success:         false,
-				Error:           "Query execution failed",
+				Error:           err.Error(),
 				ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 				Timestamp:       timestamp,
 			})
@@ -1262,7 +1262,7 @@ localProcessing:
 			h.logger.Error().Err(err).Str("sql", req.SQL).Msg("Query execution failed")
 			return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 				Success:         false,
-				Error:           "Query execution failed",
+				Error:           err.Error(),
 				ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 				Timestamp:       timestamp,
 			})
@@ -1276,7 +1276,7 @@ localProcessing:
 			h.logger.Error().Err(err).Msg("Failed to get column names")
 			return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 				Success:         false,
-				Error:           "Query execution failed",
+				Error:           err.Error(),
 				ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 				Timestamp:       timestamp,
 			})
@@ -2924,7 +2924,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 		h.logger.Error().Err(err).Str("sql", sql).Msg("Measurement query failed")
 		return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 			Success:         false,
-			Error:           "Query execution failed", // Don't expose database error details
+			Error:           err.Error(),
 			ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 			Timestamp:       time.Now().UTC().Format(time.RFC3339),
 		})
@@ -2938,7 +2938,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 		h.logger.Error().Err(err).Msg("Failed to get column names in measurement query")
 		return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 			Success:         false,
-			Error:           "Query execution failed", // Don't expose database error details
+			Error:           err.Error(),
 			ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 			Timestamp:       time.Now().UTC().Format(time.RFC3339),
 		})

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -106,7 +106,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		h.logger.Error().Err(err).Str("sql", req.SQL).Msg("Arrow query execution failed")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"success": false,
-			"error":   "Query execution failed",
+			"error":   err.Error(),
 		})
 	}
 	// Note: rows.Close() is called inside SetBodyStreamWriter callback, not here,
@@ -123,7 +123,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		h.logger.Error().Err(err).Msg("Failed to get column names")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"success": false,
-			"error":   "Query execution failed",
+			"error":   err.Error(),
 		})
 	}
 
@@ -137,7 +137,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		h.logger.Error().Err(err).Msg("Failed to get column types")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"success": false,
-			"error":   "Query execution failed",
+			"error":   err.Error(),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Pass through actual DuckDB error messages instead of generic `"Query execution failed"` in all query API responses
- Users now see actionable errors like `Parser Error: syntax error at or near "SELEC"` instead of a one-size-fits-all message
- Updated 9 error response locations across `query.go` (6) and `query_arrow.go` (3)

Closes #207

## Test plan
- [x] `go build ./cmd/... ./internal/...` passes
- [x] `go test ./internal/api/... -count=1` passes
- [ ] Manual test: send malformed SQL via `/api/v1/query` and verify DuckDB error appears in response
- [ ] Verify Grafana displays the actual error message instead of generic text