### PR TITLE
fix(compaction): prevent hourly tier race condition with active ingestion

### DIFF
--- a/RELEASE_NOTES_2026.04.1.md
+++ b/RELEASE_NOTES_2026.04.1.md
@@ -252,6 +252,10 @@ Changed all temp directories (compaction, delete rewrite) from world-readable (`
 
 ## Bug Fixes
 
+### Hourly Compaction Race Condition with Active Ingestion
+
+Fixed a race condition where hourly compaction with `hourly_min_age_hours = 0` could compact and delete source files while the ingestion pipeline was still flushing data to the same partition. This caused data gaps and duplicate data visible in query results. The hourly tier now checks file creation timestamps (matching the daily tier's existing safety check) and enforces a minimum age of 1 hour. The default `arc.toml` has been corrected from `hourly_min_age_hours = 0` to `1` and `hourly_min_files` from `5` to `10`.
+
 ### CQ Scheduler Reload on Update
 
 Continuous query updates now immediately reload the scheduler with the new definition. Previously, updated CQ definitions were only picked up after a scheduler restart.

--- a/arc.toml
+++ b/arc.toml
@@ -67,8 +67,8 @@ enabled = true
 # Hourly
 hourly_enabled = true
 hourly_schedule = "5 * * * *"
-hourly_min_age_hours = 0
-hourly_min_files = 5
+hourly_min_age_hours = 1
+hourly_min_files = 10
 
 # Daily
 daily_enabled = true

--- a/internal/compaction/hourly.go
+++ b/internal/compaction/hourly.go
@@ -29,8 +29,11 @@ type HourlyTierConfig struct {
 
 // NewHourlyTier creates a new hourly compaction tier
 func NewHourlyTier(cfg *HourlyTierConfig) *HourlyTier {
-	// Set defaults (MinAgeHours=0 is valid, meaning compact immediately)
-	if cfg.MinAgeHours < 0 {
+	// MinAgeHours must be >= 1 to prevent race conditions with active ingestion.
+	// With 0, compaction can download and delete files while late buffer flushes
+	// are still writing to the same partition, causing data loss.
+	overrodeMinAge := cfg.MinAgeHours < 1
+	if overrodeMinAge {
 		cfg.MinAgeHours = 1
 	}
 	if cfg.MinFiles == 0 {
@@ -53,6 +56,12 @@ func NewHourlyTier(cfg *HourlyTierConfig) *HourlyTier {
 			Enabled:        cfg.Enabled,
 			Logger:         cfg.Logger.With().Str("tier", "hourly").Logger(),
 		}),
+	}
+
+	if overrodeMinAge {
+		tier.Logger.Warn().
+			Int("enforced_value", cfg.MinAgeHours).
+			Msg("hourly_min_age_hours was < 1; overriding to 1 to prevent race conditions with active ingestion")
 	}
 
 	tier.Logger.Info().
@@ -217,9 +226,20 @@ func (t *HourlyTier) listHourPartitions(ctx context.Context, database, measureme
 		partitions[partitionPath].Files = append(partitions[partitionPath].Files, obj)
 	}
 
-	// Convert map to slice
+	// Convert map to slice, filtering by newest file creation time.
+	// This prevents compacting partitions that still have recently-written files,
+	// which would race with active ingestion and cause data loss.
 	result := make([]Candidate, 0, len(partitions))
 	for _, p := range partitions {
+		newestFileTime := extractNewestFileTime(p.Files)
+		if !newestFileTime.IsZero() && newestFileTime.After(cutoffTime) {
+			t.Logger.Debug().
+				Str("partition", p.PartitionPath).
+				Time("newest_file", newestFileTime).
+				Time("cutoff", cutoffTime).
+				Msg("Skipping partition: has recent files")
+			continue
+		}
 		result = append(result, *p)
 	}
 


### PR DESCRIPTION
## Summary

- **Added file-level creation time check** to hourly compaction tier — ports `extractNewestFileTime()` safety from daily tier to prevent compacting partitions with recently-written files
- **Enforced `hourly_min_age_hours >= 1`** — values below 1 are overridden with a warning log, preventing the race condition that caused data gaps
- **Fixed `arc.toml` defaults** — `hourly_min_age_hours` from 0→1, `hourly_min_files` from 5→10 (matching code default)

Closes #278

## Root Cause

With `hourly_min_age_hours = 0`, compaction runs on partitions immediately after the hour rolls over. The hourly tier only checked the partition directory time (YYYY/MM/DD/HH) — unlike the daily tier, it had **no file-level creation time check**. Late buffer flushes writing to the just-closed partition would race with compaction's download-merge-delete cycle, causing data loss and duplicates visible as gaps and spikes in Grafana dashboards.

## Test plan

- [x] `go build ./cmd/... ./internal/...` — clean
- [x] `go test ./internal/compaction/... -v` — all 40+ tests pass
- [ ] Verify warning log appears when `hourly_min_age_hours = 0` is configured
- [ ] Deploy to prospect environment and confirm data gaps no longer appear