### PR TITLE
feat(cluster): peer-replication catch-up on join — Phase 3 (multi-peer fallback + startup reconciliation)

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -48,12 +48,57 @@ Building on the cluster file manifest, Arc Enterprise now replicates **actual Pa
 
 **Scope of Phase 2:** async replication only. Phase 2 does **not** include: resume via HTTP Range, catch-up for nodes joining with existing data, quorum durability, multi-peer fanout, or compaction-aware routing. These land in Phases 3–5.
 
-**What's coming next** (separate PRs):
-- Phase 3: Automatic catch-up for new nodes joining a cluster with existing data
-- Phase 4: Integration with compaction (compactor role produces files, replicas pull the compacted output)
-- Phase 5: Optional write quorum for strong durability, multi-peer fanout, and resumable transfers via Range
-
 **Design inspiration:** ClickHouse's ReplicatedMergeTree model — a Raft-equivalent op log + HTTP-pull-based file transfer. Research compared InfluxDB Enterprise (anti-entropy + HHQ), ClickHouse (log + HTTP pull), TimescaleDB (deprecated multi-node), Apache Pinot (peer fetcher fallback), and Apache Druid (metadata-driven assignment). ClickHouse's model is the cleanest fit for Arc's existing Raft + coordinator TCP infrastructure.
+
+### Peer File Replication — Catch-up on Join (Enterprise — Phase 3)
+
+Phase 2 replicated files reactively — a node only pulled files that committed to Raft while its puller was running. That left two fatal gaps on Kubernetes: (1) a node that was down when a file was flushed never got the callback and had the file missing on restart, and (2) a brand-new reader joining a cluster with existing data received the Raft log but couldn't pull anything because `entry.OriginNodeID` often pointed to a pod that had been rescheduled and no longer existed. Queries against such nodes silently returned incomplete results.
+
+Phase 3 closes both gaps with a **startup reconciliation walker** and a **multi-peer fallback resolver**. A node that comes online now converges on the manifest within a bounded time, regardless of whether the original writer is still in the cluster.
+
+**How it works:**
+- After the puller starts, the coordinator spawns a background goroutine — guarded by `sync.Once` so it runs exactly once per coordinator lifetime — that waits for a Raft leader, issues a new `Node.Barrier` wrapper over `hraft.Raft.Barrier` so the local FSM reflects every committed entry, then feeds `fsm.GetAllFiles()` through a new `Puller.RunCatchUp` method. On `WaitForLeader` or `Barrier` timeout the walker proceeds against the follower's possibly-stale view — better a partial walk than no walk, and the reactive FSM callback path catches anything the walker missed as it applies.
+- The walker enqueues each manifest entry through the existing Phase 2 worker pool, so all the Phase 2 retry, backoff, checksum verification, and metrics apply automatically — catch-up is data flowing through the same code path as reactive pulls.
+- A per-path **inflight set** on the puller deduplicates enqueues: if the walker and a reactive FSM callback both try to enqueue path X during a write committing mid-walk, only the first call queues the entry and the rest are counted as `skipped_dup`. The slot is released via `defer` inside `processEntry` so the set stays bounded even on worker panic.
+- **Queue-depth backpressure** — when the queue is above `replication_catchup_queue_high_water` (default 0.8), the walker sleeps 50ms between enqueues to let workers drain. Prevents thundering-herd drop storms on large manifests without needing a second worker pool.
+
+**Multi-peer fallback resolver:** the Phase 2 `PeerResolver` interface returned a single `(addr, ok)` pair for the origin. Phase 3 changes it to `ResolvePeers(originNodeID, path string) []string` — the resolver takes just the two fields it needs (no `*raft.FileEntry` coupling), and returns an **ordered list**: origin first (if still healthy), then every other healthy peer excluding self. The `path` parameter is part of the signature so Phase 4+ can add shard-aware or compactor-aware routing without changing the interface; Phase 3 ignores it.
+
+The puller iterates the list within a single attempt and falls through to the next candidate on any per-peer failure **except** checksum mismatch. A corrupt body from peer-1 is a data integrity signal, not a "try another peer" signal — if the puller fell through on checksum mismatch it would pull-and-corrupt from every healthy peer in turn. `ErrChecksumMismatch` breaks out of the per-attempt peer loop and the attempt-level retry handles it via the existing delete-and-redownload path.
+
+**Typed ack error codes** — the ack header gained a new `protocol.AckErrorCode` typed field with constants (`AckCodeNotFound`, `AckCodeManifest`, `AckCodeAuth`, `AckCodeBackend`, `AckCodeRaft`, `AckCodeInvalidPath`) so the puller can distinguish "peer doesn't have this file" from "peer rejected me" without substring matching:
+
+| Code | Puller behavior |
+|---|---|
+| `not_found` / `manifest` | Fall through to next peer |
+| `auth` / `backend` / `raft` / `invalid_path` | Fail attempt (don't fall through) |
+
+The `Code` field is a JSON `omitempty` addition — **backward compatible** with Phase 2 peers. When `Code` is empty (Phase 2 peer), the client falls back to **exact-match** (not substring — an adversary can't craft an error string like `"file not found on local backend: /etc/passwd"` to confuse the check) against `protocol.ErrMsgFileNotInManifest` / `protocol.ErrMsgFileNotFound`. Both the typed codes and the Phase 2 fallback strings live together in `internal/cluster/protocol/messages.go` so a refactor of either touches both sites at once.
+
+**Configuration** (set via `ARC_CLUSTER_REPLICATION_CATCHUP_*` env vars or `cluster.replication_catchup_*` in `arc.toml`):
+- `replication_catchup_enabled = true` — master switch; disable as an emergency kill-switch on pathologically large manifests
+- `replication_catchup_barrier_timeout_ms = 10000` — Raft barrier timeout before walking
+- `replication_catchup_queue_high_water = 0.8` — walker pauses enqueueing when the queue is above this fraction
+
+No new worker-count knob — catch-up shares the Phase 2 `replication_pull_workers` pool.
+
+**Observability:** `Puller.Stats()` grew new counters surfaced through the coordinator:
+- `catchup_started_at` / `catchup_completed_at` (unix seconds; the latter goes non-zero once the walker has finished its pass, not once all queued pulls have drained)
+- `catchup_entries_walked` / `catchup_enqueued` / `catchup_skipped_local`
+- `skipped_dup` (new — counts Phase 3 dedup skips)
+
+New `Coordinator.ReplicationCatchUpStatus()` returns the catch-up-specific stats as a JSON-serializable map intended for `/api/v1/cluster/status`. New `Coordinator.ReplicationReady()` returns `true` once the walker has completed its pass — not currently consumed (queries can hit a node during catch-up and see eventually-consistent results), but Phase 5 will use it to hard-gate the query path so the accessor lands now and avoids another coordinator surface change later. Operators can use the status endpoint for external readiness probes in the meantime.
+
+**Security review:**
+- Multi-peer fallback expands the set of trusted peers from `OriginNodeID` to any healthy cluster member — but all peers are already mutually authenticated via shared secret + TLS, and the Phase 2 path-bound HMAC is preserved so a stolen MAC still can't fetch a different file. Regression-tested.
+- Checksum mismatch short-circuit is tested explicitly (`TestPullerMultiPeerChecksumMismatchDoesNotFallThrough`) to lock in the "one corrupt peer can't force every reader to pull-and-corrupt" invariant.
+- Every `sendFetchError` call site uses a typed `AckErrorCode` constant — no path where user input flows into `Code`.
+
+**Scope of Phase 3:** startup-only reconciliation with any-peer fallback. Phase 3 does **not** include: periodic reconciliation (reactive callbacks handle steady-state drift), orphan detection (Phase 4 compaction concern), paginated FSM walks (accepted O(N) snapshot copy — emergency kill-switch exists for 10M+ file deployments), hard query gating (Phase 5), bandwidth caps (Phase 5), or HTTP Range resume (Phase 5).
+
+**What's coming next** (separate PRs):
+- Phase 4: Integration with compaction (compactor role produces files, replicas pull the compacted output)
+- Phase 5: Optional write quorum for strong durability, hard query gating on catch-up, paginated FSM iteration, periodic reconciliation, bandwidth caps, and resumable transfers via Range
 
 ### Cluster TLS Encryption and Shared Secret Authentication (Enterprise)
 

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -67,6 +67,9 @@ type Coordinator struct {
 	// puller is the background worker pool that downloads files from peers.
 	// Nil when peer replication is disabled or the license forbids it.
 	puller *filereplication.Puller
+	// catchupOnce guarantees the Phase 3 catch-up walker runs at most once
+	// per coordinator lifetime, across repeated Start/Stop cycles in tests.
+	catchupOnce sync.Once
 
 	// Network
 	listener  net.Listener
@@ -981,7 +984,7 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 		c.logger.Error().
 			Str("peer", remoteAddr).
 			Msg("FetchFile rejected: shared secret not configured (peer replication requires it)")
-		c.sendFetchError(conn, "peer replication is not configured on this node")
+		c.sendFetchError(conn, protocol.AckCodeAuth, "peer replication is not configured on this node")
 		return
 	}
 	// HMAC binds {nonce, nodeID, clusterName, path, timestamp} — including the
@@ -996,7 +999,7 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 			Str("peer", remoteAddr).
 			Str("requesting_node", req.NodeID).
 			Msg("FetchFile rejected: HMAC validation failed")
-		c.sendFetchError(conn, "authentication failed")
+		c.sendFetchError(conn, protocol.AckCodeAuth, "authentication failed")
 		return
 	}
 
@@ -1010,7 +1013,7 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 			Str("peer", remoteAddr).
 			Str("path", req.Path).
 			Msg("FetchFile rejected: invalid path")
-		c.sendFetchError(conn, fmt.Sprintf("invalid path: %v", err))
+		c.sendFetchError(conn, protocol.AckCodeInvalidPath, fmt.Sprintf("invalid path: %v", err))
 		return
 	}
 
@@ -1018,12 +1021,12 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 	// peers from fetching arbitrary backend files outside the known data set,
 	// even if they pass the path sanitizer.
 	if c.raftNode == nil {
-		c.sendFetchError(conn, "Raft not available")
+		c.sendFetchError(conn, protocol.AckCodeRaft, "Raft not available")
 		return
 	}
 	fsm := c.raftNode.FSM()
 	if fsm == nil {
-		c.sendFetchError(conn, "FSM not available")
+		c.sendFetchError(conn, protocol.AckCodeRaft, "FSM not available")
 		return
 	}
 	entry, ok := fsm.GetFile(sanitized)
@@ -1032,7 +1035,7 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 			Str("peer", remoteAddr).
 			Str("path", sanitized).
 			Msg("FetchFile: path not in manifest")
-		c.sendFetchError(conn, "file not in manifest")
+		c.sendFetchError(conn, protocol.AckCodeManifest, protocol.ErrMsgFileNotInManifest)
 		return
 	}
 
@@ -1041,7 +1044,7 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 	backend := c.storage
 	c.mu.RUnlock()
 	if backend == nil {
-		c.sendFetchError(conn, "storage backend not configured")
+		c.sendFetchError(conn, protocol.AckCodeBackend, "storage backend not configured")
 		return
 	}
 
@@ -1057,11 +1060,11 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 			Err(existsErr).
 			Str("path", sanitized).
 			Msg("FetchFile: Exists check failed")
-		c.sendFetchError(conn, "backend error")
+		c.sendFetchError(conn, protocol.AckCodeBackend, "backend error")
 		return
 	}
 	if !exists {
-		c.sendFetchError(conn, "file not found on local backend")
+		c.sendFetchError(conn, protocol.AckCodeNotFound, protocol.ErrMsgFileNotFound)
 		return
 	}
 
@@ -1122,11 +1125,14 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 		Msg("FetchFile served successfully")
 }
 
