### PR TITLE
feat(cluster): add dead node removal API for Kubernetes scale-down

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -33,6 +33,17 @@ Cluster node identity is now stable across pod reschedules. When `cluster.node_i
 
 Additionally, cluster nodes now broadcast a `LeaveNotify` message to all peers during graceful shutdown. Peers immediately remove the departing node from Raft and the registry, rather than waiting for the heartbeat timeout to detect the departure. This makes rolling updates and scale-down operations clean and predictable.
 
+### Dead Node Removal API (Enterprise)
+
+New admin endpoint `DELETE /api/v1/cluster/nodes/:id` to remove a dead or permanently scaled-down node from the cluster. This removes the node from both the Raft voting configuration and the cluster FSM state, preventing dead voters from accumulating and eventually breaking quorum.
+
+```bash
+curl -X DELETE http://localhost:8000/api/v1/cluster/nodes/arc-writer-2 \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+Self-removal is prevented — use graceful shutdown (`LeaveNotify`) instead.
+
 ### RBAC Cache Lifecycle Management (Enterprise)
 
 RBACManager now has proper lifecycle management and bounded memory usage:

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1230,7 +1230,7 @@ func main() {
 	schedulerHandler.RegisterRoutes(server.GetApp())
 
 	// Register Cluster handler (always register, shows status even if clustering not enabled)
-	clusterHandler := api.NewClusterHandler(clusterCoordinator, licenseClient, logger.Get("cluster-api"))
+	clusterHandler := api.NewClusterHandler(clusterCoordinator, authManager, licenseClient, logger.Get("cluster-api"))
 	clusterHandler.RegisterRoutes(server.GetApp())
 
 	// Register MQTT handlers (always register, handlers check if manager is nil)

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/basekick-labs/arc/internal/auth"
 	"github.com/basekick-labs/arc/internal/cluster"
 	"github.com/basekick-labs/arc/internal/license"
 	"github.com/gofiber/fiber/v2"
@@ -33,6 +34,7 @@ var validStates = map[string]bool{
 // ClusterHandler handles cluster management API endpoints.
 type ClusterHandler struct {
 	coordinator   *cluster.Coordinator
+	authManager   *auth.AuthManager
 	licenseClient *license.Client
 	logger        zerolog.Logger
 }
@@ -41,11 +43,13 @@ type ClusterHandler struct {
 // The coordinator can be nil if clustering is not enabled.
 func NewClusterHandler(
 	coordinator *cluster.Coordinator,
+	authManager *auth.AuthManager,
 	licenseClient *license.Client,
 	logger zerolog.Logger,
 ) *ClusterHandler {
 	return &ClusterHandler{
 		coordinator:   coordinator,
+		authManager:   authManager,
 		licenseClient: licenseClient,
 		logger:        logger.With().Str("component", "cluster-handler").Logger(),
 	}
@@ -58,6 +62,13 @@ func (h *ClusterHandler) RegisterRoutes(app *fiber.App) {
 	app.Get("/api/v1/cluster/nodes/:id", h.handleGetNode)
 	app.Get("/api/v1/cluster/local", h.handleGetLocalNode)
 	app.Get("/api/v1/cluster/health", h.handleGetHealth)
+
+	// Admin-only: destructive operations
+	removeGroup := app.Group("/api/v1/cluster/nodes/:id")
+	if h.authManager != nil {
+		removeGroup.Use(auth.RequireAdmin(h.authManager))
+	}
+	removeGroup.Delete("", h.handleRemoveNode)
 }
 
 // handleGetStatus returns the overall cluster status.
@@ -239,4 +250,46 @@ func (h *ClusterHandler) nodeToMap(node *cluster.Node) map[string]interface{} {
 		"failed_checks":  node.GetFailedChecks(),
 		"stats":          node.GetStats(),
 	}
+}
+
+// handleRemoveNode removes a dead or unresponsive node from the cluster.
+// This is an admin-only destructive operation — it removes the node from
+// Raft voting, the cluster FSM state, and the local registry.
+func (h *ClusterHandler) handleRemoveNode(c *fiber.Ctx) error {
+	if h.coordinator == nil {
+		return h.respondNotEnabled(c)
+	}
+
+	nodeID := c.Params("id")
+	if len(nodeID) == 0 || len(nodeID) > maxNodeIDLength {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"error":   "invalid node ID",
+		})
+	}
+
+	// Prevent self-removal
+	localNode := h.coordinator.GetLocalNode()
+	if localNode != nil && localNode.ID == nodeID {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"error":   "cannot remove self from cluster — use graceful shutdown instead",
+		})
+	}
+
+	if err := h.coordinator.RemoveNodeViaRaft(nodeID); err != nil {
+		h.logger.Error().Err(err).Str("node_id", nodeID).Msg("Failed to remove node from cluster")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"success": false,
+			"error":   err.Error(),
+		})
+	}
+
+	h.logger.Info().Str("node_id", nodeID).Msg("Node removed from cluster via API")
+
+	return c.JSON(fiber.Map{
+		"success": true,
+		"message": "node removed from cluster",
+		"node_id": nodeID,
+	})
 }

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1467,18 +1467,20 @@ func (c *Coordinator) RemoveNodeViaRaft(nodeID string) error {
 		return fmt.Errorf("not the leader")
 	}
 
