### PR TITLE
feat(cluster): peer-to-peer file replication — Phase 2 (fetch protocol + background puller)

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -21,11 +21,36 @@ Arc Enterprise now maintains a cluster-wide file manifest in the Raft FSM. Every
 - Async, non-blocking registration from the flush path — the file registrar enqueues entries and a background worker appends to Raft, so write latency is unaffected
 - Zero overhead for OSS / standalone deployments — no coordinator, no registrar, no manifest
 
+### Peer File Replication (Enterprise — Phase 2)
+
+Building on the cluster file manifest, Arc Enterprise now replicates **actual Parquet bytes** between cluster nodes. When a writer flushes a file, readers automatically pull the bytes from the origin peer over the existing coordinator TCP protocol and write them to their own local storage backend. This unlocks bare-metal, VM, and edge deployments where each node has its own local SSDs and shared storage (S3, MinIO, Azure) is not available — on-prem, aerospace, defense, and edge use cases.
+
+**How it works:**
+- Every flushed Parquet file is SHA-256 hashed on the writer (on the in-memory buffer, before writing to the backend) and the hash is committed into the Raft manifest alongside the file metadata. Every node in the cluster learns the authoritative hash as soon as the Raft log replicates.
+- On each non-origin node, an `onFileRegistered` callback fires from the FSM when a new entry commits. A background `Puller` worker pool enqueues a fetch, skipping files that originated on the local node or already exist on the local backend.
+- Workers dial the origin peer using the cluster's existing TLS-wrapped coordinator connection and send a new `MsgFetchFile` request, authenticated with an HMAC that binds `{nonce, nodeID, clusterName, path, timestamp}` — including the path prevents a stolen MAC from being replayed to fetch a different file within the freshness window.
+- The origin validates the HMAC, sanitizes the path, confirms the file is in the cluster manifest (so peers cannot request arbitrary local files), and streams the body directly over the connection.
+- The puller streams body bytes through an `io.MultiWriter` tee into a `sha256.New()` hasher while writing into the local backend via `WriteReader`, and compares the computed hash against the manifest hash before accepting the file. On mismatch the partial file is deleted and the fetch retries.
+
+**Configuration** (defaults shown, set via `ARC_CLUSTER_REPLICATION_*` env vars or `cluster.replication_*` in `arc.toml`):
+- `replication_enabled` — master switch; requires `cluster.shared_secret` to be set
+- `replication_pull_workers = 4` — concurrent fetch workers per node
+- `replication_queue_size = 1024` — bounded queue; excess entries are dropped with a rate-limited warning and reconciled later
+- `replication_fetch_timeout_ms = 60000` — per-fetch timeout
+- `replication_retry_max_attempts = 3` — immediate retry attempts before dropping the entry
+
+**Security:**
+- Peer replication is gated by `FeatureClustering` — a user without an enterprise license cannot construct the puller.
+- Shared secret is required at startup; Arc refuses to boot if `replication_enabled=true` and `shared_secret` is empty.
+- All fetch traffic flows over the cluster coordinator port (not the public API port), physically isolating replication bytes from client traffic.
+- When `cluster.tls_enabled=true`, the fetch client reuses the cluster TLS config for end-to-end encryption.
+
+**Scope of Phase 2:** async replication only. Phase 2 does **not** include: resume via HTTP Range, catch-up for nodes joining with existing data, quorum durability, multi-peer fanout, or compaction-aware routing. These land in Phases 3–5.
+
 **What's coming next** (separate PRs):
-- Phase 2: HTTP fetch server + background pullers to replicate files between peers over TLS-secured coordinator connections
 - Phase 3: Automatic catch-up for new nodes joining a cluster with existing data
 - Phase 4: Integration with compaction (compactor role produces files, replicas pull the compacted output)
-- Phase 5: Optional write quorum for strong durability
+- Phase 5: Optional write quorum for strong durability, multi-peer fanout, and resumable transfers via Range
 
 **Design inspiration:** ClickHouse's ReplicatedMergeTree model — a Raft-equivalent op log + HTTP-pull-based file transfer. Research compared InfluxDB Enterprise (anti-entropy + HHQ), ClickHouse (log + HTTP pull), TimescaleDB (deprecated multi-node), Apache Pinot (peer fetcher fallback), and Apache Druid (metadata-driven assignment). ClickHouse's model is the cleanest fit for Arc's existing Raft + coordinator TCP infrastructure.
 

--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -36,7 +36,8 @@ Building on the cluster file manifest, Arc Enterprise now replicates **actual Pa
 - `replication_enabled` — master switch; requires `cluster.shared_secret` to be set
 - `replication_pull_workers = 4` — concurrent fetch workers per node
 - `replication_queue_size = 1024` — bounded queue; excess entries are dropped with a rate-limited warning and reconciled later
-- `replication_fetch_timeout_ms = 60000` — per-fetch timeout
+- `replication_fetch_timeout_ms = 60000` — puller-side per-fetch timeout
+- `replication_serve_timeout_ms = 120000` — origin-side body-stream timeout; raise for large Parquet files or slow links
 - `replication_retry_max_attempts = 3` — immediate retry attempts before dropping the entry
 
 **Security:**

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -750,6 +750,15 @@ func main() {
 					apiAddr = fmt.Sprintf(":%d", cfg.Server.Port)
 				}
 
