### PR TITLE
feat(cluster): file manifest in Raft FSM — foundation for peer replication (Phase 1)

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -10,6 +10,25 @@ The `?p=` method continues to work but Arc now logs a one-time warning on first 
 
 ## New Features
 
+### Cluster File Manifest (Enterprise — Foundation for Peer Replication)
+
+Arc Enterprise now maintains a cluster-wide file manifest in the Raft FSM. Every Parquet file flushed by a writer (or produced by compaction) is announced to the cluster via a new Raft command, producing an authoritative view of all files known to the cluster. This is the foundation for peer-to-peer file replication in bare-metal and VM deployments where nodes have their own local storage.
+
+**What this delivers today:**
+- New Raft commands `CommandRegisterFile` and `CommandDeleteFile` added to `ClusterFSM`
+- File manifest persisted in Raft snapshots and replicated to all cluster members via standard Raft consensus
+- New API endpoint `GET /api/v1/cluster/files` returns the complete cluster file manifest (supports `?database=<name>` filter)
+- Async, non-blocking registration from the flush path — the file registrar enqueues entries and a background worker appends to Raft, so write latency is unaffected
+- Zero overhead for OSS / standalone deployments — no coordinator, no registrar, no manifest
+
+**What's coming next** (separate PRs):
+- Phase 2: HTTP fetch server + background pullers to replicate files between peers over TLS-secured coordinator connections
+- Phase 3: Automatic catch-up for new nodes joining a cluster with existing data
+- Phase 4: Integration with compaction (compactor role produces files, replicas pull the compacted output)
+- Phase 5: Optional write quorum for strong durability
+
+**Design inspiration:** ClickHouse's ReplicatedMergeTree model — a Raft-equivalent op log + HTTP-pull-based file transfer. Research compared InfluxDB Enterprise (anti-entropy + HHQ), ClickHouse (log + HTTP pull), TimescaleDB (deprecated multi-node), Apache Pinot (peer fetcher fallback), and Apache Druid (metadata-driven assignment). ClickHouse's model is the cleanest fit for Arc's existing Raft + coordinator TCP infrastructure.
+
 ### Cluster TLS Encryption and Shared Secret Authentication (Enterprise)
 
 Arc Enterprise clustering now supports encrypted inter-node communication and authenticated cluster joins — bringing production-grade security to multi-node deployments.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -797,6 +797,12 @@ func main() {
 						// The registrar is non-blocking: it enqueues file registrations
 						// and a background worker appends them to the Raft manifest.
 						// OSS deployments never reach here (no coordinator).
+						//
+						// Shutdown ordering: lower priority runs first (see shutdown.go).
+						// file-registrar is at PriorityBuffer (30), cluster-coordinator is
+						// at PriorityCompaction (50). So the registrar drains its queue
+						// BEFORE Raft is stopped, ensuring pending file announcements
+						// complete while Raft is still alive.
 						fileRegistrar := cluster.NewCoordinatorFileRegistrar(clusterCoordinator, logger.Get("file-registrar"))
 						fileRegistrar.Start(context.Background())
 						arrowBuffer.SetFileRegistrar(fileRegistrar)

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -792,6 +792,19 @@ func main() {
 									Msg("WAL replication started")
 							}
 						}
+
+						// Wire up peer file replication manifest (Enterprise Phase 1).
+						// The registrar is non-blocking: it enqueues file registrations
+						// and a background worker appends them to the Raft manifest.
+						// OSS deployments never reach here (no coordinator).
+						fileRegistrar := cluster.NewCoordinatorFileRegistrar(clusterCoordinator, logger.Get("file-registrar"))
+						fileRegistrar.Start(context.Background())
+						arrowBuffer.SetFileRegistrar(fileRegistrar)
+						shutdownCoordinator.RegisterHook("file-registrar", func(ctx context.Context) error {
+							fileRegistrar.Stop()
+							return nil
+						}, shutdown.PriorityBuffer)
+						log.Info().Msg("Cluster file manifest registrar enabled")
 					}
 				}
 			}

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/basekick-labs/arc/internal/auth"
 	"github.com/basekick-labs/arc/internal/cluster"
+	clusterraft "github.com/basekick-labs/arc/internal/cluster/raft"
 	"github.com/basekick-labs/arc/internal/license"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
@@ -63,7 +64,14 @@ func (h *ClusterHandler) RegisterRoutes(app *fiber.App) {
 	app.Get("/api/v1/cluster/local", h.handleGetLocalNode)
 	app.Get("/api/v1/cluster/health", h.handleGetHealth)
 
-	// Admin-only: destructive operations
+	// Admin-only: file manifest exposes database schema + file paths
+	// and destructive node removal
+	filesGroup := app.Group("/api/v1/cluster/files")
+	if h.authManager != nil {
+		filesGroup.Use(auth.RequireAdmin(h.authManager))
+	}
+	filesGroup.Get("", h.handleGetFiles)
+
 	removeGroup := app.Group("/api/v1/cluster/nodes/:id")
 	if h.authManager != nil {
 		removeGroup.Use(auth.RequireAdmin(h.authManager))
@@ -291,5 +299,29 @@ func (h *ClusterHandler) handleRemoveNode(c *fiber.Ctx) error {
 		"success": true,
 		"message": "node removed from cluster",
 		"node_id": nodeID,
+	})
+}
+
+// handleGetFiles returns the cluster-wide file manifest from the Raft FSM.
+// Supports optional `database` query parameter to filter by database.
+// This is the authoritative view of all files known to the cluster — used
+// by the peer replication system to determine what to pull from other nodes.
+func (h *ClusterHandler) handleGetFiles(c *fiber.Ctx) error {
+	if h.coordinator == nil {
+		return h.respondNotEnabled(c)
+	}
+
+	database := c.Query("database")
+
+	var files []*clusterraft.FileEntry
+	if database != "" {
+		files = h.coordinator.GetFileManifestByDatabase(database)
+	} else {
+		files = h.coordinator.GetFileManifest()
+	}
+
+	return c.JSON(fiber.Map{
+		"files": files,
+		"total": len(files),
 	})
 }

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1615,3 +1615,75 @@ func (c *Coordinator) UpdateNodeStateViaRaft(nodeID string, state NodeState) err
 
 	return c.raftNode.UpdateNodeState(nodeID, string(state), 5*time.Second)
 }
