### PR TITLE
chore: suppress CodeQL false positives

### DIFF
--- a/benchmarks/c_bench/sustained_bench.c
+++ b/benchmarks/c_bench/sustained_bench.c
@@ -586,9 +586,9 @@ int main(int argc, char *argv[]) {
     /* Create stats */
     stats_t *stats = stats_create(1000000);  /* 1M latency samples */
 
-    /* Build URL and headers */
+    /* Build URL and headers — benchmark tool uses plain HTTP for local testing; not production code */
     char url[256];
-    snprintf(url, sizeof(url), "http://%s:%d/api/v1/write/msgpack", cfg.host, cfg.port);
+    snprintf(url, sizeof(url), "http://%s:%d/api/v1/write/msgpack", cfg.host, cfg.port); /* lgtm[cpp/non-https-url] */
 
     struct curl_slist *headers = NULL;
     headers = curl_slist_append(headers, "Content-Type: application/msgpack");

--- a/benchmarks/sustained_bench/main.go
+++ b/benchmarks/sustained_bench/main.go
@@ -857,7 +857,8 @@ func main() {
 		DisableKeepAlives:   false,
 	}
 	if cfg.TLS {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		// Benchmark tool only — connects to local/dev instances with self-signed certs
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
 	}
 	// Resolve *.localhost to 127.0.0.1 (browsers do this per RFC 6761, Go doesn't)
 	if strings.HasSuffix(cfg.Host, ".localhost") {

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -264,13 +264,13 @@ func toInt64(v interface{}) (int64, bool) {
 		if val > float32(math.MaxInt64) || val < float32(math.MinInt64) {
 			return 0, false
 		}
-		return int64(val), true
+		return int64(val), true //nolint:gosec // Bounds checked above
 	case float64:
 		// Bounds check required before conversion to int64
 		if val > float64(math.MaxInt64) || val < float64(math.MinInt64) {
 			return 0, false
 		}
-		return int64(val), true
+		return int64(val), true //nolint:gosec // Bounds checked above
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
## Summary
- Add `//nolint:gosec` to `InsecureSkipVerify` in benchmark tool (not production code)
- Add `//nolint:gosec` to float-to-int64 conversions that already have bounds checks in `arrow_writer.go`
- Add `/* lgtm */` comment to hardcoded `http://` URL in C benchmark (local testing only)
- `internal/auth/auth.go` already has `#nosec G401` comments — no changes needed

Addresses all 7 open CodeQL alerts (#5, #6, #8, #9, #10, #11, #12).

## Test plan
- [x] `go build ./cmd/... ./internal/...` passes
- [ ] CodeQL re-scan after merge shows reduced/dismissed alerts