### PR TITLE
fix: consolidate compaction schedulers to prevent daily tier starvation

### DIFF
--- a/internal/api/compaction.go
+++ b/internal/api/compaction.go
@@ -13,19 +13,17 @@ import (
 
 // CompactionHandler handles compaction API endpoints
 type CompactionHandler struct {
-	manager         *compaction.Manager
-	hourlyScheduler *compaction.Scheduler
-	dailyScheduler  *compaction.Scheduler
-	logger          zerolog.Logger
+	manager   *compaction.Manager
+	scheduler *compaction.Scheduler
+	logger    zerolog.Logger
 }
 
 // NewCompactionHandler creates a new compaction handler
-func NewCompactionHandler(manager *compaction.Manager, hourlyScheduler, dailyScheduler *compaction.Scheduler, logger zerolog.Logger) *CompactionHandler {
+func NewCompactionHandler(manager *compaction.Manager, scheduler *compaction.Scheduler, logger zerolog.Logger) *CompactionHandler {
 	return &CompactionHandler{
-		manager:         manager,
-		hourlyScheduler: hourlyScheduler,
-		dailyScheduler:  dailyScheduler,
-		logger:          logger.With().Str("component", "compaction-handler").Logger(),
+		manager:   manager,
+		scheduler: scheduler,
+		logger:    logger.With().Str("component", "compaction-handler").Logger(),
 	}
 }
 
@@ -58,13 +56,10 @@ func (h *CompactionHandler) getStatus(c *fiber.Ctx) error {
 		},
 	}
 
-	// Add scheduler status for each tier
+	// Add scheduler status
 	schedulers := fiber.Map{}
-	if h.hourlyScheduler != nil {
-		schedulers["hourly"] = h.hourlyScheduler.Status()
-	}
-	if h.dailyScheduler != nil {
-		schedulers["daily"] = h.dailyScheduler.Status()
+	if h.scheduler != nil {
+		schedulers["compaction"] = h.scheduler.Status()
 	}
 	response["schedulers"] = schedulers
 

--- a/internal/compaction/scheduler.go
+++ b/internal/compaction/scheduler.go
@@ -192,9 +192,10 @@ func (s *Scheduler) Status() map[string]interface{} {
 	defer s.mu.Unlock()
 
 	status := map[string]interface{}{
-		"enabled":  s.enabled,
-		"running":  s.running,
-		"schedule": s.schedule,
+		"enabled":    s.enabled,
+		"running":    s.running,
+		"schedule":   s.schedule,
+		"tier_names": s.tierNames,
 	}
 
 	if s.running {


### PR DESCRIPTION
Two separate Scheduler instances sharing a single Manager (and its cycleRunning atomic) caused the daily tier to silently skip whenever an hourly cycle was in progress. Since hourly fires 24x/day and daily fires once at 3 AM, daily could be starved indefinitely.

Replace the two schedulers with a single scheduler that processes all enabled tiers sequentially in one cycle. RunCompactionCycleForTiers already handles sequential tier processing, so the only change needed is at the scheduler level. The combined scheduler uses the hourly schedule so daily is evaluated every hour (the tier's own MinFiles / MinAgeHours guards prevent spurious compaction), with a fallback to the daily schedule when only the daily tier is configured.

Also exposes tier_names in Scheduler.Status() for observability, and updates the compaction API handler to accept a single scheduler.

Fixes #220