### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.6'
+          go-version: '1.26'
           cache: true
 
       - name: Build binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ARG VERSION=dev
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 
 WORKDIR /build
 

--- a/RELEASE_NOTES_2026.03.1.md
+++ b/RELEASE_NOTES_2026.03.1.md
@@ -50,6 +50,17 @@ DuckDB's `cache_httpfs` glob, metadata, and file handle caches are now properly 
 
 *Reported by [@khalid244](https://github.com/khalid244) — thank you!*
 
+## Infrastructure
+
+### Go 1.26 Upgrade
+
+Upgraded from Go 1.25.6 to Go 1.26. Key runtime improvements:
+
+- **Green Tea GC**: 10–40% reduction in GC overhead (enabled by default)
+- **30% faster cgo calls**: Benefits every DuckDB query and SQLite operation
+- **2x faster `io.ReadAll`**: Improves S3/Azure storage reads and HTTP response parsing
+- **Stack allocation for slice backing stores**: Compiler can stack-allocate more slices, reducing heap pressure in hot paths
+
 ## New Features
 
 ### Backup & Restore API

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basekick-labs/arc
 
-go 1.25.6
+go 1.26
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.25.6 to 1.26 (`go.mod`, `Dockerfile`, CI workflow)
- Free runtime improvements with zero code changes:
  - **Green Tea GC**: 10–40% less GC overhead
  - **30% faster cgo**: every DuckDB query and SQLite op
  - **2x faster `io.ReadAll`**: S3/Azure reads, HTTP parsing
  - **Stack-allocated slices**: less heap pressure in hot paths

## Test plan
- [x] `go build ./cmd/... ./internal/...` — clean
- [x] `go mod tidy` — no dependency changes
- [x] Sustained ingestion benchmark: **18.4M rec/sec**, 0 errors, no degradation
- [x] duckdb-go v2 requires `go 1.24.0` — compatible
- [x] go-sqlite3 updated Jan 2026 — compatible