### PR TITLE
perf(ingest): optimize TLE hot path with typed columnar bypass

### DIFF
--- a/RELEASE_NOTES_2026.03.1.md
+++ b/RELEASE_NOTES_2026.03.1.md
@@ -237,6 +237,8 @@ curl -X POST "http://localhost:8000/api/v1/write/tle" \
 - RBAC-aware, cluster routing enabled
 - 500 MB size limit on bulk imports
 
+**Performance:** TLE ingestion uses a typed columnar fast path that bypasses the `[]interface{}` intermediary and `convertColumnsToTyped` pass used by generic ingestion. The parser operates directly on `[]byte` input with contiguous record allocation and single-pass typed column construction, achieving ~3.5M records/sec on commodity hardware.
+
 **Example query:**
 ```sql
 SELECT object_name, orbit_type, period_min, perigee_km, apogee_km


### PR DESCRIPTION
## Summary
- **Eliminate double iteration** through `[]interface{}` intermediary: `TLERecordsToTypedColumnar` returns `*TypedColumnBatch` with concrete `[]int64`, `[]float64`, `[]string` slices directly — bypasses `convertColumnsToTyped` entirely via new `WriteTypedColumnarDirect` method
- **Optimize parser hot path**: `ParseTLEFile` now uses `bytes.Split` on raw `[]byte` input (eliminates 3-4 full-payload string copies), contiguous `[]TLERecord` allocation (eliminates per-record heap allocs), and in-place fill
- **WAL support**: `typedBatchToWALRecords` converts typed slices back to row format when WAL is enabled — zero cost on the no-WAL streaming path

### Before (3.5M rec/sec)
```
THROUGHPUT:   3534832 satellite records/sec
Latency: p50=0.30ms  p99=2.91ms
```

### After (4.6M rec/sec — +30%)
```
THROUGHPUT:   4599830 satellite records/sec
Latency: p50=1.89ms  p95=6.86ms  p99=13.24ms
```

## Test plan
- [x] `go build ./cmd/... ./internal/...`
- [x] `go test ./internal/ingest/... -run TLE` — all 8 TLE tests pass
- [x] Benchmark: 10 workers, 100 satellites, 30s sustained — 4.6M rec/sec, 0 errors
- [x] Post-implementation security + code quality review (2 parallel agents)
- [x] Review findings addressed: missing debug/info logs in typed path, `trimRightSpaces` → `trimSpaces` rename