### PR TITLE
feat(api): add Line Protocol bulk import endpoint for InfluxDB migration

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -890,6 +890,14 @@ func main() {
 	}
 	lineProtocolHandler.RegisterRoutes(server.GetApp())
 
+	// Register Import handler (CSV, Parquet, Line Protocol bulk import)
+	importHandler := api.NewImportHandler(db, storageBackend, logger.Get("import"))
+	importHandler.SetArrowBuffer(arrowBuffer)
+	if authManager != nil && rbacManager != nil {
+		importHandler.SetAuthAndRBAC(authManager, rbacManager)
+	}
+	importHandler.RegisterRoutes(server.GetApp())
+
 	// Register Query handler with dedicated query timeout
 	queryHandler := api.NewQueryHandler(db, storageBackend, logger.Get("query"), cfg.Query.Timeout)
 	if authManager != nil && rbacManager != nil {

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -1,0 +1,863 @@
+package api
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/ingest"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/basekick-labs/arc/pkg/models"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// ImportResult holds the result of a bulk import operation
+type ImportResult struct {
+	Database          string   `json:"database"`
+	Measurement       string   `json:"measurement"`
+	RowsImported      int64    `json:"rows_imported"`
+	PartitionsCreated int      `json:"partitions_created"`
+	TimeRangeMin      string   `json:"time_range_min,omitempty"`
+	TimeRangeMax      string   `json:"time_range_max,omitempty"`
+	Columns           []string `json:"columns"`
+	DurationMs        int64    `json:"duration_ms"`
+}
+
+// LPImportResult holds the result of a Line Protocol bulk import operation
+type LPImportResult struct {
+	Database     string   `json:"database"`
+	Measurements []string `json:"measurements"`
+	RowsImported int64    `json:"rows_imported"`
+	Precision    string   `json:"precision"`
+	DurationMs   int64    `json:"duration_ms"`
+}
+
+// ImportHandler handles bulk CSV, Parquet, and Line Protocol file imports
+type ImportHandler struct {
+	db      *database.DuckDB
+	storage storage.Backend
+	logger  zerolog.Logger
+
+	// ArrowBuffer for LP import (uses the streaming ingest pipeline)
+	arrowBuffer *ingest.ArrowBuffer
+
+	// RBAC support
+	authManager AuthManager
+	rbacManager RBACChecker
+
+	// Stats
+	totalRequests atomic.Int64
+	totalRecords  atomic.Int64
+	totalErrors   atomic.Int64
+}
+
+// NewImportHandler creates a new ImportHandler
+func NewImportHandler(db *database.DuckDB, storage storage.Backend, logger zerolog.Logger) *ImportHandler {
+	return &ImportHandler{
+		db:      db,
+		storage: storage,
+		logger:  logger.With().Str("component", "import-handler").Logger(),
+	}
+}
+
+// SetArrowBuffer sets the ArrowBuffer for Line Protocol import
+func (h *ImportHandler) SetArrowBuffer(buf *ingest.ArrowBuffer) {
+	h.arrowBuffer = buf
+}
+
+// SetAuthAndRBAC sets the auth and RBAC managers for permission checking
+func (h *ImportHandler) SetAuthAndRBAC(authManager AuthManager, rbacManager RBACChecker) {
+	h.authManager = authManager
+	h.rbacManager = rbacManager
+}
+
+// RegisterRoutes registers import API routes
+func (h *ImportHandler) RegisterRoutes(app *fiber.App) {
+	app.Post("/api/v1/import/csv", h.handleCSVImport)
+	app.Post("/api/v1/import/parquet", h.handleParquetImport)
+	app.Post("/api/v1/import/lp", h.handleLineProtocolImport)
+	app.Get("/api/v1/import/stats", h.Stats)
+
+	h.logger.Info().Msg("Import routes registered")
+}
+
+// handleCSVImport handles CSV file upload and import
+func (h *ImportHandler) handleCSVImport(c *fiber.Ctx) error {
+	h.totalRequests.Add(1)
+	start := time.Now()
+
+	database := c.Get("x-arc-database")
+	if database == "" {
+		database = c.Query("db")
+	}
+	if database == "" {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "database is required (set x-arc-database header or db query param)",
+		})
+	}
+
+	measurement := c.Query("measurement")
+	if measurement == "" {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "measurement query parameter is required",
+		})
+	}
+
+	if !isValidMeasurementName(measurement) {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid measurement name %q: must start with a letter and contain only alphanumeric characters, underscores, or hyphens", measurement),
+		})
+	}
+
+	// Check RBAC permissions
+	if h.rbacManager != nil && h.rbacManager.IsRBACEnabled() {
+		if err := CheckWritePermissions(c, h.rbacManager, h.logger, database, []string{measurement}); err != nil {
+			h.totalErrors.Add(1)
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": err.Error(),
+			})
+		}
+	}
+
+	// Get uploaded file
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "no file uploaded: use multipart/form-data with field name 'file'",
+		})
+	}
+
+	// Save to temp file
+	tempDir, err := os.MkdirTemp("", "arc-import-*")
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to create temp directory: " + err.Error(),
+		})
+	}
+	defer os.RemoveAll(tempDir)
+
+	tempFile := filepath.Join(tempDir, "import.csv")
+	if err := c.SaveFile(fileHeader, tempFile); err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to save uploaded file: " + err.Error(),
+		})
+	}
+
+	// Parse import options
+	opts := importOptions{
+		format:     "csv",
+		timeColumn: c.Query("time_column", "time"),
+		timeFormat: c.Query("time_format", ""),
+		delimiter:  c.Query("delimiter", ","),
+		skipRows:   c.QueryInt("skip_rows", 0),
+	}
+
+	result, err := h.importFile(c.Context(), database, measurement, tempFile, tempDir, opts)
+	if err != nil {
+		h.totalErrors.Add(1)
+		h.logger.Error().Err(err).
+			Str("database", database).
+			Str("measurement", measurement).
+			Str("format", "csv").
+			Msg("Import failed")
+		return h.importErrorResponse(c, err)
+	}
+
+	result.DurationMs = time.Since(start).Milliseconds()
+	h.totalRecords.Add(result.RowsImported)
+
+	h.logger.Info().
+		Str("database", database).
+		Str("measurement", measurement).
+		Int64("rows", result.RowsImported).
+		Int("partitions", result.PartitionsCreated).
+		Int64("duration_ms", result.DurationMs).
+		Msg("CSV import completed")
+
+	return c.JSON(fiber.Map{
+		"status": "ok",
+		"result": result,
+	})
+}
+
+// handleParquetImport handles Parquet file upload and import
+func (h *ImportHandler) handleParquetImport(c *fiber.Ctx) error {
+	h.totalRequests.Add(1)
+	start := time.Now()
+
+	database := c.Get("x-arc-database")
+	if database == "" {
+		database = c.Query("db")
+	}
+	if database == "" {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "database is required (set x-arc-database header or db query param)",
+		})
+	}
+
+	measurement := c.Query("measurement")
+	if measurement == "" {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "measurement query parameter is required",
+		})
+	}
+
+	if !isValidMeasurementName(measurement) {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid measurement name %q: must start with a letter and contain only alphanumeric characters, underscores, or hyphens", measurement),
+		})
+	}
+
+	// Check RBAC permissions
+	if h.rbacManager != nil && h.rbacManager.IsRBACEnabled() {
+		if err := CheckWritePermissions(c, h.rbacManager, h.logger, database, []string{measurement}); err != nil {
+			h.totalErrors.Add(1)
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": err.Error(),
+			})
+		}
+	}
+
+	// Get uploaded file
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "no file uploaded: use multipart/form-data with field name 'file'",
+		})
+	}
+
+	// Save to temp file
+	tempDir, err := os.MkdirTemp("", "arc-import-*")
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to create temp directory: " + err.Error(),
+		})
+	}
+	defer os.RemoveAll(tempDir)
+
+	tempFile := filepath.Join(tempDir, "import.parquet")
+	if err := c.SaveFile(fileHeader, tempFile); err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to save uploaded file: " + err.Error(),
+		})
+	}
+
+	opts := importOptions{
+		format:     "parquet",
+		timeColumn: c.Query("time_column", "time"),
+	}
+
+	result, err := h.importFile(c.Context(), database, measurement, tempFile, tempDir, opts)
+	if err != nil {
+		h.totalErrors.Add(1)
+		h.logger.Error().Err(err).
+			Str("database", database).
+			Str("measurement", measurement).
+			Str("format", "parquet").
+			Msg("Import failed")
+		return h.importErrorResponse(c, err)
+	}
+
+	result.DurationMs = time.Since(start).Milliseconds()
+	h.totalRecords.Add(result.RowsImported)
+
+	h.logger.Info().
+		Str("database", database).
+		Str("measurement", measurement).
+		Int64("rows", result.RowsImported).
+		Int("partitions", result.PartitionsCreated).
+		Int64("duration_ms", result.DurationMs).
+		Msg("Parquet import completed")
+
+	return c.JSON(fiber.Map{
+		"status": "ok",
+		"result": result,
+	})
+}
+
+// handleLineProtocolImport handles Line Protocol file upload and import.
+// Uses the same ArrowBuffer ingest pipeline as streaming LP ingestion.
+func (h *ImportHandler) handleLineProtocolImport(c *fiber.Ctx) error {
+	h.totalRequests.Add(1)
+	start := time.Now()
+
+	database := c.Get("x-arc-database")
+	if database == "" {
+		database = c.Query("db")
+	}
+	if database == "" {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "database is required (set x-arc-database header or db query param)",
+		})
+	}
+
+	if !isValidDatabaseName(database) {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid database name: must start with a letter and contain only alphanumeric characters, underscores, or hyphens (max 64 characters)",
+		})
+	}
+
+	if h.arrowBuffer == nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "line protocol import not available (ingest pipeline not configured)",
+		})
+	}
+
+	// measurement is optional for LP — lines contain measurement names
+	measurementFilter := c.Query("measurement")
+	if measurementFilter != "" && !isValidMeasurementName(measurementFilter) {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid measurement name %q: must start with a letter and contain only alphanumeric characters, underscores, or hyphens", measurementFilter),
+		})
+	}
+
+	precision := c.Query("precision", "ns")
+	if precision != "ns" && precision != "us" && precision != "ms" && precision != "s" {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid precision %q: must be ns, us, ms, or s", precision),
+		})
+	}
+
+	// Get uploaded file
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "no file uploaded: use multipart/form-data with field name 'file'",
+		})
+	}
+
+	// Read file contents
+	file, err := fileHeader.Open()
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to open uploaded file: " + err.Error(),
+		})
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to read uploaded file: " + err.Error(),
+		})
+	}
+
+	// Size limit for bulk LP import (applies to both compressed and uncompressed)
+	const maxImportSize = 500 * 1024 * 1024 // 500MB
+
+	// Detect and decompress gzip (magic bytes: 0x1f 0x8b)
+	if len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b {
+		reader, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			h.totalErrors.Add(1)
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "failed to decompress gzip file: " + err.Error(),
+			})
+		}
+		decompressed, err := io.ReadAll(io.LimitReader(reader, maxImportSize+1))
+		reader.Close()
+		if err != nil {
+			h.totalErrors.Add(1)
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "failed to decompress gzip file: " + err.Error(),
+			})
+		}
+		if len(decompressed) > maxImportSize {
+			h.totalErrors.Add(1)
+			return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+				"error": "decompressed file exceeds 500MB limit",
+			})
+		}
+		data = decompressed
+	}
+
+	// Enforce size limit on uncompressed data
+	if len(data) > maxImportSize {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+			"error": "file exceeds 500MB limit",
+		})
+	}
+
+	if len(data) == 0 {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "file is empty",
+		})
+	}
+
+	// Parse Line Protocol with precision-aware timestamp conversion
+	parser := ingest.NewLineProtocolParser()
+	records := parser.ParseBatchWithPrecision(data, precision)
+	if len(records) == 0 {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "no valid line protocol records found in file",
+		})
+	}
+
+	// Filter by measurement if specified
+	if measurementFilter != "" {
+		filtered := make([]*models.Record, 0, len(records))
+		for _, r := range records {
+			if r.Measurement == measurementFilter {
+				filtered = append(filtered, r)
+			}
+		}
+		if len(filtered) == 0 {
+			h.totalErrors.Add(1)
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": fmt.Sprintf("no records found for measurement %q", measurementFilter),
+			})
+		}
+		records = filtered
+	}
+
+	// Check RBAC permissions for all measurements
+	measurements := make(map[string]bool)
+	for _, r := range records {
+		measurements[r.Measurement] = true
+	}
+	if h.rbacManager != nil && h.rbacManager.IsRBACEnabled() {
+		measList := make([]string, 0, len(measurements))
+		for m := range measurements {
+			measList = append(measList, m)
+		}
+		if err := CheckWritePermissions(c, h.rbacManager, h.logger, database, measList); err != nil {
+			h.totalErrors.Add(1)
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": err.Error(),
+			})
+		}
+	}
+
+	// Group by measurement and convert to columnar format
+	columnarByMeasurement := ingest.BatchToColumnar(records)
+
+	// Validate all measurement names from the LP body (prevent path traversal)
+	for measurement := range columnarByMeasurement {
+		if !isValidMeasurementName(measurement) {
+			h.totalErrors.Add(1)
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": fmt.Sprintf("invalid measurement name %q in LP data: must start with a letter and contain only alphanumeric characters, underscores, or hyphens", measurement),
+			})
+		}
+	}
+
+	// Feed each measurement into the ArrowBuffer ingest pipeline
+	var totalRows int64
+	importedMeasurements := make([]string, 0, len(columnarByMeasurement))
+	for measurement, columns := range columnarByMeasurement {
+		if err := h.arrowBuffer.WriteColumnarDirect(c.Context(), database, measurement, columns); err != nil {
+			h.totalErrors.Add(1)
+			h.logger.Error().Err(err).
+				Str("database", database).
+				Str("measurement", measurement).
+				Msg("LP import: failed to write to buffer")
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"error": fmt.Sprintf("failed to ingest measurement %q: %v", measurement, err),
+			})
+		}
+		// Count rows from the time column
+		if timeCol, ok := columns["time"]; ok {
+			totalRows += int64(len(timeCol))
+		}
+		importedMeasurements = append(importedMeasurements, measurement)
+	}
+
+	// Force flush to ensure data is persisted before returning
+	if err := h.arrowBuffer.FlushAll(c.Context()); err != nil {
+		h.totalErrors.Add(1)
+		h.logger.Error().Err(err).Str("database", database).Msg("LP import: flush failed")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to flush imported data: " + err.Error(),
+		})
+	}
+
+	durationMs := time.Since(start).Milliseconds()
+	h.totalRecords.Add(totalRows)
+
+	h.logger.Info().
+		Str("database", database).
+		Strs("measurements", importedMeasurements).
+		Int64("rows", totalRows).
+		Str("precision", precision).
+		Int64("duration_ms", durationMs).
+		Msg("Line protocol import completed")
+
+	return c.JSON(fiber.Map{
+		"status": "ok",
+		"result": LPImportResult{
+			Database:     database,
+			Measurements: importedMeasurements,
+			RowsImported: totalRows,
+			Precision:    precision,
+			DurationMs:   durationMs,
+		},
+	})
+}
+
+// importOptions holds configuration for an import operation
+type importOptions struct {
+	format     string // "csv" or "parquet"
+	timeColumn string
+	timeFormat string // "", "epoch_s", "epoch_ms", "epoch_us", "epoch_ns"
+	delimiter  string
+	skipRows   int
+}
+
+// importError wraps import errors with HTTP status context
+type importError struct {
+	StatusCode int
+	Message    string
+	Err        error
+}
+
+func (e *importError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Err)
+	}
+	return e.Message
+}
+
+// importFile uses DuckDB to read the uploaded file, partition by hour, and write to storage
+func (h *ImportHandler) importFile(ctx context.Context, dbName, measurement, filePath, tempDir string, opts importOptions) (*ImportResult, error) {
+	// Build the DuckDB read expression for the source file
+	readExpr := h.buildReadExpression(filePath, opts)
+
+	// 1. Validate schema — check that time column exists and get column list
+	columns, err := h.getColumns(readExpr)
+	if err != nil {
+		return nil, &importError{
+			StatusCode: fiber.StatusUnprocessableEntity,
+			Message:    "failed to read file",
+			Err:        err,
+		}
+	}
+
+	hasTimeCol := false
+	for _, col := range columns {
+		if col == opts.timeColumn {
+			hasTimeCol = true
+			break
+		}
+	}
+	if !hasTimeCol {
+		return nil, &importError{
+			StatusCode: fiber.StatusBadRequest,
+			Message:    fmt.Sprintf("time column %q not found in file; available columns: %s", opts.timeColumn, strings.Join(columns, ", ")),
+		}
+	}
+
+	// 2. Build time cast expression for normalization to TIMESTAMP
+	timeCast := h.buildTimeCast(opts.timeColumn, opts.timeFormat)
+
+	// 3. Get row count and time range
+	statsQuery := fmt.Sprintf(
+		"SELECT COUNT(*), MIN(%s)::VARCHAR, MAX(%s)::VARCHAR FROM %s",
+		timeCast, timeCast, readExpr,
+	)
+	rows, err := h.db.Query(statsQuery)
+	if err != nil {
+		return nil, &importError{
+			StatusCode: fiber.StatusUnprocessableEntity,
+			Message:    "failed to analyze file",
+			Err:        err,
+		}
+	}
+
+	var totalRows int64
+	var minTime, maxTime string
+	if rows.Next() {
+		if err := rows.Scan(&totalRows, &minTime, &maxTime); err != nil {
+			rows.Close()
+			return nil, &importError{
+				StatusCode: fiber.StatusUnprocessableEntity,
+				Message:    "failed to read file statistics",
+				Err:        err,
+			}
+		}
+	}
+	rows.Close()
+
+	if totalRows == 0 {
+		return nil, &importError{
+			StatusCode: fiber.StatusBadRequest,
+			Message:    "file contains no rows",
+		}
+	}
+
+	// 4. Get distinct hour partitions
+	partitionQuery := fmt.Sprintf(
+		"SELECT DISTINCT date_trunc('hour', %s)::VARCHAR AS partition_hour FROM %s ORDER BY partition_hour",
+		timeCast, readExpr,
+	)
+	partRows, err := h.db.Query(partitionQuery)
+	if err != nil {
+		return nil, &importError{
+			StatusCode: fiber.StatusInternalServerError,
+			Message:    "failed to determine partitions",
+			Err:        err,
+		}
+	}
+
+	var partitionHours []string
+	for partRows.Next() {
+		var hour string
+		if err := partRows.Scan(&hour); err != nil {
+			partRows.Close()
+			return nil, &importError{
+				StatusCode: fiber.StatusInternalServerError,
+				Message:    "failed to read partition hours",
+				Err:        err,
+			}
+		}
+		partitionHours = append(partitionHours, hour)
+	}
+	partRows.Close()
+
+	// 5. For each partition hour, COPY to a temp Parquet file, then upload to storage
+	outputDir := filepath.Join(tempDir, "output")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, &importError{
+			StatusCode: fiber.StatusInternalServerError,
+			Message:    "failed to create output directory",
+			Err:        err,
+		}
+	}
+
+	// Rename the time column to "time" if it has a different name, so Arc's
+	// standard schema always has a "time" column
+	selectExpr := "*"
+	if opts.timeColumn != "time" {
+		// Build column list, renaming the time column
+		var selectCols []string
+		for _, col := range columns {
+			if col == opts.timeColumn {
+				selectCols = append(selectCols, fmt.Sprintf("%s AS time", timeCast))
+			} else {
+				selectCols = append(selectCols, fmt.Sprintf("\"%s\"", col))
+			}
+		}
+		selectExpr = strings.Join(selectCols, ", ")
+	} else {
+		// Still need to cast time column for normalization
+		var selectCols []string
+		for _, col := range columns {
+			if col == "time" {
+				selectCols = append(selectCols, fmt.Sprintf("%s AS time", timeCast))
+			} else {
+				selectCols = append(selectCols, fmt.Sprintf("\"%s\"", col))
+			}
+		}
+		selectExpr = strings.Join(selectCols, ", ")
+	}
+
+	partitionsCreated := 0
+	for _, hourStr := range partitionHours {
+		// Parse the partition hour to construct Arc's storage path
+		partTime, err := time.Parse("2006-01-02 15:04:05", hourStr)
+		if err != nil {
+			// Try with timezone suffix
+			partTime, err = time.Parse("2006-01-02 15:04:05-07", hourStr)
+			if err != nil {
+				partTime, err = time.Parse("2006-01-02T15:04:05Z", hourStr)
+				if err != nil {
+					h.logger.Warn().Str("hour", hourStr).Msg("Failed to parse partition hour, skipping")
+					continue
+				}
+			}
+		}
+		partTime = partTime.UTC()
+
+		// Generate output Parquet file
+		outFile := filepath.Join(outputDir, fmt.Sprintf("part_%s.parquet", partTime.Format("20060102_150405")))
+
+		copyQuery := fmt.Sprintf(
+			"COPY (SELECT %s FROM %s WHERE date_trunc('hour', %s) = '%s' ORDER BY %s) TO '%s' (FORMAT PARQUET, COMPRESSION SNAPPY)",
+			selectExpr, readExpr, timeCast, hourStr, timeCast, escapeSQLString(outFile),
+		)
+
+		if _, err := h.db.Exec(copyQuery); err != nil {
+			return nil, &importError{
+				StatusCode: fiber.StatusInternalServerError,
+				Message:    fmt.Sprintf("failed to write partition %s", hourStr),
+				Err:        err,
+			}
+		}
+
+		// Read the generated Parquet file
+		parquetData, err := os.ReadFile(outFile)
+		if err != nil {
+			return nil, &importError{
+				StatusCode: fiber.StatusInternalServerError,
+				Message:    "failed to read generated parquet file",
+				Err:        err,
+			}
+		}
+
+		// Generate Arc-standard storage path
+		storagePath := generateStoragePath(dbName, measurement, partTime)
+
+		// Upload to storage backend
+		if err := h.storage.Write(ctx, storagePath, parquetData); err != nil {
+			return nil, &importError{
+				StatusCode: fiber.StatusInternalServerError,
+				Message:    fmt.Sprintf("failed to upload partition %s to storage", hourStr),
+				Err:        err,
+			}
+		}
+
+		h.logger.Debug().
+			Str("partition", hourStr).
+			Str("path", storagePath).
+			Int("size_bytes", len(parquetData)).
+			Msg("Partition uploaded")
+
+		partitionsCreated++
+	}
+
+	return &ImportResult{
+		Database:          dbName,
+		Measurement:       measurement,
+		RowsImported:      totalRows,
+		PartitionsCreated: partitionsCreated,
+		TimeRangeMin:      minTime,
+		TimeRangeMax:      maxTime,
+		Columns:           columns,
+	}, nil
+}
+
+// buildReadExpression builds the DuckDB read expression for the source file
+func (h *ImportHandler) buildReadExpression(filePath string, opts importOptions) string {
+	escaped := escapeSQLString(filePath)
+	switch opts.format {
+	case "csv":
+		parts := []string{fmt.Sprintf("'%s'", escaped)}
+		parts = append(parts, "auto_detect=true")
+		parts = append(parts, "header=true")
+		if opts.delimiter != "," {
+			parts = append(parts, fmt.Sprintf("delim='%s'", escapeSQLString(opts.delimiter)))
+		}
+		if opts.skipRows > 0 {
+			parts = append(parts, fmt.Sprintf("skip=%d", opts.skipRows))
+		}
+		return fmt.Sprintf("read_csv(%s)", strings.Join(parts, ", "))
+	case "parquet":
+		return fmt.Sprintf("read_parquet('%s')", escaped)
+	default:
+		return fmt.Sprintf("read_csv('%s', auto_detect=true)", escaped)
+	}
+}
+
+// buildTimeCast builds the SQL expression to cast the time column to TIMESTAMP
+func (h *ImportHandler) buildTimeCast(timeColumn, timeFormat string) string {
+	col := fmt.Sprintf("\"%s\"", timeColumn)
+	switch timeFormat {
+	case "epoch_s":
+		return fmt.Sprintf("to_timestamp(%s::BIGINT)", col)
+	case "epoch_ms":
+		return fmt.Sprintf("to_timestamp(%s::BIGINT / 1000.0)", col)
+	case "epoch_us":
+		return fmt.Sprintf("to_timestamp(%s::BIGINT / 1000000.0)", col)
+	case "epoch_ns":
+		return fmt.Sprintf("to_timestamp(%s::BIGINT / 1000000000.0)", col)
+	default:
+		// Auto-detect: DuckDB handles most timestamp formats natively
+		return fmt.Sprintf("%s::TIMESTAMP", col)
+	}
+}
+
+// getColumns returns the column names from the source file
+func (h *ImportHandler) getColumns(readExpr string) ([]string, error) {
+	query := fmt.Sprintf("SELECT column_name FROM (DESCRIBE %s)", readExpr)
+	rows, err := h.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var columns []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		columns = append(columns, name)
+	}
+	return columns, nil
+}
+
+// generateStoragePath creates an Arc-standard storage path for a partition
+// Format: {database}/{measurement}/{YYYY}/{MM}/{DD}/{HH}/{measurement}_{YYYYMMDD}_{HHMMSS}_{nanos}.parquet
+func generateStoragePath(dbName, measurement string, partitionTime time.Time) string {
+	year := partitionTime.Format("2006")
+	month := partitionTime.Format("01")
+	day := partitionTime.Format("02")
+	hour := partitionTime.Format("15")
+
+	now := time.Now().UTC()
+	timestamp := now.Format("20060102_150405")
+	nanos := now.UnixNano() % 1_000_000_000
+
+	return fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s_%s_%09d.parquet",
+		dbName, measurement, year, month, day, hour, measurement, timestamp, nanos)
+}
+
+// importErrorResponse returns the appropriate HTTP error response for an import error
+func (h *ImportHandler) importErrorResponse(c *fiber.Ctx, err error) error {
+	if ie, ok := err.(*importError); ok {
+		return c.Status(ie.StatusCode).JSON(fiber.Map{
+			"error": ie.Error(),
+		})
+	}
+	return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+		"error": err.Error(),
+	})
+}
+
+// escapeSQLString escapes single quotes for safe use in DuckDB SQL strings
+func escapeSQLString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// Stats returns import handler statistics
+func (h *ImportHandler) Stats(c *fiber.Ctx) error {
+	return c.JSON(fiber.Map{
+		"status": "success",
+		"stats": fiber.Map{
+			"total_requests": h.totalRequests.Load(),
+			"total_records":  h.totalRecords.Load(),
+			"total_errors":   h.totalErrors.Load(),
+		},
+	})
+}

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -1,0 +1,269 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/ingest"
+	"github.com/basekick-labs/arc/pkg/models"
+)
+
+func TestBuildReadExpression_CSV(t *testing.T) {
+	h := &ImportHandler{}
+
+	tests := []struct {
+		name     string
+		opts     importOptions
+		expected string
+	}{
+		{
+			name: "default CSV",
+			opts: importOptions{format: "csv", delimiter: ","},
+			expected: "read_csv('/tmp/test.csv', auto_detect=true, header=true)",
+		},
+		{
+			name: "tab delimiter",
+			opts: importOptions{format: "csv", delimiter: "\t"},
+			expected: "read_csv('/tmp/test.csv', auto_detect=true, header=true, delim='\t')",
+		},
+		{
+			name: "skip rows",
+			opts: importOptions{format: "csv", delimiter: ",", skipRows: 2},
+			expected: "read_csv('/tmp/test.csv', auto_detect=true, header=true, skip=2)",
+		},
+		{
+			name: "semicolon with skip",
+			opts: importOptions{format: "csv", delimiter: ";", skipRows: 1},
+			expected: "read_csv('/tmp/test.csv', auto_detect=true, header=true, delim=';', skip=1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.buildReadExpression("/tmp/test.csv", tt.opts)
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildReadExpression_Parquet(t *testing.T) {
+	h := &ImportHandler{}
+
+	result := h.buildReadExpression("/tmp/test.parquet", importOptions{format: "parquet"})
+	expected := "read_parquet('/tmp/test.parquet')"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+func TestBuildTimeCast(t *testing.T) {
+	h := &ImportHandler{}
+
+	tests := []struct {
+		name       string
+		timeCol    string
+		timeFormat string
+		expected   string
+	}{
+		{"auto detect", "time", "", `"time"::TIMESTAMP`},
+		{"epoch seconds", "ts", "epoch_s", `to_timestamp("ts"::BIGINT)`},
+		{"epoch milliseconds", "timestamp", "epoch_ms", `to_timestamp("timestamp"::BIGINT / 1000.0)`},
+		{"epoch microseconds", "time", "epoch_us", `to_timestamp("time"::BIGINT / 1000000.0)`},
+		{"epoch nanoseconds", "time", "epoch_ns", `to_timestamp("time"::BIGINT / 1000000000.0)`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.buildTimeCast(tt.timeCol, tt.timeFormat)
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateStoragePath(t *testing.T) {
+	partTime := time.Date(2025, 3, 15, 14, 0, 0, 0, time.UTC)
+	path := generateStoragePath("mydb", "cpu", partTime)
+
+	// Check prefix structure
+	prefix := "mydb/cpu/2025/03/15/14/cpu_"
+	if len(path) < len(prefix) || path[:len(prefix)] != prefix {
+		t.Errorf("path %q does not start with expected prefix %q", path, prefix)
+	}
+
+	// Check it ends with .parquet
+	if path[len(path)-8:] != ".parquet" {
+		t.Errorf("path %q does not end with .parquet", path)
+	}
+}
+
+func TestGenerateStoragePath_DifferentHours(t *testing.T) {
+	tests := []struct {
+		name           string
+		partTime       time.Time
+		expectedPrefix string
+	}{
+		{
+			"midnight",
+			time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			"db/metric/2025/01/01/00/metric_",
+		},
+		{
+			"noon",
+			time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC),
+			"db/metric/2025/06/15/12/metric_",
+		},
+		{
+			"end of day",
+			time.Date(2025, 12, 31, 23, 0, 0, 0, time.UTC),
+			"db/metric/2025/12/31/23/metric_",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := generateStoragePath("db", "metric", tt.partTime)
+			if path[:len(tt.expectedPrefix)] != tt.expectedPrefix {
+				t.Errorf("got prefix %q, want %q", path[:len(tt.expectedPrefix)], tt.expectedPrefix)
+			}
+		})
+	}
+}
+
+func TestPrecisionTimestampAdjustment(t *testing.T) {
+	// ParseBatchWithPrecision converts raw timestamps to μs based on precision.
+	parser := ingest.NewLineProtocolParser()
+
+	tests := []struct {
+		name       string
+		precision  string
+		lpLine     string
+		expectedUs int64
+	}{
+		{
+			name:       "nanosecond precision (default)",
+			precision:  "ns",
+			lpLine:     "cpu value=1.0 1609459200000000000", // 2021-01-01T00:00:00Z in ns
+			expectedUs: 1609459200000000,
+		},
+		{
+			name:       "microsecond precision",
+			precision:  "us",
+			lpLine:     "cpu value=1.0 1609459200000000", // 2021-01-01T00:00:00Z in μs
+			expectedUs: 1609459200000000,
+		},
+		{
+			name:       "millisecond precision",
+			precision:  "ms",
+			lpLine:     "cpu value=1.0 1609459200000", // 2021-01-01T00:00:00Z in ms
+			expectedUs: 1609459200000000,
+		},
+		{
+			name:       "second precision",
+			precision:  "s",
+			lpLine:     "cpu value=1.0 1609459200", // 2021-01-01T00:00:00Z in s
+			expectedUs: 1609459200000000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			records := parser.ParseBatchWithPrecision([]byte(tt.lpLine), tt.precision)
+			if len(records) != 1 {
+				t.Fatalf("expected 1 record, got %d", len(records))
+			}
+
+			if records[0].Timestamp != tt.expectedUs {
+				t.Errorf("precision %s: got timestamp %d μs, want %d μs",
+					tt.precision, records[0].Timestamp, tt.expectedUs)
+			}
+		})
+	}
+}
+
+func TestParseBatchToColumnar_RoundTrip(t *testing.T) {
+	parser := ingest.NewLineProtocolParser()
+
+	lpData := []byte("cpu,host=server01 value=0.64,load=1.5 1609459200000000000\n" +
+		"cpu,host=server02 value=0.72,load=2.1 1609459200000000000\n" +
+		"mem,host=server01 used=1024 1609459200000000000\n")
+
+	records := parser.ParseBatch(lpData)
+	if len(records) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+
+	columnar := ingest.BatchToColumnar(records)
+
+	// Should have 2 measurements
+	if len(columnar) != 2 {
+		t.Fatalf("expected 2 measurements, got %d", len(columnar))
+	}
+
+	// cpu should have 2 rows
+	cpuCols, ok := columnar["cpu"]
+	if !ok {
+		t.Fatal("missing 'cpu' measurement")
+	}
+	if timeCols, ok := cpuCols["time"]; !ok || len(timeCols) != 2 {
+		t.Errorf("cpu: expected 2 time values, got %d", len(cpuCols["time"]))
+	}
+
+	// mem should have 1 row
+	memCols, ok := columnar["mem"]
+	if !ok {
+		t.Fatal("missing 'mem' measurement")
+	}
+	if timeCols, ok := memCols["time"]; !ok || len(timeCols) != 1 {
+		t.Errorf("mem: expected 1 time value, got %d", len(memCols["time"]))
+	}
+}
+
+func TestMeasurementFilter(t *testing.T) {
+	parser := ingest.NewLineProtocolParser()
+
+	lpData := []byte("cpu,host=a value=1.0 1609459200000000000\n" +
+		"mem,host=a used=1024 1609459200000000000\n" +
+		"cpu,host=b value=2.0 1609459200000000000\n")
+
+	records := parser.ParseBatch(lpData)
+
+	// Filter to cpu only
+	filtered := make([]*models.Record, 0)
+	for _, r := range records {
+		if r.Measurement == "cpu" {
+			filtered = append(filtered, r)
+		}
+	}
+
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 cpu records after filter, got %d", len(filtered))
+	}
+	for _, r := range filtered {
+		if r.Measurement != "cpu" {
+			t.Errorf("expected measurement 'cpu', got %q", r.Measurement)
+		}
+	}
+}
+
+func TestEscapeSQLString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"normal", "normal"},
+		{"it's", "it''s"},
+		{"a'b'c", "a''b''c"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		result := escapeSQLString(tt.input)
+		if result != tt.expected {
+			t.Errorf("escapeSQLString(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
Add POST /api/v1/import/lp endpoint that accepts multipart LP file uploads and routes data through Arc's high-performance ArrowBuffer ingest pipeline (same path as streaming LP ingestion). Supports gzip auto-detection, precision-aware timestamps (ns/us/ms/s), multi-measurement files, RBAC checks, and a 500MB size limit.

Key changes:
- internal/api/import.go: LP handler with ArrowBuffer pipeline, gzip decompression, database/measurement name validation (path traversal prevention), typed LPImportResult response
- internal/ingest/lineprotocol.go: ParseBatchWithPrecision() for lossless timestamp conversion; refactored ParseLine to delegate to shared parseLineWithPrecision (DRY)
- cmd/arc/main.go: Wire ImportHandler with ArrowBuffer, auth, RBAC
- internal/api/import_test.go: Tests for precision, columnar round-trip, measurement filter