-	// Remove from Raft voting configuration first
+	// Remove from Raft voting configuration. Warn on failure (node may
+	// already be removed from a previous attempt) but continue with FSM
+	// cleanup to ensure consistent state.
 	if err := c.raftNode.RemoveServer(nodeID, 5*time.Second); err != nil {
-		return fmt.Errorf("failed to remove from Raft: %w", err)
+		c.logger.Warn().Err(err).Str("node_id", nodeID).Msg("Failed to remove node from Raft configuration (may already be removed)")
 	}
 
-	// Remove from cluster FSM state
+	// Remove from cluster FSM state. The FSM callback (onRaftNodeRemoved)
+	// handles registry unregistration on all nodes, so no manual
+	// Unregister call is needed here.
 	if err := c.raftNode.RemoveNode(nodeID, 5*time.Second); err != nil {
-		c.logger.Error().Err(err).Str("node_id", nodeID).Msg("Failed to remove node from FSM (Raft voter already removed)")
+		c.logger.Error().Err(err).Str("node_id", nodeID).Msg("Failed to remove node from FSM")
+		return fmt.Errorf("failed to remove node from cluster state: %w", err)
 	}
-
-	// Remove from local registry
-	c.registry.Unregister(nodeID)
 
 	c.logger.Info().Str("node_id", nodeID).Msg("Node removed from cluster")
 	return nil

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1453,6 +1453,8 @@ func (c *Coordinator) AddNodeViaRaft(node *Node) error {
 }
 
 // RemoveNodeViaRaft removes a node from the cluster via Raft consensus.
+// It removes the node from both the Raft voting configuration and the
+// cluster FSM state, then unregisters it from the local registry.
 // Must be called on the leader.
 func (c *Coordinator) RemoveNodeViaRaft(nodeID string) error {
 	if c.raftNode == nil {
@@ -1465,7 +1467,21 @@ func (c *Coordinator) RemoveNodeViaRaft(nodeID string) error {
 		return fmt.Errorf("not the leader")
 	}
 
-	return c.raftNode.RemoveNode(nodeID, 5*time.Second)
+	// Remove from Raft voting configuration first
+	if err := c.raftNode.RemoveServer(nodeID, 5*time.Second); err != nil {
+		return fmt.Errorf("failed to remove from Raft: %w", err)
+	}
+
+	// Remove from cluster FSM state
+	if err := c.raftNode.RemoveNode(nodeID, 5*time.Second); err != nil {
+		c.logger.Error().Err(err).Str("node_id", nodeID).Msg("Failed to remove node from FSM (Raft voter already removed)")
+	}
+
+	// Remove from local registry
+	c.registry.Unregister(nodeID)
+
+	c.logger.Info().Str("node_id", nodeID).Msg("Node removed from cluster")
+	return nil
 }
 
 // UpdateNodeStateViaRaft updates a node's state via Raft consensus.


### PR DESCRIPTION
## Summary

- New admin endpoint `DELETE /api/v1/cluster/nodes/:id` to remove a dead or permanently scaled-down node from the cluster
- Fixes `RemoveNodeViaRaft()` to call both `RemoveServer()` (Raft voting) and `RemoveNode()` (FSM state) + `Unregister()` — previously only called `RemoveNode()`, leaving dead voters in the Raft configuration
- Self-removal prevented with clear error message
- Admin auth required (`auth.RequireAdmin`)

## Why

When a Kubernetes pod is permanently scaled down, its Raft voter entry persists. Without a removal API, dead voters accumulate and can eventually break quorum — the cluster can't elect a leader, process writes, or even remove the dead voters.

## Test plan

- [x] `go build ./cmd/... ./internal/...` passes
- [x] `go test ./internal/cluster/...` passes
- [x] `go test ./internal/api/...` passes
- [x] Post-implementation review: auth enforced, self-removal prevented, license-gated via coordinator
- [ ] Manual: remove a dead node via API, verify cluster health recovers