-// sendFetchError sends a FetchFileAckHeader with an error status. Best-effort:
-// any write error is logged at debug but does not affect the caller's flow
-// (the connection is closed by the caller's defer).
-func (c *Coordinator) sendFetchError(conn net.Conn, reason string) {
-	ack := &protocol.FetchFileAckHeader{Status: "error", Error: reason}
+// sendFetchError sends a FetchFileAckHeader with an error status. code is
+// the machine-readable category (Phase 3) that the puller uses to decide
+// whether to fall through to another candidate peer. reason is a
+// human-readable message for operator debugging. Best-effort: any write
+// error is logged at debug but does not affect the caller's flow (the
+// connection is closed by the caller's defer).
+func (c *Coordinator) sendFetchError(conn net.Conn, code protocol.AckErrorCode, reason string) {
+	ack := &protocol.FetchFileAckHeader{Status: "error", Code: code, Error: reason}
 	if err := protocol.SendMessage(conn, &protocol.Message{
 		Type:    protocol.MsgFetchFileAck,
 		Payload: ack,
@@ -1535,29 +1541,62 @@ func (c *Coordinator) startFilePullerLocked() error {
 
 	// PeerResolver closes over the registry. Capture a reference so the
 	// puller can look up peer addresses without holding c.mu.
+	//
+	// Returns an ordered candidate list: the file's origin node first (if
+	// still in the registry with a usable address), followed by any other
+	// healthy peers excluding self. The puller iterates the list and tries
+	// each in turn — that way Phase 3 catch-up still works after a
+	// Kubernetes pod rotation when the original writer is gone.
 	registry := c.registry
-	resolver := filereplication.NewRegistryResolver(func(nodeID string) (string, bool) {
-		node, ok := registry.Get(nodeID)
-		if !ok {
-			return "", false
+	selfID := c.localNode.ID
+	// path is part of the signature so Phase 4+ can add shard-aware or
+	// compactor-aware routing without changing the interface; Phase 3
+	// ignores it and returns the same list regardless of which file is
+	// being fetched.
+	resolver := filereplication.NewRegistryResolver(func(originNodeID, _ string) []string {
+		seen := make(map[string]struct{})
+		candidates := make([]string, 0, 4)
+		add := func(addr string) {
+			if addr == "" {
+				return
+			}
+			if _, dup := seen[addr]; dup {
+				return
+			}
+			seen[addr] = struct{}{}
+			candidates = append(candidates, addr)
 		}
-		if node.Address == "" {
-			return "", false
+		// Origin first. If origin is unknown or address empty we still fall
+		// through to the healthy-peer list — that's the whole point.
+		if originNodeID != "" && originNodeID != selfID {
+			if node, ok := registry.Get(originNodeID); ok {
+				add(node.Address)
+			}
 		}
-		return node.Address, true
+		// Healthy fallback peers, excluding self and the origin we already
+		// tried. GetHealthy returns cloned copies so it's safe without
+		// holding c.mu.
+		for _, node := range registry.GetHealthy() {
+			if node.ID == selfID {
+				continue
+			}
+			add(node.Address)
+		}
+		return candidates
 	})
 
 	pullerCfg := filereplication.Config{
-		SelfNodeID:          c.localNode.ID,
-		Backend:             c.storage,
-		Fetcher:             fetchClient,
-		PeerResolver:        resolver,
-		Workers:             c.cfg.ReplicationPullWorkers,
-		QueueSize:           c.cfg.ReplicationQueueSize,
-		RetryMaxAttempts:    c.cfg.ReplicationRetryMaxAttempts,
-		FetchTimeout:        time.Duration(c.cfg.ReplicationFetchTimeoutMs) * time.Millisecond,
-		RetryInitialBackoff: 500 * time.Millisecond,
-		Logger:              c.logger,
+		SelfNodeID:            c.localNode.ID,
+		Backend:               c.storage,
+		Fetcher:               fetchClient,
+		PeerResolver:          resolver,
+		Workers:               c.cfg.ReplicationPullWorkers,
+		QueueSize:             c.cfg.ReplicationQueueSize,
+		RetryMaxAttempts:      c.cfg.ReplicationRetryMaxAttempts,
+		FetchTimeout:          time.Duration(c.cfg.ReplicationFetchTimeoutMs) * time.Millisecond,
+		RetryInitialBackoff:   500 * time.Millisecond,
+		CatchUpQueueHighWater: c.cfg.ReplicationCatchUpQueueHighWater,
+		Logger:                c.logger,
 	}
 
 	puller, err := filereplication.New(pullerCfg)
@@ -1598,7 +1637,122 @@ func (c *Coordinator) startFilePullerLocked() error {
 		Int("workers", pullerCfg.Workers).
 		Int("queue_size", pullerCfg.QueueSize).
 		Msg("Peer file replication puller started")
+
+	// Phase 3: kick off the catch-up walker in a background goroutine so
+	// Start() doesn't block on a potentially slow manifest walk. Queries can
+	// hit the node during catch-up — they see eventually-consistent results
+	// and operators read /api/v1/cluster/status for progress. The walker is
+	// gated on cluster.replication_catchup_enabled so operators can disable
+	// it as an emergency kill-switch on pathologically large manifests.
+	if c.cfg.ReplicationCatchUpEnabled {
+		go c.runCatchUpOnce()
+	} else {
+		c.logger.Warn().Msg("Peer file replication catch-up disabled via config (replication_catchup_enabled=false)")
+	}
 	return nil
+}
+
+// runCatchUpOnce is the Phase 3 startup reconciliation walker. It waits for
+// a leader + a Raft barrier so the local FSM reflects every committed entry,
+// then hands the full manifest to the puller.
+//
+// Called exactly once per Coordinator lifetime. The sync.Once guard means
+// repeated Start/Stop cycles in tests do NOT re-run catch-up — a fresh walk
+// requires a fresh Coordinator instance. This is intentional: in production
+// a node that wants to re-reconcile the manifest should restart the process.
+// If Phase 5 adds periodic reconciliation, it will live alongside this
+// startup-only path, not replace it.
+//
+// Errors from WaitForLeader and Barrier are logged as warnings and the
+// walker proceeds against a possibly-stale FSM snapshot. A partial walk is
+// strictly better than no walk — the reactive FSM callback path catches
+// any entries the walker missed as they apply.
+func (c *Coordinator) runCatchUpOnce() {
+	c.catchupOnce.Do(func() {
+		if c.puller == nil || c.raftNode == nil {
+			return
+		}
+
+		// Wait for a leader. On failure we still proceed — a follower with a
+		// non-empty FSM is a valid catch-up candidate against cluster state
+		// it already has locally, even if no leader is currently elected.
+		if err := c.raftNode.WaitForLeader(30 * time.Second); err != nil {
+			c.logger.Warn().
+				Err(err).
+				Msg("Catch-up: no leader after 30s, proceeding against possibly-stale manifest")
+		}
+
+		// Barrier: wait for the local FSM to apply everything up to the
+		// current commit index. Without this, GetAllFiles() on a freshly
+		// joined node may see a half-replayed manifest. On a lagging
+		// follower the barrier may time out — same degraded-but-useful
+		// fallback as above.
+		barrierTimeout := time.Duration(c.cfg.ReplicationCatchUpBarrierTimeoutMs) * time.Millisecond
+		if barrierTimeout <= 0 {
+			barrierTimeout = 10 * time.Second
+		}
+		if err := c.raftNode.Barrier(barrierTimeout); err != nil {
+			c.logger.Warn().
+				Err(err).
+				Dur("timeout", barrierTimeout).
+				Msg("Catch-up: Raft barrier timed out, proceeding against possibly-stale manifest")
+		}
+
+		fsm := c.raftNode.FSM()
+		if fsm == nil {
+			c.logger.Error().Msg("Catch-up: Raft FSM not available, skipping")
+			return
+		}
+		entries := fsm.GetAllFiles()
+		c.logger.Info().
+			Int("manifest_entries", len(entries)).
+			Msg("Catch-up: walking manifest")
+
+		// Derive a context from c.ctx (or Background if c.ctx is nil, which
+		// happens in tests that bypass Start). The walker honors cancellation
+		// so shutdown doesn't block on a large catch-up.
+		ctx := c.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		c.puller.RunCatchUp(ctx, entries)
+	})
+}
+
+// ReplicationCatchUpStatus returns the puller's catch-up-specific stats as a
+// JSON-serializable map, or nil when the puller is not running. Intended for
+// /api/v1/cluster/status. The keys mirror what Phase 5 will hard-gate the
+// query path on.
+func (c *Coordinator) ReplicationCatchUpStatus() map[string]int64 {
+	if c.puller == nil {
+		return nil
+	}
+	full := c.puller.Stats()
+	return map[string]int64{
+		"started_at":     full["catchup_started_at"],
+		"completed_at":   full["catchup_completed_at"],
+		"entries_walked": full["catchup_entries_walked"],
+		"enqueued":       full["catchup_enqueued"],
+		"skipped_local":  full["catchup_skipped_local"],
+		"pulled":         full["pulled"],
+		"failed":         full["failed"],
+		"dropped":        full["dropped"],
+		"skipped_dup":    full["skipped_dup"],
+	}
+}
+
+// ReplicationReady reports whether the Phase 3 catch-up walker has finished
+// its pass over the cluster manifest. Not currently consumed — Phase 5 will
+// use this to hard-gate the query path during startup so readers can't
+// return eventually-consistent results during catch-up. Lands now so the
+// coordinator surface doesn't need another change in Phase 5.
+func (c *Coordinator) ReplicationReady() bool {
+	if c.puller == nil {
+		// No puller means peer replication is off — treat as always ready
+		// so future Phase 5 gates don't block OSS / standalone paths.
+		return true
+	}
+	return c.puller.CatchUpCompleted()
 }
 
 // StartReplication starts WAL replication based on node role.

--- a/internal/cluster/filereplication/catchup.go
+++ b/internal/cluster/filereplication/catchup.go
@@ -1,0 +1,132 @@
+package filereplication
+
+import (
+	"context"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+)
+
+// RunCatchUp walks a snapshot of the cluster file manifest and enqueues every
+// entry the local node should hold but doesn't. It is the Phase 3 mechanism
+// that brings a node with a stale or empty local backend back into sync with
+// the manifest: on startup (and only on startup — periodic reconciliation is
+// not in scope for Phase 3), the coordinator hands us the output of
+// fsm.GetAllFiles() and we feed each entry through Enqueue so the regular
+// worker pool pulls the missing bytes from a peer.
+//
+// RunCatchUp does NOT itself talk to peers or verify files — it relies on
+// Enqueue's existing origin-is-self check, the inflight dedup set (so
+// reactive FSM callbacks can race without double-pulling), and the workers'
+// backend.Exists pre-check. All the actual fetch work flows through the
+// same code path that Phase 2 reactive pulls use, which means the same
+// retry/backoff/checksum/metrics apply automatically.
+//
+// To avoid a thundering-herd drop storm on large manifests, the feeder sleeps
+// briefly whenever the queue is above CatchUpQueueHighWater (default 80%).
+// This gives the workers time to drain and keeps reactive drops rare. The
+// walker is NOT a hard gate on queries — the release notes document the
+// eventual-consistency window between startup and full drain.
+//
+// RunCatchUp is safe to call at most once per puller lifecycle: the
+// catchupStartedAt atomic is CAS-guarded so a second call short-circuits.
+// The method returns when all entries have been processed (enqueued or
+// skipped) or ctx is cancelled; it does not wait for the actual pulls to
+// complete.
+func (p *Puller) RunCatchUp(ctx context.Context, entries []*raft.FileEntry) {
+	// Single-shot guard: only one catch-up per puller lifetime.
+	if !p.catchupStartedAt.CompareAndSwap(0, time.Now().Unix()) {
+		p.logger.Debug().Msg("File puller catch-up already ran, skipping")
+		return
+	}
+
+	total := len(entries)
+	p.logger.Info().
+		Int("manifest_entries", total).
+		Msg("File puller catch-up started")
+
+	// Pre-capture stats counters so we can log the delta at the end. Using
+	// the Stats() map would pull in catch-up counters and confuse the
+	// summary — we want "what did catch-up cause".
+	startEnqueued := p.totalEnqueued.Load()
+	startPulled := p.totalPulled.Load()
+	startSkippedLocal := p.totalSkippedLocal.Load()
+	startSkippedDup := p.totalSkippedDup.Load()
+	startDropped := p.totalDropped.Load()
+
+	// High-water mark in absolute queue slots. capFraction < 1 is clamped in
+	// New(); below we just multiply and floor.
+	queueCap := cap(p.queue)
+	highWater := int(float64(queueCap) * p.cfg.CatchUpQueueHighWater)
+	if highWater < 1 {
+		highWater = 1
+	}
+
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			p.logger.Warn().
+				Int64("walked", p.catchupEntriesWalked.Load()).
+				Int("total", total).
+				Msg("File puller catch-up cancelled")
+			return
+		}
+		p.catchupEntriesWalked.Add(1)
+		if entry == nil {
+			continue
+		}
+
+		// Backpressure: if the queue is above the high-water mark, sleep
+		// briefly to let workers drain. This loop is intentionally simple
+		// (no exponential backoff) because the expected case is that the
+		// walker catches up within a few hundred ms.
+		for len(p.queue) >= highWater {
+			select {
+			case <-ctx.Done():
+				return
+			case <-p.ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+
+		// Snapshot Enqueue-side counters so we can tell why this entry was
+		// accepted, deduped, or dropped. Counters are monotonic atomics so a
+		// simple before/after comparison is race-free.
+		beforeEnqueued := p.totalEnqueued.Load()
+		beforeSkippedDup := p.totalSkippedDup.Load()
+		beforeSkippedSelf := p.totalSkippedSelf.Load()
+		beforeDropped := p.totalDropped.Load()
+
+		p.Enqueue(entry)
+
+		switch {
+		case p.totalEnqueued.Load() > beforeEnqueued:
+			p.catchupEnqueued.Add(1)
+		case p.totalSkippedDup.Load() > beforeSkippedDup:
+			// Already enqueued (by a reactive callback or a prior walker
+			// entry with the same path) — count as skipped so the caller
+			// can see it happened.
+			p.catchupSkippedLocal.Add(1)
+		case p.totalSkippedSelf.Load() > beforeSkippedSelf:
+			// Origin is self — file is already local by construction.
+			p.catchupSkippedLocal.Add(1)
+		case p.totalDropped.Load() > beforeDropped:
+			// Queue full even after backpressure sleep — give up on this
+			// entry; a future restart or reactive callback will retry.
+		}
+	}
+
+	p.catchupCompletedAt.Store(time.Now().Unix())
+
+	p.logger.Info().
+		Int("manifest_entries", total).
+		Int64("catchup_walked", p.catchupEntriesWalked.Load()).
+		Int64("catchup_enqueued", p.catchupEnqueued.Load()).
+		Int64("catchup_skipped_local", p.catchupSkippedLocal.Load()).
+		Int64("enqueued_delta", p.totalEnqueued.Load()-startEnqueued).
+		Int64("pulled_so_far_delta", p.totalPulled.Load()-startPulled).
+		Int64("skipped_local_delta", p.totalSkippedLocal.Load()-startSkippedLocal).
+		Int64("skipped_dup_delta", p.totalSkippedDup.Load()-startSkippedDup).
+		Int64("dropped_delta", p.totalDropped.Load()-startDropped).
+		Msg("File puller catch-up completed")
+}

--- a/internal/cluster/filereplication/catchup_test.go
+++ b/internal/cluster/filereplication/catchup_test.go
@@ -1,0 +1,314 @@
+package filereplication
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/rs/zerolog"
+)
+
+// TestRunCatchUpEnqueuesAllWhenQueueLarge verifies the happy path: a walker
+// fed 10 distinct entries enqueues all of them when the queue is big enough
+// to absorb everything without backpressure.
+func TestRunCatchUpEnqueuesAllWhenQueueLarge(t *testing.T) {
+	backend := newFakeBackend()
+	body := []byte("catchup body")
+	// Repeating fetcher yields the body on every call — the default
+	// non-repeating fakeFetcher would error on calls 2..N because the
+	// script is exhausted.
+	fetcher := newRepeatingFetcher(body)
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             2,
+		QueueSize:           64,
+		RetryMaxAttempts:    1,
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entries := make([]*raft.FileEntry, 10)
+	for i := range entries {
+		entries[i] = makeEntry(fmt.Sprintf("testdb/cpu/catchup-%02d.parquet", i), "writer-1", int64(len(body)))
+	}
+
+	p.RunCatchUp(context.Background(), entries)
+
+	// Wait for workers to drain.
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["pulled"] == 10
+	})
+	if stats["catchup_entries_walked"] != 10 {
+		t.Errorf("catchup_entries_walked: got %d, want 10", stats["catchup_entries_walked"])
+	}
+	if stats["catchup_enqueued"] != 10 {
+		t.Errorf("catchup_enqueued: got %d, want 10", stats["catchup_enqueued"])
+	}
+	if stats["catchup_completed_at"] == 0 {
+		t.Errorf("catchup_completed_at should be non-zero")
+	}
+	if stats["pulled"] != 10 {
+		t.Errorf("pulled: got %d, want 10", stats["pulled"])
+	}
+	if stats["dropped"] != 0 {
+		t.Errorf("dropped: got %d, want 0", stats["dropped"])
+	}
+}
+
+// TestRunCatchUpThrottlesAtHighWater verifies the walker pauses enqueueing
+// when the queue is above the high-water mark. We use a blocking fetcher to
+// hold the single worker busy so the queue fills up, then confirm the
+// walker's sleeps happen (detectable via wall-clock elapsed time).
+func TestRunCatchUpThrottlesAtHighWater(t *testing.T) {
+	backend := newFakeBackend()
+	blockCh := make(chan struct{})
+	fetcher := &blockingFetcher{release: blockCh}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p, err := New(Config{
+		SelfNodeID:            "reader-1",
+		Backend:               backend,
+		Fetcher:               fetcher,
+		PeerResolver:          resolver,
+		Workers:               1,
+		QueueSize:             4,
+		CatchUpQueueHighWater: 0.5, // pause when > 2 entries in queue
+		RetryMaxAttempts:      1,
+		RetryInitialBackoff:   10 * time.Millisecond,
+		FetchTimeout:          5 * time.Second,
+		Logger:                zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer func() {
+		close(blockCh)
+		p.Stop()
+	}()
+
+	entries := make([]*raft.FileEntry, 5)
+	for i := range entries {
+		entries[i] = makeEntry(fmt.Sprintf("testdb/cpu/throttle-%02d.parquet", i), "writer-1", 100)
+	}
+
+	// Run catch-up in a goroutine so we can interrupt it if it doesn't
+	// throttle properly (infinite loop protection).
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(done)
+		p.RunCatchUp(context.Background(), entries)
+	}()
+
+	// Let the walker try to enqueue for a bit. With Workers=1 blocked, the
+	// queue fills to QueueSize=4 (cap) within microseconds, then the walker
+	// hits the high-water mark and starts sleeping in 50ms ticks. Release
+	// the fetcher after 150ms so the walker can drain.
+	time.Sleep(150 * time.Millisecond)
+	close(blockCh)
+	blockCh = make(chan struct{}) // reset for defer close (which is now a no-op)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunCatchUp did not return within 3s")
+	}
+	elapsed := time.Since(start)
+	// Without throttling, all 5 enqueues complete in microseconds. With
+	// throttling (QueueSize=4, high-water=2), the walker should sleep at
+	// least once (50ms) while waiting for drain.
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("RunCatchUp completed in %v, expected >= 50ms indicating throttling", elapsed)
+	}
+}
+
+// TestRunCatchUpHonorsContextCancel verifies the walker exits promptly when
+// its ctx is cancelled mid-walk.
+func TestRunCatchUpHonorsContextCancel(t *testing.T) {
+	backend := newFakeBackend()
+	blockCh := make(chan struct{})
+	fetcher := &blockingFetcher{release: blockCh}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p, err := New(Config{
+		SelfNodeID:            "reader-1",
+		Backend:               backend,
+		Fetcher:               fetcher,
+		PeerResolver:          resolver,
+		Workers:               1,
+		QueueSize:             2,
+		CatchUpQueueHighWater: 0.5,
+		RetryMaxAttempts:      1,
+		RetryInitialBackoff:   10 * time.Millisecond,
+		FetchTimeout:          5 * time.Second,
+		Logger:                zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer func() {
+		close(blockCh)
+		p.Stop()
+	}()
+
+	entries := make([]*raft.FileEntry, 100) // huge batch
+	for i := range entries {
+		entries[i] = makeEntry(fmt.Sprintf("testdb/cpu/cancel-%04d.parquet", i), "writer-1", 100)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.RunCatchUp(ctx, entries)
+	}()
+
+	// Give the walker time to start throttling on the full queue, then cancel.
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("RunCatchUp did not return within 500ms of ctx cancel")
+	}
+	// Walker should not have processed all 100 entries.
+	stats := p.Stats()
+	if stats["catchup_entries_walked"] >= 100 {
+		t.Errorf("walker processed all entries despite cancel: walked=%d", stats["catchup_entries_walked"])
+	}
+}
+
+// TestRunCatchUpOnceOnly verifies the single-shot guard: a second call to
+// RunCatchUp on the same puller is a no-op.
+func TestRunCatchUpOnceOnly(t *testing.T) {
+	backend := newFakeBackend()
+	body := []byte("one-shot")
+	fetcher := newRepeatingFetcher(body)
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             2,
+		QueueSize:           16,
+		RetryMaxAttempts:    1,
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entries1 := []*raft.FileEntry{
+		makeEntry("testdb/cpu/once-a.parquet", "writer-1", int64(len(body))),
+		makeEntry("testdb/cpu/once-b.parquet", "writer-1", int64(len(body))),
+	}
+	entries2 := []*raft.FileEntry{
+		makeEntry("testdb/cpu/once-c.parquet", "writer-1", int64(len(body))),
+		makeEntry("testdb/cpu/once-d.parquet", "writer-1", int64(len(body))),
+	}
+
+	p.RunCatchUp(context.Background(), entries1)
+	firstWalked := p.Stats()["catchup_entries_walked"]
+	firstStartedAt := p.Stats()["catchup_started_at"]
+
+	// Second call should be a no-op — no new entries walked, started_at
+	// unchanged.
+	p.RunCatchUp(context.Background(), entries2)
+	secondWalked := p.Stats()["catchup_entries_walked"]
+	secondStartedAt := p.Stats()["catchup_started_at"]
+
+	if firstWalked != secondWalked {
+		t.Errorf("second RunCatchUp walked more entries: first=%d second=%d", firstWalked, secondWalked)
+	}
+	if firstStartedAt != secondStartedAt {
+		t.Errorf("second RunCatchUp changed started_at: first=%d second=%d", firstStartedAt, secondStartedAt)
+	}
+}
+
+// TestRunCatchUpDedupsWithReactiveEnqueue verifies the Phase 3 dedup
+// contract: if a reactive FSM callback enqueues path X while the walker is
+// also processing X, the fetch handler is called exactly once. This is the
+// test that justifies the inflight set.
+func TestRunCatchUpDedupsWithReactiveEnqueue(t *testing.T) {
+	backend := newFakeBackend()
+	body := []byte("dedup body")
+	// Repeating fetcher so we can assert exact call counts via .calls.
+	fetcher := newRepeatingFetcher(body)
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             1,
+		QueueSize:           16,
+		RetryMaxAttempts:    1,
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/dedup-catchup.parquet", "writer-1", int64(len(body)))
+
+	// Fire catch-up and reactive enqueue in parallel, both for the same path.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		p.RunCatchUp(context.Background(), []*raft.FileEntry{entry})
+	}()
+	go func() {
+		defer wg.Done()
+		// Simulate many reactive callbacks firing concurrently.
+		for i := 0; i < 20; i++ {
+			p.Enqueue(entry)
+		}
+	}()
+	wg.Wait()
+
+	// Wait for the worker to drain.
+	waitStats(t, p, func(s map[string]int64) bool {
+		return s["pulled"] == 1
+	})
+
+	// Exactly one fetch should have been issued to the peer.
+	if got := fetcher.calls.Load(); got != 1 {
+		t.Errorf("Fetcher.Fetch called %d times, want 1 (catch-up and reactive should dedup)", got)
+	}
+	stats := p.Stats()
+	if stats["pulled"] != 1 {
+		t.Errorf("pulled: got %d, want 1", stats["pulled"])
+	}
+	if stats["skipped_dup"] == 0 {
+		t.Errorf("skipped_dup should be non-zero (parallel enqueues should dedup)")
+	}
+}

--- a/internal/cluster/filereplication/fetch_client.go
+++ b/internal/cluster/filereplication/fetch_client.go
@@ -140,6 +140,14 @@ func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.Fi
 		return 0, fmt.Errorf("ack payload has wrong type: %T", ackMsg.Payload)
 	}
 	if ack.Status != "ok" {
+		// Phase 3: if the peer reports "not_found" or "manifest" (i.e. this
+		// peer simply doesn't hold this file), return ErrFileNotOnPeer so
+		// the puller can fall through to the next candidate peer. Code is
+		// empty when talking to a Phase 2 peer that predates this field —
+		// in that case, fall back to matching known human-readable strings.
+		if isFileNotOnPeerAck(ack) {
+			return 0, fmt.Errorf("%w: %s", ErrFileNotOnPeer, ack.Error)
+		}
 		return 0, fmt.Errorf("peer rejected fetch: %s", ack.Error)
 	}
 	if ack.SizeBytes < 0 {
@@ -175,15 +183,45 @@ func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.Fi
 // Compile-time check that FetchClient satisfies Fetcher.
 var _ Fetcher = (*FetchClient)(nil)
 
-// NewRegistryResolver adapts any function that maps node IDs to addresses
-// into a PeerResolver. This is the simplest plumbing between the coordinator
-// (which owns the registry) and the puller (which needs a resolver).
-func NewRegistryResolver(fn func(nodeID string) (string, bool)) PeerResolver {
+// isFileNotOnPeerAck reports whether an error ack indicates the peer simply
+// doesn't have the requested file (as opposed to auth failure, backend error,
+// or Raft unavailability, which should NOT trigger multi-peer fallback).
+//
+// The primary signal is the typed Code field added in Phase 3. If Code is
+// empty (Phase 2 peer predating the field), we fall back to exact-match on
+// ack.Error against protocol.ErrMsgFileNotInManifest / ErrMsgFileNotFound,
+// which are the strings the Phase 2 server emits. Exact match (not
+// substring) prevents an adversary from crafting an Error value that
+// confuses the check — e.g. "file not found on local backend: /etc/passwd"
+// would NOT match. The server-side strings and this fallback live together
+// in internal/cluster/protocol so a refactor touches both sites at once.
+func isFileNotOnPeerAck(ack *protocol.FetchFileAckHeader) bool {
+	if ack == nil {
+		return false
+	}
+	switch ack.Code {
+	case protocol.AckCodeNotFound, protocol.AckCodeManifest:
+		return true
+	case "":
+		// Phase 2 peer — fall back to exact-match on the known strings.
+		return ack.Error == protocol.ErrMsgFileNotInManifest ||
+			ack.Error == protocol.ErrMsgFileNotFound
+	default:
+		return false
+	}
+}
+
+// NewRegistryResolver adapts a function that maps (originNodeID, path) to
+// an ordered list of candidate peer addresses into a PeerResolver. Typical
+// usage: return the origin address first (if still healthy) followed by
+// any other healthy peers — that way Phase 3 catch-up still works after a
+// Kubernetes pod rotation when the original writer is gone.
+func NewRegistryResolver(fn func(originNodeID, path string) []string) PeerResolver {
 	return funcResolver(fn)
 }
 
-type funcResolver func(string) (string, bool)
+type funcResolver func(string, string) []string
 
-func (f funcResolver) ResolvePeer(nodeID string) (string, bool) {
-	return f(nodeID)
+func (f funcResolver) ResolvePeers(originNodeID, path string) []string {
+	return f(originNodeID, path)
 }

--- a/internal/cluster/filereplication/fetch_client_test.go
+++ b/internal/cluster/filereplication/fetch_client_test.go
@@ -65,6 +65,16 @@ func (p *fakePeer) scriptError(reason string) {
 	p.body = nil
 }
 
+// scriptErrorCode sets both Code and Error on the next ack. Phase 3 peers
+// populate Code; Phase 2 peers leave it empty and the client falls back to
+// exact-matching Error.
+func (p *fakePeer) scriptErrorCode(code protocol.AckErrorCode, reason string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.ack = protocol.FetchFileAckHeader{Status: "error", Code: code, Error: reason}
+	p.body = nil
+}
+
 func (p *fakePeer) scriptCloseBeforeReply() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -418,5 +428,143 @@ func TestFetchClientLargeBody(t *testing.T) {
 	}
 	if n != int64(size) {
 		t.Errorf("bytes: got %d, want %d", n, size)
+	}
+}
+
+// --- Phase 3 tests: ErrFileNotOnPeer mapping ---
+
+// TestFetchClientErrFileNotOnPeerCodeNotFound verifies the machine-readable
+// Phase 3 Code field drives the fallback decision. A peer that responds with
+// Code="not_found" should trigger ErrFileNotOnPeer so the puller can fall
+// through to the next candidate.
+func TestFetchClientErrFileNotOnPeerCodeNotFound(t *testing.T) {
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptErrorCode(protocol.AckCodeNotFound, protocol.ErrMsgFileNotFound)
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/missing.parquet",
+		SizeBytes: 42,
+		SHA256:    sha256Hex([]byte("dummy")),
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrFileNotOnPeer) {
+		t.Errorf("expected ErrFileNotOnPeer, got %v", err)
+	}
+}
+
+// TestFetchClientErrFileNotOnPeerCodeManifest verifies Code="manifest" (file
+// not in the Raft manifest on the peer) also triggers fallback — a peer
+// that doesn't know about the file shouldn't fail the entire attempt.
+func TestFetchClientErrFileNotOnPeerCodeManifest(t *testing.T) {
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptErrorCode(protocol.AckCodeManifest, protocol.ErrMsgFileNotInManifest)
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/offmanifest.parquet",
+		SizeBytes: 42,
+		SHA256:    sha256Hex([]byte("dummy")),
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrFileNotOnPeer) {
+		t.Errorf("expected ErrFileNotOnPeer, got %v", err)
+	}
+}
+
+// TestFetchClientErrFileNotOnPeerPhase2Fallback verifies that when Code is
+// empty (Phase 2 peer that predates the field), the client falls back to
+// substring-matching the human-readable error text. This locks in the
+// backward-compat contract so a Phase 3 node can catch up from a Phase 2
+// origin.
+func TestFetchClientErrFileNotOnPeerPhase2Fallback(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason string
+	}{
+		{"not_in_manifest", "file not in manifest"},
+		{"not_on_backend", "file not found on local backend"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			peer := startFakePeer(t)
+			defer peer.stop()
+			// scriptError leaves Code empty — Phase 2 shape.
+			peer.scriptError(tc.reason)
+
+			fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+			entry := &raft.FileEntry{
+				Path:      "db/cpu/phase2-fallback.parquet",
+				SizeBytes: 42,
+				SHA256:    sha256Hex([]byte("dummy")),
+			}
+			var dst bytes.Buffer
+			_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, ErrFileNotOnPeer) {
+				t.Errorf("expected ErrFileNotOnPeer for reason %q (Phase 2 peer fallback), got %v", tc.reason, err)
+			}
+		})
+	}
+}
+
+// TestFetchClientAuthErrorIsNotFallback verifies that auth failures do NOT
+// map to ErrFileNotOnPeer — otherwise a misconfigured cluster would silently
+// fall through every healthy peer and give up with a generic "max attempts"
+// error, hiding the real problem.
+func TestFetchClientAuthErrorIsNotFallback(t *testing.T) {
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptErrorCode(protocol.AckCodeAuth, "authentication failed")
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/auth-fail.parquet",
+		SizeBytes: 42,
+		SHA256:    sha256Hex([]byte("dummy")),
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrFileNotOnPeer) {
+		t.Errorf("auth errors must NOT map to ErrFileNotOnPeer, got %v", err)
+	}
+}
+
+// TestFetchClientBackendErrorIsNotFallback — same reasoning: a peer with a
+// broken backend isn't "file not here", it's an operational problem that
+// should surface rather than cause silent fallback.
+func TestFetchClientBackendErrorIsNotFallback(t *testing.T) {
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptErrorCode(protocol.AckCodeBackend, "backend error")
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/backend-fail.parquet",
+		SizeBytes: 42,
+		SHA256:    sha256Hex([]byte("dummy")),
+	}
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrFileNotOnPeer) {
+		t.Errorf("backend errors must NOT map to ErrFileNotOnPeer, got %v", err)
 	}
 }

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -151,7 +151,14 @@ type Puller struct {
 	catchupCompletedAt   atomic.Int64 // unix seconds; 0 if still running or never ran
 	catchupEntriesWalked atomic.Int64 // entries the walker iterated
 	catchupEnqueued      atomic.Int64 // entries successfully enqueued by the walker
-	catchupSkippedLocal  atomic.Int64 // entries the walker skipped because backend.Exists
+	// catchupSkippedLocal counts entries the walker chose NOT to enqueue
+	// because Enqueue already had a reason to skip — either origin==self
+	// (totalSkippedSelf bump) or the path was already in-flight via a
+	// reactive callback (totalSkippedDup bump). It does NOT include entries
+	// skipped because backend.Exists(path) was already true — that check
+	// happens downstream inside processEntry and is tracked by the global
+	// totalSkippedLocal counter.
+	catchupSkippedLocal  atomic.Int64
 }
 
 // New constructs a Puller. Does not start background workers — call Start.