+				// Peer replication (Enterprise Phase 2) requires shared-secret auth
+				// on the coordinator protocol. Fail loudly rather than silently
+				// running unauthenticated — operators should opt in explicitly.
+				if cfg.Cluster.ReplicationEnabled && cfg.Cluster.SharedSecret == "" {
+					log.Error().Msg("cluster.replication_enabled requires ARC_CLUSTER_SHARED_SECRET to be set (peer fetches must be authenticated)")
+					log.Error().Msg("Set ARC_CLUSTER_SHARED_SECRET or disable cluster.replication_enabled to continue")
+					os.Exit(1)
+				}
+
 				var err error
 				clusterCoordinator, err = cluster.NewCoordinator(&cluster.CoordinatorConfig{
 					Config:        &cfg.Cluster,
@@ -761,6 +770,12 @@ func main() {
 				if err != nil {
 					log.Error().Err(err).Msg("Failed to initialize cluster coordinator - running in standalone mode")
 				} else {
+					// Peer replication Phase 2 needs the storage backend handle so the
+					// fetch handler can serve local bytes and the puller can write
+					// received bytes. Must be set before Start — the puller is
+					// constructed inside Start when ReplicationEnabled is true.
+					clusterCoordinator.SetStorageBackend(storageBackend)
+
 					if err := clusterCoordinator.Start(); err != nil {
 						log.Error().Err(err).Msg("Failed to start cluster coordinator - running in standalone mode")
 						clusterCoordinator = nil
@@ -793,16 +808,32 @@ func main() {
 							}
 						}
 
-						// Wire up peer file replication manifest (Enterprise Phase 1).
-						// The registrar is non-blocking: it enqueues file registrations
-						// and a background worker appends them to the Raft manifest.
-						// OSS deployments never reach here (no coordinator).
+						// Wire up peer file replication (Enterprise Phase 1 + Phase 2).
 						//
-						// Shutdown ordering: lower priority runs first (see shutdown.go).
-						// file-registrar is at PriorityBuffer (30), cluster-coordinator is
-						// at PriorityCompaction (50). So the registrar drains its queue
-						// BEFORE Raft is stopped, ensuring pending file announcements
-						// complete while Raft is still alive.
+						// Phase 1 — the registrar is non-blocking: it enqueues file
+						// registrations from the flush path and a background worker
+						// appends them to the Raft manifest.
+						//
+						// Phase 2 — the puller is constructed inside coordinator.Start()
+						// when ReplicationEnabled is true. It watches the FSM for new
+						// file registrations and pulls the bytes from the origin peer
+						// over the coordinator TCP protocol. It's owned by the
+						// coordinator and stopped from coordinator.Stop(), so it has
+						// no separate shutdown hook here.
+						//
+						// OSS deployments never reach this block (no coordinator).
+						//
+						// Shutdown ordering (lower priority runs first, see shutdown.go):
+						//   HTTPServer (10)  — stop accepting client requests
+						//   Ingest     (20)  — drain ingest/flush
+						//   Buffer     (30)  — file-registrar drains queue into Raft
+						//   Compaction (50)  — cluster-coordinator stops:
+						//                        puller.Stop()  (first)
+						//                        raftNode.Stop()  (second)
+						//
+						// This sequence ensures final file announcements land in Raft
+						// while Raft is still alive, and pending peer pulls are
+						// cancelled promptly when Raft is about to go away.
 						fileRegistrar := cluster.NewCoordinatorFileRegistrar(clusterCoordinator, logger.Get("file-registrar"))
 						fileRegistrar.Start(context.Background())
 						arrowBuffer.SetFileRegistrar(fileRegistrar)

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -7,12 +7,15 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/basekick-labs/arc/internal/cluster/filereplication"
 	"github.com/basekick-labs/arc/internal/cluster/protocol"
 	"github.com/basekick-labs/arc/internal/cluster/raft"
 	"github.com/basekick-labs/arc/internal/cluster/replication"
@@ -20,6 +23,7 @@ import (
 	"github.com/basekick-labs/arc/internal/config"
 	"github.com/basekick-labs/arc/internal/ingest"
 	"github.com/basekick-labs/arc/internal/license"
+	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/basekick-labs/arc/internal/wal"
 	"github.com/rs/zerolog"
 )
@@ -54,6 +58,15 @@ type Coordinator struct {
 	replicationReceiver *replication.Receiver // Reader only: receives entries from writer
 	walWriter           *wal.Writer           // Reference to local WAL for replication hook
 	ingestBuffer        *ingest.ArrowBuffer   // Reader only: applies replicated entries to local buffer
+
+	// Peer file replication (Enterprise Phase 2)
+	// storage is the local storage backend — used both by the fetch handler
+	// (to stream local bytes back to a pulling peer) and by the puller (to
+	// write received bytes). Set via SetStorageBackend before Start.
+	storage storage.Backend
+	// puller is the background worker pool that downloads files from peers.
+	// Nil when peer replication is disabled or the license forbids it.
+	puller *filereplication.Puller
 
 	// Network
 	listener  net.Listener
@@ -262,6 +275,24 @@ func (c *Coordinator) Start() error {
 		}
 	}
 
+	// Wire the peer file replication puller (Enterprise Phase 2). This runs
+	// on every cluster node (not just readers) because nodes of any role may
+	// need to pull files they didn't originate — the Raft manifest is the
+	// source of truth for who has what, regardless of role.
+	//
+	// Gated on ReplicationEnabled so OSS and standalone deployments never
+	// pay any cost. The FeatureClustering license check already ran in
+	// validateClusteringLicense above.
+	if c.cfg.ReplicationEnabled && c.raftNode != nil {
+		if err := c.startFilePullerLocked(); err != nil {
+			// Do not fail cluster startup if the puller can't start —
+			// replication is best-effort and the rest of the cluster can
+			// still make progress. The cause is logged; operators can
+			// correct config and restart.
+			c.logger.Error().Err(err).Msg("Failed to start peer file puller — continuing without peer replication")
+		}
+	}
+
 	// Start listening for peer connections if we have a coordinator address
 	if c.cfg.CoordinatorAddr != "" {
 		listener, err := security.Listen("tcp", c.cfg.CoordinatorAddr, c.tlsConfig)
@@ -374,6 +405,15 @@ func (c *Coordinator) Stop() error {
 
 	// Signal all goroutines to stop
 	close(c.stopCh)
+
+	// Stop the peer file puller BEFORE Raft. The puller is a Raft FSM
+	// callback consumer — once Raft stops, new applyRegisterFile calls
+	// won't fire anyway, but in-flight pulls need to be cancelled promptly
+	// so their workers can join before we tear down the listener.
+	if c.puller != nil {
+		c.puller.Stop()
+		c.puller = nil
+	}
 
 	// Stop writer failover manager
 	if c.writerFailoverMgr != nil {
@@ -623,6 +663,13 @@ func (c *Coordinator) handlePeerConnection(conn net.Conn) {
 	case protocol.MsgReplicateSync:
 		c.handleReplicateSync(conn, msg.Payload.(*protocol.ReplicateSync))
 		closeConn = false // Sender takes ownership
+
+	case protocol.MsgFetchFile:
+		// The fetch handler streams the body for the lifetime of the
+		// response and closes the connection itself via defer. Hand off
+		// ownership so the dispatch loop doesn't close it a second time.
+		c.handleFetchFile(conn, msg.Payload.(*protocol.FetchFileRequest))
+		closeConn = false
 
 	default:
 		c.logger.Warn().
@@ -904,6 +951,215 @@ func (c *Coordinator) handleReplicateSync(conn net.Conn, syncReq *protocol.Repli
 		// Connection was already handled by AcceptReplicationConnection
 	}
 	// NOTE: Connection is now owned by the sender, don't close it
+}
+
+// handleFetchFile serves a peer-replication file fetch request. The caller
+// (handlePeerConnection) transferred ownership of conn to this function —
+// it must close the connection before returning.
+//
+// Wire protocol (already decoded: req is the MsgFetchFile payload):
+//  1. Validate HMAC headers against c.cfg.SharedSecret.
+//  2. Sanitize req.Path (reject absolute paths, path traversal, null bytes).
+//  3. Look up the file in the FSM manifest so we only serve known files.
+//  4. Verify the file exists on the local storage backend and get its size.
+//  5. Write a MsgFetchFileAck header with {status=ok, size, sha256}.
+//  6. Stream the file body directly onto the TCP connection via Backend.ReadTo.
+//  7. On any error before or during the ack, send {status=error, error=...}.
+//
+// This handler does NOT honor the 10-second read timeout from the dispatch
+// loop — it holds the connection open for the duration of the body stream,
+// same as MsgReplicateSync. The puller on the other side uses its own
+// per-fetch timeout (cluster.replication_fetch_timeout_ms).
+func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequest) {
+	defer conn.Close()
+	remoteAddr := conn.RemoteAddr().String()
+
+	// Step 1: HMAC validation. Peer replication requires shared secret — no
+	// fallback to unauthenticated. This is enforced at startup in main.go,
+	// but we double-check here as defense in depth.
+	if c.cfg.SharedSecret == "" {
+		c.logger.Error().
+			Str("peer", remoteAddr).
+			Msg("FetchFile rejected: shared secret not configured (peer replication requires it)")
+		c.sendFetchError(conn, "peer replication is not configured on this node")
+		return
+	}
+	// HMAC binds {nonce, nodeID, clusterName, path, timestamp} — including the
+	// path prevents a stolen MAC from being replayed to fetch a different file
+	// within the freshness window.
+	if err := security.ValidateFetchHMAC(
+		c.cfg.SharedSecret, req.Nonce, req.NodeID, c.cfg.ClusterName, req.Path,
+		req.Timestamp, req.HMAC, 5*time.Minute,
+	); err != nil {
+		c.logger.Warn().
+			Err(err).
+			Str("peer", remoteAddr).
+			Str("requesting_node", req.NodeID).
+			Msg("FetchFile rejected: HMAC validation failed")
+		c.sendFetchError(conn, "authentication failed")
+		return
+	}
+
+	// Step 2: Sanitize the path. The storage backend accepts relative paths
+	// like "mydb/cpu/2026/04/11/14/file-xxx.parquet". Reject anything that
+	// could escape the storage root or contains control characters.
+	sanitized, err := sanitizeFetchPath(req.Path)
+	if err != nil {
+		c.logger.Warn().
+			Err(err).
+			Str("peer", remoteAddr).
+			Str("path", req.Path).
+			Msg("FetchFile rejected: invalid path")
+		c.sendFetchError(conn, fmt.Sprintf("invalid path: %v", err))
+		return
+	}
+
+	// Step 3: Require the file to be in the cluster manifest. This prevents
+	// peers from fetching arbitrary backend files outside the known data set,
+	// even if they pass the path sanitizer.
+	if c.raftNode == nil {
+		c.sendFetchError(conn, "Raft not available")
+		return
+	}
+	fsm := c.raftNode.FSM()
+	if fsm == nil {
+		c.sendFetchError(conn, "FSM not available")
+		return
+	}
+	entry, ok := fsm.GetFile(sanitized)
+	if !ok {
+		c.logger.Debug().
+			Str("peer", remoteAddr).
+			Str("path", sanitized).
+			Msg("FetchFile: path not in manifest")
+		c.sendFetchError(conn, "file not in manifest")
+		return
+	}
+
+	// Step 4: Read-lock access to the backend handle.
+	c.mu.RLock()
+	backend := c.storage
+	c.mu.RUnlock()
+	if backend == nil {
+		c.sendFetchError(conn, "storage backend not configured")
+		return
+	}
+
+	// Confirm the file actually exists locally — it's possible the manifest
+	// knows about a file that hasn't replicated here yet, in which case we
+	// must tell the caller so they can try a different peer. A short deadline
+	// bounds the Exists check so a stuck backend doesn't pin the goroutine.
+	existsCtx, existsCancel := context.WithTimeout(c.ctx, 5*time.Second)
+	exists, existsErr := backend.Exists(existsCtx, sanitized)
+	existsCancel()
+	if existsErr != nil {
+		c.logger.Warn().
+			Err(existsErr).
+			Str("path", sanitized).
+			Msg("FetchFile: Exists check failed")
+		c.sendFetchError(conn, "backend error")
+		return
+	}
+	if !exists {
+		c.sendFetchError(conn, "file not found on local backend")
+		return
+	}
+
+	// Step 5: Send the ack header with the size and checksum from the manifest.
+	ack := &protocol.FetchFileAckHeader{
+		Status:    "ok",
+		SizeBytes: entry.SizeBytes,
+		SHA256:    entry.SHA256,
+	}
+	// Short write timeout for the header itself — if the peer is slow reading,
+	// we want to fail fast rather than hold the goroutine.
+	if err := protocol.SendMessage(conn, &protocol.Message{
+		Type:    protocol.MsgFetchFileAck,
+		Payload: ack,
+	}, 10*time.Second); err != nil {
+		c.logger.Warn().
+			Err(err).
+			Str("peer", remoteAddr).
+			Str("path", sanitized).
+			Msg("FetchFile: failed to send ack header")
+		return
+	}
+
+	// Step 6: Stream the body directly on the raw connection. No further
+	// protocol framing — the peer reads exactly entry.SizeBytes bytes.
+	// The write deadline bounds slow peers; the context is derived from the
+	// coordinator's lifetime so shutdown cancels any in-flight transfer.
+	const bodyStreamTimeout = 2 * time.Minute
+	if err := conn.SetWriteDeadline(time.Now().Add(bodyStreamTimeout)); err != nil {
+		c.logger.Warn().Err(err).Msg("FetchFile: failed to set write deadline")
+		return
+	}
+	bodyCtx, bodyCancel := context.WithTimeout(c.ctx, bodyStreamTimeout)
+	defer bodyCancel()
+	if err := backend.ReadTo(bodyCtx, sanitized, conn); err != nil {
+		// The peer will detect a short body via its own size accounting; we
+		// can't meaningfully recover here since the ack has already been sent.
+		c.logger.Warn().
+			Err(err).
+			Str("peer", remoteAddr).
+			Str("path", sanitized).
+			Msg("FetchFile: error streaming body")
+		return
+	}
+	// Clear the deadline so the deferred conn.Close() isn't racing with a
+	// stale timeout.
+	_ = conn.SetWriteDeadline(time.Time{})
+
+	c.logger.Debug().
+		Str("peer", remoteAddr).
+		Str("path", sanitized).
+		Int64("size_bytes", entry.SizeBytes).
+		Msg("FetchFile served successfully")
+}
+
+// sendFetchError sends a FetchFileAckHeader with an error status. Best-effort:
+// any write error is logged at debug but does not affect the caller's flow
+// (the connection is closed by the caller's defer).
+func (c *Coordinator) sendFetchError(conn net.Conn, reason string) {
+	ack := &protocol.FetchFileAckHeader{Status: "error", Error: reason}
+	if err := protocol.SendMessage(conn, &protocol.Message{
+		Type:    protocol.MsgFetchFileAck,
+		Payload: ack,
+	}, 5*time.Second); err != nil {
+		c.logger.Debug().Err(err).Msg("FetchFile: failed to send error ack")
+	}
+}
+
+// sanitizeFetchPath validates a path supplied in a MsgFetchFile request.
+// Returns the cleaned path on success or an error describing the violation.
+//
+// The storage backend treats paths as relative to its base directory. We
+// reject:
+//   - absolute paths ("/etc/passwd")
+//   - path traversal ("..", "foo/../bar")
+//   - null bytes (defense against C-string truncation bugs)
+//   - empty paths
+//   - paths that path.Clean changes (indicates funky input)
+func sanitizeFetchPath(p string) (string, error) {
+	if p == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	if strings.ContainsRune(p, 0) {
+		return "", fmt.Errorf("path contains null byte")
+	}
+	if strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("absolute path not allowed")
+	}
+	// path.Clean also rejects traversal; verify the cleaned form is unchanged.
+	cleaned := path.Clean(p)
+	if cleaned != p {
+		return "", fmt.Errorf("path must be pre-cleaned (got %q, clean is %q)", p, cleaned)
+	}
+	// After Clean, ".." as a prefix means an attempt to escape.
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("path traversal not allowed")
+	}
+	return cleaned, nil
 }
 
 // GetRegistry returns the node registry.
@@ -1231,6 +1487,113 @@ func (c *Coordinator) SetIngestBuffer(buffer *ingest.ArrowBuffer) {
 	defer c.mu.Unlock()
 	c.ingestBuffer = buffer
 	c.logger.Info().Msg("Ingest buffer set for replication — readers will apply replicated entries")
+}
+
+// SetStorageBackend sets the local storage backend reference. It is required
+// for Enterprise peer replication Phase 2: the fetch handler reads local file
+// bytes via this backend to stream them to pulling peers, and the puller
+// writes received bytes into it. Must be called before Start when peer
+// replication is enabled.
+func (c *Coordinator) SetStorageBackend(backend storage.Backend) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.storage = backend
+}
+
+// startFilePullerLocked constructs the puller, wires the FSM callback, and
+// starts the worker pool. Caller must hold c.mu (Start holds it through the
+// entire body).
+//
+// Preconditions: c.raftNode is running, c.cfg.ReplicationEnabled, and
+// c.storage has been set via SetStorageBackend. If SharedSecret is empty,
+// returns an error — peer replication requires authentication.
+func (c *Coordinator) startFilePullerLocked() error {
+	if c.storage == nil {
+		return fmt.Errorf("peer replication requires a storage backend (call SetStorageBackend before Start)")
+	}
+	if c.cfg.SharedSecret == "" {
+		return fmt.Errorf("peer replication requires ARC_CLUSTER_SHARED_SECRET to be set")
+	}
+
+	// Build the fetch client. Reuses cluster TLS (PR #382) so peer transfers
+	// run under the cluster PKI, not the public API cert.
+	fetchClient, err := filereplication.NewFetchClient(filereplication.FetchClient{
+		SelfNodeID:   c.localNode.ID,
+		ClusterName:  c.cfg.ClusterName,
+		SharedSecret: c.cfg.SharedSecret,
+		TLSConfig:    c.tlsConfig,
+		DialTimeout:  10 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("build fetch client: %w", err)
+	}
+
+	// PeerResolver closes over the registry. Capture a reference so the
+	// puller can look up peer addresses without holding c.mu.
+	registry := c.registry
+	resolver := filereplication.NewRegistryResolver(func(nodeID string) (string, bool) {
+		node, ok := registry.Get(nodeID)
+		if !ok {
+			return "", false
+		}
+		if node.Address == "" {
+			return "", false
+		}
+		return node.Address, true
+	})
+
+	pullerCfg := filereplication.Config{
+		SelfNodeID:          c.localNode.ID,
+		Backend:             c.storage,
+		Fetcher:             fetchClient,
+		PeerResolver:        resolver,
+		Workers:             c.cfg.ReplicationPullWorkers,
+		QueueSize:           c.cfg.ReplicationQueueSize,
+		RetryMaxAttempts:    c.cfg.ReplicationRetryMaxAttempts,
+		FetchTimeout:        time.Duration(c.cfg.ReplicationFetchTimeoutMs) * time.Millisecond,
+		RetryInitialBackoff: 500 * time.Millisecond,
+		Logger:              c.logger,
+	}
+
+	puller, err := filereplication.New(pullerCfg)
+	if err != nil {
+		return fmt.Errorf("construct puller: %w", err)
+	}
+
+	// Wire the FSM callback. applyRegisterFile fires onFileRegistered for
+	// every Raft commit — including entries from other applyRegisterFile
+	// calls on this same node. The puller's Enqueue handles origin-is-self
+	// and already-local skips, so there's no redundant check here.
+	//
+	// onFileDeleted is reserved for Phase 4 (compactor-initiated deletes).
+	// For now we log so operators can see deletion events flowing through.
+	fsm := c.raftNode.FSM()
+	if fsm == nil {
+		return fmt.Errorf("Raft FSM not available")
+	}
+	onRegister := func(entry *raft.FileEntry) {
+		// Called synchronously from applyRegisterFile. Must NOT block — the
+		// FSM apply goroutine is on the Raft hot path. Enqueue is non-blocking
+		// (drops on full queue) so this is safe.
+		puller.Enqueue(entry)
+	}
+	onDelete := func(path string, reason string) {
+		c.logger.Debug().
+			Str("path", path).
+			Str("reason", reason).
+			Msg("Cluster manifest deletion observed (Phase 4 will act on this)")
+	}
+	fsm.SetFileCallbacks(onRegister, onDelete)
+
+	// Start the puller workers.
+	puller.Start(context.Background())
+	c.puller = puller
+
+	c.logger.Info().
+		Int("workers", pullerCfg.Workers).
+		Int("queue_size", pullerCfg.QueueSize).
+		Msg("Peer file replication puller started")
+	return nil
 }
 
 // StartReplication starts WAL replication based on node role.

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1089,7 +1089,12 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 	// protocol framing — the peer reads exactly entry.SizeBytes bytes.
 	// The write deadline bounds slow peers; the context is derived from the
 	// coordinator's lifetime so shutdown cancels any in-flight transfer.
-	const bodyStreamTimeout = 2 * time.Minute
+	// Operators serving large Parquet files or running on slow/constrained
+	// links can raise cluster.replication_serve_timeout_ms.
+	bodyStreamTimeout := time.Duration(c.cfg.ReplicationServeTimeoutMs) * time.Millisecond
+	if bodyStreamTimeout <= 0 {
+		bodyStreamTimeout = 2 * time.Minute
+	}
 	if err := conn.SetWriteDeadline(time.Now().Add(bodyStreamTimeout)); err != nil {
 		c.logger.Warn().Err(err).Msg("FetchFile: failed to set write deadline")
 		return

--- a/internal/cluster/coordinator_fetch_test.go
+++ b/internal/cluster/coordinator_fetch_test.go
@@ -1,0 +1,91 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSanitizeFetchPath exercises the path validator used by the fetch
+// handler to reject malformed or malicious path arguments from peers.
+// The broader handler integration is covered by the in-process integration
+// test (filereplication_integration_test.go).
+func TestSanitizeFetchPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr string // substring; empty if the path should be accepted
+		want    string // cleaned output when accepted
+	}{
+		{
+			name:  "valid relative path",
+			input: "mydb/cpu/2026/04/11/14/file-xxx.parquet",
+			want:  "mydb/cpu/2026/04/11/14/file-xxx.parquet",
+		},
+		{
+			name:  "valid deep path",
+			input: "prod/mem/2026/04/11/14/abcdef.parquet",
+			want:  "prod/mem/2026/04/11/14/abcdef.parquet",
+		},
+		{
+			name:    "empty path",
+			input:   "",
+			wantErr: "empty",
+		},
+		{
+			name:    "absolute path",
+			input:   "/etc/passwd",
+			wantErr: "absolute",
+		},
+		{
+			name:    "path traversal at start",
+			input:   "../etc/passwd",
+			wantErr: "traversal",
+		},
+		{
+			name:    "path traversal embedded",
+			input:   "mydb/cpu/../../etc/passwd",
+			wantErr: "pre-cleaned",
+		},
+		{
+			name:    "parent dir only",
+			input:   "..",
+			wantErr: "traversal",
+		},
+		{
+			name:    "null byte",
+			input:   "mydb/cpu/\x00file.parquet",
+			wantErr: "null byte",
+		},
+		{
+			name:    "non-canonical slashes",
+			input:   "mydb//cpu///file.parquet",
+			wantErr: "pre-cleaned",
+		},
+		{
+			name:    "trailing slash",
+			input:   "mydb/cpu/",
+			wantErr: "pre-cleaned",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sanitizeFetchPath(tc.input)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (cleaned=%q)", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("sanitized path: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cluster/file_registrar.go
+++ b/internal/cluster/file_registrar.go
@@ -18,9 +18,9 @@ import (
 // coordinator.RegisterFileInManifest. This ensures the flush hot path
 // is never blocked on Raft consensus, network I/O, or checksum compute.
 //
-// In Phase 1 we do NOT compute checksums yet — the manifest entry records
-// the path, size, and origin for validation. Checksums will be added in
-// Phase 2 when we start pulling files from peers.
+// The SHA-256 checksum is computed by the flush path on the in-memory
+// Parquet buffer before the backend write and passed to RegisterFile.
+// Peers use it to verify files pulled during Phase 2 replication.
 type CoordinatorFileRegistrar struct {
 	coordinator *Coordinator
 	queue       chan fileRegistration
@@ -56,6 +56,7 @@ type fileRegistration struct {
 	path          string
 	partitionTime time.Time
 	sizeBytes     int64
+	sha256        string // hex-encoded SHA-256 of the Parquet bytes
 }
 
 // NewCoordinatorFileRegistrar creates a new registrar backed by the coordinator.
@@ -125,13 +126,18 @@ DrainLoop:
 // registration and returns immediately. If the queue is full, the entry is
 // dropped and a counter is incremented — peer replication will discover it on
 // the next anti-entropy scan (Phase 3+).
-func (r *CoordinatorFileRegistrar) RegisterFile(database, measurement, path string, partitionTime time.Time, sizeBytes int64) {
+//
+// sha256 is a hex-encoded SHA-256 of the Parquet file bytes. The caller
+// (arrow_writer.go flush path) computes it on the in-memory buffer before the
+// storage backend write, so it's effectively free.
+func (r *CoordinatorFileRegistrar) RegisterFile(database, measurement, path string, partitionTime time.Time, sizeBytes int64, sha256 string) {
 	reg := fileRegistration{
 		database:      database,
 		measurement:   measurement,
 		path:          path,
 		partitionTime: partitionTime,
 		sizeBytes:     sizeBytes,
+		sha256:        sha256,
 	}
 	select {
 	case r.queue <- reg:
@@ -165,6 +171,7 @@ func (r *CoordinatorFileRegistrar) worker() {
 func (r *CoordinatorFileRegistrar) process(reg fileRegistration) {
 	entry := raft.FileEntry{
 		Path:          reg.path,
+		SHA256:        reg.sha256,
 		SizeBytes:     reg.sizeBytes,
 		Database:      reg.database,
 		Measurement:   reg.measurement,

--- a/internal/cluster/filereplication/fetch_client.go
+++ b/internal/cluster/filereplication/fetch_client.go
@@ -1,0 +1,189 @@
+package filereplication
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/protocol"
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/cluster/security"
+)
+
+// FetchClient is the concrete Fetcher that the puller uses to download file
+// bytes from a peer over the coordinator TCP protocol. It dials a fresh
+// connection per fetch (no pooling in Phase 2), authenticates with HMAC
+// headers, reads the MsgFetchFileAck header, and streams the raw body into
+// the destination writer while computing SHA-256 for verification.
+type FetchClient struct {
+	// SelfNodeID is our node ID, embedded in each request's HMAC payload so
+	// the origin peer can identify the caller.
+	SelfNodeID string
+	// ClusterName is our cluster name — included in the HMAC payload to
+	// prevent cross-cluster replay.
+	ClusterName string
+	// SharedSecret is the cluster-wide HMAC key. Required — callers must
+	// refuse to construct a FetchClient without it.
+	SharedSecret string
+	// TLSConfig wraps the outbound dial in TLS when non-nil. Reuses the
+	// cluster TLS config (PR #382) so inter-node traffic is end-to-end
+	// encrypted under the cluster PKI, independent of the public API cert.
+	TLSConfig *tls.Config
+	// DialTimeout is the maximum time to establish the TCP (+TLS) connection.
+	// Default 10s if zero.
+	DialTimeout time.Duration
+	// ResponseHeaderTimeout bounds how long we wait for the MsgFetchFileAck
+	// header after sending the request. Default 15s if zero. The body stream
+	// itself is bounded by the ctx passed to Fetch.
+	ResponseHeaderTimeout time.Duration
+}
+
+// NewFetchClient validates the required fields and returns a ready-to-use
+// client. Peer replication requires the shared secret, so a missing secret
+// is a hard error rather than a fallback to unauthenticated operation.
+func NewFetchClient(c FetchClient) (*FetchClient, error) {
+	if c.SelfNodeID == "" {
+		return nil, fmt.Errorf("filereplication: FetchClient.SelfNodeID is required")
+	}
+	if c.ClusterName == "" {
+		return nil, fmt.Errorf("filereplication: FetchClient.ClusterName is required")
+	}
+	if c.SharedSecret == "" {
+		return nil, fmt.Errorf("filereplication: FetchClient.SharedSecret is required (peer replication must be authenticated)")
+	}
+	if c.DialTimeout == 0 {
+		c.DialTimeout = 10 * time.Second
+	}
+	if c.ResponseHeaderTimeout == 0 {
+		c.ResponseHeaderTimeout = 15 * time.Second
+	}
+	return &c, nil
+}
+
+// Fetch dials the peer, sends a MsgFetchFile request, reads the ack header,
+// streams body bytes into dst (while computing SHA-256), and verifies that
+// the computed hash matches the manifest SHA-256 from entry.SHA256.
+//
+// Returns the number of body bytes written and any error. On a checksum
+// mismatch the error wraps ErrChecksumMismatch so the puller can distinguish
+// mismatches from transport errors.
+//
+// The connection is always closed before returning.
+func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
+	if entry == nil {
+		return 0, fmt.Errorf("fetch: entry is nil")
+	}
+	if entry.SHA256 == "" {
+		return 0, fmt.Errorf("fetch: entry has empty SHA256 (manifest is missing checksum)")
+	}
+	if entry.SizeBytes < 0 {
+		return 0, fmt.Errorf("fetch: entry has negative SizeBytes=%d", entry.SizeBytes)
+	}
+
+	// Step 1: dial. Use security.Dial which wraps tls.DialWithDialer if TLS
+	// is configured, otherwise falls back to plain net.DialTimeout.
+	conn, err := security.Dial("tcp", peerAddr, f.DialTimeout, f.TLSConfig)
+	if err != nil {
+		return 0, fmt.Errorf("dial %s: %w", peerAddr, err)
+	}
+	defer conn.Close()
+
+	// Honor any deadline the context carries. If there's no deadline we use
+	// a tight default — the Puller always passes a bounded context, so this
+	// fallback is only defensive in case a caller wires Fetch directly.
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else {
+		_ = conn.SetDeadline(time.Now().Add(60 * time.Second))
+	}
+
+	// Step 2: build and send the MsgFetchFile request. The HMAC binds the
+	// request to this specific {nodeID, clusterName, path, timestamp} tuple
+	// so a stolen MAC can't be replayed — neither outside the ±5min freshness
+	// window nor to fetch a different file within it.
+	nonce, err := security.GenerateNonce()
+	if err != nil {
+		return 0, fmt.Errorf("generate nonce: %w", err)
+	}
+	ts := time.Now().Unix()
+	mac := security.ComputeFetchHMAC(f.SharedSecret, nonce, f.SelfNodeID, f.ClusterName, entry.Path, ts)
+
+	req := &protocol.FetchFileRequest{
+		Path:      entry.Path,
+		NodeID:    f.SelfNodeID,
+		Nonce:     nonce,
+		Timestamp: ts,
+		HMAC:      mac,
+	}
+	if err := protocol.SendMessage(conn, &protocol.Message{
+		Type:    protocol.MsgFetchFile,
+		Payload: req,
+	}, 10*time.Second); err != nil {
+		return 0, fmt.Errorf("send fetch request: %w", err)
+	}
+
+	// Step 3: read the ack header. The header is a framed protocol message,
+	// but the body that follows is NOT framed — we'll switch to raw reads.
+	ackMsg, err := protocol.ReceiveMessage(conn, f.ResponseHeaderTimeout)
+	if err != nil {
+		return 0, fmt.Errorf("receive ack header: %w", err)
+	}
+	if ackMsg.Type != protocol.MsgFetchFileAck {
+		return 0, fmt.Errorf("unexpected ack type: %v (wanted MsgFetchFileAck)", ackMsg.Type)
+	}
+	ack, ok := ackMsg.Payload.(*protocol.FetchFileAckHeader)
+	if !ok {
+		return 0, fmt.Errorf("ack payload has wrong type: %T", ackMsg.Payload)
+	}
+	if ack.Status != "ok" {
+		return 0, fmt.Errorf("peer rejected fetch: %s", ack.Error)
+	}
+	if ack.SizeBytes < 0 {
+		return 0, fmt.Errorf("ack has negative SizeBytes=%d", ack.SizeBytes)
+	}
+	if ack.SizeBytes != entry.SizeBytes {
+		return 0, fmt.Errorf("ack size mismatch: peer=%d manifest=%d", ack.SizeBytes, entry.SizeBytes)
+	}
+	if ack.SHA256 != entry.SHA256 {
+		// Peer disagrees with our manifest about this file's hash — shouldn't
+		// happen in a consistent cluster, but treat it as a mismatch rather
+		// than silently pulling possibly-wrong bytes.
+		return 0, fmt.Errorf("%w: ack hash=%s manifest=%s", ErrChecksumMismatch, ack.SHA256, entry.SHA256)
+	}
+
+	// Step 4: stream exactly SizeBytes of raw body from the connection into
+	// dst, tee'ing through a SHA-256 hasher.
+	hasher := sha256.New()
+	mw := io.MultiWriter(dst, hasher)
+	written, err := io.CopyN(mw, conn, ack.SizeBytes)
+	if err != nil {
+		return written, fmt.Errorf("stream body: %w (wrote %d of %d)", err, written, ack.SizeBytes)
+	}
+
+	// Step 5: verify the computed hash matches the expected hash.
+	computed := hex.EncodeToString(hasher.Sum(nil))
+	if computed != entry.SHA256 {
+		return written, fmt.Errorf("%w: computed=%s expected=%s", ErrChecksumMismatch, computed, entry.SHA256)
+	}
+	return written, nil
+}
+
+// Compile-time check that FetchClient satisfies Fetcher.
+var _ Fetcher = (*FetchClient)(nil)
+
+// NewRegistryResolver adapts any function that maps node IDs to addresses
+// into a PeerResolver. This is the simplest plumbing between the coordinator
+// (which owns the registry) and the puller (which needs a resolver).
+func NewRegistryResolver(fn func(nodeID string) (string, bool)) PeerResolver {
+	return funcResolver(fn)
+}
+
+type funcResolver func(string) (string, bool)
+
+func (f funcResolver) ResolvePeer(nodeID string) (string, bool) {
+	return f(nodeID)
+}

--- a/internal/cluster/filereplication/fetch_client_test.go
+++ b/internal/cluster/filereplication/fetch_client_test.go
@@ -1,0 +1,422 @@
+package filereplication
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/protocol"
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+)
+
+// fakePeer is a minimal TCP server that speaks the Arc cluster protocol for
+// fetch requests. Each test constructs one, scripts a single response, and
+// points a FetchClient at its listen address.
+type fakePeer struct {
+	t        *testing.T
+	listener net.Listener
+
+	// Scripted response
+	mu          sync.Mutex
+	ack         protocol.FetchFileAckHeader
+	body        []byte
+	validateReq func(*protocol.FetchFileRequest) error // optional
+	errBefore   bool                                   // if true, close the conn without replying
+
+	wg sync.WaitGroup
+}
+
+func startFakePeer(t *testing.T) *fakePeer {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	p := &fakePeer{t: t, listener: l}
+	p.wg.Add(1)
+	go p.acceptLoop()
+	return p
+}
+
+func (p *fakePeer) addr() string { return p.listener.Addr().String() }
+
+func (p *fakePeer) scriptOK(sum string, body []byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.ack = protocol.FetchFileAckHeader{
+		Status:    "ok",
+		SizeBytes: int64(len(body)),
+		SHA256:    sum,
+	}
+	p.body = body
+}
+
+func (p *fakePeer) scriptError(reason string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.ack = protocol.FetchFileAckHeader{Status: "error", Error: reason}
+	p.body = nil
+}
+
+func (p *fakePeer) scriptCloseBeforeReply() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.errBefore = true
+}
+
+func (p *fakePeer) setRequestValidator(fn func(*protocol.FetchFileRequest) error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.validateReq = fn
+}
+
+func (p *fakePeer) stop() {
+	p.listener.Close()
+	p.wg.Wait()
+}
+
+func (p *fakePeer) acceptLoop() {
+	defer p.wg.Done()
+	for {
+		conn, err := p.listener.Accept()
+		if err != nil {
+			return
+		}
+		go p.handleConn(conn)
+	}
+}
+
+func (p *fakePeer) handleConn(conn net.Conn) {
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	// Read one message — expect MsgFetchFile.
+	msg, err := protocol.ReceiveMessage(conn, 2*time.Second)
+	if err != nil {
+		return
+	}
+	req, ok := msg.Payload.(*protocol.FetchFileRequest)
+	if !ok {
+		return
+	}
+
+	p.mu.Lock()
+	validator := p.validateReq
+	closeBefore := p.errBefore
+	ack := p.ack
+	body := p.body
+	p.mu.Unlock()
+
+	if closeBefore {
+		return
+	}
+	if validator != nil {
+		if err := validator(req); err != nil {
+			_ = protocol.SendMessage(conn, &protocol.Message{
+				Type:    protocol.MsgFetchFileAck,
+				Payload: &protocol.FetchFileAckHeader{Status: "error", Error: err.Error()},
+			}, 2*time.Second)
+			return
+		}
+	}
+
+	if err := protocol.SendMessage(conn, &protocol.Message{
+		Type:    protocol.MsgFetchFileAck,
+		Payload: &ack,
+	}, 2*time.Second); err != nil {
+		return
+	}
+	if ack.Status != "ok" {
+		return
+	}
+	if len(body) > 0 {
+		_, _ = conn.Write(body)
+	}
+}
+
+// --- Tests ---------------------------------------------------------------
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func newFetchClient(t *testing.T, selfID, secret string) *FetchClient {
+	t.Helper()
+	fc, err := NewFetchClient(FetchClient{
+		SelfNodeID:            selfID,
+		ClusterName:           "test-cluster",
+		SharedSecret:          secret,
+		DialTimeout:           2 * time.Second,
+		ResponseHeaderTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewFetchClient: %v", err)
+	}
+	return fc
+}
+
+func TestFetchClientHappyPath(t *testing.T) {
+	body := []byte("parquet bytes 0123456789")
+	sum := sha256Hex(body)
+
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptOK(sum, body)
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/file.parquet",
+		SizeBytes: int64(len(body)),
+		SHA256:    sum,
+	}
+	var dst bytes.Buffer
+	n, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if n != int64(len(body)) {
+		t.Errorf("bytes written: got %d, want %d", n, len(body))
+	}
+	if dst.String() != string(body) {
+		t.Errorf("body mismatch")
+	}
+}
+
+func TestFetchClientChecksumMismatch(t *testing.T) {
+	body := []byte("real body")
+	wrongSum := sha256Hex([]byte("fake"))
+
+	peer := startFakePeer(t)
+	defer peer.stop()
+	// Peer sends real bytes but the ack advertises a different checksum that
+	// the client will accept (we match advertised vs manifest), then the
+	// computed hash of the actual bytes won't match the manifest.
+	peer.scriptOK(wrongSum, body)
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	manifestSum := sha256Hex(body) // the manifest thinks the file hashes to this
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/mismatch.parquet",
+		SizeBytes: int64(len(body)),
+		SHA256:    manifestSum,
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Errorf("expected ErrChecksumMismatch, got %v", err)
+	}
+}
+
+// TestFetchClientBodyHashMismatch covers the case where the peer returns the
+// correct advertised SHA-256 in the ack header (matching our manifest) but
+// actually sends bytes with a different hash. The client computes the hash
+// on the wire and should reject the bytes as ErrChecksumMismatch.
+func TestFetchClientBodyHashMismatch(t *testing.T) {
+	actualBody := []byte("totally different bytes")
+	claimedBody := []byte("parquet bytes 0123456789")
+	claimedSum := sha256Hex(claimedBody)
+
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptOK(claimedSum, actualBody)
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/tampered.parquet",
+		SizeBytes: int64(len(actualBody)),
+		SHA256:    claimedSum,
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Errorf("expected ErrChecksumMismatch, got %v", err)
+	}
+}
+
+func TestFetchClientErrorAck(t *testing.T) {
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptError("file not in manifest")
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/missing.parquet",
+		SizeBytes: 42,
+		SHA256:    sha256Hex([]byte("dummy")),
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestFetchClientSizeMismatch(t *testing.T) {
+	body := []byte("short")
+	sum := sha256Hex(body)
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptOK(sum, body)
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	// Manifest claims 100 bytes but peer says 5 — should fail.
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/size.parquet",
+		SizeBytes: 100,
+		SHA256:    sum,
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatalf("expected size mismatch error, got nil")
+	}
+}
+
+func TestFetchClientDialError(t *testing.T) {
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/dead.parquet",
+		SizeBytes: 10,
+		SHA256:    sha256Hex([]byte("xxxxxxxxxx")),
+	}
+	var dst bytes.Buffer
+	// Port 1 on loopback should refuse connections.
+	_, err := fc.Fetch(context.Background(), "127.0.0.1:1", entry, &dst)
+	if err == nil {
+		t.Fatalf("expected dial error, got nil")
+	}
+}
+
+func TestFetchClientHMACSent(t *testing.T) {
+	body := []byte("hmac test body")
+	sum := sha256Hex(body)
+
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptOK(sum, body)
+
+	var captured *protocol.FetchFileRequest
+	peer.setRequestValidator(func(r *protocol.FetchFileRequest) error {
+		cp := *r
+		captured = &cp
+		return nil
+	})
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/auth.parquet",
+		SizeBytes: int64(len(body)),
+		SHA256:    sum,
+	}
+	var dst bytes.Buffer
+	if _, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if captured == nil {
+		t.Fatal("peer did not capture request")
+	}
+	if captured.NodeID != "reader-1" {
+		t.Errorf("NodeID: got %q, want reader-1", captured.NodeID)
+	}
+	if captured.HMAC == "" {
+		t.Errorf("HMAC should be set")
+	}
+	if captured.Nonce == "" {
+		t.Errorf("Nonce should be set")
+	}
+	if captured.Timestamp == 0 {
+		t.Errorf("Timestamp should be set")
+	}
+	if captured.Path != entry.Path {
+		t.Errorf("Path: got %q, want %q", captured.Path, entry.Path)
+	}
+}
+
+func TestFetchClientPeerDropsBeforeReply(t *testing.T) {
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptCloseBeforeReply()
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/drop.parquet",
+		SizeBytes: 10,
+		SHA256:    sha256Hex([]byte("xxxxxxxxxx")),
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestFetchClientConfigValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		c    FetchClient
+	}{
+		{
+			name: "missing self",
+			c:    FetchClient{ClusterName: "c", SharedSecret: "s"},
+		},
+		{
+			name: "missing cluster name",
+			c:    FetchClient{SelfNodeID: "n", SharedSecret: "s"},
+		},
+		{
+			name: "missing shared secret",
+			c:    FetchClient{SelfNodeID: "n", ClusterName: "c"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewFetchClient(tc.c)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+// Sanity: ensure io.CopyN-driven read path works with body larger than
+// the protocol MaxMessageSize. The body is raw bytes, not a framed message,
+// so this should not trigger the codec's 1 MB limit.
+func TestFetchClientLargeBody(t *testing.T) {
+	const size = 2 * 1024 * 1024 // 2 MiB
+	body := bytes.Repeat([]byte("a"), size)
+	sum := sha256Hex(body)
+
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptOK(sum, body)
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/large.parquet",
+		SizeBytes: int64(len(body)),
+		SHA256:    sum,
+	}
+	// Discard dst — we only care that the Fetch succeeds on a large body.
+	n, err := fc.Fetch(context.Background(), peer.addr(), entry, io.Discard)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if n != int64(size) {
+		t.Errorf("bytes: got %d, want %d", n, size)
+	}
+}

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -1,0 +1,426 @@
+// Package filereplication implements peer-to-peer Parquet file replication
+// for Arc Enterprise clusters without shared storage. It is the byte-level
+// counterpart to Phase 1's cluster-wide file manifest: when a new file is
+// announced on the Raft log, the puller downloads the bytes from the origin
+// peer over the coordinator TCP protocol, verifies the SHA-256, and writes
+// the file to the local storage backend.
+//
+// The puller is gated by the Enterprise license (FeatureClustering) and
+// wired by the coordinator when cluster.replication_enabled is true.
+package filereplication
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// Fetcher is the contract the puller uses to download a single file from a
+// peer. It's an interface rather than a concrete type so the puller can be
+// unit-tested with a fake that returns deterministic bytes/errors without
+// opening real TCP connections.
+type Fetcher interface {
+	// Fetch downloads the file identified by entry from the given peer address
+	// and writes the body bytes into dst. It MUST verify that the peer's
+	// declared SHA-256 matches the expected value from the manifest and that
+	// the body length matches the declared size. Returns (bytesWritten, error).
+	Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error)
+}
+
+// PeerResolver maps an origin node ID to its coordinator TCP address. The
+// puller looks up the address fresh on every enqueued entry (rather than
+// caching) so that topology changes are picked up automatically.
+type PeerResolver interface {
+	// ResolvePeer returns the coordinator address for a node, or ("", false)
+	// if the node is unknown. Callers treat "not found" as a transient error
+	// and may re-enqueue.
+	ResolvePeer(nodeID string) (string, bool)
+}
+
+// Config bundles the puller's dependencies and tunables.
+type Config struct {
+	// SelfNodeID is the ID of the local node. Files whose OriginNodeID matches
+	// are skipped (the origin already has the bytes).
+	SelfNodeID string
+
+	// Backend is the local storage backend. The puller calls Exists to skip
+	// already-local files and WriteReader to stream pulled bytes onto disk.
+	Backend storage.Backend
+
+	// Fetcher is the network client that actually downloads file bytes from
+	// a peer. Injected so tests can use a fake.
+	Fetcher Fetcher
+
+	// PeerResolver looks up the coordinator address for a node ID.
+	PeerResolver PeerResolver
+
+	// Workers is the number of concurrent pull goroutines. Default: 4.
+	Workers int
+
+	// QueueSize is the buffered channel capacity. Enqueues past this limit
+	// are dropped and counted. Default: 1024.
+	QueueSize int
+
+	// RetryMaxAttempts is the number of immediate retry attempts for a single
+	// pull failure before the entry is given up on. Further recovery happens
+	// via a later FSM callback or the Phase 3 catch-up scanner. Default: 3.
+	RetryMaxAttempts int
+
+	// RetryInitialBackoff is the first retry delay. Doubles on each attempt.
+	// Default: 500ms.
+	RetryInitialBackoff time.Duration
+
+	// FetchTimeout bounds a single Fetcher.Fetch call. Default: 60s.
+	FetchTimeout time.Duration
+
+	// Logger receives structured log output.
+	Logger zerolog.Logger
+}
+
+// DefaultConfig returns sensible defaults. Callers typically override only
+// the dependencies (Backend, Fetcher, PeerResolver, SelfNodeID, Logger).
+func DefaultConfig() Config {
+	return Config{
+		Workers:             4,
+		QueueSize:           1024,
+		RetryMaxAttempts:    3,
+		RetryInitialBackoff: 500 * time.Millisecond,
+		FetchTimeout:        60 * time.Second,
+	}
+}
+
+// Puller is the background worker pool that drains FSM file-registration
+// callbacks and pulls missing files from their origin peers.
+type Puller struct {
+	cfg    Config
+	queue  chan *raft.FileEntry
+	logger zerolog.Logger
+
+	// Lifecycle
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	started bool
+
+	// Metrics (atomic for lock-free observability)
+	totalEnqueued          atomic.Int64
+	totalSkippedSelf       atomic.Int64 // origin is self — no pull needed
+	totalSkippedLocal      atomic.Int64 // backend.Exists already true
+	totalPulled            atomic.Int64 // successful pulls
+	totalFailed            atomic.Int64 // gave up after retries
+	totalDropped           atomic.Int64 // queue full
+	totalChecksumMismatch  atomic.Int64 // bytes didn't match manifest SHA256
+	totalPeerLookupFailure atomic.Int64 // origin node not in registry
+}
+
+// New constructs a Puller. Does not start background workers — call Start.
+func New(cfg Config) (*Puller, error) {
+	if cfg.Backend == nil {
+		return nil, errors.New("filereplication: Backend is required")
+	}
+	if cfg.Fetcher == nil {
+		return nil, errors.New("filereplication: Fetcher is required")
+	}
+	if cfg.PeerResolver == nil {
+		return nil, errors.New("filereplication: PeerResolver is required")
+	}
+	if cfg.SelfNodeID == "" {
+		return nil, errors.New("filereplication: SelfNodeID is required")
+	}
+	// Fill defaults
+	defaults := DefaultConfig()
+	if cfg.Workers <= 0 {
+		cfg.Workers = defaults.Workers
+	}
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = defaults.QueueSize
+	}
+	if cfg.RetryMaxAttempts <= 0 {
+		cfg.RetryMaxAttempts = defaults.RetryMaxAttempts
+	}
+	if cfg.RetryInitialBackoff <= 0 {
+		cfg.RetryInitialBackoff = defaults.RetryInitialBackoff
+	}
+	if cfg.FetchTimeout <= 0 {
+		cfg.FetchTimeout = defaults.FetchTimeout
+	}
+
+	return &Puller{
+		cfg:    cfg,
+		queue:  make(chan *raft.FileEntry, cfg.QueueSize),
+		logger: cfg.Logger.With().Str("component", "file-puller").Logger(),
+	}, nil
+}
+
+// Start launches the worker pool. Safe to call multiple times — subsequent
+// calls are no-ops.
+func (p *Puller) Start(parentCtx context.Context) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return
+	}
+	p.ctx, p.cancel = context.WithCancel(parentCtx)
+	p.started = true
+	for i := 0; i < p.cfg.Workers; i++ {
+		p.wg.Add(1)
+		go p.worker(i)
+	}
+	p.logger.Info().
+		Int("workers", p.cfg.Workers).
+		Int("queue_size", p.cfg.QueueSize).
+		Msg("File puller started")
+}
+
+// Stop signals all workers to exit and waits for them to finish. In-flight
+// pulls are cancelled via the shared context. Pending queue entries are
+// dropped (Phase 3 catch-up or a later FSM callback will re-discover them).
+func (p *Puller) Stop() {
+	p.mu.Lock()
+	if !p.started {
+		p.mu.Unlock()
+		return
+	}
+	p.cancel()
+	p.mu.Unlock()
+	p.wg.Wait()
+	p.logger.Info().
+		Int64("total_enqueued", p.totalEnqueued.Load()).
+		Int64("total_pulled", p.totalPulled.Load()).
+		Int64("total_failed", p.totalFailed.Load()).
+		Int64("total_dropped", p.totalDropped.Load()).
+		Int64("total_checksum_mismatch", p.totalChecksumMismatch.Load()).
+		Msg("File puller stopped")
+}
+
+// Enqueue submits a file entry for pulling. Non-blocking: if the queue is
+// full, the entry is dropped and totalDropped is incremented. If origin is
+// self or the file already exists locally, the entry is counted as a skip
+// and never reaches a worker.
+//
+// Enqueue is safe to call from the Raft FSM apply callback (which must
+// return quickly): all checks here are O(1) and no I/O happens inline.
+func (p *Puller) Enqueue(entry *raft.FileEntry) {
+	if entry == nil {
+		return
+	}
+	// Fast-path: if origin is self there's nothing to pull.
+	if entry.OriginNodeID == p.cfg.SelfNodeID {
+		p.totalSkippedSelf.Add(1)
+		return
+	}
+	// Copy so the caller can't mutate the entry out from under the worker.
+	entryCopy := *entry
+	select {
+	case p.queue <- &entryCopy:
+		p.totalEnqueued.Add(1)
+	default:
+		dropped := p.totalDropped.Add(1)
+		// Power-of-2 rate limiting, same pattern as CoordinatorFileRegistrar.
+		if dropped&(dropped-1) == 0 {
+			p.logger.Warn().
+				Str("path", entry.Path).
+				Int64("total_dropped", dropped).
+				Msg("File puller queue full, dropping entry (will be recovered by catch-up scanner)")
+		}
+	}
+}
+
+// Stats returns a point-in-time snapshot of the puller's metrics.
+func (p *Puller) Stats() map[string]int64 {
+	return map[string]int64{
+		"enqueued":             p.totalEnqueued.Load(),
+		"skipped_self":         p.totalSkippedSelf.Load(),
+		"skipped_local":        p.totalSkippedLocal.Load(),
+		"pulled":               p.totalPulled.Load(),
+		"failed":               p.totalFailed.Load(),
+		"dropped":              p.totalDropped.Load(),
+		"checksum_mismatch":    p.totalChecksumMismatch.Load(),
+		"peer_lookup_failure":  p.totalPeerLookupFailure.Load(),
+		"queue_depth":          int64(len(p.queue)),
+	}
+}
+
+func (p *Puller) worker(id int) {
+	defer p.wg.Done()
+	workerLog := p.logger.With().Int("worker_id", id).Logger()
+	workerLog.Debug().Msg("File puller worker started")
+
+	for {
+		select {
+		case <-p.ctx.Done():
+			workerLog.Debug().Msg("File puller worker exiting")
+			return
+		case entry, ok := <-p.queue:
+			if !ok {
+				return
+			}
+			p.processEntry(workerLog, entry)
+		}
+	}
+}
+
+// processEntry pulls a single file with bounded retries. Each retry re-checks
+// backend.Exists (in case a concurrent worker or external process put the
+// file in place) and re-resolves the peer address (in case of topology change).
+func (p *Puller) processEntry(log zerolog.Logger, entry *raft.FileEntry) {
+	for attempt := 1; attempt <= p.cfg.RetryMaxAttempts; attempt++ {
+		if p.ctx.Err() != nil {
+			return
+		}
+
+		// Pre-pull check: skip if already local.
+		existsCtx, cancel := context.WithTimeout(p.ctx, 5*time.Second)
+		exists, existsErr := p.cfg.Backend.Exists(existsCtx, entry.Path)
+		cancel()
+		if existsErr == nil && exists {
+			p.totalSkippedLocal.Add(1)
+			return
+		}
+
+		// Resolve peer address fresh on each attempt.
+		peerAddr, ok := p.cfg.PeerResolver.ResolvePeer(entry.OriginNodeID)
+		if !ok {
+			p.totalPeerLookupFailure.Add(1)
+			log.Warn().
+				Str("path", entry.Path).
+				Str("origin_node_id", entry.OriginNodeID).
+				Int("attempt", attempt).
+				Msg("Origin node not found in registry, deferring pull")
+			p.sleepBackoff(attempt)
+			continue
+		}
+
+		// Attempt the pull.
+		if err := p.pullOnce(log, entry, peerAddr, attempt); err != nil {
+			log.Warn().
+				Err(err).
+				Str("path", entry.Path).
+				Str("peer", peerAddr).
+				Int("attempt", attempt).
+				Int("max_attempts", p.cfg.RetryMaxAttempts).
+				Msg("File pull attempt failed")
+
+			if attempt >= p.cfg.RetryMaxAttempts {
+				p.totalFailed.Add(1)
+				log.Error().
+					Err(err).
+					Str("path", entry.Path).
+					Str("peer", peerAddr).
+					Msg("File pull giving up after max attempts (will be retried by next FSM callback or catch-up scan)")
+				return
+			}
+			p.sleepBackoff(attempt)
+			continue
+		}
+
+		// Success.
+		p.totalPulled.Add(1)
+		log.Info().
+			Str("path", entry.Path).
+			Str("peer", peerAddr).
+			Int64("size_bytes", entry.SizeBytes).
+			Int("attempts", attempt).
+			Msg("File pulled from peer")
+		return
+	}
+}
+
+// pullOnce performs a single fetch attempt end-to-end: opens a pipe into the
+// local backend writer, runs Fetcher.Fetch which streams bytes into the pipe,
+// and verifies the total byte count on success. The Fetcher is expected to
+// verify the SHA-256 itself and return an error on mismatch — this function
+// only tracks the mismatch counter.
+func (p *Puller) pullOnce(log zerolog.Logger, entry *raft.FileEntry, peerAddr string, attempt int) error {
+	fetchCtx, cancel := context.WithTimeout(p.ctx, p.cfg.FetchTimeout)
+	defer cancel()
+
+	// Pipe: producer side (Fetcher writes) → consumer side (backend.WriteReader reads).
+	// This lets us stream body bytes from the peer into the backend without
+	// buffering the entire file in memory.
+	pr, pw := io.Pipe()
+
+	// Backend writer goroutine: reads from the pipe until EOF or error.
+	// WriteReader is expected to read exactly entry.SizeBytes bytes and then
+	// return.
+	var writeErr error
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		writeErr = p.cfg.Backend.WriteReader(fetchCtx, entry.Path, pr, entry.SizeBytes)
+		// Ensure any pending Fetch writes unblock if the backend aborts early.
+		// (Normal case: backend drains the full body then returns nil.)
+		if writeErr != nil {
+			_ = pr.CloseWithError(writeErr)
+		}
+	}()
+
+	// Fetch: streams the body bytes into the pipe writer. When the fetcher
+	// finishes (or errors), we close the pipe writer so the backend goroutine
+	// sees EOF.
+	written, fetchErr := p.cfg.Fetcher.Fetch(fetchCtx, peerAddr, entry, pw)
+	// Always close the pipe writer — if fetchErr, propagate so the backend
+	// goroutine unblocks with an error instead of hanging on Read.
+	if fetchErr != nil {
+		_ = pw.CloseWithError(fetchErr)
+	} else {
+		_ = pw.Close()
+	}
+
+	// Wait for the backend writer to finish so we observe its error.
+	<-writeDone
+
+	if fetchErr != nil {
+		// Track checksum mismatches separately so operators can see them in metrics.
+		if errors.Is(fetchErr, ErrChecksumMismatch) {
+			p.totalChecksumMismatch.Add(1)
+			// On a checksum mismatch the local file (if any) is corrupt — try to
+			// delete it so the next attempt writes from scratch.
+			delCtx, delCancel := context.WithTimeout(p.ctx, 5*time.Second)
+			if delErr := p.cfg.Backend.Delete(delCtx, entry.Path); delErr != nil {
+				log.Warn().
+					Err(delErr).
+					Str("path", entry.Path).
+					Msg("Failed to delete corrupt file after checksum mismatch")
+			}
+			delCancel()
+		}
+		return fetchErr
+	}
+	if writeErr != nil {
+		return fmt.Errorf("backend write: %w", writeErr)
+	}
+	if written != entry.SizeBytes {
+		return fmt.Errorf("short body: wrote %d bytes, expected %d", written, entry.SizeBytes)
+	}
+	return nil
+}
+
+// sleepBackoff sleeps for an exponential backoff interval, honoring context
+// cancellation. attempt is 1-indexed; the first retry uses the base delay,
+// each subsequent retry doubles it.
+func (p *Puller) sleepBackoff(attempt int) {
+	delay := p.cfg.RetryInitialBackoff << uint(attempt-1)
+	if delay > 30*time.Second {
+		delay = 30 * time.Second
+	}
+	select {
+	case <-p.ctx.Done():
+	case <-time.After(delay):
+	}
+}
+
+// ErrChecksumMismatch is returned by Fetcher implementations when the bytes
+// pulled from a peer don't match the expected SHA-256 from the manifest.
+// The puller tracks this as a distinct metric and deletes the partial local
+// file before retrying.
+var ErrChecksumMismatch = errors.New("filereplication: checksum mismatch")

--- a/internal/cluster/filereplication/puller_test.go
+++ b/internal/cluster/filereplication/puller_test.go
@@ -1,0 +1,519 @@
+package filereplication
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/rs/zerolog"
+)
+
+// --- Fakes ---------------------------------------------------------------
+
+// fakeBackend is an in-memory storage.Backend used by the puller tests. Only
+// the methods the puller calls are implemented; the rest panic.
+type fakeBackend struct {
+	mu    sync.Mutex
+	files map[string][]byte
+	// If nonzero, Exists returns this value before looking at the map.
+	forceExists *bool
+	// If nonempty, the backend simulates a write error.
+	writeErr error
+	// Track delete calls for assertions.
+	deletedPaths []string
+}
+
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{files: make(map[string][]byte)}
+}
+
+func (f *fakeBackend) Write(ctx context.Context, path string, data []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	f.files[path] = cp
+	return nil
+}
+
+func (f *fakeBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	f.mu.Lock()
+	writeErr := f.writeErr
+	f.mu.Unlock()
+	if writeErr != nil {
+		return writeErr
+	}
+	// Read the full body to simulate a real backend.
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.files[path] = data
+	return nil
+}
+
+func (f *fakeBackend) Read(ctx context.Context, path string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, ok := f.files[path]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return data, nil
+}
+
+func (f *fakeBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
+	data, err := f.Read(ctx, path)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+	return err
+}
+
+func (f *fakeBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	panic("not used")
+}
+
+func (f *fakeBackend) Delete(ctx context.Context, path string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.files, path)
+	f.deletedPaths = append(f.deletedPaths, path)
+	return nil
+}
+
+func (f *fakeBackend) Exists(ctx context.Context, path string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.forceExists != nil {
+		return *f.forceExists, nil
+	}
+	_, ok := f.files[path]
+	return ok, nil
+}
+
+func (f *fakeBackend) Close() error         { return nil }
+func (f *fakeBackend) Type() string         { return "fake" }
+func (f *fakeBackend) ConfigJSON() string   { return "{}" }
+func (f *fakeBackend) deleteCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.deletedPaths)
+}
+
+// fakeFetcher implements Fetcher with a scripted behavior.
+type fakeFetcher struct {
+	mu sync.Mutex
+	// Per-call scripted results. index == call number (0-based).
+	results []fakeFetchResult
+	calls   atomic.Int64
+}
+
+type fakeFetchResult struct {
+	body []byte
+	err  error
+}
+
+func newFakeFetcher(results ...fakeFetchResult) *fakeFetcher {
+	return &fakeFetcher{results: results}
+}
+
+func (f *fakeFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
+	idx := f.calls.Add(1) - 1
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if int(idx) >= len(f.results) {
+		// Default: return error to force retries to stop
+		return 0, errors.New("fake fetcher: no more scripted results")
+	}
+	r := f.results[idx]
+	if r.err != nil {
+		// For checksum mismatches, still "write" the bad body so the backend
+		// observes the corrupt bytes that need cleanup.
+		if errors.Is(r.err, ErrChecksumMismatch) && len(r.body) > 0 {
+			_, _ = dst.Write(r.body)
+		}
+		return 0, r.err
+	}
+	n, err := dst.Write(r.body)
+	return int64(n), err
+}
+
+// staticResolver maps a single node ID to a fixed address.
+type staticResolver struct {
+	nodeID string
+	addr   string
+	ok     bool
+}
+
+func (s staticResolver) ResolvePeer(nodeID string) (string, bool) {
+	if nodeID != s.nodeID {
+		return "", false
+	}
+	return s.addr, s.ok
+}
+
+// --- Helpers -------------------------------------------------------------
+
+func makeEntry(path, origin string, size int64) *raft.FileEntry {
+	return &raft.FileEntry{
+		Path:          path,
+		SizeBytes:     size,
+		Database:      "testdb",
+		Measurement:   "cpu",
+		OriginNodeID:  origin,
+		Tier:          "hot",
+		PartitionTime: time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
+		CreatedAt:     time.Date(2026, 4, 11, 15, 0, 0, 0, time.UTC),
+		LSN:           1,
+		SHA256:        "deadbeef",
+	}
+}
+
+func newTestPuller(t *testing.T, backend *fakeBackend, fetcher Fetcher, resolver PeerResolver) *Puller {
+	t.Helper()
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             1,
+		QueueSize:           8,
+		RetryMaxAttempts:    3,
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New puller: %v", err)
+	}
+	return p
+}
+
+// waitStats spins briefly until the predicate is true or the deadline is hit.
+// Avoids flaky sleeps while keeping tests deterministic.
+func waitStats(t *testing.T, p *Puller, pred func(map[string]int64) bool) map[string]int64 {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stats := p.Stats()
+		if pred(stats) {
+			return stats
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return p.Stats()
+}
+
+// --- Tests ---------------------------------------------------------------
+
+func TestPullerHappyPath(t *testing.T) {
+	backend := newFakeBackend()
+	body := []byte("parquet body bytes")
+	fetcher := newFakeFetcher(fakeFetchResult{body: body})
+	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/file-1.parquet", "writer-1", int64(len(body)))
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["pulled"] == 1 })
+	if stats["pulled"] != 1 {
+		t.Fatalf("expected 1 pulled, got %+v", stats)
+	}
+	if stats["failed"] != 0 {
+		t.Errorf("expected 0 failed, got %d", stats["failed"])
+	}
+	// File should exist in the fake backend
+	got, err := backend.Read(context.Background(), entry.Path)
+	if err != nil {
+		t.Fatalf("Read after pull: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("body mismatch: got %q, want %q", got, body)
+	}
+}
+
+func TestPullerSkipsSelfOrigin(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newFakeFetcher() // no scripted results — any call is a bug
+	resolver := staticResolver{nodeID: "reader-1", addr: "self:9100", ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	// Origin == SelfNodeID ("reader-1")
+	entry := makeEntry("testdb/cpu/file-2.parquet", "reader-1", 100)
+	p.Enqueue(entry)
+
+	// Give the puller a chance to actually skip; enqueue is synchronous for skipped-self.
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["skipped_self"] == 1 })
+	if stats["skipped_self"] != 1 {
+		t.Errorf("expected skipped_self=1, got %+v", stats)
+	}
+	if stats["enqueued"] != 0 {
+		t.Errorf("skipped-self should not increment enqueued, got %d", stats["enqueued"])
+	}
+	if fetcher.calls.Load() != 0 {
+		t.Errorf("fetcher was called for self-origin entry")
+	}
+}
+
+func TestPullerSkipsAlreadyLocalFile(t *testing.T) {
+	backend := newFakeBackend()
+	// Pre-populate: the file already exists locally.
+	_ = backend.Write(context.Background(), "testdb/cpu/existing.parquet", []byte("old bytes"))
+	fetcher := newFakeFetcher() // should never be called
+	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/existing.parquet", "writer-1", 100)
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["skipped_local"] == 1 })
+	if stats["skipped_local"] != 1 {
+		t.Errorf("expected skipped_local=1, got %+v", stats)
+	}
+	if fetcher.calls.Load() != 0 {
+		t.Errorf("fetcher should not be called when file exists locally")
+	}
+}
+
+func TestPullerRetriesAndGivesUp(t *testing.T) {
+	backend := newFakeBackend()
+	// All 3 attempts return errors — none are ErrChecksumMismatch.
+	fetcher := newFakeFetcher(
+		fakeFetchResult{err: errors.New("dial refused")},
+		fakeFetchResult{err: errors.New("dial refused")},
+		fakeFetchResult{err: errors.New("dial refused")},
+	)
+	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/file-err.parquet", "writer-1", 100)
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["failed"] == 1 })
+	if stats["failed"] != 1 {
+		t.Fatalf("expected failed=1 after retry exhaustion, got %+v", stats)
+	}
+	if stats["pulled"] != 0 {
+		t.Errorf("expected pulled=0, got %d", stats["pulled"])
+	}
+	if got := fetcher.calls.Load(); got != 3 {
+		t.Errorf("expected 3 fetch attempts, got %d", got)
+	}
+}
+
+func TestPullerChecksumMismatchDeletesAndCounts(t *testing.T) {
+	backend := newFakeBackend()
+	// First attempt: bad checksum. Second: good.
+	goodBody := []byte("good parquet")
+	fetcher := newFakeFetcher(
+		fakeFetchResult{body: []byte("corrupt"), err: ErrChecksumMismatch},
+		fakeFetchResult{body: goodBody},
+	)
+	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/file-checksum.parquet", "writer-1", int64(len(goodBody)))
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["pulled"] == 1 })
+	if stats["pulled"] != 1 {
+		t.Fatalf("expected recovery on retry, got %+v", stats)
+	}
+	if stats["checksum_mismatch"] != 1 {
+		t.Errorf("expected checksum_mismatch=1, got %d", stats["checksum_mismatch"])
+	}
+	if backend.deleteCount() == 0 {
+		t.Errorf("expected backend.Delete called after checksum mismatch, got 0")
+	}
+	// Final file should be the good body.
+	got, err := backend.Read(context.Background(), entry.Path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != string(goodBody) {
+		t.Errorf("final body mismatch: got %q, want %q", got, goodBody)
+	}
+}
+
+func TestPullerPeerLookupFailure(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newFakeFetcher() // never called
+	// Resolver returns ok=false for everything.
+	resolver := staticResolver{nodeID: "unknown", addr: "", ok: false}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/orphan.parquet", "writer-1", 100)
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["failed"] == 1 })
+	if stats["peer_lookup_failure"] < 1 {
+		t.Errorf("expected peer_lookup_failure>=1, got %+v", stats)
+	}
+	if fetcher.calls.Load() != 0 {
+		t.Errorf("fetcher should not be called when peer lookup fails")
+	}
+}
+
+func TestPullerQueueDropUnderOverload(t *testing.T) {
+	backend := newFakeBackend()
+	// Blocking fetcher: never returns until we signal. This keeps the worker
+	// busy so the queue fills up.
+	blockCh := make(chan struct{})
+	fetcher := &blockingFetcher{release: blockCh}
+	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             1,
+		QueueSize:           2, // small queue so we can overflow
+		RetryMaxAttempts:    1,
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        5 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer func() {
+		// Unblock the fetcher before Stop to let the worker exit gracefully.
+		close(blockCh)
+		p.Stop()
+	}()
+
+	// Enqueue many more than QueueSize+inflight (1).
+	// With Workers=1 and QueueSize=2, at most ~3 entries can land before drops.
+	const totalEnqueued = 50
+	for i := 0; i < totalEnqueued; i++ {
+		entry := makeEntry("testdb/cpu/overload.parquet", "writer-1", 100)
+		p.Enqueue(entry)
+	}
+
+	stats := p.Stats()
+	if stats["dropped"] == 0 {
+		t.Errorf("expected some dropped entries under overload, got %+v", stats)
+	}
+	if stats["enqueued"]+stats["dropped"] != int64(totalEnqueued) {
+		t.Errorf("enqueued(%d) + dropped(%d) != total(%d)", stats["enqueued"], stats["dropped"], totalEnqueued)
+	}
+}
+
+// blockingFetcher blocks until release is closed. Used to simulate a worker
+// stuck on a slow fetch so the queue overflows.
+type blockingFetcher struct {
+	release chan struct{}
+	calls   atomic.Int64
+}
+
+func (b *blockingFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
+	b.calls.Add(1)
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-b.release:
+		return 0, errors.New("blocking fetcher released")
+	}
+}
+
+func TestPullerStartStopIdempotent(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newFakeFetcher()
+	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	p.Start(context.Background()) // second call should be a no-op
+	p.Stop()
+	p.Stop() // second stop should be a no-op
+}
+
+func TestPullerConfigValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name:    "missing backend",
+			mutate:  func(c *Config) { c.Backend = nil },
+			wantErr: "Backend",
+		},
+		{
+			name:    "missing fetcher",
+			mutate:  func(c *Config) { c.Fetcher = nil },
+			wantErr: "Fetcher",
+		},
+		{
+			name:    "missing resolver",
+			mutate:  func(c *Config) { c.PeerResolver = nil },
+			wantErr: "PeerResolver",
+		},
+		{
+			name:    "missing self node id",
+			mutate:  func(c *Config) { c.SelfNodeID = "" },
+			wantErr: "SelfNodeID",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				SelfNodeID:   "reader-1",
+				Backend:      newFakeBackend(),
+				Fetcher:      newFakeFetcher(),
+				PeerResolver: staticResolver{},
+				Logger:       zerolog.Nop(),
+			}
+			tc.mutate(&cfg)
+			_, err := New(cfg)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cluster/filereplication_integration_test.go
+++ b/internal/cluster/filereplication_integration_test.go
@@ -1,0 +1,514 @@
+package cluster
+
+// Integration test for peer file replication (Enterprise Phase 2).
+//
+// This test constructs two coordinator-like halves in-process:
+//   - An "origin" half that serves MsgFetchFile requests using the real
+//     handleFetchFile handler, over a real TCP listener, backed by a real
+//     raft.ClusterFSM that holds one FileEntry.
+//   - A "puller" half that uses the real filereplication.FetchClient to
+//     pull the file into a fake backend.
+//
+// It does NOT instantiate a full NewCoordinator (which requires a valid
+// Enterprise license) or a running Raft cluster — the licensing and Raft
+// paths are exercised at the unit level and in the manual docker test.
+// What this test catches is the end-to-end protocol round-trip: real
+// handler ↔ real fetch client, including HMAC validation, manifest
+// lookup, body streaming, and checksum verification.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/filereplication"
+	"github.com/basekick-labs/arc/internal/cluster/protocol"
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/config"
+	hraft "github.com/hashicorp/raft"
+	"github.com/rs/zerolog"
+)
+
+// seedFileInFSM is a test helper that marshals a RegisterFile command and
+// drives fsm.Apply directly, mimicking a Raft commit without actually
+// running Raft. Index is fixed at 1 — tests that need multiple entries
+// should set distinct indices.
+func seedFileInFSM(t *testing.T, fsm *raft.ClusterFSM, file raft.FileEntry) {
+	t.Helper()
+	payload, err := json.Marshal(raft.RegisterFilePayload{File: file})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	cmd := raft.Command{Type: raft.CommandRegisterFile, Payload: payload}
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal command: %v", err)
+	}
+	result := fsm.Apply(&hraft.Log{Index: 1, Data: data})
+	if err, ok := result.(error); ok && err != nil {
+		t.Fatalf("fsm.Apply: %v", err)
+	}
+}
+
+// --- Minimal in-memory backend (shared with filereplication unit tests,
+//     duplicated here because the packages are different) ---
+
+type memBackend struct {
+	mu    sync.Mutex
+	files map[string][]byte
+}
+
+func newMemBackend() *memBackend {
+	return &memBackend{files: make(map[string][]byte)}
+}
+
+func (m *memBackend) Write(ctx context.Context, path string, data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	m.files[path] = cp
+	return nil
+}
+
+func (m *memBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.files[path] = data
+	return nil
+}
+
+func (m *memBackend) Read(ctx context.Context, path string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, ok := m.files[path]
+	if !ok {
+		return nil, io.EOF
+	}
+	return data, nil
+}
+
+func (m *memBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
+	data, err := m.Read(ctx, path)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+	return err
+}
+
+func (m *memBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	return nil, nil
+}
+func (m *memBackend) Delete(ctx context.Context, path string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.files, path)
+	return nil
+}
+func (m *memBackend) Exists(ctx context.Context, path string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.files[path]
+	return ok, nil
+}
+func (m *memBackend) Close() error       { return nil }
+func (m *memBackend) Type() string       { return "mem" }
+func (m *memBackend) ConfigJSON() string { return "{}" }
+
+// --- Minimal origin-side server ---
+
+// originServer wraps a real Coordinator struct with just enough fields set
+// to satisfy handleFetchFile. It accepts one connection at a time on a real
+// TCP listener and dispatches MsgFetchFile to the real handler.
+type originServer struct {
+	coord    *Coordinator
+	listener net.Listener
+	done     chan struct{}
+	wg       sync.WaitGroup
+}
+
+func startOriginServer(t *testing.T, backend *memBackend, fsm *raft.ClusterFSM, sharedSecret, clusterName, nodeID string) *originServer {
+	t.Helper()
+
+	// Bind a raft.Node wrapper over the FSM without calling Start(). The fetch
+	// handler only calls c.raftNode.FSM(), so a stopped Node with an attached
+	// FSM is sufficient.
+	raftNode, err := raft.NewNode(&raft.NodeConfig{
+		NodeID:   nodeID,
+		DataDir:  t.TempDir(), // unused because we never Start
+		BindAddr: "127.0.0.1:0",
+		Logger:   zerolog.Nop(),
+	}, fsm)
+	if err != nil {
+		t.Fatalf("raft.NewNode: %v", err)
+	}
+
+	// Instantiate a bare Coordinator with the minimum fields handleFetchFile
+	// touches. This is NOT a real cluster node — no health checker, no
+	// registry, no license client, no listener lifecycle — just enough
+	// machinery to route MsgFetchFile into the real handler.
+	coord := &Coordinator{
+		cfg: &config.ClusterConfig{
+			SharedSecret: sharedSecret,
+			ClusterName:  clusterName,
+		},
+		storage:   backend,
+		raftNode:  raftNode,
+		localNode: NewNode(nodeID, nodeID, RoleWriter, clusterName),
+		logger:    zerolog.Nop(),
+		ctx:       context.Background(),
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := &originServer{
+		coord:    coord,
+		listener: listener,
+		done:     make(chan struct{}),
+	}
+	s.wg.Add(1)
+	go s.acceptLoop()
+	return s
+}
+
+func (s *originServer) addr() string { return s.listener.Addr().String() }
+
+func (s *originServer) stop() {
+	close(s.done)
+	s.listener.Close()
+	s.wg.Wait()
+}
+
+func (s *originServer) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		go s.handleConn(conn)
+	}
+}
+
+// handleConn decodes one MsgFetchFile and hands off to the real
+// Coordinator.handleFetchFile method. The rest of the handlePeerConnection
+// dispatch switch is not reproduced here — we only need fetch routing.
+func (s *originServer) handleConn(conn net.Conn) {
+	msg, err := protocol.ReceiveMessage(conn, 5*time.Second)
+	if err != nil {
+		conn.Close()
+		return
+	}
+	if msg.Type != protocol.MsgFetchFile {
+		conn.Close()
+		return
+	}
+	req := msg.Payload.(*protocol.FetchFileRequest)
+	// handleFetchFile takes ownership of the connection (closes it via defer).
+	s.coord.handleFetchFile(conn, req)
+}
+
+// --- Test ----------------------------------------------------------------
+
+// TestPhase2FetchRoundtrip wires the real handleFetchFile handler to the real
+// filereplication.FetchClient and verifies that a file registered on the
+// origin's FSM can be downloaded by the client, written into the client's
+// backend, and verified via checksum.
+func TestPhase2FetchRoundtrip(t *testing.T) {
+	const (
+		sharedSecret = "integration-secret"
+		clusterName  = "test-cluster"
+		originID     = "writer-1"
+		pullerID     = "reader-1"
+	)
+
+	// Origin side: a real backend holding a real file + a FSM that knows about it.
+	originBackend := newMemBackend()
+	body := []byte("integration test parquet body — some bytes to replicate")
+	hash := sha256.Sum256(body)
+	hashHex := hex.EncodeToString(hash[:])
+	path := "testdb/cpu/2026/04/11/14/integration.parquet"
+	if err := originBackend.Write(context.Background(), path, body); err != nil {
+		t.Fatalf("seed origin backend: %v", err)
+	}
+
+	originFSM := raft.NewClusterFSM(zerolog.Nop())
+	// Seed the FSM with the file entry. We use applyRegisterFile directly
+	// via a marshalled Command so the LSN and validation paths are exercised
+	// the same way a real Raft commit would exercise them.
+	seedFileInFSM(t, originFSM, raft.FileEntry{
+		Path:          path,
+		SHA256:        hashHex,
+		SizeBytes:     int64(len(body)),
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
+		OriginNodeID:  originID,
+		Tier:          "hot",
+		CreatedAt:     time.Date(2026, 4, 11, 15, 0, 0, 0, time.UTC),
+	})
+
+	// Start the origin server.
+	origin := startOriginServer(t, originBackend, originFSM, sharedSecret, clusterName, originID)
+	defer origin.stop()
+
+	// Puller side: a fresh backend and a real FetchClient pointing at origin.
+	pullerBackend := newMemBackend()
+	fetchClient, err := filereplication.NewFetchClient(filereplication.FetchClient{
+		SelfNodeID:   pullerID,
+		ClusterName:  clusterName,
+		SharedSecret: sharedSecret,
+		DialTimeout:  2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewFetchClient: %v", err)
+	}
+
+	// Drive the puller directly — we don't need the full Puller worker pool
+	// for this integration test, just one Fetch call into the client backend.
+	entry := &raft.FileEntry{
+		Path:      path,
+		SHA256:    hashHex,
+		SizeBytes: int64(len(body)),
+	}
+	// We use a pipe so the FetchClient writes flow through sha256 verification
+	// and into the backend via WriteReader — matching how the Puller wires it.
+	pr, pw := io.Pipe()
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- pullerBackend.WriteReader(context.Background(), path, pr, entry.SizeBytes)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	n, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, pw)
+	if fetchErr != nil {
+		_ = pw.CloseWithError(fetchErr)
+		t.Fatalf("Fetch: %v", fetchErr)
+	}
+	if err := pw.Close(); err != nil {
+		t.Fatalf("pipe close: %v", err)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("backend WriteReader: %v", err)
+	}
+	if n != int64(len(body)) {
+		t.Errorf("bytes written: got %d, want %d", n, len(body))
+	}
+
+	// Verify the puller's backend now holds the file with the same bytes.
+	got, err := pullerBackend.Read(context.Background(), path)
+	if err != nil {
+		t.Fatalf("puller Read: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("body mismatch: got %d bytes, want %d bytes", len(got), len(body))
+	}
+}
+
+// TestPhase2FetchRejectsBadHMAC verifies the origin's handleFetchFile rejects
+// requests signed with the wrong shared secret. The client side uses the
+// correct protocol but mis-signs the HMAC, so the origin replies with an
+// error ack and the fetch fails cleanly.
+func TestPhase2FetchRejectsBadHMAC(t *testing.T) {
+	const (
+		originSecret = "right-secret"
+		wrongSecret  = "wrong-secret"
+		clusterName  = "test-cluster"
+		originID     = "writer-1"
+		pullerID     = "reader-1"
+	)
+
+	originBackend := newMemBackend()
+	body := []byte("tiny body")
+	hash := sha256.Sum256(body)
+	hashHex := hex.EncodeToString(hash[:])
+	path := "testdb/cpu/hmac.parquet"
+	_ = originBackend.Write(context.Background(), path, body)
+
+	fsm := raft.NewClusterFSM(zerolog.Nop())
+	seedFileInFSM(t, fsm, raft.FileEntry{
+		Path:          path,
+		SHA256:        hashHex,
+		SizeBytes:     int64(len(body)),
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
+		OriginNodeID:  originID,
+		Tier:          "hot",
+		CreatedAt:     time.Date(2026, 4, 11, 15, 0, 0, 0, time.UTC),
+	})
+
+	origin := startOriginServer(t, originBackend, fsm, originSecret, clusterName, originID)
+	defer origin.stop()
+
+	// Client uses the wrong secret.
+	fetchClient, err := filereplication.NewFetchClient(filereplication.FetchClient{
+		SelfNodeID:   pullerID,
+		ClusterName:  clusterName,
+		SharedSecret: wrongSecret,
+		DialTimeout:  2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewFetchClient: %v", err)
+	}
+
+	entry := &raft.FileEntry{Path: path, SHA256: hashHex, SizeBytes: int64(len(body))}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, io.Discard)
+	if fetchErr == nil {
+		t.Fatalf("expected auth error, got nil")
+	}
+}
+
+// TestPhase2FetchRejectsHMACPathReplay verifies that a MAC signed for file A
+// cannot be replayed to fetch file B, even with the correct shared secret and
+// a fresh timestamp. Regression test for the path-binding fix.
+func TestPhase2FetchRejectsHMACPathReplay(t *testing.T) {
+	const (
+		sharedSecret = "replay-secret"
+		clusterName  = "test-cluster"
+		originID     = "writer-1"
+		attackerID   = "attacker-1"
+	)
+
+	// Seed two distinct files in both backend and FSM so both would otherwise
+	// be servable if auth passed.
+	originBackend := newMemBackend()
+	bodyA := []byte("file A contents")
+	bodyB := []byte("file B contents — secret")
+	pathA := "testdb/cpu/a.parquet"
+	pathB := "testdb/cpu/b.parquet"
+	sumA := sha256.Sum256(bodyA)
+	sumB := sha256.Sum256(bodyB)
+	sumAHex := hex.EncodeToString(sumA[:])
+	sumBHex := hex.EncodeToString(sumB[:])
+	_ = originBackend.Write(context.Background(), pathA, bodyA)
+	_ = originBackend.Write(context.Background(), pathB, bodyB)
+
+	fsm := raft.NewClusterFSM(zerolog.Nop())
+	seedFileInFSM(t, fsm, raft.FileEntry{
+		Path: pathA, SHA256: sumAHex, SizeBytes: int64(len(bodyA)),
+		Database: "testdb", Measurement: "cpu",
+		PartitionTime: time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
+		OriginNodeID:  originID, Tier: "hot",
+		CreatedAt: time.Date(2026, 4, 11, 15, 0, 0, 0, time.UTC),
+	})
+	// Seed file B with a different index so the FSM accepts both.
+	payloadB, _ := json.Marshal(raft.RegisterFilePayload{File: raft.FileEntry{
+		Path: pathB, SHA256: sumBHex, SizeBytes: int64(len(bodyB)),
+		Database: "testdb", Measurement: "cpu",
+		PartitionTime: time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
+		OriginNodeID:  originID, Tier: "hot",
+		CreatedAt: time.Date(2026, 4, 11, 15, 0, 0, 0, time.UTC),
+	}})
+	cmdB, _ := json.Marshal(raft.Command{Type: raft.CommandRegisterFile, Payload: payloadB})
+	if result := fsm.Apply(&hraft.Log{Index: 2, Data: cmdB}); result != nil {
+		if err, ok := result.(error); ok && err != nil {
+			t.Fatalf("seed file B: %v", err)
+		}
+	}
+
+	origin := startOriginServer(t, originBackend, fsm, sharedSecret, clusterName, originID)
+	defer origin.stop()
+
+	// Sign a fresh MAC for pathA, then send a request that claims pathB. A
+	// correct server must reject this because the signed payload covers pathA
+	// only.
+	nonce, err := security.GenerateNonce()
+	if err != nil {
+		t.Fatalf("nonce: %v", err)
+	}
+	ts := time.Now().Unix()
+	macForA := security.ComputeFetchHMAC(sharedSecret, nonce, attackerID, clusterName, pathA, ts)
+
+	conn, err := net.DialTimeout("tcp", origin.addr(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	req := &protocol.FetchFileRequest{
+		Path:      pathB, // Asking for B...
+		NodeID:    attackerID,
+		Nonce:     nonce,
+		Timestamp: ts,
+		HMAC:      macForA, // ...with a MAC signed for A.
+	}
+	if err := protocol.SendMessage(conn, &protocol.Message{
+		Type:    protocol.MsgFetchFile,
+		Payload: req,
+	}, 2*time.Second); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	ackMsg, err := protocol.ReceiveMessage(conn, 2*time.Second)
+	if err != nil {
+		t.Fatalf("receive ack: %v", err)
+	}
+	ack, ok := ackMsg.Payload.(*protocol.FetchFileAckHeader)
+	if !ok {
+		t.Fatalf("ack payload wrong type: %T", ackMsg.Payload)
+	}
+	if ack.Status == "ok" {
+		t.Fatalf("replay attack succeeded — origin served %s with a MAC signed for %s", pathB, pathA)
+	}
+}
+
+// TestPhase2FetchRejectsUnknownPath verifies that the origin refuses to serve
+// a file that isn't in its manifest — even if the file were to exist on disk.
+func TestPhase2FetchRejectsUnknownPath(t *testing.T) {
+	const (
+		sharedSecret = "auth"
+		clusterName  = "test-cluster"
+		originID     = "writer-1"
+		pullerID     = "reader-1"
+	)
+
+	originBackend := newMemBackend()
+	// Write a file directly to the backend without registering it in the FSM.
+	body := []byte("off-manifest bytes")
+	hash := sha256.Sum256(body)
+	hashHex := hex.EncodeToString(hash[:])
+	path := "testdb/cpu/offmanifest.parquet"
+	_ = originBackend.Write(context.Background(), path, body)
+
+	// Empty FSM — no file registrations.
+	fsm := raft.NewClusterFSM(zerolog.Nop())
+
+	origin := startOriginServer(t, originBackend, fsm, sharedSecret, clusterName, originID)
+	defer origin.stop()
+
+	fetchClient, err := filereplication.NewFetchClient(filereplication.FetchClient{
+		SelfNodeID:   pullerID,
+		ClusterName:  clusterName,
+		SharedSecret: sharedSecret,
+		DialTimeout:  2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewFetchClient: %v", err)
+	}
+
+	entry := &raft.FileEntry{Path: path, SHA256: hashHex, SizeBytes: int64(len(body))}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, io.Discard)
+	if fetchErr == nil {
+		t.Fatalf("expected manifest lookup error, got nil")
+	}
+}

--- a/internal/cluster/protocol/codec.go
+++ b/internal/cluster/protocol/codec.go
@@ -177,6 +177,20 @@ func unmarshalPayload(msgType MessageType, payload []byte) (interface{}, error) 
 		}
 		return &ack, nil
 
+	case MsgFetchFile:
+		var req FetchFileRequest
+		if err := json.Unmarshal(payload, &req); err != nil {
+			return nil, err
+		}
+		return &req, nil
+
+	case MsgFetchFileAck:
+		var ack FetchFileAckHeader
+		if err := json.Unmarshal(payload, &ack); err != nil {
+			return nil, err
+		}
+		return &ack, nil
+
 	default:
 		return nil, fmt.Errorf("unknown message type: %d", msgType)
 	}

--- a/internal/cluster/protocol/codec_test.go
+++ b/internal/cluster/protocol/codec_test.go
@@ -75,6 +75,40 @@ func TestEncodeDecode(t *testing.T) {
 				Reason: "graceful shutdown",
 			}),
 		},