+
+// RegisterFileInManifest appends a file entry to the cluster-wide manifest
+// via Raft. Returns nil if Raft is not initialized (standalone mode).
+// Only the Raft leader can append; non-leader nodes silently skip — the
+// manifest is not critical for correctness in Phase 1 since replication is
+// not yet active. A future phase will add forwarding to the leader.
+func (c *Coordinator) RegisterFileInManifest(file raft.FileEntry) error {
+	if c.raftNode == nil {
+		// Standalone mode — no manifest needed
+		return nil
+	}
+
+	if !c.raftNode.IsLeader() {
+		// Non-leader writers can't append directly. In Phase 1 this is
+		// acceptable: the manifest is informational. Phase 2 will add
+		// leader forwarding for non-leader writers.
+		c.logger.Debug().
+			Str("path", file.Path).
+			Msg("Skipping manifest registration (not the Raft leader)")
+		return nil
+	}
+
+	if err := c.raftNode.RegisterFile(file, 5*time.Second); err != nil {
+		return fmt.Errorf("register file in manifest: %w", err)
+	}
+	return nil
+}
+
+// DeleteFileFromManifest removes a file from the cluster-wide manifest.
+// Called by retention and compaction cleanup.
+func (c *Coordinator) DeleteFileFromManifest(path, reason string) error {
+	if c.raftNode == nil {
+		return nil
+	}
+
+	if !c.raftNode.IsLeader() {
+		c.logger.Debug().
+			Str("path", path).
+			Msg("Skipping manifest deletion (not the Raft leader)")
+		return nil
+	}
+
+	if err := c.raftNode.DeleteFile(path, reason, 5*time.Second); err != nil {
+		return fmt.Errorf("delete file from manifest: %w", err)
+	}
+	return nil
+}
+
+// GetFileManifest returns the current file manifest from the Raft FSM.
+// Returns nil if Raft is not initialized.
+func (c *Coordinator) GetFileManifest() []*raft.FileEntry {
+	if c.raftNode == nil {
+		return nil
+	}
+	fsm := c.raftNode.FSM()
+	if fsm == nil {
+		return nil
+	}
+	return fsm.GetAllFiles()
+}
+
+// GetFileManifestByDatabase returns files for a specific database.
+func (c *Coordinator) GetFileManifestByDatabase(database string) []*raft.FileEntry {
+	if c.raftNode == nil {
+		return nil
+	}
+	fsm := c.raftNode.FSM()
+	if fsm == nil {
+		return nil
+	}
+	return fsm.GetFilesByDatabase(database)
+}

--- a/internal/cluster/file_registrar.go
+++ b/internal/cluster/file_registrar.go
@@ -1,0 +1,186 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/rs/zerolog"
+)
+
+// CoordinatorFileRegistrar implements ingest.FileRegistrar by forwarding
+// file registration events to the cluster coordinator's Raft manifest.
+//
+// The registration is fully async: RegisterFile enqueues the entry and
+// returns immediately. A background worker drains the queue and calls
+// coordinator.RegisterFileInManifest. This ensures the flush hot path
+// is never blocked on Raft consensus, network I/O, or checksum compute.
+//
+// In Phase 1 we do NOT compute checksums yet — the manifest entry records
+// the path, size, and origin for validation. Checksums will be added in
+// Phase 2 when we start pulling files from peers.
+type CoordinatorFileRegistrar struct {
+	coordinator *Coordinator
+	queue       chan fileRegistration
+	logger      zerolog.Logger
+
+	// Metrics (atomic for lock-free access)
+	totalEnqueued  atomic.Int64 // files successfully enqueued
+	totalApplied   atomic.Int64 // files successfully applied to Raft
+	totalDropped   atomic.Int64 // files dropped due to full queue
+	totalApplyErrs atomic.Int64 // files that failed to apply (includes non-leader skips)
+
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	started bool
+	mu      sync.Mutex
+}
+
+// Stats returns a snapshot of registrar metrics.
+func (r *CoordinatorFileRegistrar) Stats() map[string]int64 {
+	return map[string]int64{
+		"enqueued":    r.totalEnqueued.Load(),
+		"applied":     r.totalApplied.Load(),
+		"dropped":     r.totalDropped.Load(),
+		"apply_errs":  r.totalApplyErrs.Load(),
+		"queue_depth": int64(len(r.queue)),
+	}
+}
+
+type fileRegistration struct {
+	database      string
+	measurement   string
+	path          string
+	partitionTime time.Time
+	sizeBytes     int64
+}
+
+// NewCoordinatorFileRegistrar creates a new registrar backed by the coordinator.
+// The coordinator must be started before the registrar is used.
+func NewCoordinatorFileRegistrar(coord *Coordinator, logger zerolog.Logger) *CoordinatorFileRegistrar {
+	return &CoordinatorFileRegistrar{
+		coordinator: coord,
+		// Buffered queue — drops are preferable to blocking the flush path.
+		// 4096 is well above the expected flush rate (~10-100/sec) with
+		// headroom for bursts during backfill or catch-up.
+		queue:  make(chan fileRegistration, 4096),
+		logger: logger.With().Str("component", "file-registrar").Logger(),
+	}
+}
+
+// Start launches the background worker that drains the registration queue.
+func (r *CoordinatorFileRegistrar) Start(parentCtx context.Context) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return
+	}
+	r.ctx, r.cancel = context.WithCancel(parentCtx)
+	r.started = true
+	r.wg.Add(1)
+	go r.worker()
+	r.logger.Info().Msg("File registrar background worker started")
+}
+
+// Stop signals the worker to exit, drains any pending entries, and waits for
+// the worker to finish. Best-effort drain: entries still in-flight after the
+// drain timeout are discarded (they can be recovered by anti-entropy in a
+// future phase).
+func (r *CoordinatorFileRegistrar) Stop() {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return
+	}
+	r.cancel()
+	r.mu.Unlock()
+	r.wg.Wait()
+
+	// Drain remaining queue entries (best-effort, bounded by deadline).
+	drainDeadline := time.Now().Add(2 * time.Second)
+	drained := 0
+DrainLoop:
+	for time.Now().Before(drainDeadline) {
+		select {
+		case reg := <-r.queue:
+			r.process(reg)
+			drained++
+		default:
+			break DrainLoop
+		}
+	}
+
+	r.logger.Info().
+		Int("drained", drained).
+		Int64("total_enqueued", r.totalEnqueued.Load()).
+		Int64("total_applied", r.totalApplied.Load()).
+		Int64("total_dropped", r.totalDropped.Load()).
+		Msg("File registrar background worker stopped")
+}
+
+// RegisterFile implements ingest.FileRegistrar. Non-blocking: enqueues the
+// registration and returns immediately. If the queue is full, the entry is
+// dropped and a counter is incremented — peer replication will discover it on
+// the next anti-entropy scan (Phase 3+).
+func (r *CoordinatorFileRegistrar) RegisterFile(database, measurement, path string, partitionTime time.Time, sizeBytes int64) {
+	reg := fileRegistration{
+		database:      database,
+		measurement:   measurement,
+		path:          path,
+		partitionTime: partitionTime,
+		sizeBytes:     sizeBytes,
+	}
+	select {
+	case r.queue <- reg:
+		r.totalEnqueued.Add(1)
+	default:
+		dropped := r.totalDropped.Add(1)
+		// Rate-limit the warning to avoid log spam under sustained overflow.
+		// Log on every power of 2 so we see bursts without flooding logs.
+		if dropped&(dropped-1) == 0 {
+			r.logger.Warn().
+				Str("path", path).
+				Int64("total_dropped", dropped).
+				Msg("File registrar queue full, dropping manifest entry (will be recovered by anti-entropy)")
+		}
+	}
+}
+
+func (r *CoordinatorFileRegistrar) worker() {
+	defer r.wg.Done()
+
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case reg := <-r.queue:
+			r.process(reg)
+		}
+	}
+}
+
+func (r *CoordinatorFileRegistrar) process(reg fileRegistration) {
+	entry := raft.FileEntry{
+		Path:          reg.path,
+		SizeBytes:     reg.sizeBytes,
+		Database:      reg.database,
+		Measurement:   reg.measurement,
+		PartitionTime: reg.partitionTime,
+		OriginNodeID:  r.coordinator.localNode.ID,
+		Tier:          "hot",
+		CreatedAt:     time.Now().UTC(),
+	}
+
+	if err := r.coordinator.RegisterFileInManifest(entry); err != nil {
+		r.totalApplyErrs.Add(1)
+		r.logger.Debug().
+			Err(err).
+			Str("path", reg.path).
+			Msg("Failed to register file in cluster manifest")
+		return
+	}
+	r.totalApplied.Add(1)
+}

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/raft"
 	"github.com/rs/zerolog"
