### PR TITLE
feat(bench): add ClickHouse targets to sustained_bench

### DIFF
--- a/benchmarks/sustained_bench/main.go
+++ b/benchmarks/sustained_bench/main.go
@@ -1,11 +1,14 @@
 // Sustained load benchmark for Arc ingestion
-// Usage: go run benchmarks/sustained_bench.go [flags]
+// Usage: go run benchmarks/sustained_bench/main.go [flags]
 //
 // Examples:
-//   go run benchmarks/sustained_bench.go --duration 30
-//   go run benchmarks/sustained_bench.go --duration 60 --workers 200 --compress zstd
-//   go run benchmarks/sustained_bench.go --batch-size 5000 --compress gzip
-//   go run benchmarks/sustained_bench.go --protocol lineprotocol --workers 20
+//   go run benchmarks/sustained_bench/main.go --duration 30
+//   go run benchmarks/sustained_bench/main.go --duration 60 --workers 200 --compress zstd
+//   go run benchmarks/sustained_bench/main.go --batch-size 5000 --compress gzip
+//   go run benchmarks/sustained_bench/main.go --protocol lineprotocol --workers 20
+//   go run benchmarks/sustained_bench/main.go --target clickhouse --data-type iot --duration 60
+//   go run benchmarks/sustained_bench/main.go --target clickhouse --data-type iot --batch-size 100000 --workers 10
+//   go run benchmarks/sustained_bench/main.go --target clickhouse --data-type iot --async-insert --workers 50
 
 package main
 
@@ -14,6 +17,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -29,6 +33,7 @@ import (
 	"time"
 
 	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/klauspost/compress/zstd"
 )
 
@@ -41,8 +46,12 @@ type Config struct {
 	ZstdLevel   int
 	DataType    string
 	Protocol    string // "msgpack" or "lineprotocol"
+	Target      string // "arc" or "clickhouse"
 	Host        string
 	Port        int
+	CHPort      int
+	Database    string
+	AsyncInsert bool
 	Token       string
 	TLS         bool
 }
@@ -670,6 +679,527 @@ func generateFinancialBatches(count, batchSize int, compress string, zstdLevel i
 	return batches
 }
 
