### PR TITLE
fix(ingest): remove useless UTF-8 bulk pre-validation from msgpack path

### DIFF
--- a/RELEASE_NOTES_2026.04.1.md
+++ b/RELEASE_NOTES_2026.04.1.md
@@ -138,9 +138,9 @@ Upgraded the Apache Arrow columnar format library. Key fixes:
 
 Replaced per-field UTF-8 validation with a single bulk validation pass over the entire HTTP payload. Previously, every string field was individually validated via `SanitizeUTF8()` during parsing — for a 1000-row batch with 5 string fields, this meant ~5000 validation calls. Now, `ValidateUTF8Bytes()` validates the entire payload once; when valid (the common case), all per-field sanitization is skipped.
 
-This optimization applies to both ingestion paths:
-- **Line Protocol**: Pre-validates in `ParseBatchWithPrecision`, skips 3 `SanitizeUTF8` call sites in `parseFieldValue`
-- **MessagePack**: Pre-validates in `Decode`, short-circuits `sanitizeStringColumns` and `sanitizeStringFields`
+This optimization applies to the **Line Protocol** ingestion path, pre-validating in `ParseBatchWithPrecision` and skipping 3 `SanitizeUTF8` call sites in `parseFieldValue` when the payload is valid UTF-8 (the common case).
+
+**Note:** MessagePack payloads are excluded from bulk pre-validation because MessagePack is a binary format — the raw bytes contain type markers, length prefixes, and packed numerics that are never valid UTF-8. Bulk validation would always fail, adding cost with zero benefit. Per-field `SanitizeUTF8()` handles the extracted string values after decoding.
 
 **Benchmark results (Apple M3 Max, arm64):**
 

