### PR TITLE
fix(compaction): prevent orphaned files from manifest cleanup bugs

### DIFF
--- a/internal/compaction/manager.go
+++ b/internal/compaction/manager.go
@@ -834,8 +834,8 @@ func (m *Manager) filterCandidateFiles(ctx context.Context, candidate Candidate)
 
 	filesInManifests, err := m.ManifestManager.GetFilesInManifests(ctx)
 	if err != nil {
-		m.logger.Warn().Err(err).Msg("Failed to get files in manifests, proceeding without filtering")
-		return candidate, len(candidate.Files) > 0
+		m.logger.Warn().Err(err).Msg("Failed to get files in manifests, skipping partition to avoid re-compaction")
+		return candidate, false
 	}
 
 	if len(filesInManifests) == 0 {


### PR DESCRIPTION
## Summary

Fixes #240 — Three bugs in the compaction manifest system could leave orphaned input files alongside compacted output files, causing queries to return duplicated data.

- **Stale manifest deletion skipped input file cleanup** — Manifests older than 7 days were deleted without removing tracked input files. Now follows the same recovery path as normal manifests (verify output → delete inputs → delete manifest).
- **Manifest deleted despite failed input file deletion** — Recovery deleted the manifest unconditionally even when some input files failed to delete. Now keeps the manifest for retry on the next recovery cycle.
- **Manifest filtering skipped on error** — When `GetFilesInManifests()` failed, candidates were returned unfiltered, risking re-compaction of in-progress files. Now skips the partition entirely.

## Test plan

- [x] `go test ./internal/compaction/... -v` — all tests pass
- [x] `go build ./cmd/... ./internal/...` — compiles cleanly
- [ ] Verify stale manifest recovery cleans up input files before deleting manifest
- [ ] Verify manifest is retained when input file deletion fails