### PR TITLE
fix(auth): add Close() to RBACManager and bound permission caches (#295, #296)

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -34,6 +34,18 @@ The `SET memory_limit` command in both the main DuckDB connection (`duckdb.go`) 
 
 ## Bug Fixes
 
+### RBACManager Goroutine Leak — No Close() Method
+
+The RBACManager background cache cleanup goroutine (`cacheCleanupLoop`) ran in an infinite loop with no shutdown mechanism, leaking a goroutine on every Arc restart.
+
+**Fix:** Added a `done` channel and `Close()` method following the same pattern used by AuthManager. RBACManager is now registered with the shutdown coordinator at `PriorityAuth`.
+
+### RBAC Permission Caches Grow Unbounded
+
+Both the token cache and permission cache in RBACManager had no maximum size — only TTL-based expiration. Under high cardinality (many tokens × databases × measurements), the caches could grow indefinitely.
+
+**Fix:** Added a configurable `MaxCacheSize` (default 10,000 entries per cache). When a cache exceeds its limit, a random entry is evicted on insertion. Combined with the existing TTL cleanup, this bounds memory usage while maintaining cache effectiveness.
+
 ### WAL Filename Rotation Collision
 
 Fixed a bug where WAL filenames used second precision (`arc-YYYYMMDD_HHMMSS.wal`), allowing two rotations within the same second to produce identical filenames. The second rotation would reopen the existing file via `O_APPEND` and write a new header, corrupting the WAL structure.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -860,6 +860,7 @@ func main() {
 			LicenseClient: licenseClient,
 			Logger:        logger.Get("rbac"),
 		})
+		shutdownCoordinator.Register("rbac", rbacManager, shutdown.PriorityAuth)
 		if rbacManager.IsRBACEnabled() {
 			log.Info().Msg("Enterprise RBAC enabled")
 		}

--- a/internal/auth/rbac_manager.go
+++ b/internal/auth/rbac_manager.go
@@ -84,9 +84,15 @@ type RBACManager struct {
 	permCacheMu  sync.RWMutex
 	permCacheTTL time.Duration
 
+	// Maximum cache sizes — oldest entries evicted when exceeded
+	maxCacheSize int
+
 	// Cache stats
 	cacheHits   atomic.Int64
 	cacheMisses atomic.Int64
+
+	// Shutdown
+	done chan struct{}
 }
 
 // RBACManagerConfig holds configuration for the RBAC manager
@@ -95,6 +101,7 @@ type RBACManagerConfig struct {
 	LicenseClient *license.Client
 	Logger        zerolog.Logger
 	CacheTTL      time.Duration // TTL for permission cache (default: 30s)
+	MaxCacheSize  int           // Max entries per cache (default: 10000)
 }
 
 // NewRBACManager creates a new RBAC manager