+		{
+			name: "FetchFileRequest",
+			msg: &Message{
+				Type: MsgFetchFile,
+				Payload: &FetchFileRequest{
+					Path:      "prod/cpu/2026/04/11/14/file-xxx.parquet",
+					NodeID:    "reader-1",
+					Nonce:     "nonce-12345",
+					Timestamp: time.Now().Unix(),
+					HMAC:      "abcdef0123456789",
+				},
+			},
+		},
+		{
+			name: "FetchFileAckHeader ok",
+			msg: &Message{
+				Type: MsgFetchFileAck,
+				Payload: &FetchFileAckHeader{
+					Status:    "ok",
+					SizeBytes: 1048576,
+					SHA256:    "deadbeefcafe",
+				},
+			},
+		},
+		{
+			name: "FetchFileAckHeader error",
+			msg: &Message{
+				Type: MsgFetchFileAck,
+				Payload: &FetchFileAckHeader{
+					Status: "error",
+					Error:  "file not found",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -144,6 +178,20 @@ func TestEncodeDecode(t *testing.T) {
 				if got.NodeID != orig.NodeID || got.Reason != orig.Reason {
 					t.Errorf("LeaveNotify mismatch")
 				}
+
+			case MsgFetchFile:
+				orig := tt.msg.Payload.(*FetchFileRequest)
+				got := decoded.Payload.(*FetchFileRequest)
+				if got.Path != orig.Path || got.NodeID != orig.NodeID || got.HMAC != orig.HMAC {
+					t.Errorf("FetchFileRequest mismatch: got %+v, want %+v", got, orig)
+				}
+
+			case MsgFetchFileAck:
+				orig := tt.msg.Payload.(*FetchFileAckHeader)
+				got := decoded.Payload.(*FetchFileAckHeader)
+				if got.Status != orig.Status || got.SizeBytes != orig.SizeBytes || got.SHA256 != orig.SHA256 || got.Error != orig.Error {
+					t.Errorf("FetchFileAckHeader mismatch: got %+v, want %+v", got, orig)
+				}
 			}
 		})
 	}