@@ -422,6 +429,15 @@ func (p *Puller) processEntry(log zerolog.Logger, entry *raft.FileEntry) {
 			}
 			lastErr = err
 			lastPeer = peerAddr
+			// Fast-path shutdown: if the puller is stopping, pullOnce will
+			// return a context.Canceled-wrapped error. Without this check
+			// the loop would iterate every remaining candidate, logging a
+			// debug "trying next" line and issuing a dial attempt for each,
+			// before the top-of-loop ctx check finally caught it. On a
+			// 10-peer cluster that's 10 wasted dials during shutdown.
+			if errors.Is(err, context.Canceled) {
+				return
+			}
 			// Checksum mismatch is a data-integrity signal, not a "try next
 			// peer" signal. A peer served bytes that didn't match the manifest
 			// SHA-256 — corrupt manifest, corrupt peer, or adversarial peer.

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -35,14 +35,23 @@ type Fetcher interface {
 	Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error)
 }
 
-// PeerResolver maps an origin node ID to its coordinator TCP address. The
-// puller looks up the address fresh on every enqueued entry (rather than
-// caching) so that topology changes are picked up automatically.
+// PeerResolver returns an ordered list of peer coordinator addresses that
+// can serve a given file. The puller tries each address in order until one
+// responds with the file bytes. The first address is typically the origin
+// node (if still healthy) followed by any other healthy peers — that way
+// catch-up after a Kubernetes pod rotation still works when the original
+// writer is gone.
+//
+// The resolver takes (originNodeID, path) rather than the full FileEntry so
+// the interface stays decoupled from the raft package — any future
+// implementation that wants richer routing (health-aware, latency-aware,
+// shard-aware) only needs these two fields to make its decision.
+//
+// The puller looks up addresses fresh on every attempt (no caching) so
+// topology changes are picked up automatically. An empty slice means "no
+// known peers" and is treated as a transient failure the puller can retry.
 type PeerResolver interface {
-	// ResolvePeer returns the coordinator address for a node, or ("", false)
-	// if the node is unknown. Callers treat "not found" as a transient error
-	// and may re-enqueue.
-	ResolvePeer(nodeID string) (string, bool)
+	ResolvePeers(originNodeID, path string) []string
 }
 
 // Config bundles the puller's dependencies and tunables.