@@ -102,6 +109,11 @@ func NewRBACManager(cfg *RBACManagerConfig) *RBACManager {
 	cacheTTL := cfg.CacheTTL
 	if cacheTTL == 0 {
 		cacheTTL = 30 * time.Second // Default 30s cache
+	}
+
+	maxCacheSize := cfg.MaxCacheSize
+	if maxCacheSize == 0 {
+		maxCacheSize = 10000 // Default 10k entries per cache
 	}
 
 	rm := &RBACManager{
@@ -112,6 +124,8 @@ func NewRBACManager(cfg *RBACManagerConfig) *RBACManager {
 		tokenCacheTTL: cacheTTL,
 		permCache:     make(map[permissionCacheKey]*permissionCacheEntry),
 		permCacheTTL:  cacheTTL,
+		maxCacheSize:  maxCacheSize,
+		done:          make(chan struct{}),
 	}
 
 	// Start background cache cleanup
@@ -120,13 +134,24 @@ func NewRBACManager(cfg *RBACManagerConfig) *RBACManager {
 	return rm
 }
 
+// Close stops the background cleanup goroutine.
+func (rm *RBACManager) Close() error {
+	close(rm.done)
+	return nil
+}
+
 // cacheCleanupLoop periodically cleans expired cache entries
 func (rm *RBACManager) cacheCleanupLoop() {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		rm.cleanupExpiredCache()
+	for {
+		select {
+		case <-ticker.C:
+			rm.cleanupExpiredCache()
+		case <-rm.done:
+			return
+		}
 	}
 }
 
@@ -905,8 +930,14 @@ func (rm *RBACManager) CheckPermission(req *PermissionCheckRequest) *PermissionC
 	// Cache miss - compute permission
 	result := rm.checkPermissionUncached(req)
 
-	// Cache the result
+	// Cache the result (evict a random entry if over max size)
 	rm.permCacheMu.Lock()
+	if len(rm.permCache) >= rm.maxCacheSize {
+		for k := range rm.permCache {
+			delete(rm.permCache, k)
+			break
+		}
+	}
 	rm.permCache[cacheKey] = &permissionCacheEntry{
 		result:    result,
 		expiresAt: time.Now().Add(rm.permCacheTTL),
@@ -1023,8 +1054,14 @@ func (rm *RBACManager) CheckPermissionsBatch(reqs []*PermissionCheckRequest) []*
 				}
 			}
 
-			// Cache the result
+			// Cache the result (evict a random entry if over max size)
 			rm.permCacheMu.Lock()
+			if len(rm.permCache) >= rm.maxCacheSize {
+				for k := range rm.permCache {
+					delete(rm.permCache, k)
+					break
+				}
+			}
 			rm.permCache[cacheKey] = &permissionCacheEntry{
 				result:    result,
 				expiresAt: time.Now().Add(rm.permCacheTTL),
@@ -1101,7 +1138,13 @@ func (rm *RBACManager) getTokenRBACData(tokenID int64) (*tokenRBACData, error) {
 		return nil, err
 	}
 
-	// Cache the result (already holding write lock)
+	// Cache the result (already holding write lock, evict if over max size)
+	if len(rm.tokenCache) >= rm.maxCacheSize {
+		for k := range rm.tokenCache {
+			delete(rm.tokenCache, k)
+			break
+		}
+	}
 	rm.tokenCache[tokenID] = data
 
 	return data, nil

--- a/internal/auth/rbac_manager.go
+++ b/internal/auth/rbac_manager.go
@@ -155,6 +155,28 @@ func (rm *RBACManager) cacheCleanupLoop() {
 	}
 }
 
+// evictPermCacheIfFull removes a random entry from the permission cache if it
+// has reached maxCacheSize. Caller must hold permCacheMu write lock.
+func (rm *RBACManager) evictPermCacheIfFull() {
+	if len(rm.permCache) >= rm.maxCacheSize {
+		for k := range rm.permCache {
+			delete(rm.permCache, k)
+			break
+		}
+	}
+}
+
+// evictTokenCacheIfFull removes a random entry from the token cache if it
+// has reached maxCacheSize. Caller must hold tokenCacheMu write lock.
+func (rm *RBACManager) evictTokenCacheIfFull() {
+	if len(rm.tokenCache) >= rm.maxCacheSize {
+		for k := range rm.tokenCache {
+			delete(rm.tokenCache, k)
+			break
+		}
+	}
+}
+
 // cleanupExpiredCache removes expired entries from both caches
 func (rm *RBACManager) cleanupExpiredCache() {
 	now := time.Now()
@@ -930,14 +952,9 @@ func (rm *RBACManager) CheckPermission(req *PermissionCheckRequest) *PermissionC
 	// Cache miss - compute permission
 	result := rm.checkPermissionUncached(req)
 
-	// Cache the result (evict a random entry if over max size)
+	// Cache the result
 	rm.permCacheMu.Lock()
-	if len(rm.permCache) >= rm.maxCacheSize {
-		for k := range rm.permCache {
-			delete(rm.permCache, k)
-			break
-		}
-	}
+	rm.evictPermCacheIfFull()
 	rm.permCache[cacheKey] = &permissionCacheEntry{
 		result:    result,
 		expiresAt: time.Now().Add(rm.permCacheTTL),
@@ -1054,14 +1071,9 @@ func (rm *RBACManager) CheckPermissionsBatch(reqs []*PermissionCheckRequest) []*
 				}
 			}
 
-			// Cache the result (evict a random entry if over max size)
+			// Cache the result
 			rm.permCacheMu.Lock()
-			if len(rm.permCache) >= rm.maxCacheSize {
-				for k := range rm.permCache {
-					delete(rm.permCache, k)
-					break
-				}
-			}
+			rm.evictPermCacheIfFull()
 			rm.permCache[cacheKey] = &permissionCacheEntry{
 				result:    result,
 				expiresAt: time.Now().Add(rm.permCacheTTL),
@@ -1138,13 +1150,8 @@ func (rm *RBACManager) getTokenRBACData(tokenID int64) (*tokenRBACData, error) {
 		return nil, err
 	}
 
-	// Cache the result (already holding write lock, evict if over max size)
-	if len(rm.tokenCache) >= rm.maxCacheSize {
-		for k := range rm.tokenCache {
-			delete(rm.tokenCache, k)
-			break
-		}
-	}
+	// Cache the result (already holding write lock)
+	rm.evictTokenCacheIfFull()
 	rm.tokenCache[tokenID] = data
 
 	return data, nil


### PR DESCRIPTION
## Summary

- **#295**: `cacheCleanupLoop` goroutine ran forever with no shutdown mechanism. Added `done` channel + `Close()` method following the AuthManager pattern. Registered with shutdown coordinator at `PriorityAuth`.
- **#296**: Both `tokenCache` and `permCache` had no max size — only TTL-based expiration. Added configurable `MaxCacheSize` (default 10,000 entries per cache) with random eviction on insertion when exceeded.

## Test plan

- [x] `go build ./cmd/... ./internal/...` passes
- [x] `go test ./internal/auth/...` passes
- [x] Post-implementation security review: RBAC is license-gated, no race conditions in Close(), eviction is safe (re-checks hit database)

Closes #295
Closes #296