@@ -26,6 +27,10 @@ const (
 	CommandPromoteWriter
 	// CommandDemoteWriter demotes a writer node to standby.
 	CommandDemoteWriter
+	// CommandRegisterFile announces a newly written file to the cluster manifest.
+	CommandRegisterFile
+	// CommandDeleteFile removes a file from the cluster manifest.
+	CommandDeleteFile
 )
 
 // Command represents a command to be applied to the FSM.
@@ -80,10 +85,38 @@ type DemoteWriterPayload struct {
 	NodeID string `json:"node_id"` // Node to demote to standby
 }
 
+// FileEntry represents a single Parquet file in the cluster-wide manifest.
+// This is the authoritative record of a file's existence, used by peer
+// replication to decide what to pull from other nodes.
+type FileEntry struct {
+	Path          string    `json:"path"`           // Relative storage path (e.g. "db/measurement/2026/04/11/14/file.parquet")
+	SHA256        string    `json:"sha256"`         // Content checksum for verification
+	SizeBytes     int64     `json:"size_bytes"`     // File size
+	Database      string    `json:"database"`       // Arc database name
+	Measurement   string    `json:"measurement"`    // Arc measurement name
+	PartitionTime time.Time `json:"partition_time"` // Partition time (for hot/cold routing)
+	OriginNodeID  string    `json:"origin_node_id"` // Node that first wrote the file
+	Tier          string    `json:"tier"`           // "hot" or "cold"
+	CreatedAt     time.Time `json:"created_at"`     // When the file was first registered
+	LSN           uint64    `json:"lsn"`            // Raft log index at registration (for ordering)
+}
+
+// RegisterFilePayload is the payload for CommandRegisterFile.
+type RegisterFilePayload struct {
+	File FileEntry `json:"file"`
+}
+
+// DeleteFilePayload is the payload for CommandDeleteFile.
+type DeleteFilePayload struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason,omitempty"` // "retention", "compaction", "manual"
+}
+
 // FSMSnapshot represents a snapshot of the FSM state.
 type FSMSnapshot struct {
-	Nodes           map[string]*NodeInfo `json:"nodes"`
-	PrimaryWriterID string               `json:"primary_writer_id,omitempty"`
+	Nodes           map[string]*NodeInfo  `json:"nodes"`
+	PrimaryWriterID string                `json:"primary_writer_id,omitempty"`
+	Files           map[string]*FileEntry `json:"files,omitempty"` // File manifest (peer replication)
 }
 
 // ClusterFSM implements the raft.FSM interface for cluster state management.