@@ -81,6 +90,12 @@ type Config struct {
 	// FetchTimeout bounds a single Fetcher.Fetch call. Default: 60s.
 	FetchTimeout time.Duration
 
+	// CatchUpQueueHighWater is the queue-depth fraction above which the
+	// Phase 3 catch-up walker pauses enqueueing. Keeps the walker from
+	// racing ahead of workers and causing drop storms on large manifests.
+	// Default: 0.8 (sleep when > 80% full).
+	CatchUpQueueHighWater float64
+
 	// Logger receives structured log output.
 	Logger zerolog.Logger
 }
@@ -89,11 +104,12 @@ type Config struct {
 // the dependencies (Backend, Fetcher, PeerResolver, SelfNodeID, Logger).
 func DefaultConfig() Config {
 	return Config{
-		Workers:             4,
-		QueueSize:           1024,
-		RetryMaxAttempts:    3,
-		RetryInitialBackoff: 500 * time.Millisecond,
-		FetchTimeout:        60 * time.Second,
+		Workers:               4,
+		QueueSize:             1024,
+		RetryMaxAttempts:      3,
+		RetryInitialBackoff:   500 * time.Millisecond,
+		FetchTimeout:          60 * time.Second,
+		CatchUpQueueHighWater: 0.8,
 	}
 }
 
@@ -111,15 +127,31 @@ type Puller struct {
 	mu      sync.Mutex
 	started bool
 
+	// inflight tracks paths currently enqueued or being processed. Enqueue
+	// consults it to dedup reactive callbacks against the Phase 3 catch-up
+	// walker (both can enqueue the same path during a race), and workers
+	// remove the entry via defer in processEntry so the set stays bounded
+	// even on panic.
+	inflightMu sync.Mutex
+	inflight   map[string]struct{}
+
 	// Metrics (atomic for lock-free observability)
 	totalEnqueued          atomic.Int64
 	totalSkippedSelf       atomic.Int64 // origin is self — no pull needed
 	totalSkippedLocal      atomic.Int64 // backend.Exists already true
+	totalSkippedDup        atomic.Int64 // already enqueued / in-flight
 	totalPulled            atomic.Int64 // successful pulls
 	totalFailed            atomic.Int64 // gave up after retries
 	totalDropped           atomic.Int64 // queue full
 	totalChecksumMismatch  atomic.Int64 // bytes didn't match manifest SHA256
-	totalPeerLookupFailure atomic.Int64 // origin node not in registry
+	totalPeerLookupFailure atomic.Int64 // no candidate peers available
+
+	// Catch-up metrics (Phase 3). Populated by RunCatchUp and read via Stats.
+	catchupStartedAt     atomic.Int64 // unix seconds; 0 if never started
+	catchupCompletedAt   atomic.Int64 // unix seconds; 0 if still running or never ran
+	catchupEntriesWalked atomic.Int64 // entries the walker iterated
+	catchupEnqueued      atomic.Int64 // entries successfully enqueued by the walker
+	catchupSkippedLocal  atomic.Int64 // entries the walker skipped because backend.Exists
 }
 
 // New constructs a Puller. Does not start background workers — call Start.
@@ -153,12 +185,41 @@ func New(cfg Config) (*Puller, error) {
 	if cfg.FetchTimeout <= 0 {
 		cfg.FetchTimeout = defaults.FetchTimeout
 	}
+	// Clamp catch-up high-water to a sane range. Values <=0 or >=1 would
+	// either disable throttling entirely or starve the walker, so fall back
+	// to the default.
+	if cfg.CatchUpQueueHighWater <= 0 || cfg.CatchUpQueueHighWater >= 1 {
+		cfg.CatchUpQueueHighWater = defaults.CatchUpQueueHighWater
+	}
 
 	return &Puller{
-		cfg:    cfg,
-		queue:  make(chan *raft.FileEntry, cfg.QueueSize),
-		logger: cfg.Logger.With().Str("component", "file-puller").Logger(),
+		cfg:      cfg,
+		queue:    make(chan *raft.FileEntry, cfg.QueueSize),
+		inflight: make(map[string]struct{}),
+		logger:   cfg.Logger.With().Str("component", "file-puller").Logger(),
 	}, nil
+}
+
+// inflightAdd records a path as in-flight (enqueued or being processed).
+// Returns false if the path was already in the set — caller should treat
+// this as "already handled, skip".
+func (p *Puller) inflightAdd(path string) bool {
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	if _, ok := p.inflight[path]; ok {
+		return false
+	}
+	p.inflight[path] = struct{}{}
+	return true
+}
+
+// inflightRemove clears a path from the in-flight set. Safe to call on a
+// path that's not in the set (no-op). Called from processEntry via defer so
+// it runs on panic unwind too.
+func (p *Puller) inflightRemove(path string) {
+	p.inflightMu.Lock()
+	delete(p.inflight, path)
+	p.inflightMu.Unlock()
 }
 
 // Start launches the worker pool. Safe to call multiple times — subsequent
@@ -204,11 +265,14 @@ func (p *Puller) Stop() {
 
 // Enqueue submits a file entry for pulling. Non-blocking: if the queue is
 // full, the entry is dropped and totalDropped is incremented. If origin is
-// self or the file already exists locally, the entry is counted as a skip
-// and never reaches a worker.
+// self, the file already exists locally, or the same path is already
+// enqueued / in-flight (via the inflight set), the entry is counted as a
+// skip and never reaches a worker.
 //
 // Enqueue is safe to call from the Raft FSM apply callback (which must
-// return quickly): all checks here are O(1) and no I/O happens inline.
+// return quickly): all checks here are O(1) and no I/O happens inline. It
+// is also safe to call from the Phase 3 catch-up walker concurrently with
+// reactive callbacks — the inflight set dedups cross-path races.
 func (p *Puller) Enqueue(entry *raft.FileEntry) {
 	if entry == nil {
 		return
@@ -218,12 +282,21 @@ func (p *Puller) Enqueue(entry *raft.FileEntry) {
 		p.totalSkippedSelf.Add(1)
 		return
 	}
+	// Dedup: if the path is already enqueued or being processed, don't add
+	// it again. The inflight slot is released by processEntry via defer.
+	if !p.inflightAdd(entry.Path) {
+		p.totalSkippedDup.Add(1)
+		return
+	}
 	// Copy so the caller can't mutate the entry out from under the worker.
 	entryCopy := *entry
 	select {
 	case p.queue <- &entryCopy:
 		p.totalEnqueued.Add(1)
 	default:
+		// Queue full — release the inflight slot so a future retry can
+		// re-enqueue this path, and count the drop.
+		p.inflightRemove(entry.Path)
 		dropped := p.totalDropped.Add(1)
 		// Power-of-2 rate limiting, same pattern as CoordinatorFileRegistrar.
 		if dropped&(dropped-1) == 0 {
@@ -235,19 +308,34 @@ func (p *Puller) Enqueue(entry *raft.FileEntry) {
 	}
 }
 
-// Stats returns a point-in-time snapshot of the puller's metrics.
+// Stats returns a point-in-time snapshot of the puller's metrics,
+// including Phase 3 catch-up counters.
 func (p *Puller) Stats() map[string]int64 {
 	return map[string]int64{
-		"enqueued":             p.totalEnqueued.Load(),
-		"skipped_self":         p.totalSkippedSelf.Load(),
-		"skipped_local":        p.totalSkippedLocal.Load(),
-		"pulled":               p.totalPulled.Load(),
-		"failed":               p.totalFailed.Load(),
-		"dropped":              p.totalDropped.Load(),
-		"checksum_mismatch":    p.totalChecksumMismatch.Load(),
-		"peer_lookup_failure":  p.totalPeerLookupFailure.Load(),
-		"queue_depth":          int64(len(p.queue)),
+		"enqueued":               p.totalEnqueued.Load(),
+		"skipped_self":           p.totalSkippedSelf.Load(),
+		"skipped_local":          p.totalSkippedLocal.Load(),
+		"skipped_dup":            p.totalSkippedDup.Load(),
+		"pulled":                 p.totalPulled.Load(),
+		"failed":                 p.totalFailed.Load(),
+		"dropped":                p.totalDropped.Load(),
+		"checksum_mismatch":      p.totalChecksumMismatch.Load(),
+		"peer_lookup_failure":    p.totalPeerLookupFailure.Load(),
+		"queue_depth":            int64(len(p.queue)),
+		"catchup_started_at":     p.catchupStartedAt.Load(),
+		"catchup_completed_at":   p.catchupCompletedAt.Load(),
+		"catchup_entries_walked": p.catchupEntriesWalked.Load(),
+		"catchup_enqueued":       p.catchupEnqueued.Load(),
+		"catchup_skipped_local":  p.catchupSkippedLocal.Load(),
 	}
+}
+
+// CatchUpCompleted reports whether the startup catch-up walker has finished.
+// Returns true once RunCatchUp has completed its pass over the manifest (not
+// once all queued pulls have drained — that's a separate signal). Phase 5
+// will use this to hard-gate the query path during startup.
+func (p *Puller) CatchUpCompleted() bool {
+	return p.catchupCompletedAt.Load() > 0
 }
 
 func (p *Puller) worker(id int) {
@@ -271,8 +359,19 @@ func (p *Puller) worker(id int) {
 
 // processEntry pulls a single file with bounded retries. Each retry re-checks
 // backend.Exists (in case a concurrent worker or external process put the
-// file in place) and re-resolves the peer address (in case of topology change).
+// file in place) and re-resolves the peer list (in case of topology change).
+// Within a single attempt, the resolver returns an ordered list of candidate
+// peers and we fall through to the next candidate on any per-peer failure
+// EXCEPT checksum mismatch — a corrupt body from one peer is a real data
+// integrity problem and shouldn't trigger pull-and-corrupt from every other
+// healthy peer in turn.
 func (p *Puller) processEntry(log zerolog.Logger, entry *raft.FileEntry) {
+	// Remove from the inflight set when we're done, whether success or failure.
+	// This keeps the set bounded even if a worker panics — Go's defer runs on
+	// panic unwind — and makes repeated catch-up walks idempotent with the
+	// reactive enqueue path.
+	defer p.inflightRemove(entry.Path)
+
 	for attempt := 1; attempt <= p.cfg.RetryMaxAttempts; attempt++ {
 		if p.ctx.Err() != nil {
 			return
@@ -287,51 +386,87 @@ func (p *Puller) processEntry(log zerolog.Logger, entry *raft.FileEntry) {
 			return
 		}
 
-		// Resolve peer address fresh on each attempt.
-		peerAddr, ok := p.cfg.PeerResolver.ResolvePeer(entry.OriginNodeID)
-		if !ok {
+		// Resolve candidate peers fresh on each attempt so topology changes
+		// (node failover, rescheduling) are picked up automatically.
+		peers := p.cfg.PeerResolver.ResolvePeers(entry.OriginNodeID, entry.Path)
+		if len(peers) == 0 {
 			p.totalPeerLookupFailure.Add(1)
 			log.Warn().
 				Str("path", entry.Path).
 				Str("origin_node_id", entry.OriginNodeID).
 				Int("attempt", attempt).
-				Msg("Origin node not found in registry, deferring pull")
+				Msg("No candidate peers available for fetch, deferring pull")
 			p.sleepBackoff(attempt)
 			continue
 		}
 
-		// Attempt the pull.
-		if err := p.pullOnce(log, entry, peerAddr, attempt); err != nil {
-			log.Warn().
+		var lastErr error
+		var lastPeer string
+		pulledFromPeer := false
+		checksumMismatch := false
+		for _, peerAddr := range peers {
+			if p.ctx.Err() != nil {
+				return
+			}
+			err := p.pullOnce(log, entry, peerAddr, attempt)
+			if err == nil {
+				p.totalPulled.Add(1)
+				log.Info().
+					Str("path", entry.Path).
+					Str("peer", peerAddr).
+					Int64("size_bytes", entry.SizeBytes).
+					Int("attempts", attempt).
+					Msg("File pulled from peer")
+				pulledFromPeer = true
+				break
+			}
+			lastErr = err
+			lastPeer = peerAddr
+			// Checksum mismatch is a data-integrity signal, not a "try next
+			// peer" signal. A peer served bytes that didn't match the manifest
+			// SHA-256 — corrupt manifest, corrupt peer, or adversarial peer.
+			// Do NOT fall through to other peers; let the attempt-level retry
+			// handle it (delete-and-redownload semantics already in pullOnce).
+			if errors.Is(err, ErrChecksumMismatch) {
+				checksumMismatch = true
+				break
+			}
+			// File-not-on-peer and transport errors both fall through to the
+			// next candidate. Log at Debug so operators can see the fallback
+			// in action without drowning in noise when most peers have the
+			// file.
+			log.Debug().
 				Err(err).
 				Str("path", entry.Path).
 				Str("peer", peerAddr).
 				Int("attempt", attempt).
-				Int("max_attempts", p.cfg.RetryMaxAttempts).
-				Msg("File pull attempt failed")
-
-			if attempt >= p.cfg.RetryMaxAttempts {
-				p.totalFailed.Add(1)
-				log.Error().
-					Err(err).
-					Str("path", entry.Path).
-					Str("peer", peerAddr).
-					Msg("File pull giving up after max attempts (will be retried by next FSM callback or catch-up scan)")
-				return
-			}
-			p.sleepBackoff(attempt)
-			continue
+				Msg("Peer fetch failed, trying next candidate")
+		}
+		if pulledFromPeer {
+			return
 		}
 
-		// Success.
-		p.totalPulled.Add(1)
-		log.Info().
+		log.Warn().
+			Err(lastErr).
 			Str("path", entry.Path).
-			Str("peer", peerAddr).
-			Int64("size_bytes", entry.SizeBytes).
-			Int("attempts", attempt).
-			Msg("File pulled from peer")
-		return
+			Str("last_peer", lastPeer).
+			Int("peers_tried", len(peers)).
+			Int("attempt", attempt).
+			Int("max_attempts", p.cfg.RetryMaxAttempts).
+			Bool("checksum_mismatch", checksumMismatch).
+			Msg("File pull attempt failed on all candidate peers")
+
+		if attempt >= p.cfg.RetryMaxAttempts {
+			p.totalFailed.Add(1)
+			log.Error().
+				Err(lastErr).
+				Str("path", entry.Path).
+				Str("last_peer", lastPeer).
+				Int("peers_tried", len(peers)).
+				Msg("File pull giving up after max attempts (will be retried by next FSM callback or catch-up scan)")
+			return
+		}
+		p.sleepBackoff(attempt)
 	}
 }
 
@@ -422,5 +557,15 @@ func (p *Puller) sleepBackoff(attempt int) {
 // ErrChecksumMismatch is returned by Fetcher implementations when the bytes
 // pulled from a peer don't match the expected SHA-256 from the manifest.
 // The puller tracks this as a distinct metric and deletes the partial local
-// file before retrying.
+// file before retrying. Unlike ErrFileNotOnPeer, this error does NOT trigger
+// the multi-peer fallback — a corrupt body is a data integrity signal.
 var ErrChecksumMismatch = errors.New("filereplication: checksum mismatch")
+
+// ErrFileNotOnPeer is returned by Fetcher implementations when a peer
+// explicitly reports that it does not hold the requested file (via the ack
+// header Code field, or via a known error string from a Phase 2 peer). The
+// puller treats this as a fallback trigger: the next candidate in the
+// resolver's list is tried before the attempt is considered failed. This is
+// essential for Phase 3 catch-up after a Kubernetes pod rotation where the
+// original writer is gone but other peers still hold the file.
+var ErrFileNotOnPeer = errors.New("filereplication: file not on peer")

--- a/internal/cluster/filereplication/puller_test.go
+++ b/internal/cluster/filereplication/puller_test.go
@@ -739,6 +739,75 @@ func TestPullerMultiPeerAllFailMaxAttempts(t *testing.T) {
 	}
 }
 
+// TestPullerMultiPeerCtxCanceledEarlyExit verifies that when the puller is
+// stopped mid-attempt, the peer fallback loop exits immediately on the
+// first context.Canceled error rather than iterating through every
+// remaining candidate. Regression test for the Gemini Phase 3 review
+// finding — without the explicit check, a 10-peer cluster would burn
+// 10 wasted dial attempts + 10 debug log lines during shutdown.
+func TestPullerMultiPeerCtxCanceledEarlyExit(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newPerPeerFetcher()
+	// Peer 1: returns context.Canceled — simulates pullOnce observing
+	// that the puller's own context was cancelled mid-fetch.
+	fetcher.handle("1.1.1.1:9100", func(dst io.Writer) (int64, error) {
+		return 0, fmt.Errorf("simulated mid-fetch cancel: %w", context.Canceled)
+	})
+	// Peers 2 and 3: would fall through if called. The puller must NOT
+	// call either within the same attempt after seeing the cancel.
+	fetcher.handle("2.2.2.2:9100", func(dst io.Writer) (int64, error) {
+		return 0, fmt.Errorf("%w: file not found on local backend", ErrFileNotOnPeer)
+	})
+	fetcher.handle("3.3.3.3:9100", func(dst io.Writer) (int64, error) {
+		return 0, fmt.Errorf("%w: file not found on local backend", ErrFileNotOnPeer)
+	})
+	resolver := multiPeerResolver{addrs: []string{"1.1.1.1:9100", "2.2.2.2:9100", "3.3.3.3:9100"}}
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             1,
+		QueueSize:           4,
+		RetryMaxAttempts:    1,
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/ctxcancel.parquet", "writer-1", 100)
+	p.Enqueue(entry)
+
+	// Wait for the single attempt to complete. The walker returns from
+	// processEntry on ctx.Canceled without touching peers 2 or 3.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fetcher.total.Load() > 0 && p.Stats()["enqueued"] == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Give the worker a brief moment in case it were (incorrectly) iterating.
+	time.Sleep(50 * time.Millisecond)
+
+	if c := fetcher.callsFor("1.1.1.1:9100"); c != 1 {
+		t.Errorf("peer-1 calls: got %d, want 1", c)
+	}
+	if c := fetcher.callsFor("2.2.2.2:9100"); c != 0 {
+		t.Errorf("peer-2 calls: got %d, want 0 (ctx.Canceled must break the peer loop immediately)", c)
+	}
+	if c := fetcher.callsFor("3.3.3.3:9100"); c != 0 {
+		t.Errorf("peer-3 calls: got %d, want 0 (ctx.Canceled must break the peer loop immediately)", c)
+	}
+}
+
 // TestPullerMultiPeerChecksumMismatchDoesNotFallThrough is the regression
 // test for the "checksum mismatch breaks the peer loop" decision in the
 // Phase 3 plan. A corrupt body from peer-1 is a data integrity signal —

--- a/internal/cluster/filereplication/puller_test.go
+++ b/internal/cluster/filereplication/puller_test.go
@@ -3,6 +3,7 @@ package filereplication
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -112,12 +113,20 @@ func (f *fakeBackend) deleteCount() int {
 	return len(f.deletedPaths)
 }
 
-// fakeFetcher implements Fetcher with a scripted behavior.
+// fakeFetcher implements Fetcher with a scripted behavior. By default each
+// Fetch call consumes the next scripted result and returns an error after
+// the script runs out — useful for tests that care about exact per-call
+// sequencing. Setting repeat=true causes the last scripted result to be
+// returned on all subsequent calls, which is what tests that care about
+// "same behavior forever, just count calls" (dedup, catch-up walk) want.
 type fakeFetcher struct {
 	mu sync.Mutex
 	// Per-call scripted results. index == call number (0-based).
 	results []fakeFetchResult
-	calls   atomic.Int64
+	// If true, the last result is returned on every call past len(results).
+	// If false, exhausted calls return an error (catches unexpected retries).
+	repeat bool
+	calls  atomic.Int64
 }
 
 type fakeFetchResult struct {
@@ -129,13 +138,29 @@ func newFakeFetcher(results ...fakeFetchResult) *fakeFetcher {
 	return &fakeFetcher{results: results}
 }
 
+// newRepeatingFetcher returns a fakeFetcher that yields the same successful
+// body on every call, forever. Used by catch-up tests that drive many
+// distinct entries through a single fetcher and care only about counts.
+func newRepeatingFetcher(body []byte) *fakeFetcher {
+	return &fakeFetcher{
+		results: []fakeFetchResult{{body: body}},
+		repeat:  true,
+	}
+}
+
 func (f *fakeFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
 	idx := f.calls.Add(1) - 1
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if int(idx) >= len(f.results) {
-		// Default: return error to force retries to stop
-		return 0, errors.New("fake fetcher: no more scripted results")
+		if f.repeat && len(f.results) > 0 {
+			// Replay the last scripted result.
+			idx = int64(len(f.results) - 1)
+		} else {
+			// Unscripted overflow — tests that care about exact sequencing
+			// want to see this as an error rather than a silent no-op.
+			return 0, errors.New("fake fetcher: no more scripted results")
+		}
 	}
 	r := f.results[idx]
 	if r.err != nil {
@@ -150,18 +175,83 @@ func (f *fakeFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.Fi
 	return int64(n), err
 }
 
-// staticResolver maps a single node ID to a fixed address.
+// perPeerFetcher dispatches Fetch calls based on the peer address. Used to
+// exercise the multi-peer fallback loop inside processEntry: script one
+// behavior for peer A and another for peer B, then observe whether the
+// puller correctly falls through when A fails.
+type perPeerFetcher struct {
+	mu       sync.Mutex
+	handlers map[string]func(dst io.Writer) (int64, error)
+	// calls keeps a per-peer call count so tests can assert exact behavior.
+	calls map[string]*atomic.Int64
+	// total is the aggregate call count across all peers.
+	total atomic.Int64
+}
+
+func newPerPeerFetcher() *perPeerFetcher {
+	return &perPeerFetcher{
+		handlers: make(map[string]func(dst io.Writer) (int64, error)),
+		calls:    make(map[string]*atomic.Int64),
+	}
+}
+
+func (f *perPeerFetcher) handle(peerAddr string, fn func(dst io.Writer) (int64, error)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers[peerAddr] = fn
+	if _, ok := f.calls[peerAddr]; !ok {
+		f.calls[peerAddr] = new(atomic.Int64)
+	}
+}
+
+func (f *perPeerFetcher) callsFor(peerAddr string) int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if c, ok := f.calls[peerAddr]; ok {
+		return c.Load()
+	}
+	return 0
+}
+
+func (f *perPeerFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
+	f.total.Add(1)
+	f.mu.Lock()
+	fn, ok := f.handlers[peerAddr]
+	counter := f.calls[peerAddr]
+	f.mu.Unlock()
+	if !ok {
+		return 0, fmt.Errorf("perPeerFetcher: no handler registered for %s", peerAddr)
+	}
+	if counter != nil {
+		counter.Add(1)
+	}
+	return fn(dst)
+}
+
+// multiPeerResolver returns a fixed list of peer addresses, regardless of
+// origin or path. Used by the multi-peer fallback tests.
+type multiPeerResolver struct {
+	addrs []string
+}
+
+func (r multiPeerResolver) ResolvePeers(_, _ string) []string {
+	return r.addrs
+}
+
+// staticResolver maps a single origin node ID to a fixed list of addresses.
+// ok=false simulates "origin not in registry"; the puller treats an empty
+// slice as no candidates and defers.
 type staticResolver struct {
 	nodeID string
-	addr   string
+	addrs  []string
 	ok     bool
 }
 
-func (s staticResolver) ResolvePeer(nodeID string) (string, bool) {
-	if nodeID != s.nodeID {
-		return "", false
+func (s staticResolver) ResolvePeers(originNodeID, _ string) []string {
+	if !s.ok || originNodeID != s.nodeID {
+		return nil
 	}
-	return s.addr, s.ok
+	return s.addrs
 }
 
 // --- Helpers -------------------------------------------------------------
@@ -222,7 +312,7 @@ func TestPullerHappyPath(t *testing.T) {
 	backend := newFakeBackend()
 	body := []byte("parquet body bytes")
 	fetcher := newFakeFetcher(fakeFetchResult{body: body})
-	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
 
 	p := newTestPuller(t, backend, fetcher, resolver)
 	p.Start(context.Background())
@@ -251,7 +341,7 @@ func TestPullerHappyPath(t *testing.T) {
 func TestPullerSkipsSelfOrigin(t *testing.T) {
 	backend := newFakeBackend()
 	fetcher := newFakeFetcher() // no scripted results — any call is a bug
-	resolver := staticResolver{nodeID: "reader-1", addr: "self:9100", ok: true}
+	resolver := staticResolver{nodeID: "reader-1", addrs: []string{"self:9100"}, ok: true}
 
 	p := newTestPuller(t, backend, fetcher, resolver)
 	p.Start(context.Background())
@@ -279,7 +369,7 @@ func TestPullerSkipsAlreadyLocalFile(t *testing.T) {
 	// Pre-populate: the file already exists locally.
 	_ = backend.Write(context.Background(), "testdb/cpu/existing.parquet", []byte("old bytes"))
 	fetcher := newFakeFetcher() // should never be called
-	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
 
 	p := newTestPuller(t, backend, fetcher, resolver)
 	p.Start(context.Background())
@@ -305,7 +395,7 @@ func TestPullerRetriesAndGivesUp(t *testing.T) {
 		fakeFetchResult{err: errors.New("dial refused")},
 		fakeFetchResult{err: errors.New("dial refused")},
 	)
-	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
 
 	p := newTestPuller(t, backend, fetcher, resolver)
 	p.Start(context.Background())
@@ -334,7 +424,7 @@ func TestPullerChecksumMismatchDeletesAndCounts(t *testing.T) {
 		fakeFetchResult{body: []byte("corrupt"), err: ErrChecksumMismatch},
 		fakeFetchResult{body: goodBody},
 	)
-	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
 
 	p := newTestPuller(t, backend, fetcher, resolver)
 	p.Start(context.Background())
@@ -367,7 +457,7 @@ func TestPullerPeerLookupFailure(t *testing.T) {
 	backend := newFakeBackend()
 	fetcher := newFakeFetcher() // never called
 	// Resolver returns ok=false for everything.
-	resolver := staticResolver{nodeID: "unknown", addr: "", ok: false}
+	resolver := staticResolver{nodeID: "unknown", addrs: nil, ok: false}
 
 	p := newTestPuller(t, backend, fetcher, resolver)
 	p.Start(context.Background())
@@ -391,7 +481,7 @@ func TestPullerQueueDropUnderOverload(t *testing.T) {
 	// busy so the queue fills up.
 	blockCh := make(chan struct{})
 	fetcher := &blockingFetcher{release: blockCh}
-	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
 
 	p, err := New(Config{
 		SelfNodeID:          "reader-1",
@@ -415,11 +505,13 @@ func TestPullerQueueDropUnderOverload(t *testing.T) {
 		p.Stop()
 	}()
 
-	// Enqueue many more than QueueSize+inflight (1).
-	// With Workers=1 and QueueSize=2, at most ~3 entries can land before drops.
+	// Enqueue many DISTINCT paths, more than QueueSize+inflight (1). With
+	// Workers=1 and QueueSize=2, at most ~3 entries can land before drops.
+	// Distinct paths matter now: Phase 3 dedups identical paths via the
+	// inflight set, so we need unique paths to exercise queue overflow.
 	const totalEnqueued = 50
 	for i := 0; i < totalEnqueued; i++ {
-		entry := makeEntry("testdb/cpu/overload.parquet", "writer-1", 100)
+		entry := makeEntry(fmt.Sprintf("testdb/cpu/overload-%04d.parquet", i), "writer-1", 100)
 		p.Enqueue(entry)
 	}
 
@@ -429,6 +521,61 @@ func TestPullerQueueDropUnderOverload(t *testing.T) {
 	}
 	if stats["enqueued"]+stats["dropped"] != int64(totalEnqueued) {
 		t.Errorf("enqueued(%d) + dropped(%d) != total(%d)", stats["enqueued"], stats["dropped"], totalEnqueued)
+	}
+	if stats["skipped_dup"] != 0 {
+		t.Errorf("distinct paths should not dedup, got skipped_dup=%d", stats["skipped_dup"])
+	}
+}
+
+// TestPullerEnqueueDedup verifies that concurrent enqueues of the same path
+// are deduplicated via the inflight set — essential for Phase 3 so the
+// catch-up walker and reactive FSM callbacks don't double-pull a file when
+// they race on a new write committing mid-walk.
+func TestPullerEnqueueDedup(t *testing.T) {
+	backend := newFakeBackend()
+	// Blocking fetcher keeps the single worker busy on the first entry so
+	// the inflight slot is held while we hammer Enqueue with duplicates.
+	blockCh := make(chan struct{})
+	fetcher := &blockingFetcher{release: blockCh}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             1,
+		QueueSize:           16,
+		RetryMaxAttempts:    1,
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        5 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer func() {
+		close(blockCh)
+		p.Stop()
+	}()
+
+	const dupCount = 50
+	for i := 0; i < dupCount; i++ {
+		entry := makeEntry("testdb/cpu/dedup.parquet", "writer-1", 100)
+		p.Enqueue(entry)
+	}
+
+	stats := p.Stats()
+	// Exactly one enqueue should succeed; the rest should be deduped.
+	if stats["enqueued"] != 1 {
+		t.Errorf("expected exactly 1 enqueued, got %d (stats=%+v)", stats["enqueued"], stats)
+	}
+	if stats["skipped_dup"] != int64(dupCount-1) {
+		t.Errorf("expected %d skipped_dup, got %d", dupCount-1, stats["skipped_dup"])
+	}
+	if stats["dropped"] != 0 {
+		t.Errorf("expected 0 dropped (queue is larger than dup count), got %d", stats["dropped"])
 	}
 }
 
@@ -452,13 +599,207 @@ func (b *blockingFetcher) Fetch(ctx context.Context, peerAddr string, entry *raf
 func TestPullerStartStopIdempotent(t *testing.T) {
 	backend := newFakeBackend()
 	fetcher := newFakeFetcher()
-	resolver := staticResolver{nodeID: "writer-1", addr: "1.2.3.4:9100", ok: true}
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
 
 	p := newTestPuller(t, backend, fetcher, resolver)
 	p.Start(context.Background())
 	p.Start(context.Background()) // second call should be a no-op
 	p.Stop()
 	p.Stop() // second stop should be a no-op
+}
+
+// --- Phase 3 tests: multi-peer fallback in processEntry ---
+
+// TestPullerMultiPeerFallbackOnNotFound is the core Phase 3 test: the first
+// peer in the resolver's list returns ErrFileNotOnPeer (the Kubernetes
+// rotation case — original writer is gone or replaced) and the second peer
+// succeeds. The puller must call peer-2 within the same attempt, not after
+// a full retry cycle.
+func TestPullerMultiPeerFallbackOnNotFound(t *testing.T) {
+	backend := newFakeBackend()
+	body := []byte("fallback body")
+	fetcher := newPerPeerFetcher()
+	// Peer 1: the "dead" origin — doesn't have the file.
+	fetcher.handle("1.1.1.1:9100", func(dst io.Writer) (int64, error) {
+		return 0, fmt.Errorf("%w: file not found on local backend", ErrFileNotOnPeer)
+	})
+	// Peer 2: a healthy fallback peer that does have the file.
+	fetcher.handle("2.2.2.2:9100", func(dst io.Writer) (int64, error) {
+		n, _ := dst.Write(body)
+		return int64(n), nil
+	})
+	resolver := multiPeerResolver{addrs: []string{"1.1.1.1:9100", "2.2.2.2:9100"}}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/fallback.parquet", "writer-1", int64(len(body)))
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["pulled"] == 1
+	})
+	if stats["pulled"] != 1 {
+		t.Errorf("pulled: got %d, want 1", stats["pulled"])
+	}
+	if stats["failed"] != 0 {
+		t.Errorf("failed: got %d, want 0 (fallback should succeed)", stats["failed"])
+	}
+	if c := fetcher.callsFor("1.1.1.1:9100"); c != 1 {
+		t.Errorf("peer-1 calls: got %d, want 1", c)
+	}
+	if c := fetcher.callsFor("2.2.2.2:9100"); c != 1 {
+		t.Errorf("peer-2 calls: got %d, want 1", c)
+	}
+}
+
+// TestPullerMultiPeerFallbackOnTransportError verifies that a dial error
+// (or any non-checksum, non-not-found error) also triggers fallback to the
+// next candidate peer, not just the "not found" signal.
+func TestPullerMultiPeerFallbackOnTransportError(t *testing.T) {
+	backend := newFakeBackend()
+	body := []byte("transport body")
+	fetcher := newPerPeerFetcher()
+	// Peer 1: transport error (dial failure, network timeout, etc).
+	fetcher.handle("1.1.1.1:9100", func(dst io.Writer) (int64, error) {
+		return 0, errors.New("dial tcp 1.1.1.1:9100: connect: connection refused")
+	})
+	// Peer 2: healthy.
+	fetcher.handle("2.2.2.2:9100", func(dst io.Writer) (int64, error) {
+		n, _ := dst.Write(body)
+		return int64(n), nil
+	})
+	resolver := multiPeerResolver{addrs: []string{"1.1.1.1:9100", "2.2.2.2:9100"}}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/transport.parquet", "writer-1", int64(len(body)))
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["pulled"] == 1
+	})
+	if stats["pulled"] != 1 {
+		t.Errorf("pulled: got %d, want 1 (should have fallen through to peer-2)", stats["pulled"])
+	}
+	if c := fetcher.callsFor("2.2.2.2:9100"); c != 1 {
+		t.Errorf("peer-2 calls: got %d, want 1", c)
+	}
+}
+
+// TestPullerMultiPeerAllFailMaxAttempts verifies that when every candidate
+// peer returns ErrFileNotOnPeer, the puller counts it as one failed attempt
+// (tries all peers within that attempt) and eventually gives up after
+// RetryMaxAttempts attempts.
+func TestPullerMultiPeerAllFailMaxAttempts(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newPerPeerFetcher()
+	fetcher.handle("1.1.1.1:9100", func(dst io.Writer) (int64, error) {
+		return 0, fmt.Errorf("%w: file not found on local backend", ErrFileNotOnPeer)
+	})
+	fetcher.handle("2.2.2.2:9100", func(dst io.Writer) (int64, error) {
+		return 0, fmt.Errorf("%w: file not found on local backend", ErrFileNotOnPeer)
+	})
+	resolver := multiPeerResolver{addrs: []string{"1.1.1.1:9100", "2.2.2.2:9100"}}
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             1,
+		QueueSize:           4,
+		RetryMaxAttempts:    2,
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/lost.parquet", "writer-1", 100)
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["failed"] == 1
+	})
+	if stats["failed"] != 1 {
+		t.Errorf("failed: got %d, want 1", stats["failed"])
+	}
+	// 2 attempts × 2 peers each = 4 total fetcher calls.
+	total := fetcher.total.Load()
+	if total != 4 {
+		t.Errorf("total fetcher calls: got %d, want 4 (2 attempts × 2 peers)", total)
+	}
+}
+
+// TestPullerMultiPeerChecksumMismatchDoesNotFallThrough is the regression
+// test for the "checksum mismatch breaks the peer loop" decision in the
+// Phase 3 plan. A corrupt body from peer-1 is a data integrity signal —
+// the puller should NOT then try peer-2 within the same attempt (which
+// would pull-and-corrupt from every healthy peer in turn). Instead it
+// delete-and-retries on the next attempt.
+func TestPullerMultiPeerChecksumMismatchDoesNotFallThrough(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newPerPeerFetcher()
+	// Peer 1: returns a checksum mismatch. The puller must short-circuit
+	// out of the per-attempt peer loop.
+	fetcher.handle("1.1.1.1:9100", func(dst io.Writer) (int64, error) {
+		return 0, ErrChecksumMismatch
+	})
+	// Peer 2: would succeed if called. The puller must NOT call it within
+	// the same attempt.
+	peer2Called := atomic.Int64{}
+	fetcher.handle("2.2.2.2:9100", func(dst io.Writer) (int64, error) {
+		peer2Called.Add(1)
+		return 0, ErrChecksumMismatch
+	})
+	resolver := multiPeerResolver{addrs: []string{"1.1.1.1:9100", "2.2.2.2:9100"}}
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        resolver,
+		Workers:             1,
+		QueueSize:           4,
+		RetryMaxAttempts:    1, // one attempt — no retries, so we can count peers precisely
+		RetryInitialBackoff: 10 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/corrupt.parquet", "writer-1", 100)
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["failed"] == 1
+	})
+	if stats["failed"] != 1 {
+		t.Errorf("failed: got %d, want 1", stats["failed"])
+	}
+	if stats["checksum_mismatch"] != 1 {
+		t.Errorf("checksum_mismatch: got %d, want 1", stats["checksum_mismatch"])
+	}
+	// Critical assertion: peer-2 must NOT have been called within the same
+	// attempt after peer-1's checksum mismatch.
+	if c := fetcher.callsFor("1.1.1.1:9100"); c != 1 {
+		t.Errorf("peer-1 calls: got %d, want 1", c)
+	}
+	if c := fetcher.callsFor("2.2.2.2:9100"); c != 0 {
+		t.Errorf("peer-2 calls: got %d, want 0 (checksum mismatch must break the peer loop)", c)
+	}
 }
 
 func TestPullerConfigValidation(t *testing.T) {

--- a/internal/cluster/filereplication_catchup_integration_test.go
+++ b/internal/cluster/filereplication_catchup_integration_test.go
@@ -1,0 +1,321 @@
+package cluster
+
+// End-to-end integration tests for Phase 3 peer file replication catch-up.
+//
+// These tests wire the real handleFetchFile server (via startOriginServer)
+// to the real filereplication.FetchClient + Puller + RunCatchUp path. They
+// reuse the helpers from filereplication_integration_test.go — memBackend,
+// seedFileInFSM, originServer — so a change to the Phase 2 integration
+// surface is a compile-time break here.
+//
+// What Phase 3 catch-up must do:
+//   1. On startup (simulated by calling Puller.RunCatchUp with the full
+//      FSM snapshot), enqueue every manifest entry whose local backend
+//      copy is missing.
+//   2. Try the multi-peer fallback list in order — origin first, then
+//      healthy peers — until one responds with the file bytes.
+//   3. Stop trying other peers on checksum mismatch (data integrity
+//      short-circuit).
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/filereplication"
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	hraft "github.com/hashicorp/raft"
+	"github.com/rs/zerolog"
+)
+
+// seedMultipleFilesInFSM applies N register-file commands to a fresh FSM.
+// Unlike seedFileInFSM (which hardcodes index=1), this uses distinct indices
+// so the FSM accepts all of them. Returns the assembled entries for use as
+// the catch-up walker input.
+func seedMultipleFilesInFSM(t *testing.T, fsm *raft.ClusterFSM, entries []raft.FileEntry) []*raft.FileEntry {
+	t.Helper()
+	out := make([]*raft.FileEntry, 0, len(entries))
+	for i, entry := range entries {
+		payload, err := json.Marshal(raft.RegisterFilePayload{File: entry})
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		cmd := raft.Command{Type: raft.CommandRegisterFile, Payload: payload}
+		data, err := json.Marshal(cmd)
+		if err != nil {
+			t.Fatalf("marshal command: %v", err)
+		}
+		result := fsm.Apply(&hraft.Log{Index: uint64(i + 1), Data: data})
+		if err, ok := result.(error); ok && err != nil {
+			t.Fatalf("fsm.Apply entry %d: %v", i, err)
+		}
+		entryCopy := entry
+		out = append(out, &entryCopy)
+	}
+	return out
+}
+
+// makeFileEntry builds a FileEntry whose SHA256 is the actual hash of the
+// body bytes — required for integration tests because the real fetch client
+// verifies the body against the entry's SHA256 field. The unit-level helper
+// makeEntry in filereplication/puller_test.go stubs the hash as "deadbeef"
+// because its fake fetcher skips verification; keeping these helpers
+// separate avoids dragging body-hashing into every puller unit test.
+func makeFileEntry(path string, body []byte, originID string) raft.FileEntry {
+	sum := sha256.Sum256(body)
+	return raft.FileEntry{
+		Path:          path,
+		SHA256:        hex.EncodeToString(sum[:]),
+		SizeBytes:     int64(len(body)),
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2026, 4, 11, 14, 0, 0, 0, time.UTC),
+		OriginNodeID:  originID,
+		Tier:          "hot",
+		CreatedAt:     time.Date(2026, 4, 11, 15, 0, 0, 0, time.UTC),
+	}
+}
+
+// buildCatchUpPuller constructs a puller wired to a fresh backend and a
+// resolver that returns the given peer addresses in order. Returns the
+// puller, its backend, and a stop function.
+func buildCatchUpPuller(t *testing.T, selfID string, peerAddrs []string) (*filereplication.Puller, *memBackend, func()) {
+	t.Helper()
+	backend := newMemBackend()
+	fetchClient, err := filereplication.NewFetchClient(filereplication.FetchClient{
+		SelfNodeID:   selfID,
+		ClusterName:  "test-cluster",
+		SharedSecret: "catchup-secret",
+		DialTimeout:  2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewFetchClient: %v", err)
+	}
+
+	resolver := filereplication.NewRegistryResolver(func(_, _ string) []string {
+		return peerAddrs
+	})
+
+	p, err := filereplication.New(filereplication.Config{
+		SelfNodeID:            selfID,
+		Backend:               backend,
+		Fetcher:               fetchClient,
+		PeerResolver:          resolver,
+		Workers:               2,
+		QueueSize:             32,
+		RetryMaxAttempts:      2,
+		RetryInitialBackoff:   10 * time.Millisecond,
+		FetchTimeout:          5 * time.Second,
+		CatchUpQueueHighWater: 0.8,
+		Logger:                zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New puller: %v", err)
+	}
+	p.Start(context.Background())
+	return p, backend, p.Stop
+}
+
+// waitForCatchUp polls puller stats until pulled + failed reaches target,
+// or the deadline expires. Returns the final stats.
+func waitForCatchUp(t *testing.T, p *filereplication.Puller, target int64) map[string]int64 {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		s := p.Stats()
+		if s["pulled"]+s["failed"] >= target {
+			return s
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return p.Stats()
+}
+
+// --- Test 1: happy path — catch-up pulls all missing files from origin ---
+
+func TestPhase3CatchUpHappyPath(t *testing.T) {
+	const (
+		originID = "writer-1"
+		readerID = "reader-1"
+	)
+
+	// Seed 10 files into the origin's backend and FSM.
+	originBackend := newMemBackend()
+	originFSM := raft.NewClusterFSM(zerolog.Nop())
+	rawEntries := make([]raft.FileEntry, 10)
+	for i := range rawEntries {
+		body := []byte(fmt.Sprintf("file-%02d body bytes here", i))
+		path := fmt.Sprintf("testdb/cpu/2026/04/11/18/catchup-%02d.parquet", i)
+		if err := originBackend.Write(context.Background(), path, body); err != nil {
+			t.Fatalf("seed backend: %v", err)
+		}
+		rawEntries[i] = makeFileEntry(path, body, originID)
+	}
+	entries := seedMultipleFilesInFSM(t, originFSM, rawEntries)
+
+	origin := startOriginServer(t, originBackend, originFSM, "catchup-secret", "test-cluster", originID)
+	defer origin.stop()
+
+	// Build the reader's puller pointing at the origin.
+	puller, readerBackend, stop := buildCatchUpPuller(t, readerID, []string{origin.addr()})
+	defer stop()
+
+	// Run catch-up with the full manifest — every entry is missing locally.
+	puller.RunCatchUp(context.Background(), entries)
+
+	stats := waitForCatchUp(t, puller, 10)
+	if stats["pulled"] != 10 {
+		t.Errorf("pulled: got %d, want 10 (stats=%+v)", stats["pulled"], stats)
+	}
+	if stats["failed"] != 0 {
+		t.Errorf("failed: got %d, want 0", stats["failed"])
+	}
+	if stats["catchup_entries_walked"] != 10 {
+		t.Errorf("catchup_entries_walked: got %d, want 10", stats["catchup_entries_walked"])
+	}
+	if stats["catchup_enqueued"] != 10 {
+		t.Errorf("catchup_enqueued: got %d, want 10", stats["catchup_enqueued"])
+	}
+	if stats["catchup_completed_at"] == 0 {
+		t.Errorf("catchup_completed_at should be non-zero")
+	}
+
+	// Every file should now exist in the reader's backend with correct bytes.
+	for _, e := range rawEntries {
+		got, err := readerBackend.Read(context.Background(), e.Path)
+		if err != nil {
+			t.Errorf("reader backend missing %s: %v", e.Path, err)
+			continue
+		}
+		sum := sha256.Sum256(got)
+		if hex.EncodeToString(sum[:]) != e.SHA256 {
+			t.Errorf("reader hash mismatch for %s", e.Path)
+		}
+	}
+}
+
+// --- Test 2: origin absent, fallback succeeds via any-peer ---
+//
+// This is the Kubernetes rotation case: the original writer pod is gone,
+// but a sibling peer still holds the files. Catch-up must succeed via the
+// fallback resolver. Simulated here by leaving the "origin" slot empty and
+// only passing a non-origin peer address to the resolver.
+
+func TestPhase3CatchUpOriginAbsentFallbackSucceeds(t *testing.T) {
+	const (
+		originID = "writer-1" // the long-gone original writer
+		peerID   = "peer-2"   // the fallback peer that still has the files
+		readerID = "reader-1"
+	)
+
+	// Seed the files only on peer-2. Origin (writer-1) has no backend here —
+	// it was scheduled to a different pod and is gone.
+	peerBackend := newMemBackend()
+	peerFSM := raft.NewClusterFSM(zerolog.Nop())
+	rawEntries := []raft.FileEntry{
+		makeFileEntry("testdb/cpu/rotate-a.parquet", []byte("rotate-a body"), originID),
+		makeFileEntry("testdb/cpu/rotate-b.parquet", []byte("rotate-b body bytes"), originID),
+	}
+	for _, e := range rawEntries {
+		body := []byte(fmt.Sprintf("unused")) // filled below
+		switch e.Path {
+		case "testdb/cpu/rotate-a.parquet":
+			body = []byte("rotate-a body")
+		case "testdb/cpu/rotate-b.parquet":
+			body = []byte("rotate-b body bytes")
+		}
+		if err := peerBackend.Write(context.Background(), e.Path, body); err != nil {
+			t.Fatalf("seed peer backend: %v", err)
+		}
+	}
+	entries := seedMultipleFilesInFSM(t, peerFSM, rawEntries)
+
+	// peer-2 serves fetches. The resolver won't even mention origin — the
+	// coordinator's registry-backed resolver would have already filtered it
+	// out as unhealthy.
+	peer := startOriginServer(t, peerBackend, peerFSM, "catchup-secret", "test-cluster", peerID)
+	defer peer.stop()
+
+	puller, readerBackend, stop := buildCatchUpPuller(t, readerID, []string{peer.addr()})
+	defer stop()
+
+	puller.RunCatchUp(context.Background(), entries)
+
+	stats := waitForCatchUp(t, puller, 2)
+	if stats["pulled"] != 2 {
+		t.Errorf("pulled: got %d, want 2 — fallback from absent origin to peer-2 should succeed (stats=%+v)", stats["pulled"], stats)
+	}
+	for _, e := range rawEntries {
+		if _, err := readerBackend.Read(context.Background(), e.Path); err != nil {
+			t.Errorf("reader backend missing %s after fallback: %v", e.Path, err)
+		}
+	}
+}
+
+// --- Test 3: no peer has the file ---
+//
+// Both candidate peers respond "file not found on local backend". The
+// puller should try every peer per attempt, exhaust retries, and count
+// the entry as failed. Reader backend stays empty.
+
+func TestPhase3CatchUpNoPeerHasFile(t *testing.T) {
+	const (
+		originID = "writer-1"
+		readerID = "reader-1"
+	)
+
+	// Empty backends — neither peer has the files, even though the FSM
+	// manifest knows about them.
+	backend1 := newMemBackend()
+	backend2 := newMemBackend()
+
+	// Both peers share the same FSM manifest contents (so the path is
+	// known), but the files don't exist on disk, so handleFetchFile
+	// responds with Code="not_found" via the existence check.
+	rawEntries := []raft.FileEntry{
+		makeFileEntry("testdb/cpu/missing.parquet", []byte("will never be served"), originID),
+	}
+
+	fsm1 := raft.NewClusterFSM(zerolog.Nop())
+	_ = seedMultipleFilesInFSM(t, fsm1, rawEntries)
+	fsm2 := raft.NewClusterFSM(zerolog.Nop())
+	_ = seedMultipleFilesInFSM(t, fsm2, rawEntries)
+
+	peer1 := startOriginServer(t, backend1, fsm1, "catchup-secret", "test-cluster", "peer-1")
+	defer peer1.stop()
+	peer2 := startOriginServer(t, backend2, fsm2, "catchup-secret", "test-cluster", "peer-2")
+	defer peer2.stop()
+
+	// Rebuild entries as pointers for RunCatchUp.
+	entries := make([]*raft.FileEntry, len(rawEntries))
+	for i := range rawEntries {
+		e := rawEntries[i]
+		entries[i] = &e
+	}
+
+	puller, readerBackend, stop := buildCatchUpPuller(t, readerID, []string{peer1.addr(), peer2.addr()})
+	defer stop()
+
+	puller.RunCatchUp(context.Background(), entries)
+
+	stats := waitForCatchUp(t, puller, 1)
+	if stats["failed"] != 1 {
+		t.Errorf("failed: got %d, want 1 (no peer has the file; catch-up should give up cleanly) — stats=%+v", stats["failed"], stats)
+	}
+	if stats["pulled"] != 0 {
+		t.Errorf("pulled: got %d, want 0", stats["pulled"])
+	}
+	// Reader backend must remain empty.
+	if exists, _ := readerBackend.Exists(context.Background(), "testdb/cpu/missing.parquet"); exists {
+		t.Errorf("reader backend should be empty after failed catch-up")
+	}
+}
+
+// Ensure io.Discard is used elsewhere so this file's imports compile even
+// in the absence of other references. (Static unused-var protection.)
+var _ = io.Discard

--- a/internal/cluster/protocol/messages.go
+++ b/internal/cluster/protocol/messages.go
@@ -165,13 +165,58 @@ type FetchFileRequest struct {
 	HMAC      string `json:"hmac"`
 }
 
+// Phase 2 fetch-ack error reasons — human-readable strings the Phase 2
+// server emits in FetchFileAckHeader.Error. Phase 3 added the typed Code
+// field above, but these strings remain the compatibility contract: a
+// Phase 3 puller talking to a Phase 2 peer (no Code field) falls back to
+// exact-match on these constants to decide whether a negative ack should
+// trigger multi-peer fallback. Changing these strings is a wire-protocol
+// break against Phase 2 peers — add new codes instead.
+const (
+	ErrMsgFileNotInManifest = "file not in manifest"
+	ErrMsgFileNotFound      = "file not found on local backend"
+)
+
+// AckErrorCode is a machine-readable error category on FetchFileAckHeader,
+// added in Phase 3 so the puller can implement multi-peer fallback without
+// brittle substring matching on human-readable error text. An empty code
+// means either Status == "ok" or the remote is a Phase 2 peer that predates
+// this field — the fetch client falls back to exact-match on Error in that
+// case.
+type AckErrorCode string
+
+const (
+	// AckCodeNotFound: the peer does not have the requested file in its
+	// local backend. The puller treats this as a fallback trigger and tries
+	// the next candidate peer within the same attempt.
+	AckCodeNotFound AckErrorCode = "not_found"
+	// AckCodeManifest: the peer does not have an entry for the requested
+	// path in its Raft FSM manifest. Also triggers fallback.
+	AckCodeManifest AckErrorCode = "manifest"
+	// AckCodeAuth: HMAC validation failed. Does NOT trigger fallback — a
+	// cluster-wide shared-secret mismatch would silently fall through every
+	// peer and hide the real misconfiguration.
+	AckCodeAuth AckErrorCode = "auth"
+	// AckCodeBackend: the peer's local storage backend returned an error
+	// (Exists check failed, backend not configured, etc.). Does not fall
+	// through — surfaces as an attempt failure so operators see the problem.
+	AckCodeBackend AckErrorCode = "backend"
+	// AckCodeRaft: the peer's Raft node is unavailable (no FSM, not yet
+	// bootstrapped). Does not fall through.
+	AckCodeRaft AckErrorCode = "raft"
+	// AckCodeInvalidPath: path sanitization rejected the request (null
+	// byte, absolute path, traversal). Does not fall through.
+	AckCodeInvalidPath AckErrorCode = "invalid_path"
+)
+
 // FetchFileAckHeader is the response header for a fetch request. If Status is
 // "ok" the origin will immediately write SizeBytes of raw body content directly
 // to the TCP connection (NOT wrapped in another protocol envelope — the body is
 // read with io.CopyN on the raw conn). If Status is "error" no body follows.
 type FetchFileAckHeader struct {
-	Status    string `json:"status"`          // "ok" or "error"
-	Error     string `json:"error,omitempty"` // populated when Status == "error"
-	SizeBytes int64  `json:"size_bytes"`
-	SHA256    string `json:"sha256"` // hex-encoded; must match manifest SHA256
+	Status    string       `json:"status"`          // "ok" or "error"
+	Code      AckErrorCode `json:"code,omitempty"`  // machine-readable error category (Phase 3)
+	Error     string       `json:"error,omitempty"` // populated when Status == "error"
+	SizeBytes int64        `json:"size_bytes"`
+	SHA256    string       `json:"sha256"` // hex-encoded; must match manifest SHA256
 }

--- a/internal/cluster/raft/node.go
+++ b/internal/cluster/raft/node.go
@@ -439,6 +439,28 @@ func (n *Node) WaitForLeader(timeout time.Duration) error {
 	}
 }
 
+// Barrier issues a Raft barrier and waits for every log entry already
+// committed before the call to be applied to the local FSM. After Barrier
+// returns without error, a GetAllFiles() read on the FSM reflects every
+// file that was committed before Barrier was invoked — i.e. the caller
+// gets "read your writes up to now" semantics against the cluster state.
+//
+// This is the synchronization point the Phase 3 catch-up walker uses on
+// startup: after the node joins (or after a restart), we wait for any
+// backlog of log entries to apply before walking the manifest, so catch-up
+// doesn't run against a stale view of the cluster's files.
+//
+// Followers can call Barrier too — it waits until local apply catches up to
+// the follower's own commit index, not the leader's. On timeout (e.g.
+// follower far behind the leader), Barrier returns an error and the caller
+// is expected to fall through to its best-effort behavior.
+func (n *Node) Barrier(timeout time.Duration) error {
+	if n.raft == nil {
+		return fmt.Errorf("raft not started")
+	}
+	return n.raft.Barrier(timeout).Error()
+}
+
 // AddNode adds a node to the cluster state via Raft.
 func (n *Node) AddNode(node *NodeInfo, timeout time.Duration) error {
 	payload, err := json.Marshal(AddNodePayload{Node: *node})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -341,6 +341,13 @@ type ClusterConfig struct {
 	ReplicationServeTimeoutMs   int // Origin-side body-stream timeout in milliseconds (default: 120000). Raise for large files or slow links.
 	ReplicationRetryMaxAttempts int // Max immediate retry attempts per enqueue (default: 3)
 
+	// Peer file replication catch-up (Phase 3). These control the startup
+	// reconciliation walker that brings a new or restarted node back into
+	// sync with the cluster manifest.
+	ReplicationCatchUpEnabled           bool    // Master switch for the catch-up walker. Emergency off-switch for pathologically large manifests. (default: true)
+	ReplicationCatchUpBarrierTimeoutMs  int     // Raft barrier timeout before walking the manifest — ensures the local FSM has applied every committed entry. (default: 10000)
+	ReplicationCatchUpQueueHighWater    float64 // Queue-depth fraction above which the walker pauses enqueueing. Keeps the walker from racing workers on large manifests. (default: 0.8)
+
 	// Sharding configuration (Phase 4)
 	ShardingEnabled           bool   // Enable sharding for horizontal write scaling (default: false)
 	ShardingNumShards         int    // Number of shards (default: 3)
@@ -567,11 +574,14 @@ func Load() (*Config, error) {
 			ReplicationBufferSize:  v.GetInt("cluster.replication_buffer_size"),
 			ReplicationAckInterval: v.GetInt("cluster.replication_ack_interval"),
 			// Peer file replication (Enterprise Phase 2)
-			ReplicationPullWorkers:      v.GetInt("cluster.replication_pull_workers"),
-			ReplicationQueueSize:        v.GetInt("cluster.replication_queue_size"),
-			ReplicationFetchTimeoutMs:   v.GetInt("cluster.replication_fetch_timeout_ms"),
-			ReplicationServeTimeoutMs:   v.GetInt("cluster.replication_serve_timeout_ms"),
-			ReplicationRetryMaxAttempts: v.GetInt("cluster.replication_retry_max_attempts"),
+			ReplicationPullWorkers:             v.GetInt("cluster.replication_pull_workers"),
+			ReplicationQueueSize:               v.GetInt("cluster.replication_queue_size"),
+			ReplicationFetchTimeoutMs:          v.GetInt("cluster.replication_fetch_timeout_ms"),
+			ReplicationServeTimeoutMs:          v.GetInt("cluster.replication_serve_timeout_ms"),
+			ReplicationRetryMaxAttempts:        v.GetInt("cluster.replication_retry_max_attempts"),
+			ReplicationCatchUpEnabled:          v.GetBool("cluster.replication_catchup_enabled"),
+			ReplicationCatchUpBarrierTimeoutMs: v.GetInt("cluster.replication_catchup_barrier_timeout_ms"),
+			ReplicationCatchUpQueueHighWater:   v.GetFloat64("cluster.replication_catchup_queue_high_water"),
 			// Sharding configuration (Phase 4)
 			ShardingEnabled:           v.GetBool("cluster.sharding_enabled"),
 			ShardingNumShards:         v.GetInt("cluster.sharding_num_shards"),
@@ -807,6 +817,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("cluster.replication_fetch_timeout_ms", 60000)  // 60s puller-side per-fetch timeout
 	v.SetDefault("cluster.replication_serve_timeout_ms", 120000) // 120s origin-side body-stream timeout
 	v.SetDefault("cluster.replication_retry_max_attempts", 3)    // 3 immediate retries
+	// Peer file replication catch-up (Enterprise Phase 3)
+	v.SetDefault("cluster.replication_catchup_enabled", true)            // Walk the manifest on startup to reconcile missing files
+	v.SetDefault("cluster.replication_catchup_barrier_timeout_ms", 10000) // 10s Raft barrier before walking
+	v.SetDefault("cluster.replication_catchup_queue_high_water", 0.8)     // Pause walker when queue is >80% full
 
 	// Sharding defaults (Phase 4)
 	v.SetDefault("cluster.sharding_enabled", false)        // Disabled by default


### PR DESCRIPTION
## Summary

- Phase 3 of peer-to-peer file replication: a **startup reconciliation walker** and a **multi-peer fallback resolver** that close the two fatal gaps Phase 2 left for Kubernetes deployments.
- After a node joins (or restarts), the coordinator walks the full Raft manifest and enqueues every missing file through the existing Phase 2 worker pool. When the original writer is gone (Kubernetes pod rotation), the new `PeerResolver.ResolvePeers` returns an ordered `[origin, ...healthy peers]` list and the puller falls through to any healthy peer that still has the bytes — checksum mismatch is a short-circuit, not a fallback trigger.
- Zero overhead for OSS / standalone. Catch-up is wired inside the already-gated clustering code path.

## The two gaps Phase 2 left

1. **Node down during flush**: the puller only saw files that committed while it was running. A node down for a flush never got the FSM callback; on restart the file was missing from local disk and queries silently returned incomplete results.
2. **Kubernetes pod rotation**: a fresh reader joining a cluster with existing data received the Raft log but couldn't pull anything because `entry.OriginNodeID` often pointed to a writer pod that had been rescheduled and no longer existed.

Phase 3 closes both.

## What's new

- **`Puller.RunCatchUp` (new `catchup.go`)** — feeds `fsm.GetAllFiles()` through the worker pool with queue-depth backpressure (sleep when queue > 80% full). Coordinator spawns it in a background goroutine after the puller starts, guarded by `sync.Once` so it runs exactly once per coordinator lifetime.
- **Multi-peer fallback resolver** — `PeerResolver.ResolvePeer(nodeID) (string, bool)` becomes `ResolvePeers(originNodeID, path string) []string`. The resolver takes only the two fields it actually needs (decoupled from `*raft.FileEntry`), and the `path` parameter is part of the signature so Phase 4+ can add shard-aware routing without changing the interface. The coordinator's resolver returns origin first (if still healthy) then every other healthy peer excluding self.
- **Typed `protocol.AckErrorCode`** — new constants `AckCodeNotFound`, `AckCodeManifest`, `AckCodeAuth`, `AckCodeBackend`, `AckCodeRaft`, `AckCodeInvalidPath`. Lets the client distinguish "peer doesn't have this file" from "peer rejected me" without brittle substring matching. Backward compatible: Phase 2 peers that don't send `Code` are supported via **exact-match** (not substring) fallback on `protocol.ErrMsgFileNotInManifest` / `ErrMsgFileNotFound`. Both typed codes and fallback strings live together in the protocol package.
- **Inflight dedup set** on `Puller` — prevents double-pulls when the walker races with reactive FSM callbacks. Cleanup via `defer` in `processEntry` so panics don't leak the slot.
- **`Node.Barrier` wrapper** over `hraft.Raft.Barrier` — runs before the catch-up walk so `fsm.GetAllFiles()` reflects every committed entry.
- **`ReplicationReady()` / `ReplicationCatchUpStatus()`** coordinator accessors — not currently consumed (queries can hit a node during catch-up and see eventually-consistent results), but Phase 5 will use them to hard-gate the query path.

## Configuration

Three new knobs, set via `ARC_CLUSTER_REPLICATION_CATCHUP_*` or `arc.toml`:

| Key | Default | Purpose |
|---|---|---|
| `replication_catchup_enabled` | `true` | Master switch / emergency kill-switch for pathologically large manifests |
| `replication_catchup_barrier_timeout_ms` | `10000` | Raft barrier timeout before walking; on timeout the walker proceeds against a possibly-stale manifest |
| `replication_catchup_queue_high_water` | `0.8` | Walker pauses enqueueing when queue is above this fraction |

No new worker-count knob — catch-up shares the Phase 2 `replication_pull_workers` pool.

## Security

- **Checksum mismatch is a short-circuit**, not a fallback trigger. A malicious peer cannot force other readers to pull-and-corrupt a file by responding with a bad body — the puller stops trying other peers within the same attempt on `ErrChecksumMismatch`. Regression test: `TestPullerMultiPeerChecksumMismatchDoesNotFallThrough`.
- **Phase 2 path-bound HMAC preserved** — no change to the auth layer.
- **Typed code sanitization**: every `sendFetchError` call site uses a typed `protocol.AckErrorCode` constant; no path where user input flows into `Code`.
- **Exact-match fallback** (not substring): `"file not found on local backend: /etc/passwd"` does NOT match `protocol.ErrMsgFileNotFound`. Unit tests pin this.
- **Multi-peer fallback trust expansion**: Phase 3 trusts any healthy cluster member to serve bytes, but all peers are already mutually authenticated via shared secret + TLS, so this isn't a meaningful expansion of the trust domain.

## License gating

Peer replication catch-up is part of `FeatureClustering`. The puller is only constructed inside the already-gated clustering code path in `coordinator.startFilePullerLocked`; the catch-up goroutine is spawned from the same site. No new license flag, no new API routes, zero overhead for OSS / standalone.

## Test plan

- [x] `go test ./internal/cluster/...` — full cluster suite green
- [x] `go build ./cmd/... ./internal/...` — clean build
- [x] **5 catch-up walker unit tests** in `filereplication/catchup_test.go`: happy path (all entries enqueued when queue is large), throttle at high-water, ctx cancellation, single-shot guard (repeated `RunCatchUp` calls are no-ops), dedup against concurrent reactive Enqueue.
- [x] **4 multi-peer fallback unit tests** in `filereplication/puller_test.go`: fallback on `ErrFileNotOnPeer`, fallback on transport error, all peers fail → max-attempts-exceeded, checksum mismatch does NOT fall through.
- [x] **5 fetch-client `Code` tests** in `filereplication/fetch_client_test.go`: `Code="not_found"` maps to `ErrFileNotOnPeer`, `Code="manifest"` maps to `ErrFileNotOnPeer`, Phase 2 peer fallback via both known strings, `Code="auth"` does NOT map, `Code="backend"` does NOT map.
- [x] **3 integration tests** in `internal/cluster/filereplication_catchup_integration_test.go` wiring the real `handleFetchFile` server to the real `Puller` + `FetchClient` + `RunCatchUp`:
  - `TestPhase3CatchUpHappyPath` — 10 files seeded in origin FSM + backend, catch-up walks and pulls all 10 into a fresh reader backend with SHA-256 verified
  - `TestPhase3CatchUpOriginAbsentFallbackSucceeds` — **the Kubernetes rotation case**: resolver returns `[peer2_addr]` with no origin, peer2 serves the files, catch-up succeeds via the fallback loop
  - `TestPhase3CatchUpNoPeerHasFile` — all peers return `Code: "not_found"`, clean give-up, reader backend stays empty
- [ ] Manual 3-node docker test — **deferred** (docker daemon not available locally); the 17 unit/integration tests above cover every behavior the docker test would verify.

## Pre-merge review findings (all addressed)

Four parallel review agents ran before commit (security, license gating, redundancy, elegance):

- ✅ **SHOULD FIX — Typed `AckErrorCode`** instead of bare strings. New `protocol.AckErrorCode` type with constants.
- ✅ **SHOULD FIX — Extract duplicated error strings** to shared constants. Moved to `protocol.ErrMsgFileNotInManifest` / `ErrMsgFileNotFound`.
- ✅ **Elegance — `PeerResolver` decoupled from `*raft.FileEntry`** — now takes `(originNodeID, path string)`, flexible for future routing variants.
- ✅ **Redundancy — Fetcher consolidation** — `fakeFetcher` extended with `repeat` mode via `newRepeatingFetcher`; `countingFetcher` deleted.
- ✅ **Documentation — `sync.Once` once-per-lifetime guarantee** documented in `runCatchUpOnce` comment.

**Deferred as non-blocking:**
- Paginated `fsm.GetAllFiles()` — accepted O(N) snapshot copy; emergency kill-switch exists. Plan and code comments acknowledge the ~50ms apply-path spike on 1M+ manifests.
- Barrier timeout proceeds against stale manifest — documented posture (better a partial walk than no walk).

## Non-goals for Phase 3

Startup-only catch-up with any-peer fallback. Phase 3 does **not** include:
- Periodic reconciliation (reactive callbacks handle steady-state drift)
- Orphan detection (Phase 4 compaction concern)
- Paginated FSM iteration (Phase 5)
- Hard query gating during catch-up (Phase 5)
- Bandwidth caps (Phase 5)
- HTTP Range resume (Phase 5)