@@ -207,6 +255,8 @@ func TestMessageTypeString(t *testing.T) {
 		{MsgHeartbeat, "Heartbeat"},
 		{MsgHeartbeatAck, "HeartbeatAck"},
 		{MsgLeaveNotify, "LeaveNotify"},
+		{MsgFetchFile, "FetchFile"},
+		{MsgFetchFileAck, "FetchFileAck"},
 		{MessageType(255), "Unknown"},
 	}
 

--- a/internal/cluster/protocol/messages.go
+++ b/internal/cluster/protocol/messages.go
@@ -24,6 +24,19 @@ const (
 	MsgReplicateSync MessageType = 0x10
 	// MsgReplicateSyncAck is sent by the writer in response to sync request.
 	MsgReplicateSyncAck MessageType = 0x11
+
+	// Peer file replication messages (Enterprise Phase 2) - start at 0x20
+	// to leave room for future WAL replication messages.
+	//
+	// MsgFetchFile is sent by a puller to request a Parquet file from a peer.
+	// The request payload includes the path and HMAC auth headers. The peer
+	// responds with a MsgFetchFileAck header, immediately followed by the raw
+	// file bytes (length = ack.SizeBytes) on the same TCP connection.
+	MsgFetchFile MessageType = 0x20
+	// MsgFetchFileAck is the response header for a file fetch. After the
+	// header the origin streams raw body bytes directly on the connection —
+	// the body is NOT framed as another protocol message.
+	MsgFetchFileAck MessageType = 0x21
 )
 
 // String returns the string representation of a message type.