@@ -91,7 +124,8 @@ type FSMSnapshot struct {
 type ClusterFSM struct {
 	mu              sync.RWMutex
 	nodes           map[string]*NodeInfo
-	primaryWriterID string // ID of the current primary writer node
+	primaryWriterID string                // ID of the current primary writer node
+	files           map[string]*FileEntry // File manifest (path → entry) for peer replication
 	logger          zerolog.Logger
 
 	// Callbacks for state changes
@@ -99,12 +133,15 @@ type ClusterFSM struct {
 	onNodeRemoved    func(string)
 	onNodeUpdated    func(*NodeInfo)
 	onWriterPromoted func(newPrimaryID, oldPrimaryID string)
+	onFileRegistered func(*FileEntry)
+	onFileDeleted    func(path string, reason string)
 }
 
 // NewClusterFSM creates a new cluster FSM.
 func NewClusterFSM(logger zerolog.Logger) *ClusterFSM {
 	return &ClusterFSM{
 		nodes:  make(map[string]*NodeInfo),
+		files:  make(map[string]*FileEntry),
 		logger: logger.With().Str("component", "cluster-fsm").Logger(),
 	}
 }
@@ -123,6 +160,14 @@ func (f *ClusterFSM) SetWriterPromotedCallback(cb func(newPrimaryID, oldPrimaryI
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.onWriterPromoted = cb
+}
+
+// SetFileCallbacks sets the callbacks for file manifest events (peer replication).
+func (f *ClusterFSM) SetFileCallbacks(onRegistered func(*FileEntry), onDeleted func(path, reason string)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.onFileRegistered = onRegistered
+	f.onFileDeleted = onDeleted
 }
 
 // GetPrimaryWriterID returns the current primary writer node ID.
@@ -154,6 +199,10 @@ func (f *ClusterFSM) Apply(log *raft.Log) interface{} {
 		return f.applyPromoteWriter(cmd.Payload)
 	case CommandDemoteWriter:
 		return f.applyDemoteWriter(cmd.Payload)
+	case CommandRegisterFile:
+		return f.applyRegisterFile(cmd.Payload, log.Index)
+	case CommandDeleteFile:
+		return f.applyDeleteFile(cmd.Payload)
 	default:
 		return fmt.Errorf("unknown command type: %d", cmd.Type)
 	}
@@ -343,6 +392,78 @@ func (f *ClusterFSM) applyDemoteWriter(payload []byte) interface{} {
 	return nil
 }
 
+func (f *ClusterFSM) applyRegisterFile(payload []byte, logIndex uint64) interface{} {
+	var p RegisterFilePayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("failed to unmarshal register file payload: %w", err)
+	}
+
+	if p.File.Path == "" {
+		return fmt.Errorf("register file: path is required")
+	}
+
+	// Stamp the LSN from the Raft log index
+	p.File.LSN = logIndex
+	if p.File.CreatedAt.IsZero() {
+		p.File.CreatedAt = time.Now().UTC()
+	}
+
+	f.mu.Lock()
+	entry := p.File
+	f.files[entry.Path] = &entry
+	callback := f.onFileRegistered
+	f.mu.Unlock()
+
+	f.logger.Debug().
+		Str("path", entry.Path).
+		Str("database", entry.Database).
+		Str("measurement", entry.Measurement).
+		Str("origin", entry.OriginNodeID).
+		Int64("size_bytes", entry.SizeBytes).
+		Uint64("lsn", entry.LSN).
+		Msg("File registered in cluster manifest")
+
+	if callback != nil {
+		entryCopy := entry
+		callback(&entryCopy)
+	}
+
+	return nil
+}
+
+func (f *ClusterFSM) applyDeleteFile(payload []byte) interface{} {
+	var p DeleteFilePayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("failed to unmarshal delete file payload: %w", err)
+	}
+
+	if p.Path == "" {
+		return fmt.Errorf("delete file: path is required")
+	}
+
+	f.mu.Lock()
+	_, existed := f.files[p.Path]
+	delete(f.files, p.Path)
+	callback := f.onFileDeleted
+	f.mu.Unlock()
+
+	if !existed {
+		// Idempotent — deletion of a non-existent file is a no-op
+		return nil
+	}
+
+	f.logger.Debug().
+		Str("path", p.Path).
+		Str("reason", p.Reason).
+		Msg("File removed from cluster manifest")
+
+	if callback != nil {
+		callback(p.Path, p.Reason)
+	}
+
+	return nil
+}
+
 // Snapshot returns a snapshot of the FSM state.
 func (f *ClusterFSM) Snapshot() (raft.FSMSnapshot, error) {
 	f.mu.RLock()
@@ -355,7 +476,14 @@ func (f *ClusterFSM) Snapshot() (raft.FSMSnapshot, error) {
 		nodes[id] = &nodeCopy
 	}
 
-	return &fsmSnapshot{nodes: nodes, primaryWriterID: f.primaryWriterID}, nil
+	// Deep copy files
+	files := make(map[string]*FileEntry, len(f.files))
+	for path, file := range f.files {
+		fileCopy := *file
+		files[path] = &fileCopy
+	}
+
+	return &fsmSnapshot{nodes: nodes, primaryWriterID: f.primaryWriterID, files: files}, nil
 }
 
 // Restore restores the FSM from a snapshot.
@@ -370,10 +498,16 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 	f.mu.Lock()
 	f.nodes = snapshot.Nodes
 	f.primaryWriterID = snapshot.PrimaryWriterID
+	if snapshot.Files != nil {
+		f.files = snapshot.Files
+	} else {
+		f.files = make(map[string]*FileEntry)
+	}
 	f.mu.Unlock()
 
 	f.logger.Info().
 		Int("node_count", len(snapshot.Nodes)).
+		Int("file_count", len(snapshot.Files)).
 		Str("primary_writer", snapshot.PrimaryWriterID).
 		Msg("FSM restored from snapshot")
 
@@ -436,15 +570,65 @@ func (f *ClusterFSM) TotalCores() int {
 	return total
 }
 
+// GetFile returns a copy of the file entry for the given path, or nil if not found.
+func (f *ClusterFSM) GetFile(path string) (*FileEntry, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	entry, exists := f.files[path]
+	if !exists {
+		return nil, false
+	}
+	entryCopy := *entry
+	return &entryCopy, true
+}
+
+// GetAllFiles returns copies of all files in the manifest.
+func (f *ClusterFSM) GetAllFiles() []*FileEntry {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	files := make([]*FileEntry, 0, len(f.files))
+	for _, file := range f.files {
+		fileCopy := *file
+		files = append(files, &fileCopy)
+	}
+	return files
+}
+
+// GetFilesByDatabase returns copies of all files for the given database.
+func (f *ClusterFSM) GetFilesByDatabase(database string) []*FileEntry {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	var files []*FileEntry
+	for _, file := range f.files {
+		if file.Database == database {
+			fileCopy := *file
+			files = append(files, &fileCopy)
+		}
+	}
+	return files
+}
+
+// FileCount returns the number of files in the manifest.
+func (f *ClusterFSM) FileCount() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.files)
+}
+
 // fsmSnapshot implements raft.FSMSnapshot.
 type fsmSnapshot struct {
 	nodes           map[string]*NodeInfo
 	primaryWriterID string
+	files           map[string]*FileEntry
 }
 
 // Persist writes the snapshot to the given sink.
 func (s *fsmSnapshot) Persist(sink raft.SnapshotSink) error {
-	snapshot := FSMSnapshot{Nodes: s.nodes, PrimaryWriterID: s.primaryWriterID}
+	snapshot := FSMSnapshot{
+		Nodes:           s.nodes,
+		PrimaryWriterID: s.primaryWriterID,
+		Files:           s.files,
+	}
 
 	data, err := json.Marshal(snapshot)
 	if err != nil {

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -126,7 +126,11 @@ type ClusterFSM struct {
 	nodes           map[string]*NodeInfo
 	primaryWriterID string                // ID of the current primary writer node
 	files           map[string]*FileEntry // File manifest (path → entry) for peer replication
-	logger          zerolog.Logger
+	// Secondary index: database → set of file paths. Maintained alongside
+	// the primary `files` map on register/delete to avoid O(N) scans when
+	// filtering by database.
+	filesByDB map[string]map[string]struct{}
+	logger    zerolog.Logger
 
 	// Callbacks for state changes
 	onNodeAdded      func(*NodeInfo)
@@ -140,9 +144,10 @@ type ClusterFSM struct {
 // NewClusterFSM creates a new cluster FSM.
 func NewClusterFSM(logger zerolog.Logger) *ClusterFSM {
 	return &ClusterFSM{
-		nodes:  make(map[string]*NodeInfo),
-		files:  make(map[string]*FileEntry),
-		logger: logger.With().Str("component", "cluster-fsm").Logger(),
+		nodes:     make(map[string]*NodeInfo),
+		files:     make(map[string]*FileEntry),
+		filesByDB: make(map[string]map[string]struct{}),
+		logger:    logger.With().Str("component", "cluster-fsm").Logger(),
 	}
 }
 
@@ -401,16 +406,38 @@ func (f *ClusterFSM) applyRegisterFile(payload []byte, logIndex uint64) interfac
 	if p.File.Path == "" {
 		return fmt.Errorf("register file: path is required")
 	}
-
-	// Stamp the LSN from the Raft log index
-	p.File.LSN = logIndex
 	if p.File.CreatedAt.IsZero() {
-		p.File.CreatedAt = time.Now().UTC()
+		// The creator is responsible for setting CreatedAt before appending
+		// to Raft. We do NOT fill it in here because time.Now() inside Apply
+		// is non-deterministic — log replay on other nodes would produce
+		// different values and diverge FSM state.
+		return fmt.Errorf("register file: created_at is required")
 	}
+
+	// Stamp the LSN from the Raft log index (deterministic across all nodes)
+	p.File.LSN = logIndex
 
 	f.mu.Lock()
 	entry := p.File
+	// If the file was already registered under a different database (unlikely
+	// but possible if an operator moves a file across databases), remove the
+	// old index entry first to keep filesByDB consistent.
+	if old, existed := f.files[entry.Path]; existed && old.Database != entry.Database {
+		if oldIdx, ok := f.filesByDB[old.Database]; ok {
+			delete(oldIdx, old.Path)
+			if len(oldIdx) == 0 {
+				delete(f.filesByDB, old.Database)
+			}
+		}
+	}
 	f.files[entry.Path] = &entry
+	// Maintain the database → files secondary index
+	idx, ok := f.filesByDB[entry.Database]
+	if !ok {
+		idx = make(map[string]struct{})
+		f.filesByDB[entry.Database] = idx
+	}
+	idx[entry.Path] = struct{}{}
 	callback := f.onFileRegistered
 	f.mu.Unlock()
 
@@ -442,8 +469,17 @@ func (f *ClusterFSM) applyDeleteFile(payload []byte) interface{} {
 	}
 
 	f.mu.Lock()
-	_, existed := f.files[p.Path]
+	existing, existed := f.files[p.Path]
 	delete(f.files, p.Path)
+	if existed {
+		// Remove from the database → files secondary index
+		if idx, ok := f.filesByDB[existing.Database]; ok {
+			delete(idx, p.Path)
+			if len(idx) == 0 {
+				delete(f.filesByDB, existing.Database)
+			}
+		}
+	}
 	callback := f.onFileDeleted
 	f.mu.Unlock()
 
@@ -502,6 +538,16 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 		f.files = snapshot.Files
 	} else {
 		f.files = make(map[string]*FileEntry)
+	}
+	// Rebuild the database → files secondary index from the restored files
+	f.filesByDB = make(map[string]map[string]struct{}, len(f.files))
+	for path, entry := range f.files {
+		idx, ok := f.filesByDB[entry.Database]
+		if !ok {
+			idx = make(map[string]struct{})
+			f.filesByDB[entry.Database] = idx
+		}
+		idx[path] = struct{}{}
 	}
 	f.mu.Unlock()
 
@@ -583,6 +629,13 @@ func (f *ClusterFSM) GetFile(path string) (*FileEntry, bool) {
 }
 
 // GetAllFiles returns copies of all files in the manifest.
+//
+// WARNING: This is O(N) in the number of files and allocates a full copy.
+// For large clusters with millions of files this can cause memory pressure
+// and GC pauses. It is suitable for small-to-medium clusters (< ~100k files)
+// and administrative/debugging use. A future phase will add a paginated or
+// streaming variant for the API handler when scale demands it — tracked as
+// a follow-up to Phase 1.
 func (f *ClusterFSM) GetAllFiles() []*FileEntry {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
@@ -595,14 +648,20 @@ func (f *ClusterFSM) GetAllFiles() []*FileEntry {
 }
 
 // GetFilesByDatabase returns copies of all files for the given database.
+// Uses the filesByDB secondary index for O(k) lookup where k is the number
+// of files for the database — no longer scans the full manifest.
 func (f *ClusterFSM) GetFilesByDatabase(database string) []*FileEntry {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
-	var files []*FileEntry
-	for _, file := range f.files {
-		if file.Database == database {
-			fileCopy := *file
-			files = append(files, &fileCopy)
+	idx, ok := f.filesByDB[database]
+	if !ok {
+		return nil
+	}
+	files := make([]*FileEntry, 0, len(idx))
+	for path := range idx {
+		if entry, exists := f.files[path]; exists {
+			entryCopy := *entry
+			files = append(files, &entryCopy)
 		}
 	}
 	return files

--- a/internal/cluster/raft/fsm_test.go
+++ b/internal/cluster/raft/fsm_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/raft"
 	"github.com/rs/zerolog"
@@ -408,4 +409,199 @@ func (s *testSnapshotSink) Cancel() error {
 
 func (s *testSnapshotSink) Close() error {
 	return nil
+}
+
+// File manifest tests (peer replication, Phase 1)
+
+func makeFileEntry(path, db, measurement string, size int64) FileEntry {
+	return FileEntry{
+		Path:          path,
+		SHA256:        "",
+		SizeBytes:     size,
+		Database:      db,
+		Measurement:   measurement,
+		PartitionTime: time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
+		OriginNodeID:  "writer-1",
+		Tier:          "hot",
+	}
+}
+
+func TestFSMRegisterFile(t *testing.T) {
+	fsm := newTestFSM()
+
+	file := makeFileEntry("db/cpu/2026/04/11/14/file.parquet", "db", "cpu", 1024)
+	data := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: file})
+
+	// Simulate a Raft log entry with an Index (LSN)
+	log := &raft.Log{Index: 42, Data: data}
+	if result := fsm.Apply(log); result != nil {
+		t.Fatalf("Apply returned error: %v", result)
+	}
+
+	got, exists := fsm.GetFile(file.Path)
+	if !exists {
+		t.Fatal("File should exist after register")
+	}
+	if got.Path != file.Path {
+		t.Errorf("Path mismatch: got %s, want %s", got.Path, file.Path)
+	}
+	if got.Database != "db" || got.Measurement != "cpu" {
+		t.Errorf("db/measurement mismatch: got %s/%s", got.Database, got.Measurement)
+	}
+	if got.LSN != 42 {
+		t.Errorf("LSN should be stamped from log.Index: got %d, want 42", got.LSN)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be auto-populated")
+	}
+
+	if count := fsm.FileCount(); count != 1 {
+		t.Errorf("FileCount() = %d, want 1", count)
+	}
+}
+
+func TestFSMDeleteFile(t *testing.T) {
+	fsm := newTestFSM()
+
+	file := makeFileEntry("db/cpu/2026/04/11/14/file.parquet", "db", "cpu", 1024)
+	regData := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: file})
+	fsm.Apply(&raft.Log{Index: 1, Data: regData})
+
+	delData := makeCommand(t, CommandDeleteFile, DeleteFilePayload{Path: file.Path, Reason: "retention"})
+	if result := fsm.Apply(&raft.Log{Index: 2, Data: delData}); result != nil {
+		t.Fatalf("Apply returned error: %v", result)
+	}
+
+	if _, exists := fsm.GetFile(file.Path); exists {
+		t.Error("File should not exist after delete")
+	}
+	if count := fsm.FileCount(); count != 0 {
+		t.Errorf("FileCount() = %d, want 0", count)
+	}
+}
+
+func TestFSMDeleteNonexistentFile(t *testing.T) {
+	fsm := newTestFSM()
+
+	// Deleting a file that was never registered should be a no-op (idempotent)
+	delData := makeCommand(t, CommandDeleteFile, DeleteFilePayload{Path: "db/cpu/ghost.parquet"})
+	result := fsm.Apply(&raft.Log{Index: 1, Data: delData})
+	if result != nil {
+		t.Errorf("Delete of non-existent file should not error, got %v", result)
+	}
+}
+
+func TestFSMGetFilesByDatabase(t *testing.T) {
+	fsm := newTestFSM()
+
+	files := []FileEntry{
+		makeFileEntry("prod/cpu/file1.parquet", "prod", "cpu", 100),
+		makeFileEntry("prod/memory/file2.parquet", "prod", "memory", 200),
+		makeFileEntry("staging/cpu/file3.parquet", "staging", "cpu", 300),
+	}
+
+	for i, f := range files {
+		data := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: f})
+		fsm.Apply(&raft.Log{Index: uint64(i + 1), Data: data})
+	}
+
+	prodFiles := fsm.GetFilesByDatabase("prod")
+	if len(prodFiles) != 2 {
+		t.Errorf("GetFilesByDatabase(prod) = %d files, want 2", len(prodFiles))
+	}
+
+	stagingFiles := fsm.GetFilesByDatabase("staging")
+	if len(stagingFiles) != 1 {
+		t.Errorf("GetFilesByDatabase(staging) = %d files, want 1", len(stagingFiles))
+	}
+
+	emptyFiles := fsm.GetFilesByDatabase("nonexistent")
+	if len(emptyFiles) != 0 {
+		t.Errorf("GetFilesByDatabase(nonexistent) = %d files, want 0", len(emptyFiles))
+	}
+}
+
+func TestFSMFileCallbacks(t *testing.T) {
+	fsm := newTestFSM()
+
+	var registeredFile *FileEntry
+	var deletedPath, deletedReason string
+
+	fsm.SetFileCallbacks(
+		func(f *FileEntry) { registeredFile = f },
+		func(path, reason string) { deletedPath = path; deletedReason = reason },
+	)
+
+	file := makeFileEntry("db/cpu/file.parquet", "db", "cpu", 512)
+	regData := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: file})
+	fsm.Apply(&raft.Log{Index: 10, Data: regData})
+
+	if registeredFile == nil {
+		t.Fatal("onFileRegistered callback should have fired")
+	}
+	if registeredFile.Path != file.Path {
+		t.Errorf("callback got path %s, want %s", registeredFile.Path, file.Path)
+	}
+	if registeredFile.LSN != 10 {
+		t.Errorf("callback got LSN %d, want 10", registeredFile.LSN)
+	}
+
+	delData := makeCommand(t, CommandDeleteFile, DeleteFilePayload{Path: file.Path, Reason: "compaction"})
+	fsm.Apply(&raft.Log{Index: 11, Data: delData})
+
+	if deletedPath != file.Path {
+		t.Errorf("onFileDeleted callback got path %s, want %s", deletedPath, file.Path)
+	}
+	if deletedReason != "compaction" {
+		t.Errorf("onFileDeleted callback got reason %s, want compaction", deletedReason)
+	}
+}
+
+func TestFSMSnapshotRestoreWithFiles(t *testing.T) {
+	fsm := newTestFSM()
+
+	// Add a node and some files
+	node := NodeInfo{ID: "node-1", Role: "writer", State: "healthy"}
+	fsm.Apply(&raft.Log{Index: 1, Data: makeCommand(t, CommandAddNode, AddNodePayload{Node: node})})
+
+	files := []FileEntry{
+		makeFileEntry("prod/cpu/file1.parquet", "prod", "cpu", 100),
+		makeFileEntry("prod/mem/file2.parquet", "prod", "mem", 200),
+	}
+	for i, f := range files {
+		data := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: f})
+		fsm.Apply(&raft.Log{Index: uint64(i + 2), Data: data})
+	}
+
+	// Snapshot
+	snapshot, err := fsm.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot() failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	sink := &testSnapshotSink{Writer: &buf}
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("Persist() failed: %v", err)
+	}
+
+	// Restore into a new FSM
+	fsm2 := newTestFSM()
+	if err := fsm2.Restore(io.NopCloser(&buf)); err != nil {
+		t.Fatalf("Restore() failed: %v", err)
+	}
+
+	if fsm2.NodeCount() != 1 {
+		t.Errorf("Restored NodeCount() = %d, want 1", fsm2.NodeCount())
+	}
+	if fsm2.FileCount() != 2 {
+		t.Errorf("Restored FileCount() = %d, want 2", fsm2.FileCount())
+	}
+
+	if _, exists := fsm2.GetFile("prod/cpu/file1.parquet"); !exists {
+		t.Error("file1 should exist after restore")
+	}
+	if _, exists := fsm2.GetFile("prod/mem/file2.parquet"); !exists {
+		t.Error("file2 should exist after restore")
+	}
 }

