### PR TITLE
fix(mqtt): make CleanSession configurable, default to false (#239)

### DIFF
--- a/internal/mqtt/manager.go
+++ b/internal/mqtt/manager.go
@@ -162,6 +162,7 @@ func (m *SubscriptionManager) Create(ctx context.Context, req *CreateSubscriptio
 		ConnectTimeoutSeconds: req.ConnectTimeoutSeconds,
 		ReconnectMinSeconds:   req.ReconnectMinSeconds,
 		ReconnectMaxSeconds:   req.ReconnectMaxSeconds,
+		CleanSession:          req.CleanSession,
 		Status:                StatusStopped,
 	}
 
@@ -285,6 +286,9 @@ func (m *SubscriptionManager) Update(ctx context.Context, id string, req *Update
 	}
 	if req.ReconnectMaxSeconds != nil {
 		sub.ReconnectMaxSeconds = *req.ReconnectMaxSeconds
+	}
+	if req.CleanSession != nil {
+		sub.CleanSession = *req.CleanSession
 	}
 
 	// Validate updated subscription

--- a/internal/mqtt/subscriber.go
+++ b/internal/mqtt/subscriber.go
@@ -88,7 +88,7 @@ func (s *Subscriber) Start() error {
 	s.client = pahomqtt.NewClient(opts)
 
 	// Connect
-	s.logger.Info().Str("broker", s.config.Broker).Msg("Connecting to MQTT broker")
+	s.logger.Info().Str("broker", s.config.Broker).Bool("clean_session", s.config.CleanSession).Msg("Connecting to MQTT broker")
 
 	token := s.client.Connect()
 	if !token.WaitTimeout(time.Duration(s.config.ConnectTimeoutSeconds) * time.Second) {
@@ -209,8 +209,8 @@ func (s *Subscriber) buildClientOptions() (*pahomqtt.ClientOptions, error) {
 	opts.SetConnectionLostHandler(s.onConnectionLost)
 	opts.SetReconnectingHandler(s.onReconnecting)
 
-	// Clean session
-	opts.SetCleanSession(true)
+	// Clean session — default false preserves QoS=1 at-least-once delivery across reconnects
+	opts.SetCleanSession(s.config.CleanSession)
 
 	return opts, nil
 }

--- a/internal/mqtt/subscription.go
+++ b/internal/mqtt/subscription.go
@@ -54,6 +54,7 @@ type Subscription struct {
 	ConnectTimeoutSeconds int                `json:"connect_timeout_seconds"`
 	ReconnectMinSeconds   int                `json:"reconnect_min_seconds"`
 	ReconnectMaxSeconds   int                `json:"reconnect_max_seconds"`
+	CleanSession          bool               `json:"clean_session"`
 	CreatedAt             time.Time          `json:"created_at"`
 	UpdatedAt             time.Time          `json:"updated_at"`
 }
@@ -79,6 +80,7 @@ type CreateSubscriptionRequest struct {
 	ConnectTimeoutSeconds int               `json:"connect_timeout_seconds"`
 	ReconnectMinSeconds   int               `json:"reconnect_min_seconds"`
 	ReconnectMaxSeconds   int               `json:"reconnect_max_seconds"`
+	CleanSession          bool              `json:"clean_session"`
 }
 
 // UpdateSubscriptionRequest is the request body for updating a subscription
@@ -102,6 +104,7 @@ type UpdateSubscriptionRequest struct {
 	ConnectTimeoutSeconds *int               `json:"connect_timeout_seconds,omitempty"`
 	ReconnectMinSeconds   *int               `json:"reconnect_min_seconds,omitempty"`
 	ReconnectMaxSeconds   *int               `json:"reconnect_max_seconds,omitempty"`
+	CleanSession          *bool              `json:"clean_session,omitempty"`
 }
 
 // SubscriptionStats contains runtime statistics for a subscription
@@ -274,6 +277,7 @@ func ValidateCreateRequest(req *CreateSubscriptionRequest) error {
 		ConnectTimeoutSeconds: req.ConnectTimeoutSeconds,
 		ReconnectMinSeconds:   req.ReconnectMinSeconds,
 		ReconnectMaxSeconds:   req.ReconnectMaxSeconds,
+		CleanSession:          req.CleanSession,
 	}
 	s.SetDefaults()
 	return s.Validate()


### PR DESCRIPTION
## Summary

- `CleanSession` was hardcoded to `true` in `subscriber.go`, which told the MQTT broker to discard unacknowledged messages on disconnect — silently breaking QoS=1 at-least-once delivery across reconnects
- Now configurable per subscription via `clean_session` API field, defaulting to `false` (persistent sessions)
- Added SQLite migration for existing databases (column defaults to `0`)
- Logs `clean_session` value on connect for debugging

## Test plan

- [x] `go build ./cmd/... ./internal/...` passes
- [x] `go test ./internal/mqtt/... -v` passes
- [x] Security review: parameterized SQL, safe migration, admin-only API
- [x] Code quality review: consistent with existing patterns (TLSEnabled, AutoStart)

Closes #239