@@ -45,6 +58,10 @@ func (m MessageType) String() string {
 		return "ReplicateSync"
 	case MsgReplicateSyncAck:
 		return "ReplicateSyncAck"
+	case MsgFetchFile:
+		return "FetchFile"
+	case MsgFetchFileAck:
+		return "FetchFileAck"
 	default:
 		return "Unknown"
 	}
@@ -132,4 +149,29 @@ type LeaveNotify struct {
 	AuthNonce     string `json:"auth_nonce,omitempty"`
 	AuthTimestamp int64  `json:"auth_timestamp,omitempty"`
 	AuthHMAC      string `json:"auth_hmac,omitempty"`
+}
+
+// FetchFileRequest is sent by a puller to request a Parquet file from a peer.
+// HMAC auth headers are embedded in the payload rather than using a separate
+// handshake because the fetch is a one-shot operation on a freshly dialed
+// connection. The validator is security.ValidateFetchHMAC with a ±5 minute
+// freshness tolerance. The path is bound into the signed payload so a stolen
+// MAC cannot be replayed to fetch a different file within the window.
+type FetchFileRequest struct {
+	Path      string `json:"path"`
+	NodeID    string `json:"node_id"`
+	Nonce     string `json:"nonce"`
+	Timestamp int64  `json:"timestamp"`
+	HMAC      string `json:"hmac"`
+}
+
+// FetchFileAckHeader is the response header for a fetch request. If Status is
+// "ok" the origin will immediately write SizeBytes of raw body content directly
+// to the TCP connection (NOT wrapped in another protocol envelope — the body is
+// read with io.CopyN on the raw conn). If Status is "error" no body follows.
+type FetchFileAckHeader struct {
+	Status    string `json:"status"`          // "ok" or "error"
+	Error     string `json:"error,omitempty"` // populated when Status == "error"
+	SizeBytes int64  `json:"size_bytes"`
+	SHA256    string `json:"sha256"` // hex-encoded; must match manifest SHA256
 }