--- a/internal/ingest/msgpack.go
+++ b/internal/ingest/msgpack.go
@@ -28,9 +28,11 @@ func NewMessagePackDecoder(logger zerolog.Logger) *MessagePackDecoder {
 // Returns either []models.Record or []models.ColumnarRecord depending on input format
 // The raw bytes are preserved in ColumnarRecord.RawPayload for zero-copy WAL
 func (d *MessagePackDecoder) Decode(data []byte) (interface{}, error) {
-	// Pre-validate the entire payload as UTF-8 in one pass.
-	// If valid, skip per-field SanitizeUTF8 calls during decoding.
-	validUTF8 := ValidateUTF8Bytes(data)
+	// NOTE: No bulk UTF-8 pre-validation here. MessagePack is a binary format —
+	// the raw bytes contain type markers, length prefixes, and packed numerics
+	// that are not valid UTF-8. Bulk validation would always fail, adding cost
+	// with zero benefit. Per-field sanitization handles the extracted strings.
+	// (Bulk pre-validation is used in the Line Protocol path where payloads ARE UTF-8.)
 
 	// IMPORTANT: Decode to generic interface{} first to handle both map and array formats
 	// Telegraf and other clients may send data in array-encoded format which would fail
@@ -47,7 +49,7 @@ func (d *MessagePackDecoder) Decode(data []byte) (interface{}, error) {
 	switch payload := rawPayload.(type) {
 	case map[string]interface{}:
 		// Standard map format - convert to MsgPackPayload and decode
-		result, err := d.decodeMapPayload(payload, data, validUTF8)
+		result, err := d.decodeMapPayload(payload, data)
 		if err != nil {
 			d.totalErrors++
 			return nil, err
@@ -63,7 +65,7 @@ func (d *MessagePackDecoder) Decode(data []byte) (interface{}, error) {
 		for _, item := range payload {
 			switch typedItem := item.(type) {
 			case map[string]interface{}:
-				result, err := d.decodeMapPayload(typedItem, nil, validUTF8)
+				result, err := d.decodeMapPayload(typedItem, nil)
 				if err != nil {
 					d.logger.Error().Err(err).Msg("Failed to decode array item")
 					continue
@@ -84,14 +86,14 @@ func (d *MessagePackDecoder) Decode(data []byte) (interface{}, error) {
 }
 
 // decodeMapPayload decodes a map[string]interface{} payload
-func (d *MessagePackDecoder) decodeMapPayload(payload map[string]interface{}, rawData []byte, validUTF8 bool) (interface{}, error) {
+func (d *MessagePackDecoder) decodeMapPayload(payload map[string]interface{}, rawData []byte) (interface{}, error) {
 	// Check for batch format
 	if batch, ok := payload["batch"]; ok {
 		if batchSlice, ok := batch.([]interface{}); ok {
 			var results []interface{}
 			for _, item := range batchSlice {
 				if itemMap, ok := item.(map[string]interface{}); ok {
-					result, err := d.decodeMapPayload(itemMap, nil, validUTF8)
+					result, err := d.decodeMapPayload(itemMap, nil)
 					if err != nil {
 						d.logger.Error().Err(err).Msg("Failed to decode batch item")
 						continue
@@ -107,7 +109,7 @@ func (d *MessagePackDecoder) decodeMapPayload(payload map[string]interface{}, ra
 	msgPayload := d.mapToPayload(payload)
 
 	// Decode item with raw data for zero-copy WAL
-	return d.decodeItemWithRaw(msgPayload, rawData, validUTF8)
+	return d.decodeItemWithRaw(msgPayload, rawData)
 }
 
 // mapToPayload converts a generic map to MsgPackPayload struct
@@ -171,20 +173,20 @@ func (d *MessagePackDecoder) mapToPayload(m map[string]interface{}) *models.MsgP
 }
 
 // decodeItemWithRaw decodes a single item and passes raw bytes for zero-copy WAL
-func (d *MessagePackDecoder) decodeItemWithRaw(payload *models.MsgPackPayload, rawData []byte, validUTF8 bool) (interface{}, error) {
+func (d *MessagePackDecoder) decodeItemWithRaw(payload *models.MsgPackPayload, rawData []byte) (interface{}, error) {
 	// FAST PATH: Columnar format (zero-copy passthrough to Arrow and WAL)
 	if payload.Columns != nil {
-		return d.decodeColumnar(payload, rawData, validUTF8)
+		return d.decodeColumnar(payload, rawData)
 	}
 
 	// LEGACY PATH: Row format (requires flattening, no zero-copy WAL)
-	return d.decodeRow(payload, validUTF8)
+	return d.decodeRow(payload)
 }
 
 // decodeColumnar handles columnar format (ZERO-COPY passthrough)
 // Input:  {m: "cpu", columns: {time: [...], val: [...], region: [...]}}
 // Output: ColumnarRecord with validated columns and optional raw bytes for WAL
-func (d *MessagePackDecoder) decodeColumnar(payload *models.MsgPackPayload, rawData []byte, validUTF8 bool) (*models.ColumnarRecord, error) {
+func (d *MessagePackDecoder) decodeColumnar(payload *models.MsgPackPayload, rawData []byte) (*models.ColumnarRecord, error) {
 	// Extract measurement
 	measurement, err := d.extractMeasurement(payload.M)
 	if err != nil {
@@ -236,7 +238,7 @@ func (d *MessagePackDecoder) decodeColumnar(payload *models.MsgPackPayload, rawD
 	}
 
 	// Sanitize string columns to ensure valid UTF-8 (prevents DuckDB query failures)
-	sanitizedCount := d.sanitizeStringColumns(payload.Columns, validUTF8)
+	sanitizedCount := d.sanitizeStringColumns(payload.Columns)
 	if sanitizedCount > 0 {
 		d.logger.Warn().
 			Str("measurement", measurement).
@@ -256,7 +258,7 @@ func (d *MessagePackDecoder) decodeColumnar(payload *models.MsgPackPayload, rawD
 // decodeRow handles row format (legacy, requires flattening)
 // Input:  {m: "cpu", t: 1633024800000, h: "server01", fields: {...}, tags: {...}}
 // Output: Record with flattened structure
-func (d *MessagePackDecoder) decodeRow(payload *models.MsgPackPayload, validUTF8 bool) (*models.Record, error) {
+func (d *MessagePackDecoder) decodeRow(payload *models.MsgPackPayload) (*models.Record, error) {
 	// Extract measurement
 	measurement, err := d.extractMeasurement(payload.M)
 	if err != nil {
@@ -302,7 +304,7 @@ func (d *MessagePackDecoder) decodeRow(payload *models.MsgPackPayload, validUTF8
 	}
 
 	// Sanitize string fields to ensure valid UTF-8 (prevents DuckDB query failures)
-	sanitizedCount := d.sanitizeStringFields(fields, validUTF8)
+	sanitizedCount := d.sanitizeStringFields(fields)
 	if sanitizedCount > 0 {
 		d.logger.Warn().
 			Str("measurement", measurement).
@@ -537,11 +539,7 @@ func toInt64Timestamp(v interface{}) (int64, bool) {
 // sanitizeStringColumns sanitizes string values in columnar data to ensure valid UTF-8.
 // This prevents DuckDB query failures caused by non-UTF-8 data in Parquet files.
 // Returns count of sanitized fields for logging.
-// Skipped entirely when the payload has been pre-validated as valid UTF-8.
-func (d *MessagePackDecoder) sanitizeStringColumns(columns map[string][]interface{}, validUTF8 bool) int {
-	if validUTF8 {
-		return 0
-	}
+func (d *MessagePackDecoder) sanitizeStringColumns(columns map[string][]interface{}) int {
 	sanitizedCount := 0
 	for _, colData := range columns {
 		for i, val := range colData {
@@ -560,11 +558,7 @@ func (d *MessagePackDecoder) sanitizeStringColumns(columns map[string][]interfac
 // sanitizeStringFields sanitizes string values in row-format fields to ensure valid UTF-8.
 // This prevents DuckDB query failures caused by non-UTF-8 data in Parquet files.
 // Returns count of sanitized fields for logging.
-// Skipped entirely when the payload has been pre-validated as valid UTF-8.
-func (d *MessagePackDecoder) sanitizeStringFields(fields map[string]interface{}, validUTF8 bool) int {
-	if validUTF8 {
-		return 0
-	}
+func (d *MessagePackDecoder) sanitizeStringFields(fields map[string]interface{}) int {
 	sanitizedCount := 0
 	for key, val := range fields {
 		if s, ok := val.(string); ok {


### PR DESCRIPTION
## Summary

- **Remove `ValidateUTF8Bytes()` from the MessagePack decode path** — MessagePack is a binary format (type markers, length prefixes, packed numerics), so bulk UTF-8 validation always returns `false`. This added ~2-4ms of wasted scanning per request with zero benefit, since per-field `SanitizeUTF8()` still ran regardless.
- **Remove `validUTF8 bool` parameter** from all 6 internal msgpack methods (`decodeMapPayload`, `decodeItemWithRaw`, `decodeColumnar`, `decodeRow`, `sanitizeStringColumns`, `sanitizeStringFields`)
- **Line Protocol pre-validation unchanged** — LP payloads are actual UTF-8 text, so bulk validation correctly skips per-field checks there

## Test plan

- [x] `go build ./cmd/... ./internal/...`
- [x] `go test ./internal/ingest/...` — all tests pass (except pre-existing flaky `TestBufferFlushTimingUnderLoad`)
- [x] Sustained benchmark with `--workers 50 --duration 60 --batch-size 1000` confirms p50 at 0.46ms baseline