--- a/internal/cluster/raft/fsm_test.go
+++ b/internal/cluster/raft/fsm_test.go
@@ -414,6 +414,9 @@ func (s *testSnapshotSink) Close() error {
 // File manifest tests (peer replication, Phase 1)
 
 func makeFileEntry(path, db, measurement string, size int64) FileEntry {
+	// Fixed timestamps — FSM Apply requires CreatedAt to be set by the caller
+	// (never stamped inside Apply because that would be non-deterministic
+	// during log replay on different nodes).
 	return FileEntry{
 		Path:          path,
 		SHA256:        "",
@@ -423,6 +426,7 @@ func makeFileEntry(path, db, measurement string, size int64) FileEntry {
 		PartitionTime: time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
 		OriginNodeID:  "writer-1",
 		Tier:          "hot",
+		CreatedAt:     time.Date(2026, 4, 11, 15, 0, 0, 0, time.UTC),
 	}
 }
 
@@ -451,12 +455,46 @@ func TestFSMRegisterFile(t *testing.T) {
 	if got.LSN != 42 {
 		t.Errorf("LSN should be stamped from log.Index: got %d, want 42", got.LSN)
 	}
-	if got.CreatedAt.IsZero() {
-		t.Error("CreatedAt should be auto-populated")
+	if !got.CreatedAt.Equal(file.CreatedAt) {
+		t.Errorf("CreatedAt should match input: got %v, want %v", got.CreatedAt, file.CreatedAt)
 	}
 
 	if count := fsm.FileCount(); count != 1 {
 		t.Errorf("FileCount() = %d, want 1", count)
+	}
+}
+
+// TestFSMRegisterFileRejectsZeroCreatedAt verifies that the FSM rejects
+// register commands without CreatedAt — preventing non-deterministic
+// time.Now() stamping inside Apply that would diverge state across nodes.
+func TestFSMRegisterFileRejectsZeroCreatedAt(t *testing.T) {
+	fsm := newTestFSM()
+
+	file := FileEntry{
+		Path:         "db/cpu/file.parquet",
+		Database:     "db",
+		Measurement:  "cpu",
+		SizeBytes:    100,
+		OriginNodeID: "writer-1",
+		Tier:         "hot",
+		// CreatedAt intentionally left zero
+	}
+	data := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: file})
+
+	result := fsm.Apply(&raft.Log{Index: 1, Data: data})
+	if result == nil {
+		t.Fatal("Expected error for zero CreatedAt, got nil")
+	}
+	err, ok := result.(error)
+	if !ok {
+		t.Fatalf("Expected error result, got %T: %v", result, result)
+	}
+	if err.Error() == "" {
+		t.Error("Expected non-empty error message")
+	}
+
+	if fsm.FileCount() != 0 {
+		t.Error("File should not be registered when CreatedAt is zero")
 	}
 }
 
@@ -554,6 +592,91 @@ func TestFSMFileCallbacks(t *testing.T) {
 	}
 	if deletedReason != "compaction" {
 		t.Errorf("onFileDeleted callback got reason %s, want compaction", deletedReason)
+	}
+}
+
+// TestFSMFilesByDatabaseIndexConsistency verifies that the filesByDB
+// secondary index stays in sync with the primary files map across register,
+// delete, and snapshot/restore operations.
+func TestFSMFilesByDatabaseIndexConsistency(t *testing.T) {
+	fsm := newTestFSM()
+
+	// Register 3 files across 2 databases
+	files := []FileEntry{
+		makeFileEntry("prod/cpu/f1.parquet", "prod", "cpu", 100),
+		makeFileEntry("prod/mem/f2.parquet", "prod", "mem", 200),
+		makeFileEntry("staging/cpu/f3.parquet", "staging", "cpu", 300),
+	}
+	for i, f := range files {
+		data := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: f})
+		fsm.Apply(&raft.Log{Index: uint64(i + 1), Data: data})
+	}
+
+	// After register: prod=2, staging=1
+	if got := len(fsm.GetFilesByDatabase("prod")); got != 2 {
+		t.Errorf("After register: GetFilesByDatabase(prod) = %d, want 2", got)
+	}
+	if got := len(fsm.GetFilesByDatabase("staging")); got != 1 {
+		t.Errorf("After register: GetFilesByDatabase(staging) = %d, want 1", got)
+	}
+
+	// Delete one prod file → prod=1, staging=1
+	delData := makeCommand(t, CommandDeleteFile, DeleteFilePayload{Path: "prod/cpu/f1.parquet"})
+	fsm.Apply(&raft.Log{Index: 10, Data: delData})
+
+	if got := len(fsm.GetFilesByDatabase("prod")); got != 1 {
+		t.Errorf("After delete one prod: GetFilesByDatabase(prod) = %d, want 1", got)
+	}
+
+	// Delete the remaining prod file → prod should be empty (nil or 0), staging=1
+	delData2 := makeCommand(t, CommandDeleteFile, DeleteFilePayload{Path: "prod/mem/f2.parquet"})
+	fsm.Apply(&raft.Log{Index: 11, Data: delData2})
+
+	if got := len(fsm.GetFilesByDatabase("prod")); got != 0 {
+		t.Errorf("After delete all prod: GetFilesByDatabase(prod) = %d, want 0", got)
+	}
+	// Internal consistency: the database bucket should be removed from filesByDB
+	// when its last file is deleted, to prevent unbounded growth.
+	fsm.mu.RLock()
+	_, prodIdxExists := fsm.filesByDB["prod"]
+	fsm.mu.RUnlock()
+	if prodIdxExists {
+		t.Error("filesByDB[prod] should be removed after last file deleted (prevents index bloat)")
+	}
+
+	// Snapshot + restore into a fresh FSM, then verify the index is rebuilt correctly
+	snapshot, err := fsm.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := snapshot.Persist(&testSnapshotSink{Writer: &buf}); err != nil {
+		t.Fatalf("Persist failed: %v", err)
+	}
+
+	fsm2 := newTestFSM()
+	if err := fsm2.Restore(io.NopCloser(&buf)); err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+
+	// After restore, the index should be rebuilt and staging=1 should work
+	if got := len(fsm2.GetFilesByDatabase("staging")); got != 1 {
+		t.Errorf("After restore: GetFilesByDatabase(staging) = %d, want 1", got)
+	}
+	if got := len(fsm2.GetFilesByDatabase("prod")); got != 0 {
+		t.Errorf("After restore: GetFilesByDatabase(prod) = %d, want 0", got)
+	}
+
+	// Verify internal index state matches the primary files map
+	fsm2.mu.RLock()
+	totalIndexed := 0
+	for _, idx := range fsm2.filesByDB {
+		totalIndexed += len(idx)
+	}
+	fileCount := len(fsm2.files)
+	fsm2.mu.RUnlock()
+	if totalIndexed != fileCount {
+		t.Errorf("Index inconsistency after restore: totalIndexed=%d, fileCount=%d", totalIndexed, fileCount)
 	}
 }
 