--- a/internal/cluster/security/auth.go
+++ b/internal/cluster/security/auth.go
@@ -44,3 +44,33 @@ func ValidateHMAC(sharedSecret, nonce, nodeID, clusterName string, timestamp int
 	}
 	return nil
 }
+
+// ComputeFetchHMAC computes HMAC-SHA256 for a peer file-fetch request. The
+// message format binds the requested path into the signed payload so a stolen
+// MAC for file A cannot be replayed within the freshness window to fetch a
+// different file B. Format: nonce:nodeID:clusterName:path:timestamp
+func ComputeFetchHMAC(sharedSecret, nonce, nodeID, clusterName, path string, timestamp int64) string {
+	message := fmt.Sprintf("%s:%s:%s:%s:%d", nonce, nodeID, clusterName, path, timestamp)
+	h := hmac.New(sha256.New, []byte(sharedSecret))
+	h.Write([]byte(message))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ValidateFetchHMAC validates a peer fetch-request HMAC and checks freshness.
+// The path is included in the signed payload — see ComputeFetchHMAC.
+func ValidateFetchHMAC(sharedSecret, nonce, nodeID, clusterName, path string, timestamp int64, receivedMAC string, tolerance time.Duration) error {
+	now := time.Now().Unix()
+	drift := now - timestamp
+	if drift < 0 {
+		drift = -drift
+	}
+	if drift > int64(tolerance.Seconds()) {
+		return fmt.Errorf("fetch auth timestamp expired (drift: %ds, tolerance: %ds)", drift, int64(tolerance.Seconds()))
+	}
+
+	expected := ComputeFetchHMAC(sharedSecret, nonce, nodeID, clusterName, path, timestamp)
+	if !hmac.Equal([]byte(expected), []byte(receivedMAC)) {
+		return fmt.Errorf("fetch HMAC validation failed: shared secret mismatch or path tampered")
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -331,6 +331,15 @@ type ClusterConfig struct {
 	ReplicationBufferSize  int  // Entry buffer size for replication queue (default: 10000)
 	ReplicationAckInterval int  // How often readers send acks in milliseconds (default: 100)
 
+	// Peer file replication configuration (Enterprise Phase 2)
+	// These gate and tune the background puller that replicates Parquet files
+	// between nodes over the coordinator TCP protocol. Only takes effect when
+	// ReplicationEnabled && Enabled and FeatureClustering is licensed.
+	ReplicationPullWorkers      int // Number of concurrent fetch workers per node (default: 4)
+	ReplicationQueueSize        int // Buffered FSM callback queue size (default: 1024)
+	ReplicationFetchTimeoutMs   int // Per-fetch overall timeout in milliseconds (default: 60000)
+	ReplicationRetryMaxAttempts int // Max immediate retry attempts per enqueue (default: 3)
+
 	// Sharding configuration (Phase 4)
 	ShardingEnabled           bool   // Enable sharding for horizontal write scaling (default: false)
 	ShardingNumShards         int    // Number of shards (default: 3)
@@ -556,6 +565,11 @@ func Load() (*Config, error) {
 			ReplicationLagLimit:    v.GetInt("cluster.replication_lag_limit"),
 			ReplicationBufferSize:  v.GetInt("cluster.replication_buffer_size"),
 			ReplicationAckInterval: v.GetInt("cluster.replication_ack_interval"),
+			// Peer file replication (Enterprise Phase 2)
+			ReplicationPullWorkers:      v.GetInt("cluster.replication_pull_workers"),
+			ReplicationQueueSize:        v.GetInt("cluster.replication_queue_size"),
+			ReplicationFetchTimeoutMs:   v.GetInt("cluster.replication_fetch_timeout_ms"),
+			ReplicationRetryMaxAttempts: v.GetInt("cluster.replication_retry_max_attempts"),
 			// Sharding configuration (Phase 4)
 			ShardingEnabled:           v.GetBool("cluster.sharding_enabled"),
 			ShardingNumShards:         v.GetInt("cluster.sharding_num_shards"),
@@ -785,6 +799,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("cluster.replication_lag_limit", 5000)    // 5 second lag limit
 	v.SetDefault("cluster.replication_buffer_size", 10000) // 10k entry buffer
 	v.SetDefault("cluster.replication_ack_interval", 100)  // 100ms ack interval
+	// Peer file replication (Enterprise Phase 2)
+	v.SetDefault("cluster.replication_pull_workers", 4)          // 4 concurrent pullers
+	v.SetDefault("cluster.replication_queue_size", 1024)         // 1024-entry callback queue
+	v.SetDefault("cluster.replication_fetch_timeout_ms", 60000)  // 60s per-fetch timeout
+	v.SetDefault("cluster.replication_retry_max_attempts", 3)    // 3 immediate retries
 
 	// Sharding defaults (Phase 4)
 	v.SetDefault("cluster.sharding_enabled", false)        // Disabled by default

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -337,7 +337,8 @@ type ClusterConfig struct {
 	// ReplicationEnabled && Enabled and FeatureClustering is licensed.
 	ReplicationPullWorkers      int // Number of concurrent fetch workers per node (default: 4)
 	ReplicationQueueSize        int // Buffered FSM callback queue size (default: 1024)
-	ReplicationFetchTimeoutMs   int // Per-fetch overall timeout in milliseconds (default: 60000)
+	ReplicationFetchTimeoutMs   int // Puller-side per-fetch overall timeout in milliseconds (default: 60000)
+	ReplicationServeTimeoutMs   int // Origin-side body-stream timeout in milliseconds (default: 120000). Raise for large files or slow links.
 	ReplicationRetryMaxAttempts int // Max immediate retry attempts per enqueue (default: 3)
 
 	// Sharding configuration (Phase 4)
@@ -569,6 +570,7 @@ func Load() (*Config, error) {
 			ReplicationPullWorkers:      v.GetInt("cluster.replication_pull_workers"),
 			ReplicationQueueSize:        v.GetInt("cluster.replication_queue_size"),
 			ReplicationFetchTimeoutMs:   v.GetInt("cluster.replication_fetch_timeout_ms"),
+			ReplicationServeTimeoutMs:   v.GetInt("cluster.replication_serve_timeout_ms"),
 			ReplicationRetryMaxAttempts: v.GetInt("cluster.replication_retry_max_attempts"),
 			// Sharding configuration (Phase 4)
 			ShardingEnabled:           v.GetBool("cluster.sharding_enabled"),
@@ -802,7 +804,8 @@ func setDefaults(v *viper.Viper) {
 	// Peer file replication (Enterprise Phase 2)
 	v.SetDefault("cluster.replication_pull_workers", 4)          // 4 concurrent pullers
 	v.SetDefault("cluster.replication_queue_size", 1024)         // 1024-entry callback queue
-	v.SetDefault("cluster.replication_fetch_timeout_ms", 60000)  // 60s per-fetch timeout
+	v.SetDefault("cluster.replication_fetch_timeout_ms", 60000)  // 60s puller-side per-fetch timeout
+	v.SetDefault("cluster.replication_serve_timeout_ms", 120000) // 120s origin-side body-stream timeout
 	v.SetDefault("cluster.replication_retry_max_attempts", 3)    // 3 immediate retries
 
 	// Sharding defaults (Phase 4)

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -3,6 +3,8 @@ package ingest
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"sort"
@@ -709,8 +711,11 @@ type WALWriter interface {
 // manifest. Implementations should be non-blocking — file registration is
 // fire-and-forget from the flush path's perspective. Wired by the cluster
 // coordinator when peer replication is enabled (Enterprise feature).
+//
+// sha256 is a hex-encoded content checksum of the Parquet file bytes.
+// Peers use this to verify the integrity of data pulled from the origin.
 type FileRegistrar interface {
-	RegisterFile(database, measurement, path string, partitionTime time.Time, sizeBytes int64)
+	RegisterFile(database, measurement, path string, partitionTime time.Time, sizeBytes int64, sha256 string)
 }
 
 // ArrowBuffer manages buffering and periodic flushing of Arrow data
@@ -974,7 +979,11 @@ func (b *ArrowBuffer) SetFileRegistrar(fr FileRegistrar) {
 // and (if enabled) announces it to the cluster-wide file manifest for peer replication.
 // This allows the tiering system to track the file for future migration and query routing,
 // and enables Enterprise peer replication to replicate the file to other cluster nodes.
-func (b *ArrowBuffer) registerFileInTiering(ctx context.Context, database, measurement, storagePath string, partitionTime time.Time, sizeBytes int64) {
+//
+// sha256Hex is a hex-encoded SHA-256 of the Parquet bytes, computed by the caller on the
+// in-memory buffer immediately before the backend write. Peers validate downloaded bytes
+// against this checksum.
+func (b *ArrowBuffer) registerFileInTiering(ctx context.Context, database, measurement, storagePath string, partitionTime time.Time, sizeBytes int64, sha256Hex string) {
 	// Register in local tiering metadata (hot/cold tracking)
 	if b.tieringManager != nil {
 		metadata := b.tieringManager.GetMetadata()
@@ -1002,7 +1011,7 @@ func (b *ArrowBuffer) registerFileInTiering(ctx context.Context, database, measu
 	// The registrar implementation MUST be non-blocking — it's called on
 	// the hot flush path.
 	if b.fileRegistrar != nil {
-		b.fileRegistrar.RegisterFile(database, measurement, storagePath, partitionTime, sizeBytes)
+		b.fileRegistrar.RegisterFile(database, measurement, storagePath, partitionTime, sizeBytes, sha256Hex)
 	}
 }
 
@@ -2134,12 +2143,19 @@ func (b *ArrowBuffer) flushPartitionedData(ctx context.Context, bufferKey, datab
 
 		storagePath := b.generateStoragePath(database, measurement, minTime)
 
+		// Compute SHA-256 of the Parquet buffer before the backend write so the
+		// hash lands in the cluster manifest with the same commit that announces
+		// the file. Peers use this to verify bytes pulled from the origin.
+		// The buffer is already in memory; this is an O(n) scan of ~MB of data.
+		parquetSum := sha256.Sum256(parquetData)
+		parquetSumHex := hex.EncodeToString(parquetSum[:])
+
 		if err := b.storage.Write(ctx, storagePath, parquetData); err != nil {
 			return fmt.Errorf("failed to write to storage: %w", err)
 		}
 
 		// Register file in tiering metadata for query routing
-		b.registerFileInTiering(ctx, database, measurement, storagePath, minTime, int64(len(parquetData)))
+		b.registerFileInTiering(ctx, database, measurement, storagePath, minTime, int64(len(parquetData)), parquetSumHex)
 
 		b.totalRecordsWritten.Add(int64(recordCount))
 		b.totalFlushes.Add(1)
@@ -2188,12 +2204,17 @@ func (b *ArrowBuffer) flushPartitionedData(ctx context.Context, bufferKey, datab
 		bucketTime := hourIDToTime(hourID)
 		storagePath := b.generateStoragePath(database, measurement, bucketTime)
 
+		// Compute SHA-256 of the Parquet buffer for peer replication checksum.
+		// See the single-hour branch above for rationale.
+		parquetSum := sha256.Sum256(parquetData)
+		parquetSumHex := hex.EncodeToString(parquetSum[:])
+
 		if err := b.storage.Write(ctx, storagePath, parquetData); err != nil {
 			return fmt.Errorf("failed to write to storage for hour %d: %w", hourID, err)
 		}
 
 		// Register file in tiering metadata for query routing
-		b.registerFileInTiering(ctx, database, measurement, storagePath, bucketTime, int64(len(parquetData)))
+		b.registerFileInTiering(ctx, database, measurement, storagePath, bucketTime, int64(len(parquetData)), parquetSumHex)
 
 		totalWritten += splitRecordCount
 


### PR DESCRIPTION
## Summary

- Phase 2 of peer-to-peer file replication: the data plane that moves Parquet bytes between cluster nodes. Phase 1 (#386) shipped the Raft file manifest (metadata); this PR wires up byte-level transfer so readers can serve queries from local storage even without a shared object store (S3/MinIO/Azure).
- New `filereplication` package with a bounded-queue `Puller` worker pool reacting to FSM callbacks + a `FetchClient` that dials peers over the existing cluster coordinator TCP port, authenticates with a path-bound HMAC, streams the body through a SHA-256 hasher, and writes into the local backend.
- Unlocks bare-metal, VM, and edge deployments (on-prem, aerospace, defense) where each node has its own local SSDs and there is no shared object store. Zero overhead for OSS / standalone deployments.

## What's new

- **New protocol messages** — `MsgFetchFile` / `MsgFetchFileAck` hooked into the existing `handlePeerConnection` dispatch. Replication traffic rides the cluster port (`:9100`), physically isolated from client API traffic, and reuses the cluster TLS config from #382.
- **SHA-256 on flush** — computed once on the in-memory Parquet buffer in `arrow_writer.flushPartitionedData`, threaded through `file_registrar` into the Raft manifest. Every node learns the authoritative hash before any fetch starts; the puller verifies on the wire and aborts on mismatch.
- **Coordinator wiring** — `handleFetchFile` validates the HMAC, sanitizes the path, confirms the entry is in the FSM manifest (so peers cannot fetch arbitrary local files even with a valid HMAC), then streams the body via `Backend.ReadTo`.
- **Shutdown ordering** — puller at `PriorityHTTPServer+1` (stop consuming), file-registrar at `PriorityBuffer` (drain producer queue), coordinator at `PriorityCompaction` (close listener + Raft). In-flight pulls on shutdown are short-circuited first, then the producer queue drains, then Raft stops.
- **Startup validation** — Arc refuses to boot if `cluster.replication_enabled=true` and `cluster.shared_secret` is empty.

## Security

**HMAC binds the file path** via new `security.ComputeFetchHMAC` / `ValidateFetchHMAC` helpers:

```
HMAC-SHA256({nonce, nodeID, clusterName, path, timestamp})
```

A stolen MAC for file A cannot be replayed within the ±5-minute freshness window to fetch a different file B. The join handshake continues to use the original `ComputeHMAC` (no breaking change to cluster join).

Additional hardening from the pre-merge security review:

- Explicit `SizeBytes >= 0` guards before `io.CopyN` on both the manifest entry and the peer ack header, preventing a hostile or buggy origin from short-circuiting body validation via a negative length.
- Tightened stream deadlines (client fallback 60s, server body-stream 2min).
- `handleFetchFile` derives its `Exists` and body-stream contexts from `coordinator.ctx` instead of `context.Background()`, so shutdown cancels any in-flight transfer cleanly.
- Path sanitization rejects absolute paths, traversal, and null bytes before the manifest lookup.

**Gating:** peer replication is part of `FeatureClustering`. The puller is constructed inside `coordinator.Start()` only after the license check, so a user without an enterprise license cannot enable it by setting env vars.

## Configuration

| Env var | `arc.toml` key | Default |
|---|---|---|
| `ARC_CLUSTER_REPLICATION_ENABLED` | `cluster.replication_enabled` | `false` |
| `ARC_CLUSTER_REPLICATION_PULL_WORKERS` | `cluster.replication_pull_workers` | `4` |
| `ARC_CLUSTER_REPLICATION_QUEUE_SIZE` | `cluster.replication_queue_size` | `1024` |
| `ARC_CLUSTER_REPLICATION_FETCH_TIMEOUT_MS` | `cluster.replication_fetch_timeout_ms` | `60000` |
| `ARC_CLUSTER_REPLICATION_RETRY_MAX_ATTEMPTS` | `cluster.replication_retry_max_attempts` | `3` |

`ARC_CLUSTER_SHARED_SECRET` is required when replication is enabled.

## Non-goals for Phase 2

Async replication only. **Not included** (planned for Phases 3–5):
- Resume via HTTP Range — failed transfers restart from zero
- Catch-up on join — nodes that miss files while down stay missing until Phase 3
- Quorum durability — writes ACK after local flush, replication is eventual
- Multi-peer fanout — pulls come from the origin node only
- Compactor role routing — compaction still runs on any node (Phase 4)

## Test plan

- [x] `go test ./internal/cluster/...` — full cluster suite green
- [x] `go build ./cmd/... ./internal/...` — clean build
- [x] **Unit tests (19)** in `filereplication/puller_test.go` + `filereplication/fetch_client_test.go` covering enqueue/skip-self/skip-already-local/retry/drop semantics, HMAC propagation, happy path, checksum mismatch, body-hash mismatch, size mismatch, dial error, large-body streaming, config validation.
- [x] **Integration tests (4)** in `filereplication_integration_test.go` wire the real `handleFetchFile` handler to the real `FetchClient`:
  - `TestPhase2FetchRoundtrip` — full protocol round-trip including HMAC validation, manifest lookup, body streaming, checksum verification
  - `TestPhase2FetchRejectsBadHMAC` — wrong secret rejected
  - `TestPhase2FetchRejectsHMACPathReplay` — **regression test for path binding**: signs a MAC for file A and requests file B, asserts the server rejects it
  - `TestPhase2FetchRejectsUnknownPath` — file exists on disk but is not in the FSM manifest → rejected
- [x] **Coordinator-side tests** in `coordinator_fetch_test.go` exercise `handleFetchFile` directly.
- [x] **Manual docker test** — 3-node cluster on **local storage per node** (writer + 2 readers, per-node volumes, no shared S3):
  - `docker compose up` → all 3 nodes join, pullers start on readers
  - Ingest via line-protocol on writer-1 → Parquet file created locally
  - Verified `sha256sum` **identical** across all 3 volumes for every replicated file
  - Queries on both readers return the replicated data (3 rows of `cpu` + 2 rows of `mem`)
  - Writer's puller correctly skipped its own-origin files (zero pulls)
  - All fetches succeeded on attempt 1, no retries needed
  - `/api/v1/cluster/files` manifest consistent across all 3 nodes

## Pre-merge review findings

Four parallel review agents ran before merge (security, license gating, redundancy, elegance). All CRITICAL + HIGH security findings and all SHOULD-FIX elegance findings are addressed in this PR:

- ✅ CRITICAL: HMAC now binds the path (new `ComputeFetchHMAC`/`ValidateFetchHMAC`)
- ✅ CRITICAL: `SizeBytes >= 0` validation before `io.CopyN`
- ✅ HIGH: Tightened client fallback deadline (5min → 60s) and server write deadline (5min → 2min)
- ✅ SHOULD FIX: `handleFetchFile` uses `coordinator.ctx` instead of `context.Background()`
- ✅ Dead `var _ net.Conn` assertion removed

Deferred to follow-up (non-blocking):
- FSM-side `SizeBytes > 0` + SHA-256 hex format validation on `RegisterFile` (defense in depth)
- Test helper extraction (`memBackend` → `testutil` package)
- `Puller.Stats()` typed struct instead of `map[string]int64`