+// ClickHouse table schemas per data type
+var clickHouseSchemas = map[string]struct {
+	table  string
+	create string
+}{
+	"iot": {
+		table: "cpu",
+		create: `CREATE TABLE IF NOT EXISTS cpu (
+			time DateTime64(6),
+			host String,
+			value Float64,
+			cpu_idle Float64,
+			cpu_user Float64
+		) ENGINE = MergeTree() ORDER BY (host, time)`,
+	},
+	"financial": {
+		table: "trades",
+		create: `CREATE TABLE IF NOT EXISTS trades (
+			time DateTime64(6),
+			symbol String,
+			exchange String,
+			price Float64,
+			bid Float64,
+			ask Float64,
+			bid_size Int64,
+			ask_size Int64,
+			volume Int64,
+			trade_id Int64
+		) ENGINE = MergeTree() ORDER BY (symbol, time)`,
+	},
+	"industrial": {
+		table: "pump_telemetry",
+		create: `CREATE TABLE IF NOT EXISTS pump_telemetry (
+			time DateTime64(6),
+			pump_id String,
+			facility String,
+			pump_type String,
+			flow_rate Float64,
+			pressure_in Float64,
+			pressure_out Float64,
+			temperature Float64,
+			vibration Float64,
+			current Float64,
+			rpm Int64,
+			power Float64
+		) ENGINE = MergeTree() ORDER BY (pump_id, time)`,
+	},
+	"aerospace": {
+		table: "rocket_telemetry",
+		create: `CREATE TABLE IF NOT EXISTS rocket_telemetry (
+			time DateTime64(6),
+			sensor_id String,
+			value Float64
+		) ENGINE = MergeTree() ORDER BY (sensor_id, time)`,
+	},
+	"energy": {
+		table: "wind_turbine",
+		create: `CREATE TABLE IF NOT EXISTS wind_turbine (
+			time DateTime64(6),
+			turbine_id String,
+			farm String,
+			wind_speed Float64,
+			wind_direction Float64,
+			rotor_rpm Float64,
+			power_output Float64,
+			blade_pitch Float64,
+			nacelle_temp Float64,
+			generator_temp Float64
+		) ENGINE = MergeTree() ORDER BY (turbine_id, time)`,
+	},
+	"racing": {
+		table: "car_telemetry",
+		create: `CREATE TABLE IF NOT EXISTS car_telemetry (
+			time DateTime64(6),
+			car_number String,
+			driver String,
+			speed Float64,
+			engine_rpm Float64,
+			throttle Float64,
+			brake Float64,
+			steering Float64,
+			gear Int64
+		) ENGINE = MergeTree() ORDER BY (car_number, time)`,
+	},
+}
+
+func ensureClickHouseTable(conn clickhouse.Conn, dataType string) (string, error) {
+	schema, ok := clickHouseSchemas[dataType]
+	if !ok {
+		return "", fmt.Errorf("unsupported data type for ClickHouse: %s", dataType)
+	}
+	if err := conn.Exec(context.Background(), schema.create); err != nil {
+		return "", fmt.Errorf("create table: %w", err)
+	}
+	return schema.table, nil
+}
+
+// Columnar batch for ClickHouse native protocol.
+// Each column is a typed slice matching the CREATE TABLE column order.
+type columnBatch struct {
+	columns []interface{} // Each element is a typed slice ([]time.Time, []string, []float64, []int64)
+}
+
+func generateIOTColumnBatches(count, batchSize int) []columnBatch {
+	hosts := make([]string, 1000)
+	for i := range hosts {
+		hosts[i] = fmt.Sprintf("server%03d", i)
+	}
+
+	batches := make([]columnBatch, count)
+	for i := 0; i < count; i++ {
+		now := time.Now()
+		times := make([]time.Time, batchSize)
+		hostVals := make([]string, batchSize)
+		values := make([]float64, batchSize)
+		cpuIdle := make([]float64, batchSize)
+		cpuUser := make([]float64, batchSize)
+
+		for j := 0; j < batchSize; j++ {
+			times[j] = now.Add(time.Duration(j) * time.Microsecond)
+			hostVals[j] = hosts[rand.Intn(len(hosts))]
+			values[j] = roundTo(rand.Float64()*100, 2)
+			cpuIdle[j] = roundTo(rand.Float64()*100, 2)
+			cpuUser[j] = roundTo(rand.Float64()*100, 2)
+		}
+
+		batches[i] = columnBatch{columns: []interface{}{times, hostVals, values, cpuIdle, cpuUser}}
+		if (i+1)%100 == 0 {
+			fmt.Printf("  Progress: %d/%d\n", i+1, count)
+		}
+	}
+	return batches
+}
+
+func generateFinancialColumnBatches(count, batchSize int) []columnBatch {
+	symbols := []string{
+		"AAPL", "GOOGL", "MSFT", "AMZN", "META", "NVDA", "TSLA", "JPM", "V", "JNJ",
+		"WMT", "PG", "UNH", "HD", "MA", "DIS", "PYPL", "BAC", "ADBE", "NFLX",
+	}
+	exchanges := []string{"NYSE", "NASDAQ", "ARCA", "BATS", "IEX"}
+
+	batches := make([]columnBatch, count)
+	for i := 0; i < count; i++ {
+		now := time.Now()
+		times := make([]time.Time, batchSize)
+		symbolVals := make([]string, batchSize)
+		exchangeVals := make([]string, batchSize)
+		prices := make([]float64, batchSize)
+		bids := make([]float64, batchSize)
+		asks := make([]float64, batchSize)
+		bidSizes := make([]int64, batchSize)
+		askSizes := make([]int64, batchSize)
+		volumes := make([]int64, batchSize)
+		tradeIDs := make([]int64, batchSize)
+
+		for j := 0; j < batchSize; j++ {
+			times[j] = now.Add(time.Duration(j) * time.Microsecond)
+			symbolVals[j] = symbols[rand.Intn(len(symbols))]
+			exchangeVals[j] = exchanges[rand.Intn(len(exchanges))]
+			basePrice := roundTo(10+rand.Float64()*490, 2)
+			prices[j] = basePrice
+			bids[j] = roundTo(basePrice-rand.Float64()*0.04-0.01, 2)
+			asks[j] = roundTo(basePrice+rand.Float64()*0.04+0.01, 2)
+			bidSizes[j] = int64(100 + rand.Intn(9900))
+			askSizes[j] = int64(100 + rand.Intn(9900))
+			volumes[j] = int64(1 + rand.Intn(999))
+			tradeIDs[j] = int64(1000000 + rand.Intn(8999999))
+		}
+
+		batches[i] = columnBatch{columns: []interface{}{times, symbolVals, exchangeVals, prices, bids, asks, bidSizes, askSizes, volumes, tradeIDs}}
+		if (i+1)%100 == 0 {
+			fmt.Printf("  Progress: %d/%d\n", i+1, count)
+		}
+	}
+	return batches
+}
+
+func generateIndustrialColumnBatches(count, batchSize int) []columnBatch {
+	pumpIDs := make([]string, 100)
+	for i := range pumpIDs {
+		pumpIDs[i] = fmt.Sprintf("pump_%03d", i)
+	}
+	facilities := []string{"mine_alpha", "mine_beta", "refinery_1", "plant_east", "plant_west"}
+	pumpTypes := []string{"centrifugal", "positive_displacement", "submersible", "diaphragm"}
+
+	batches := make([]columnBatch, count)
+	for i := 0; i < count; i++ {
+		now := time.Now()
+		times := make([]time.Time, batchSize)
+		pumpIDVals := make([]string, batchSize)
+		facilityVals := make([]string, batchSize)
+		pumpTypeVals := make([]string, batchSize)
+		flowRate := make([]float64, batchSize)
+		pressureIn := make([]float64, batchSize)
+		pressureOut := make([]float64, batchSize)
+		temperature := make([]float64, batchSize)
+		vibration := make([]float64, batchSize)
+		current := make([]float64, batchSize)
+		rpm := make([]int64, batchSize)
+		power := make([]float64, batchSize)
+
+		for j := 0; j < batchSize; j++ {
+			times[j] = now.Add(time.Duration(j) * time.Microsecond)
+			pumpIDVals[j] = pumpIDs[rand.Intn(len(pumpIDs))]
+			facilityVals[j] = facilities[rand.Intn(len(facilities))]
+			pumpTypeVals[j] = pumpTypes[rand.Intn(len(pumpTypes))]
+			flowRate[j] = roundTo(50+rand.Float64()*450, 1)
+			pressureIn[j] = roundTo(10+rand.Float64()*40, 1)
+			pressureOut[j] = roundTo(100+rand.Float64()*400, 1)
+			temperature[j] = roundTo(20+rand.Float64()*60, 1)
+			vibration[j] = roundTo(rand.Float64()*10, 2)
+			current[j] = roundTo(10+rand.Float64()*90, 1)
+			rpm[j] = int64(1000 + rand.Intn(2500))
+			power[j] = roundTo(5+rand.Float64()*95, 1)
+		}
+
+		batches[i] = columnBatch{columns: []interface{}{times, pumpIDVals, facilityVals, pumpTypeVals, flowRate, pressureIn, pressureOut, temperature, vibration, current, rpm, power}}
+		if (i+1)%100 == 0 {
+			fmt.Printf("  Progress: %d/%d\n", i+1, count)
+		}
+	}
+	return batches
+}
+
+func generateAerospaceColumnBatches(count, batchSize int) []columnBatch {
+	sensorIDs := make([]string, 2000)
+	for i := range sensorIDs {
+		sensorIDs[i] = fmt.Sprintf("sens_%04d", i)
+	}
+
+	batches := make([]columnBatch, count)
+	for i := 0; i < count; i++ {
+		now := time.Now()
+		times := make([]time.Time, batchSize)
+		sensorIDVals := make([]string, batchSize)
+		values := make([]float64, batchSize)
+
+		for j := 0; j < batchSize; j++ {
+			times[j] = now.Add(time.Duration(j) * time.Microsecond)
+			sensorIDVals[j] = sensorIDs[rand.Intn(len(sensorIDs))]
+			values[j] = roundTo(rand.Float64()*1000, 2)
+		}
+
+		batches[i] = columnBatch{columns: []interface{}{times, sensorIDVals, values}}
+		if (i+1)%100 == 0 {
+			fmt.Printf("  Progress: %d/%d\n", i+1, count)
+		}
+	}
+	return batches
+}
+
+func generateEnergyColumnBatches(count, batchSize int) []columnBatch {
+	turbineIDs := make([]string, 200)
+	for i := range turbineIDs {
+		turbineIDs[i] = fmt.Sprintf("turbine_%03d", i)
+	}
+	farms := []string{"north_ridge", "coastal_1", "plains_west", "offshore_a", "hilltop"}
+
+	batches := make([]columnBatch, count)
+	for i := 0; i < count; i++ {
+		now := time.Now()
+		times := make([]time.Time, batchSize)
+		turbineIDVals := make([]string, batchSize)
+		farmVals := make([]string, batchSize)
+		windSpeed := make([]float64, batchSize)
+		windDirection := make([]float64, batchSize)
+		rotorRPM := make([]float64, batchSize)
+		powerOutput := make([]float64, batchSize)
+		bladePitch := make([]float64, batchSize)
+		nacelleTemp := make([]float64, batchSize)
+		generatorTemp := make([]float64, batchSize)
+
+		for j := 0; j < batchSize; j++ {
+			times[j] = now.Add(time.Duration(j) * time.Microsecond)
+			turbineIDVals[j] = turbineIDs[rand.Intn(len(turbineIDs))]
+			farmVals[j] = farms[rand.Intn(len(farms))]
+			windSpeed[j] = roundTo(2+rand.Float64()*23, 1)
+			windDirection[j] = roundTo(rand.Float64()*360, 1)
+			rotorRPM[j] = roundTo(5+rand.Float64()*15, 1)
+			powerOutput[j] = roundTo(rand.Float64()*5000, 1)
+			bladePitch[j] = roundTo(rand.Float64()*25, 1)
+			nacelleTemp[j] = roundTo(15+rand.Float64()*45, 1)
+			generatorTemp[j] = roundTo(40+rand.Float64()*60, 1)
+		}
+
+		batches[i] = columnBatch{columns: []interface{}{times, turbineIDVals, farmVals, windSpeed, windDirection, rotorRPM, powerOutput, bladePitch, nacelleTemp, generatorTemp}}
+		if (i+1)%100 == 0 {
+			fmt.Printf("  Progress: %d/%d\n", i+1, count)
+		}
+	}
+	return batches
+}
+
+func generateRacingColumnBatches(count, batchSize int) []columnBatch {
+	carNumbers := []string{"1", "4", "11", "14", "16", "22", "44", "55", "63", "77",
+		"10", "18", "20", "23", "24", "27", "31", "40", "81", "2"}
+	drivers := []string{"VER", "NOR", "PER", "ALO", "LEC", "TSU", "HAM", "SAI", "RUS", "BOT",
+		"GAS", "STR", "MAG", "HUL", "RIC", "ALB", "SAR", "ZHO", "PIA", "LAW"}
+
+	batches := make([]columnBatch, count)
+	for i := 0; i < count; i++ {
+		now := time.Now()
+		times := make([]time.Time, batchSize)
+		carNumberVals := make([]string, batchSize)
+		driverVals := make([]string, batchSize)
+		speed := make([]float64, batchSize)
+		engineRPM := make([]float64, batchSize)
+		throttle := make([]float64, batchSize)
+		brake := make([]float64, batchSize)
+		steering := make([]float64, batchSize)
+		gear := make([]int64, batchSize)
+
+		for j := 0; j < batchSize; j++ {
+			idx := rand.Intn(len(carNumbers))
+			times[j] = now.Add(time.Duration(j) * time.Microsecond)
+			carNumberVals[j] = carNumbers[idx]
+			driverVals[j] = drivers[idx]
+			speed[j] = roundTo(50+rand.Float64()*300, 1)
+			engineRPM[j] = roundTo(float64(8000+rand.Intn(7000)), 0)
+			throttle[j] = roundTo(rand.Float64()*100, 1)
+			brake[j] = roundTo(rand.Float64()*100, 1)
+			steering[j] = roundTo(-180+rand.Float64()*360, 1)
+			gear[j] = int64(1 + rand.Intn(8))
+		}
+
+		batches[i] = columnBatch{columns: []interface{}{times, carNumberVals, driverVals, speed, engineRPM, throttle, brake, steering, gear}}
+		if (i+1)%100 == 0 {
+			fmt.Printf("  Progress: %d/%d\n", i+1, count)
+		}
+	}
+	return batches
+}
+
+func generateColumnBatches(dataType string, count, batchSize int) []columnBatch {
+	switch dataType {
+	case "financial":
+		return generateFinancialColumnBatches(count, batchSize)
+	case "industrial":
+		return generateIndustrialColumnBatches(count, batchSize)
+	case "aerospace":
+		return generateAerospaceColumnBatches(count, batchSize)
+	case "energy":
+		return generateEnergyColumnBatches(count, batchSize)
+	case "racing":
+		return generateRacingColumnBatches(count, batchSize)
+	default:
+		return generateIOTColumnBatches(count, batchSize)
+	}
+}
+
+func clickhouseWorker(id int, cfg *Config, colBatches []columnBatch, stats *Stats, tableName string) {
+	settings := clickhouse.Settings{
+		"max_execution_time": 60,
+	}
+	if cfg.AsyncInsert {
+		settings["async_insert"] = 1
+		settings["wait_for_async_insert"] = 1
+		settings["async_insert_busy_timeout_ms"] = 200
+	}
+
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{fmt.Sprintf("%s:%d", cfg.Host, cfg.CHPort)},
+		Auth: clickhouse.Auth{
+			Database: cfg.Database,
+		},
+		Settings: settings,
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		DialTimeout:     10 * time.Second,
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Hour,
+	})
+	if err != nil {
+		fmt.Printf("Worker %d: failed to connect: %v\n", id, err)
+		return
+	}
+	defer conn.Close()
+
+	ctx := context.Background()
+	batchIdx := 0
+
+	for stats.running.Load() {
+		cb := colBatches[batchIdx%len(colBatches)]
+		batchIdx++
+
+		start := time.Now()
+
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO "+tableName)
+		if err != nil {
+			stats.totalErrors.Add(1)
+			if stats.totalErrors.Load() <= 3 {
+				fmt.Printf("Worker %d: PrepareBatch error: %v\n", id, err)
+			}
+			continue
+		}
+
+		// Columnar append — pass entire typed slices instead of row-by-row
+		appendErr := false
+		for colIdx, colData := range cb.columns {
+			if err := batch.Column(colIdx).Append(colData); err != nil {
+				stats.totalErrors.Add(1)
+				if stats.totalErrors.Load() <= 3 {
+					fmt.Printf("Worker %d: Column(%d) Append error: %v\n", id, colIdx, err)
+				}
+				appendErr = true
+				break
+			}
+		}
+		if appendErr {
+			continue
+		}
+
+		if err := batch.Send(); err != nil {
+			stats.totalErrors.Add(1)
+			if stats.totalErrors.Load() <= 3 {
+				fmt.Printf("Worker %d: Send error: %v\n", id, err)
+			}
+			continue
+		}
+
+		latencyMs := float64(time.Since(start).Microseconds()) / 1000.0
+		stats.totalSent.Add(int64(cfg.BatchSize))
+		stats.addLatency(id, latencyMs)
+	}
+}
+
+// generateClickHouseJSONBatches produces JSONEachRow payloads for ClickHouse HTTP interface.
+func generateClickHouseJSONBatches(dataType string, count, batchSize int) [][]byte {
+	batches := make([][]byte, count)
+
+	for i := 0; i < count; i++ {
+		var buf bytes.Buffer
+		now := time.Now()
+
+		for j := 0; j < batchSize; j++ {
+			ts := now.Add(time.Duration(j) * time.Microsecond).UTC().Format("2006-01-02 15:04:05.000000")
+			var row map[string]interface{}
+
+			switch dataType {
+			case "financial":
+				symbols := []string{"AAPL", "GOOGL", "MSFT", "AMZN", "META", "NVDA", "TSLA", "JPM", "V", "JNJ",
+					"WMT", "PG", "UNH", "HD", "MA", "DIS", "PYPL", "BAC", "ADBE", "NFLX"}
+				exchanges := []string{"NYSE", "NASDAQ", "ARCA", "BATS", "IEX"}
+				basePrice := roundTo(10+rand.Float64()*490, 2)
+				row = map[string]interface{}{
+					"time": ts, "symbol": symbols[rand.Intn(len(symbols))], "exchange": exchanges[rand.Intn(len(exchanges))],
+					"price": basePrice, "bid": roundTo(basePrice-rand.Float64()*0.04-0.01, 2),
+					"ask": roundTo(basePrice+rand.Float64()*0.04+0.01, 2),
+					"bid_size": 100 + rand.Intn(9900), "ask_size": 100 + rand.Intn(9900),
+					"volume": 1 + rand.Intn(999), "trade_id": 1000000 + rand.Intn(8999999),
+				}
+			case "aerospace":
+				row = map[string]interface{}{
+					"time": ts, "sensor_id": fmt.Sprintf("sens_%04d", rand.Intn(2000)),
+					"value": roundTo(rand.Float64()*1000, 2),
+				}
+			default: // iot
+				row = map[string]interface{}{
+					"time": ts, "host": fmt.Sprintf("server%03d", rand.Intn(1000)),
+					"value": roundTo(rand.Float64()*100, 2), "cpu_idle": roundTo(rand.Float64()*100, 2),
+					"cpu_user": roundTo(rand.Float64()*100, 2),
+				}
+			}
+
+			docBytes, _ := json.Marshal(row)
+			buf.Write(docBytes)
+			buf.WriteByte('\n')
+		}
+
+		batches[i] = buf.Bytes()
+		if (i+1)%100 == 0 {
+			fmt.Printf("  Progress: %d/%d\n", i+1, count)
+		}
+	}
+	return batches
+}
+
+func clickhouseHTTPWorker(id int, cfg *Config, batches [][]byte, stats *Stats, client *http.Client, tableName string) {
+	url := fmt.Sprintf("http://%s:%d/?query=INSERT+INTO+%s+FORMAT+JSONEachRow", cfg.Host, cfg.CHPort, tableName)
+	batchIdx := 0
+
+	for stats.running.Load() {
+		batch := batches[batchIdx%len(batches)]
+		batchIdx++
+
+		start := time.Now()
+
+		req, err := http.NewRequest("POST", url, bytes.NewReader(batch))
+		if err != nil {
+			stats.totalErrors.Add(1)
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			stats.totalErrors.Add(1)
+			if stats.totalErrors.Load() <= 3 {
+				fmt.Printf("Worker %d: HTTP error: %v\n", id, err)
+			}
+			continue
+		}
+
+		latencyMs := float64(time.Since(start).Microseconds()) / 1000.0
+
+		if resp.StatusCode == 200 {
+			stats.totalSent.Add(int64(cfg.BatchSize))
+			stats.addLatency(id, latencyMs)
+		} else {
+			stats.totalErrors.Add(1)
+			if stats.totalErrors.Load() <= 3 {
+				body, _ := io.ReadAll(resp.Body)
+				fmt.Printf("Worker %d: HTTP %d: %s\n", id, resp.StatusCode, string(body)[:min(200, len(body))])
+			}
+		}
+		resp.Body.Close()
+	}
+}
+
 func worker(id int, cfg *Config, batches [][]byte, stats *Stats, client *http.Client) {
 	var url string
 	var contentType string
@@ -754,8 +1284,12 @@ func main() {
 	flag.IntVar(&cfg.ZstdLevel, "zstd-level", 3, "Zstd compression level (1-22)")
 	flag.StringVar(&cfg.DataType, "data-type", "iot", "Data type: iot, financial, industrial, aerospace, energy, racing")
 	flag.StringVar(&cfg.Protocol, "protocol", "msgpack", "Protocol: msgpack, lineprotocol")
+	flag.StringVar(&cfg.Target, "target", "arc", "Target: arc, clickhouse, clickhouse-http")
 	flag.StringVar(&cfg.Host, "host", "localhost", "Server host")
-	flag.IntVar(&cfg.Port, "port", 8000, "Server port")
+	flag.IntVar(&cfg.Port, "port", 8000, "Server port (Arc HTTP)")
+	flag.IntVar(&cfg.CHPort, "ch-port", 9000, "ClickHouse native port")
+	flag.StringVar(&cfg.Database, "database", "default", "ClickHouse database name")
+	flag.BoolVar(&cfg.AsyncInsert, "async-insert", false, "Enable ClickHouse async_insert (server-side batching)")
 	flag.BoolVar(&cfg.TLS, "tls", false, "Use HTTPS instead of HTTP")
 	flag.Parse()
 
@@ -790,14 +1324,28 @@ func main() {
 	}
 
 	fmt.Println("================================================================================")
-	fmt.Printf("SUSTAINED LOAD TEST - GO CLIENT (%s)\n", compressLabel)
-	fmt.Println("================================================================================")
-	scheme := "http"
-	if cfg.TLS {
-		scheme = "https"
+	if cfg.Target == "clickhouse" {
+		asyncLabel := ""
+		if cfg.AsyncInsert {
+			asyncLabel = " + ASYNC INSERT"
+		}
+		fmt.Printf("SUSTAINED LOAD TEST - CLICKHOUSE NATIVE PROTOCOL (LZ4%s)\n", asyncLabel)
+		fmt.Println("================================================================================")
+		fmt.Printf("Target: clickhouse://%s:%d (database: %s)\n", cfg.Host, cfg.CHPort, cfg.Database)
+	} else if cfg.Target == "clickhouse-http" {
+		fmt.Println("SUSTAINED LOAD TEST - CLICKHOUSE HTTP (JSONEachRow)")
+		fmt.Println("================================================================================")
+		fmt.Printf("Target: http://%s:%d (database: %s)\n", cfg.Host, cfg.CHPort, cfg.Database)
+	} else {
+		fmt.Printf("SUSTAINED LOAD TEST - GO CLIENT (%s)\n", compressLabel)
+		fmt.Println("================================================================================")
+		scheme := "http"
+		if cfg.TLS {
+			scheme = "https"
+		}
+		fmt.Printf("Target: %s://%s:%d%s\n", scheme, cfg.Host, cfg.Port, endpoint)
+		fmt.Printf("Protocol: %s\n", protocolLabel)
 	}
-	fmt.Printf("Target: %s://%s:%d%s\n", scheme, cfg.Host, cfg.Port, endpoint)
-	fmt.Printf("Protocol: %s\n", protocolLabel)
 	fmt.Printf("Data type: %s\n", dataTypeLabel)
 	fmt.Printf("Duration: %ds\n", cfg.Duration)
 	fmt.Printf("Batch size: %d\n", cfg.BatchSize)
@@ -810,82 +1358,173 @@ func main() {
 	fmt.Printf("Pre-generating %d batches...\n", cfg.Pregenerate)
 	startGen := time.Now()
 
-	var batches [][]byte
-	if cfg.Protocol == "lineprotocol" {
-		batches = generateLineProtocolBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel, cfg.DataType)
-	} else if cfg.DataType == "financial" {
-		batches = generateFinancialBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
-	} else if cfg.DataType == "industrial" {
-		batches = generateIndustrialBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
-	} else if cfg.DataType == "aerospace" {
-		batches = generateAerospaceBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
-	} else if cfg.DataType == "energy" {
-		batches = generateEnergyBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
-	} else if cfg.DataType == "racing" {
-		batches = generateRacingBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
-	} else {
-		batches = generateIOTBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
-	}
-
-	genTime := time.Since(startGen)
-	var totalSize int64
-	for _, b := range batches {
-		totalSize += int64(len(b))
-	}
-	avgSize := float64(totalSize) / float64(len(batches))
-
-	sizeLabel := "uncompressed"
-	if cfg.Compress != "none" {
-		sizeLabel = cfg.Compress
-	}
-	fmt.Printf("✓ Generated %d batches in %.1fs\n", cfg.Pregenerate, genTime.Seconds())
-	fmt.Printf("  Avg size: %.1f KB (%s)\n", avgSize/1024, sizeLabel)
-	fmt.Println()
-
-	if cfg.Token != "" {
-		fmt.Printf("Using auth token: %s...\n", cfg.Token[:min(8, len(cfg.Token))])
-	} else {
-		fmt.Println("No ARC_TOKEN set - authentication may fail")
-	}
-
-	// Create HTTP client with connection pooling
-	transport := &http.Transport{
-		MaxIdleConns:        cfg.Workers + 50,
-		MaxIdleConnsPerHost: cfg.Workers + 50,
-		MaxConnsPerHost:     cfg.Workers + 50,
-		IdleConnTimeout:     30 * time.Second,
-		DisableKeepAlives:   false,
-	}
-	if cfg.TLS {
-		// Benchmark tool only — connects to local/dev instances with self-signed certs
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
-	}
-	// Resolve *.localhost to 127.0.0.1 (browsers do this per RFC 6761, Go doesn't)
-	if strings.HasSuffix(cfg.Host, ".localhost") {
-		dialer := &net.Dialer{Timeout: 10 * time.Second}
-		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			_, port, _ := net.SplitHostPort(addr)
-			return dialer.DialContext(ctx, network, net.JoinHostPort("127.0.0.1", port))
-		}
-	}
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   120 * time.Second,
-	}
-
-	// Run benchmark
-	fmt.Println("Starting test...")
 	stats := &Stats{}
 	stats.initWorkers(cfg.Workers)
 	stats.running.Store(true)
 
 	var wg sync.WaitGroup
-	for i := 0; i < cfg.Workers; i++ {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			worker(id, &cfg, batches, stats, client)
-		}(i)
+
+	if cfg.Target == "clickhouse" {
+		// ClickHouse native protocol path — columnar inserts
+		colBatches := generateColumnBatches(cfg.DataType, cfg.Pregenerate, cfg.BatchSize)
+
+		genTime := time.Since(startGen)
+		fmt.Printf("✓ Generated %d batches in %.1fs\n", cfg.Pregenerate, genTime.Seconds())
+		fmt.Printf("  %d rows per batch (columnar native protocol)\n", cfg.BatchSize)
+		fmt.Println()
+
+		// Create table
+		setupConn, err := clickhouse.Open(&clickhouse.Options{
+			Addr: []string{fmt.Sprintf("%s:%d", cfg.Host, cfg.CHPort)},
+			Auth: clickhouse.Auth{Database: cfg.Database},
+		})
+		if err != nil {
+			fmt.Printf("Failed to connect to ClickHouse: %v\n", err)
+			os.Exit(1)
+		}
+		tableName, err := ensureClickHouseTable(setupConn, cfg.DataType)
+		if err != nil {
+			fmt.Printf("Failed to create table: %v\n", err)
+			os.Exit(1)
+		}
+		setupConn.Close()
+		fmt.Printf("✓ Table '%s' ready in database '%s'\n", tableName, cfg.Database)
+		fmt.Println()
+
+		// Launch ClickHouse workers
+		fmt.Println("Starting test...")
+		for i := 0; i < cfg.Workers; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				clickhouseWorker(id, &cfg, colBatches, stats, tableName)
+			}(i)
+		}
+	} else if cfg.Target == "clickhouse-http" {
+		// ClickHouse HTTP interface — JSONEachRow
+		jsonBatches := generateClickHouseJSONBatches(cfg.DataType, cfg.Pregenerate, cfg.BatchSize)
+
+		genTime := time.Since(startGen)
+		var totalSize int64
+		for _, b := range jsonBatches {
+			totalSize += int64(len(b))
+		}
+		avgSize := float64(totalSize) / float64(len(jsonBatches))
+		fmt.Printf("✓ Generated %d batches in %.1fs\n", cfg.Pregenerate, genTime.Seconds())
+		fmt.Printf("  Avg size: %.1f KB (JSONEachRow)\n", avgSize/1024)
+		fmt.Println()
+
+		// Create table via native connection
+		setupConn, err := clickhouse.Open(&clickhouse.Options{
+			Addr: []string{fmt.Sprintf("%s:9000", cfg.Host)},
+			Auth: clickhouse.Auth{Database: cfg.Database},
+		})
+		if err != nil {
+			fmt.Printf("Failed to connect to ClickHouse: %v\n", err)
+			os.Exit(1)
+		}
+		tableName, err := ensureClickHouseTable(setupConn, cfg.DataType)
+		if err != nil {
+			fmt.Printf("Failed to create table: %v\n", err)
+			os.Exit(1)
+		}
+		setupConn.Close()
+		fmt.Printf("✓ Table '%s' ready in database '%s'\n", tableName, cfg.Database)
+		fmt.Println()
+
+		// HTTP client for ClickHouse
+		client := &http.Client{
+			Transport: &http.Transport{
+				MaxIdleConns:        cfg.Workers + 50,
+				MaxIdleConnsPerHost: cfg.Workers + 50,
+				MaxConnsPerHost:     cfg.Workers + 50,
+				IdleConnTimeout:     30 * time.Second,
+			},
+			Timeout: 120 * time.Second,
+		}
+
+		fmt.Println("Starting test...")
+		for i := 0; i < cfg.Workers; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				clickhouseHTTPWorker(id, &cfg, jsonBatches, stats, client, tableName)
+			}(i)
+		}
+	} else {
+		// Arc HTTP path
+		var batches [][]byte
+		if cfg.Protocol == "lineprotocol" {
+			batches = generateLineProtocolBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel, cfg.DataType)
+		} else if cfg.DataType == "financial" {
+			batches = generateFinancialBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
+		} else if cfg.DataType == "industrial" {
+			batches = generateIndustrialBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
+		} else if cfg.DataType == "aerospace" {
+			batches = generateAerospaceBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
+		} else if cfg.DataType == "energy" {
+			batches = generateEnergyBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
+		} else if cfg.DataType == "racing" {
+			batches = generateRacingBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
+		} else {
+			batches = generateIOTBatches(cfg.Pregenerate, cfg.BatchSize, cfg.Compress, cfg.ZstdLevel)
+		}
+
+		genTime := time.Since(startGen)
+		var totalSize int64
+		for _, b := range batches {
+			totalSize += int64(len(b))
+		}
+		avgSize := float64(totalSize) / float64(len(batches))
+
+		sizeLabel := "uncompressed"
+		if cfg.Compress != "none" {
+			sizeLabel = cfg.Compress
+		}
+		fmt.Printf("✓ Generated %d batches in %.1fs\n", cfg.Pregenerate, genTime.Seconds())
+		fmt.Printf("  Avg size: %.1f KB (%s)\n", avgSize/1024, sizeLabel)
+		fmt.Println()
+
+		if cfg.Token != "" {
+			fmt.Printf("Using auth token: %s...\n", cfg.Token[:min(8, len(cfg.Token))])
+		} else {
+			fmt.Println("No ARC_TOKEN set - authentication may fail")
+		}
+
+		// Create HTTP client with connection pooling
+		transport := &http.Transport{
+			MaxIdleConns:        cfg.Workers + 50,
+			MaxIdleConnsPerHost: cfg.Workers + 50,
+			MaxConnsPerHost:     cfg.Workers + 50,
+			IdleConnTimeout:     30 * time.Second,
+			DisableKeepAlives:   false,
+		}
+		if cfg.TLS {
+			// Benchmark tool only — connects to local/dev instances with self-signed certs
+			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+		}
+		// Resolve *.localhost to 127.0.0.1 (browsers do this per RFC 6761, Go doesn't)
+		if strings.HasSuffix(cfg.Host, ".localhost") {
+			dialer := &net.Dialer{Timeout: 10 * time.Second}
+			transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				_, port, _ := net.SplitHostPort(addr)
+				return dialer.DialContext(ctx, network, net.JoinHostPort("127.0.0.1", port))
+			}
+		}
+		client := &http.Client{
+			Transport: transport,
+			Timeout:   120 * time.Second,
+		}
+
+		// Launch Arc workers
+		fmt.Println("Starting test...")
+		for i := 0; i < cfg.Workers; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				worker(id, &cfg, batches, stats, client)
+			}(i)
+		}
 	}
 
 	// Progress reporting


### PR DESCRIPTION
Add ClickHouse native TCP and HTTP (JSONEachRow) as benchmark targets alongside Arc, enabling apples-to-apples ingestion throughput comparison.

- Native protocol with columnar inserts, LZ4 compression, async_insert option
- HTTP interface with JSONEachRow format
- Auto table creation for all 6 data types (iot, financial, industrial, aerospace, energy, racing)
- New flags: --target, --ch-port, --database, --async-insert