--- a/internal/cluster/raft/node.go
+++ b/internal/cluster/raft/node.go
@@ -514,6 +514,39 @@ func (n *Node) DemoteWriter(nodeID string, timeout time.Duration) error {
 	return n.Apply(cmd, timeout)
 }
 
+// RegisterFile appends a file to the cluster-wide manifest via Raft.
+// Called by writers after flushing a new Parquet file, and by compactors
+// after producing a compacted output. The Raft log index becomes the LSN.
+func (n *Node) RegisterFile(file FileEntry, timeout time.Duration) error {
+	payload, err := json.Marshal(RegisterFilePayload{File: file})
+	if err != nil {
+		return fmt.Errorf("failed to marshal register file payload: %w", err)
+	}
+
+	cmd := &Command{
+		Type:    CommandRegisterFile,
+		Payload: payload,
+	}
+
+	return n.Apply(cmd, timeout)
+}
+
+// DeleteFile removes a file from the cluster-wide manifest via Raft.
+// Called by retention policies and post-compaction cleanup.
+func (n *Node) DeleteFile(path, reason string, timeout time.Duration) error {
+	payload, err := json.Marshal(DeleteFilePayload{Path: path, Reason: reason})
+	if err != nil {
+		return fmt.Errorf("failed to marshal delete file payload: %w", err)
+	}
+
+	cmd := &Command{
+		Type:    CommandDeleteFile,
+		Payload: payload,
+	}
+
+	return n.Apply(cmd, timeout)
+}
+
 // LeaderCh returns a channel that signals leadership changes.
 // True means this node became leader, false means it lost leadership.
 func (n *Node) LeaderCh() <-chan bool {

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -705,6 +705,14 @@ type WALWriter interface {
 	Close() error
 }
 
+// FileRegistrar announces a newly written Parquet file to the cluster-wide
+// manifest. Implementations should be non-blocking — file registration is
+// fire-and-forget from the flush path's perspective. Wired by the cluster
+// coordinator when peer replication is enabled (Enterprise feature).
+type FileRegistrar interface {
+	RegisterFile(database, measurement, path string, partitionTime time.Time, sizeBytes int64)
+}
+
 // ArrowBuffer manages buffering and periodic flushing of Arrow data
 // Uses lock sharding to reduce contention across concurrent writes
 type ArrowBuffer struct {
@@ -717,6 +725,11 @@ type ArrowBuffer struct {
 
 	// Optional tiering manager for registering files in tier metadata
 	tieringManager *tiering.Manager
+
+	// Optional file registrar for cluster-wide file manifest (Enterprise peer replication)
+	// Set by cmd/arc/main.go when clustering + peer replication is enabled.
+	// Called asynchronously after each flush — never blocks the flush path.
+	fileRegistrar FileRegistrar
 
 	// OPTIMIZATION: Shard buffers to reduce lock contention
 	// Configurable via ingest.shard_count (default 32)
@@ -948,34 +961,48 @@ func (b *ArrowBuffer) SetTieringManager(tm *tiering.Manager) {
 	b.logger.Info().Msg("Tiering manager enabled for ArrowBuffer - files will be auto-registered")
 }
 
-// registerFileInTiering registers a newly written parquet file in the tiering metadata.
-// This allows the tiering system to track the file for future migration and query routing.
+// SetFileRegistrar sets the cluster-wide file manifest registrar.
+// When set, newly written Parquet files are announced to the cluster manifest
+// asynchronously (non-blocking) — used by peer replication to discover files
+// that need to be pulled from other nodes.
+func (b *ArrowBuffer) SetFileRegistrar(fr FileRegistrar) {
+	b.fileRegistrar = fr
+	b.logger.Info().Msg("File registrar enabled for ArrowBuffer - files will be announced to cluster manifest")
+}
+
+// registerFileInTiering registers a newly written parquet file in the tiering metadata
+// and (if enabled) announces it to the cluster-wide file manifest for peer replication.
+// This allows the tiering system to track the file for future migration and query routing,
+// and enables Enterprise peer replication to replicate the file to other cluster nodes.
 func (b *ArrowBuffer) registerFileInTiering(ctx context.Context, database, measurement, storagePath string, partitionTime time.Time, sizeBytes int64) {
-	if b.tieringManager == nil {
-		return
+	// Register in local tiering metadata (hot/cold tracking)
+	if b.tieringManager != nil {
+		metadata := b.tieringManager.GetMetadata()
+		if metadata != nil {
+			file := &tiering.FileMetadata{
+				Path:          storagePath,
+				Database:      database,
+				Measurement:   measurement,
+				PartitionTime: partitionTime,
+				Tier:          tiering.TierHot,
+				SizeBytes:     sizeBytes,
+				CreatedAt:     time.Now().UTC(),
+			}
+			if err := metadata.RecordFile(ctx, file); err != nil {
+				b.logger.Warn().Err(err).
+					Str("path", storagePath).
+					Str("database", database).
+					Str("measurement", measurement).
+					Msg("Failed to register file in tiering metadata")
+			}
+		}
 	}
 
-	metadata := b.tieringManager.GetMetadata()
-	if metadata == nil {
-		return
-	}
-
-	file := &tiering.FileMetadata{
-		Path:          storagePath,
-		Database:      database,
-		Measurement:   measurement,
-		PartitionTime: partitionTime,
-		Tier:          tiering.TierHot,
-		SizeBytes:     sizeBytes,
-		CreatedAt:     time.Now().UTC(),
-	}
-
-	if err := metadata.RecordFile(ctx, file); err != nil {
-		b.logger.Warn().Err(err).
-			Str("path", storagePath).
-			Str("database", database).
-			Str("measurement", measurement).
-			Msg("Failed to register file in tiering metadata")
+	// Announce to cluster-wide file manifest (peer replication).
+	// The registrar implementation MUST be non-blocking — it's called on
+	// the hot flush path.
+	if b.fileRegistrar != nil {
+		b.fileRegistrar.RegisterFile(database, measurement, storagePath, partitionTime, sizeBytes)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of peer-to-peer file replication for Arc Enterprise clusters on local storage (bare-metal, VMs, edge). This PR adds the foundation: a cluster-wide file manifest in the Raft FSM that tracks every Parquet file across all nodes. No actual byte-level replication yet — that's Phase 2.

**Why this phased approach:** File replication is a significant feature. Shipping the manifest first lets us validate the design, measure overhead, and observe the cluster file view via API before adding the HTTP fetch server and background pullers.

## What's in this PR

### New Raft commands
- `CommandRegisterFile` — announces a file to the cluster
- `CommandDeleteFile` — removes a file (idempotent)
- `FileEntry` struct with path, sha256, size, db/measurement, partition time, origin node, tier, LSN

### File manifest in ClusterFSM
- Map of `path → *FileEntry` in the FSM state
- Persisted in Raft snapshots, replicated to all members via standard consensus
- LSN stamped from `log.Index` for ordering
- Callbacks for file registered/deleted events (Phase 2 will wire these to a pull queue)

### Async, non-blocking flush hook
- New `ingest.FileRegistrar` interface (minimal surface, non-blocking contract)
- `cluster.CoordinatorFileRegistrar` is a buffered async worker (queue size 4096) that drains registrations into the Raft log
- **Flush hot path never blocks on Raft consensus, network I/O, or checksum compute**
- Graceful drain on shutdown (best-effort, 2s deadline)
- Metrics: enqueued / applied / dropped / apply_errs / queue_depth
- Drop warnings are rate-limited to powers of 2 to avoid log spam under overflow

### New API endpoint
- `GET /api/v1/cluster/files` — returns the full cluster manifest
- `GET /api/v1/cluster/files?database=<name>` — filtered view
- **Admin-auth required** (exposes database schema + file paths)

### OSS / standalone: zero overhead
- No coordinator → no registrar → nil check in ArrowBuffer.registerFileInTiering short-circuits → zero cost
- The feature is fully behind the existing `FeatureClustering` enterprise license

## Design inspiration

Research compared how ClickHouse (ReplicatedMergeTree), InfluxDB Enterprise (anti-entropy + HHQ), TimescaleDB (deprecated multi-node), Apache Pinot (peer fetcher fallback), and Apache Druid (metadata-driven) handle file replication without shared storage. ClickHouse's model — Raft-equivalent op log + HTTP pull — is the cleanest fit for Arc's existing Raft + coordinator TCP infrastructure.

## Test plan

- [x] `go build ./cmd/... ./internal/...` passes
- [x] `go test ./internal/cluster/...` passes (including 6 new tests for the file manifest)
- [x] `go test ./internal/ingest/...` passes (flush path not regressed)
- [x] `go test ./internal/api/...` passes
- [x] Post-implementation security review: admin auth added to the new endpoint after initial review flagged it as a critical issue
- [x] Post-implementation code quality review: graceful drain, metrics, and rate-limited log warnings added after review feedback
- [ ] Manual: 3-node docker cluster with clustering + replication enabled, ingest data, verify `/api/v1/cluster/files` shows all flushed files with correct LSN ordering

## What's coming next (separate PRs)

- **Phase 2**: HTTP fetch server on the coordinator port + background pullers that fetch missing files from peers. This is where actual byte-level replication kicks in.
- **Phase 3**: Automatic catch-up for new nodes joining a cluster with existing historical data
- **Phase 4**: Integration with compaction (compactor role produces files, replicas pull the compacted output, old files are deleted cluster-wide via `CommandDeleteFile`)
- **Phase 5**: Optional write quorum for strong durability