### PR TITLE
feat(cluster): wire IngestHandler on readers for query freshness

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -33,6 +33,12 @@ Cluster node identity is now stable across pod reschedules. When `cluster.node_i
 
 Additionally, cluster nodes now broadcast a `LeaveNotify` message to all peers during graceful shutdown. Peers immediately remove the departing node from Raft and the registry, rather than waiting for the heartbeat timeout to detect the departure. This makes rolling updates and scale-down operations clean and predictable.
 
+### Reader Query Freshness via WAL Replication (Enterprise)
+
+Reader nodes now apply replicated WAL entries to their local ArrowBuffer, enabling near-real-time query freshness. Previously, readers received WAL entries from the writer but only persisted them to their local WAL — the data was invisible to queries until flushed to Parquet. Now, replicated entries are decoded (both columnar and row formats) and written directly to the reader's in-memory buffer, making unflushed writer data queryable on readers.
+
+This is the foundation for zero-latency reads across clustered deployments — ingested data is queryable on readers within milliseconds of arriving at the writer.
+
 ### Dead Node Removal API (Enterprise)
 
 New admin endpoint `DELETE /api/v1/cluster/nodes/:id` to remove a dead or permanently scaled-down node from the cluster. This removes the node from both the Raft voting configuration and the cluster FSM state, preventing dead voters from accumulating and eventually breaking quorum.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -783,6 +783,7 @@ func main() {
 						// Wire up WAL replication if enabled
 						if cfg.Cluster.ReplicationEnabled && walWriter != nil {
 							clusterCoordinator.SetWAL(walWriter)
+							clusterCoordinator.SetIngestBuffer(arrowBuffer)
 							if err := clusterCoordinator.StartReplication(); err != nil {
 								log.Warn().Err(err).Msg("Failed to start WAL replication")
 							} else {

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1369,8 +1369,10 @@ func (c *Coordinator) startReceiverWithAddr(writerAddr string) error {
 // LocalWAL path already handles WAL persistence).
 func (c *Coordinator) buildReplicationIngestHandler() replication.IngestHandler {
 	return replication.IngestHandlerFunc(func(ctx context.Context, payload []byte) error {
-		// Safety: check buffer is still available (coordinator may be shutting down)
+		// Safety: read-lock to avoid data race with SetIngestBuffer
+		c.mu.RLock()
 		buf := c.ingestBuffer
+		c.mu.RUnlock()
 		if buf == nil {
 			return nil
 		}
@@ -1401,7 +1403,10 @@ func (c *Coordinator) buildReplicationIngestHandler() replication.IngestHandler 
 		if err := msgpack.Unmarshal(msgpackData, &records); err == nil && len(records) > 0 {
 			byMeasurement := make(map[string][]map[string]interface{})
 			for _, r := range records {
-				m, _ := r["measurement"].(string)
+				m, _ := r["_measurement"].(string)
+				if m == "" {
+					m, _ = r["measurement"].(string)
+				}
 				if m == "" {
 					m, _ = r["m"].(string)
 				}
@@ -1426,26 +1431,23 @@ func (c *Coordinator) buildReplicationIngestHandler() replication.IngestHandler 
 }
 
 // rowsToColumns converts row-format records to columnar format for ArrowBuffer.
+// Metadata keys (_measurement, measurement, m, _database, database) are filtered
+// out to prevent them from being ingested as regular data columns.
 func rowsToColumns(rows []map[string]interface{}) map[string][]interface{} {
 	if len(rows) == 0 {
 		return map[string][]interface{}{}
 	}
-	// Collect all column names
-	colSet := make(map[string]bool)
-	for _, r := range rows {
-		for k := range r {
-			if k != "measurement" && k != "m" {
-				colSet[k] = true
+	columns := make(map[string][]interface{})
+	for i, r := range rows {
+		for k, v := range r {
+			if k == "measurement" || k == "m" || k == "_measurement" || k == "database" || k == "_database" {
+				continue
 			}
+			if _, ok := columns[k]; !ok {
+				columns[k] = make([]interface{}, len(rows))
+			}
+			columns[k][i] = v
 		}
-	}
-	columns := make(map[string][]interface{}, len(colSet))
-	for col := range colSet {
-		arr := make([]interface{}, len(rows))
-		for i, r := range rows {
-			arr[i] = r[col]
-		}
-		columns[col] = arr
 	}
 	return columns
 }

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -12,11 +12,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Basekick-Labs/msgpack/v6"
 	"github.com/basekick-labs/arc/internal/cluster/protocol"
 	"github.com/basekick-labs/arc/internal/cluster/raft"
 	"github.com/basekick-labs/arc/internal/cluster/replication"
 	"github.com/basekick-labs/arc/internal/cluster/security"
 	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/ingest"
 	"github.com/basekick-labs/arc/internal/license"
 	"github.com/basekick-labs/arc/internal/wal"
 	"github.com/rs/zerolog"
@@ -51,6 +53,7 @@ type Coordinator struct {
 	replicationSender   *replication.Sender   // Writer only: sends entries to readers
 	replicationReceiver *replication.Receiver // Reader only: receives entries from writer
 	walWriter           *wal.Writer           // Reference to local WAL for replication hook
+	ingestBuffer        *ingest.ArrowBuffer   // Reader only: applies replicated entries to local buffer
 
 	// Network
 	listener  net.Listener
@@ -1220,6 +1223,16 @@ func (c *Coordinator) SetWAL(walWriter *wal.Writer) {
 	c.walWriter = walWriter
 }
 
+// SetIngestBuffer sets the ArrowBuffer for reader nodes to apply replicated
+// entries. This enables query freshness — readers can query unflushed writer
+// data that arrives via WAL replication.
+func (c *Coordinator) SetIngestBuffer(buffer *ingest.ArrowBuffer) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ingestBuffer = buffer
+	c.logger.Info().Msg("Ingest buffer set for replication — readers will apply replicated entries")
+}
+
 // StartReplication starts WAL replication based on node role.
 // - Writers start a Sender to stream entries to readers
 // - Readers start a Receiver to receive entries from the writer
@@ -1321,10 +1334,18 @@ func (c *Coordinator) waitForWriterAndStartReceiver() {
 // startReceiverWithAddr starts the replication receiver with the given writer address.
 // Caller must hold c.mu lock.
 func (c *Coordinator) startReceiverWithAddr(writerAddr string) error {
+	// Build IngestHandler if ArrowBuffer is available — allows reader to
+	// apply replicated entries to its local buffer for query freshness.
+	var ingestHandler replication.IngestHandler
+	if c.ingestBuffer != nil {
+		ingestHandler = c.buildReplicationIngestHandler()
+	}
+
 	c.replicationReceiver = replication.NewReceiver(&replication.ReceiverConfig{
 		ReaderID:          c.localNode.ID,
 		WriterAddr:        writerAddr,
 		LocalWAL:          c.walWriter,
+		IngestHandler:     ingestHandler,
 		ReconnectInterval: 5 * time.Second,
 		AckInterval:       time.Duration(c.cfg.ReplicationAckInterval) * time.Millisecond,
 		Logger:            c.logger,
@@ -1337,9 +1358,96 @@ func (c *Coordinator) startReceiverWithAddr(writerAddr string) error {
 
 	c.logger.Info().
 		Str("writer_addr", writerAddr).
+		Bool("ingest_handler", ingestHandler != nil).
 		Msg("Replication receiver started (reader mode)")
 
 	return nil
+}
+
+// buildReplicationIngestHandler creates an IngestHandler that parses WAL envelope
+// payloads and writes them to the local ArrowBuffer (NoWAL variant — the receiver's
+// LocalWAL path already handles WAL persistence).
+func (c *Coordinator) buildReplicationIngestHandler() replication.IngestHandler {
+	return replication.IngestHandlerFunc(func(ctx context.Context, payload []byte) error {
+		// Safety: check buffer is still available (coordinator may be shutting down)
+		buf := c.ingestBuffer
+		if buf == nil {
+			return nil
+		}
+
+		// Parse WAL envelope to extract database name and msgpack payload
+		database, msgpackData := wal.ParseEnvelope(payload, "default")
+
+		// Try columnar format first (map with "m" + "columns" keys)
+		var rawMap map[string]interface{}
+		if err := msgpack.Unmarshal(msgpackData, &rawMap); err == nil {
+			if measurement, ok := rawMap["m"].(string); ok && measurement != "" {
+				if columns, ok := rawMap["columns"].(map[string]interface{}); ok && len(columns) > 0 {
+					typedColumns := make(map[string][]interface{}, len(columns))
+					for k, v := range columns {
+						if arr, ok := v.([]interface{}); ok {
+							typedColumns[k] = arr
+						}
+					}
+					if len(typedColumns) > 0 {
+						return buf.WriteColumnarDirectNoWAL(ctx, database, measurement, typedColumns)
+					}
+				}
+			}
+		}
+
+		// Fall back to row format (array of maps)
+		var records []map[string]interface{}
+		if err := msgpack.Unmarshal(msgpackData, &records); err == nil && len(records) > 0 {
+			byMeasurement := make(map[string][]map[string]interface{})
+			for _, r := range records {
+				m, _ := r["measurement"].(string)
+				if m == "" {
+					m, _ = r["m"].(string)
+				}
+				if m != "" {
+					byMeasurement[m] = append(byMeasurement[m], r)
+				}
+			}
+			for measurement, rows := range byMeasurement {
+				columns := rowsToColumns(rows)
+				if len(columns) > 0 {
+					if err := buf.WriteColumnarDirectNoWAL(ctx, database, measurement, columns); err != nil {
+						return fmt.Errorf("write replicated rows for %s: %w", measurement, err)
+					}
+				}
+			}
+			return nil
+		}
+
+		c.logger.Debug().Int("payload_size", len(payload)).Msg("Skipped unrecognized replicated entry format")
+		return nil
+	})
+}
+
+// rowsToColumns converts row-format records to columnar format for ArrowBuffer.
+func rowsToColumns(rows []map[string]interface{}) map[string][]interface{} {
+	if len(rows) == 0 {
+		return map[string][]interface{}{}
+	}
+	// Collect all column names
+	colSet := make(map[string]bool)
+	for _, r := range rows {
+		for k := range r {
+			if k != "measurement" && k != "m" {
+				colSet[k] = true
+			}
+		}
+	}
+	columns := make(map[string][]interface{}, len(colSet))
+	for col := range colSet {
+		arr := make([]interface{}, len(rows))
+		for i, r := range rows {
+			arr[i] = r[col]
+		}
+		columns[col] = arr
+	}
+	return columns
 }
 
 // StopReplication stops WAL replication.

--- a/internal/cluster/replication/receiver.go
+++ b/internal/cluster/replication/receiver.go
@@ -27,6 +27,13 @@ type IngestHandler interface {
 	ApplyReplicatedEntry(ctx context.Context, payload []byte) error
 }
 
+// IngestHandlerFunc is an adapter to allow the use of ordinary functions as IngestHandler.
+type IngestHandlerFunc func(ctx context.Context, payload []byte) error
+
+func (f IngestHandlerFunc) ApplyReplicatedEntry(ctx context.Context, payload []byte) error {
+	return f(ctx, payload)
+}
+
 // ReceiverConfig holds configuration for the replication receiver.
 type ReceiverConfig struct {
 	// ReaderID is this reader's unique identifier

--- a/internal/wal/reader.go
+++ b/internal/wal/reader.go
@@ -139,16 +139,8 @@ func (r *Reader) readEntry(f *os.File) (*Entry, error) {
 		return nil, fmt.Errorf("checksum mismatch: expected %d, got %d", expectedChecksum, actualChecksum)
 	}
 
-	// Check for envelope format: [0x01 marker][2-byte dbLen][dbName][msgpack]
-	var database string
-	msgpackData := payload
-	if len(payload) > 3 && payload[0] == WALEnvelopeMarker {
-		dbLen := binary.BigEndian.Uint16(payload[1:3])
-		if int(3+dbLen) <= len(payload) {
-			database = string(payload[3 : 3+dbLen])
-			msgpackData = payload[3+dbLen:]
-		}
-	}
+	// Parse envelope to extract database name and inner msgpack payload
+	database, msgpackData := ParseEnvelope(payload, "")
 
 	// Try row format first (array of maps from Append path)
 	var records []map[string]interface{}

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -40,6 +40,20 @@ const (
 	WALEnvelopeMarker = 0x01
 )
 
+// ParseEnvelope extracts the database name and msgpack payload from a WAL entry.
+// If the payload uses the envelope format [0x01][2-byte dbLen][dbName][msgpack],
+// it returns the database name and the inner msgpack bytes. Otherwise, it returns
+// defaultDB and the original payload unchanged.
+func ParseEnvelope(payload []byte, defaultDB string) (database string, msgpackData []byte) {
+	if len(payload) > 3 && payload[0] == WALEnvelopeMarker {
+		dbLen := binary.BigEndian.Uint16(payload[1:3])
+		if int(3+dbLen) <= len(payload) {
+			return string(payload[3 : 3+dbLen]), payload[3+dbLen:]
+		}
+	}
+	return defaultDB, payload
+}
+
 // SyncMode defines how WAL syncs to disk
 type SyncMode string
 


### PR DESCRIPTION
## Summary

- Reader nodes now apply replicated WAL entries to their local ArrowBuffer, enabling near-real-time query freshness across the cluster
- `buildReplicationIngestHandler()` parses WAL envelope, decodes both columnar and row msgpack formats, writes via `WriteColumnarDirectNoWAL` (avoids WAL double-write since receiver's LocalWAL already handles persistence)
- Added `IngestHandlerFunc` adapter type (follows `http.HandlerFunc` pattern)
- Extracted `wal.ParseEnvelope()` as shared utility — replaces inline envelope parsing in both `wal/reader.go` and `coordinator.go`
- Foundation for #249 (query in-flight buffer data)

## Data flow (after this change)

```
Writer: Ingest → ArrowBuffer → WAL → replication hook → Sender → TCP → Reader
Reader: Receiver → LocalWAL (persistence) + IngestHandler → ArrowBuffer (query freshness)
```

## Test plan

- [x] `go build ./cmd/... ./internal/...` passes
- [x] `go test ./internal/cluster/...` passes
- [x] `go test ./internal/wal/...` passes
- [x] Post-implementation review: nil safety, envelope parsing, format detection