### PR TITLE
fix(compaction): batch filename collision causes up to 84% data loss

### DIFF
--- a/RELEASE_NOTES_2026.04.1.md
+++ b/RELEASE_NOTES_2026.04.1.md
@@ -266,6 +266,10 @@ Changed all temp directories (compaction, delete rewrite) from world-readable (`
 
 ## Bug Fixes
 
+### Compaction Batch Filename Collision — Data Loss
+
+When a partition had more than 30 files, compaction split them into sequential batches of 30. Each batch generated its output filename with second-precision timestamps, causing all batches to produce the same filename. Each batch overwrote the previous batch's compacted file, destroying up to 84% of data. Fixed by adding nanosecond precision to compacted filenames for guaranteed uniqueness.
+
 ### Hourly Compaction Race Condition with Active Ingestion
 
 Fixed a race condition where hourly compaction with `hourly_min_age_hours = 0` could compact and delete source files while the ingestion pipeline was still flushing data to the same partition. This caused data gaps and duplicate data visible in query results. The hourly tier now checks file creation timestamps (matching the daily tier's existing safety check) and enforces a minimum age of 1 hour. The default `arc.toml` has been corrected from `hourly_min_age_hours = 0` to `1` and `hourly_min_files` from `5` to `10`.

--- a/internal/compaction/daily.go
+++ b/internal/compaction/daily.go
@@ -277,28 +277,36 @@ func extractNewestFileTime(files []string) time.Time {
 		// Remove .parquet extension
 		filename = strings.TrimSuffix(filename, ".parquet")
 
-		// Check if it's a daily compacted file: measurement_YYYYMMDD_HHMMSS_daily
+		// Check if it's a tier-compacted file: measurement_YYYYMMDD_HHMMSS_{nanos}_{daily|compacted}
+		// Strip the tier suffix, then handle like a raw file
+		tierSuffix := ""
 		if strings.HasSuffix(filename, "_daily") {
-			// Remove _daily suffix
-			filename = strings.TrimSuffix(filename, "_daily")
+			tierSuffix = "_daily"
+		} else if strings.HasSuffix(filename, "_compacted") {
+			tierSuffix = "_compacted"
+		}
+
+		if tierSuffix != "" {
+			filename = strings.TrimSuffix(filename, tierSuffix)
 			fileParts := strings.Split(filename, "_")
 			if len(fileParts) < 3 {
 				continue
 			}
-			// Last two parts are date and time: YYYYMMDD_HHMMSS
+			// Try parsing last two parts as YYYYMMDD_HHMMSS (old format without nanos)
 			dateTimePart := fileParts[len(fileParts)-2] + "_" + fileParts[len(fileParts)-1]
-			// Parse timestamp: YYYYMMDD_HHMMSS
 			fileTime, err := time.Parse("20060102_150405", dateTimePart)
-			if err != nil {
-				continue
+			if err != nil && len(fileParts) >= 4 {
+				// New format with nanos: ..._YYYYMMDD_HHMMSS_nanos — skip nanos, take 3rd and 2nd from end
+				dateTimePart = fileParts[len(fileParts)-3] + "_" + fileParts[len(fileParts)-2]
+				fileTime, err = time.Parse("20060102_150405", dateTimePart)
 			}
-			if fileTime.After(newest) {
+			if err == nil && fileTime.After(newest) {
 				newest = fileTime
 			}
 			continue
 		}
 
-		// Handle hourly file: measurement_YYYYMMDD_HHMMSS_nanos
+		// Handle raw hourly file: measurement_YYYYMMDD_HHMMSS_nanos
 		fileParts := strings.Split(filename, "_")
 		if len(fileParts) < 3 {
 			continue

--- a/internal/compaction/job.go
+++ b/internal/compaction/job.go
@@ -476,13 +476,19 @@ func (j *Job) downloadSingleFile(ctx context.Context, tempDir string, index int,
 // It validates each file and only compacts valid ones, storing the list of
 // successfully compacted files' storage keys in j.compactedFiles.
 func (j *Job) compactFiles(ctx context.Context, files []downloadedFile, tempDir string) (string, error) {
-	// Generate output filename with tier-specific suffix (use UTC for consistency)
-	timestamp := time.Now().UTC().Format("20060102_150405")
+	// Generate output filename with tier-specific suffix.
+	// Format: {measurement}_{YYYYMMDD}_{HHMMSS}_{nanos}_{suffix}.parquet
+	// The nanos field guarantees uniqueness when multiple batches run
+	// sequentially for the same partition (SplitCandidateIntoBatches).
+	// Without it, batches within the same second produce identical filenames
+	// and each overwrites the previous, destroying data.
+	now := time.Now().UTC()
+	timestamp := now.Format("20060102_150405")
 	suffix := "compacted"
 	if j.Tier != "hourly" {
 		suffix = j.Tier
 	}
-	outputFile := filepath.Join(tempDir, fmt.Sprintf("%s_%s_%s.parquet", j.Measurement, timestamp, suffix))
+	outputFile := filepath.Join(tempDir, fmt.Sprintf("%s_%s_%d_%s.parquet", j.Measurement, timestamp, now.UnixNano(), suffix))
 
 	// Use the shared DuckDB connection instead of creating a new one
 	// This prevents memory retention from DuckDB's jemalloc not releasing memory on Close()


### PR DESCRIPTION
## Summary

- **Root cause**: When partitions have >30 files, `SplitCandidateIntoBatches` creates sequential batches of 30. Each batch generated output filenames with second-precision timestamps (`YYYYMMDD_HHMMSS`), causing all batches to produce identical filenames. Each batch overwrote the previous — only the last batch survived.
- **Impact**: Up to 84% data loss on any measurement with >30 files/hour. Triggered by `max_buffer_age_ms=500` which produces ~120 files/hour.
- **Fix**: Added nanosecond timestamp to compacted filenames for guaranteed uniqueness while preserving `YYYYMMDD_HHMMSS` prefix for `extractNewestFileTime` compatibility.

Closes #357

## Test plan

- [x] `go build ./cmd/... ./internal/...` — clean
- [x] `go test ./internal/compaction/...` — pass
- [ ] Deploy to monitoring server and verify data retention across compaction cycles