### PR TITLE
fix(query): unify cache_httpfs TTLs with s3_cache_ttl_seconds (#214)

### DIFF
--- a/RELEASE_NOTES_2026.03.1.md
+++ b/RELEASE_NOTES_2026.03.1.md
@@ -44,6 +44,12 @@ Fixed a bug where `time_bucket()` and `date_trunc()` GROUP BY queries returned o
 
 *Reported by [@khalid244](https://github.com/khalid244) — thank you!*
 
+### Unified cache_httpfs TTLs and Scaled Cache Sizes (#214)
+
+DuckDB's `cache_httpfs` glob, metadata, and file handle caches are now properly tuned. Metadata and file handle TTLs match `s3_cache_ttl_seconds` (these reference immutable parquet files). Glob TTL is fixed at 10 seconds — directory listings change during compaction, and S3 LIST overhead is negligible. Cache sizes now scale proportionally with `s3_cache_size` (glob: 5% of block count, metadata/file handles: 10%), with floors at DuckDB defaults for small deployments. No new config settings.
+
+*Reported by [@khalid244](https://github.com/khalid244) — thank you!*
+
 ## New Features
 
 ### Backup & Restore API

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -237,6 +237,21 @@ func configureS3Access(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 					if _, err := db.Exec(fmt.Sprintf("SET GLOBAL cache_httpfs_max_in_mem_cache_block_count=%d", maxBlocks)); err != nil {
 						logger.Warn().Err(err).Int64("max_blocks", maxBlocks).Msg("Failed to set cache_httpfs_max_in_mem_cache_block_count")
 					}
+					// Scale glob/metadata/file-handle cache sizes proportionally.
+					// A 7-day hourly query generates ~168 glob patterns — the default
+					// 64 entries causes constant eviction on large deployments.
+					globEntries := max(maxBlocks/20, 64)      // ~5% of blocks, floor at default
+					metadataEntries := max(maxBlocks/10, 250)  // ~10% of blocks, floor at default
+					fileHandleEntries := max(maxBlocks/10, 250)
+					if _, err := db.Exec(fmt.Sprintf("SET GLOBAL cache_httpfs_glob_cache_entry_size=%d", globEntries)); err != nil {
+						logger.Warn().Err(err).Msg("Failed to set cache_httpfs_glob_cache_entry_size")
+					}
+					if _, err := db.Exec(fmt.Sprintf("SET GLOBAL cache_httpfs_metadata_cache_entry_size=%d", metadataEntries)); err != nil {
+						logger.Warn().Err(err).Msg("Failed to set cache_httpfs_metadata_cache_entry_size")
+					}
+					if _, err := db.Exec(fmt.Sprintf("SET GLOBAL cache_httpfs_file_handle_cache_entry_size=%d", fileHandleEntries)); err != nil {
+						logger.Warn().Err(err).Msg("Failed to set cache_httpfs_file_handle_cache_entry_size")
+					}
 				} else {
 					logger.Warn().
 						Int64("configured_bytes", cfg.S3CacheSize).
@@ -244,9 +259,23 @@ func configureS3Access(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 				}
 			}
 			if cfg.S3CacheTTLSeconds > 0 {
-				if _, err := db.Exec(fmt.Sprintf("SET GLOBAL cache_httpfs_in_mem_cache_block_timeout_millisec=%d", cfg.S3CacheTTLSeconds*1000)); err != nil {
-					logger.Warn().Err(err).Int("ttl_ms", cfg.S3CacheTTLSeconds*1000).Msg("Failed to set cache_httpfs_in_mem_cache_block_timeout_millisec")
+				ttlMs := cfg.S3CacheTTLSeconds * 1000
+				if _, err := db.Exec(fmt.Sprintf("SET GLOBAL cache_httpfs_in_mem_cache_block_timeout_millisec=%d", ttlMs)); err != nil {
+					logger.Warn().Err(err).Int("ttl_ms", ttlMs).Msg("Failed to set cache_httpfs_in_mem_cache_block_timeout_millisec")
 				}
+				// Metadata and file handle TTLs match s3_cache_ttl_seconds — these
+				// reference immutable individual parquet files.
+				if _, err := db.Exec(fmt.Sprintf("SET GLOBAL cache_httpfs_metadata_cache_entry_timeout_millisec=%d", ttlMs)); err != nil {
+					logger.Warn().Err(err).Msg("Failed to set cache_httpfs_metadata_cache_entry_timeout_millisec")
+				}
+				if _, err := db.Exec(fmt.Sprintf("SET GLOBAL cache_httpfs_file_handle_cache_entry_timeout_millisec=%d", ttlMs)); err != nil {
+					logger.Warn().Err(err).Msg("Failed to set cache_httpfs_file_handle_cache_entry_timeout_millisec")
+				}
+			}
+			// Glob TTL: 10s — directory listings change during compaction and S3 LIST
+			// overhead is negligible. Post-compaction invalidation handles the rest.
+			if _, err := db.Exec("SET GLOBAL cache_httpfs_glob_cache_entry_timeout_millisec=10000"); err != nil {
+				logger.Warn().Err(err).Msg("Failed to set cache_httpfs_glob_cache_entry_timeout_millisec")
 			}
 			logger.Info().
 				Int64("cache_size_bytes", cfg.S3CacheSize).


### PR DESCRIPTION
- Metadata and file handle cache TTLs linked to s3_cache_ttl_seconds (these reference immutable individual parquet files)
- Glob cache TTL fixed at 10s (directory listings change during compaction, S3 LIST overhead is negligible)
- Cache sizes scale proportionally with s3_cache_size: glob ~5% of block count, metadata/file handles ~10%, with floors at defaults

No new config settings — all four cache layers are now properly tuned.