### PR TITLE
feat(cluster): automatic compactor failover

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -51,6 +51,10 @@ In clustered deployments, compaction now runs on exactly one node to prevent dup
 | `completion_dir` | auto-derived | Local directory for subprocess → parent handoff |
 | `completion_orphan_timeout_ms` | `600000` | Sweep stale manifests from crashed subprocesses |
 
+### Cluster Health Detection via Heartbeats (Enterprise)
+
+Cluster nodes now exchange periodic heartbeat messages over the coordinator protocol. The health checker uses heartbeat freshness to detect unresponsive peers — nodes that miss 3 consecutive heartbeats (~15s) are marked unhealthy, enabling automatic failover for both writers and compactors. Self-reported node state is propagated alongside heartbeats so peers can detect degraded nodes that are still reachable but unable to serve.
+
 ### Cluster TLS Encryption and Shared Secret Authentication (Enterprise)
 
 Arc Enterprise clustering now supports encrypted inter-node communication and authenticated cluster joins — bringing production-grade security to multi-node deployments.

--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -10,133 +10,46 @@ The `?p=` method continues to work but Arc now logs a one-time warning on first 
 
 ## New Features
 
-### Cluster File Manifest (Enterprise — Foundation for Peer Replication)
+### Peer File Replication (Enterprise)
 
-Arc Enterprise now maintains a cluster-wide file manifest in the Raft FSM. Every Parquet file flushed by a writer (or produced by compaction) is announced to the cluster via a new Raft command, producing an authoritative view of all files known to the cluster. This is the foundation for peer-to-peer file replication in bare-metal and VM deployments where nodes have their own local storage.
+Arc Enterprise clusters now replicate Parquet files between nodes automatically. When a writer flushes a file, all other nodes pull the bytes from the origin peer (or any healthy peer that already has a copy) and write them to their own local storage. This enables bare-metal, VM, and edge deployments where each node has its own local SSDs and shared storage (S3, MinIO, Azure) is not available.
 
-**What this delivers today:**
-- New Raft commands `CommandRegisterFile` and `CommandDeleteFile` added to `ClusterFSM`
-- File manifest persisted in Raft snapshots and replicated to all cluster members via standard Raft consensus
-- New API endpoint `GET /api/v1/cluster/files` returns the complete cluster file manifest (supports `?database=<name>` filter)
-- Async, non-blocking registration from the flush path — the file registrar enqueues entries and a background worker appends to Raft, so write latency is unaffected
-- Zero overhead for OSS / standalone deployments — no coordinator, no registrar, no manifest
+Every file is SHA-256 hashed at flush time and the hash is committed into a Raft-backed cluster manifest. Receivers verify the hash after download — checksum mismatches trigger automatic retry. When a node starts (or restarts), it walks the manifest and catches up on any files it missed, pulling from whichever healthy peer has them. The original writer doesn't need to be alive.
 
-### Peer File Replication (Enterprise — Phase 2)
+- Non-leader nodes forward manifest commands to the Raft leader automatically — no silent data loss if the writer isn't the Raft leader.
+- `GET /api/v1/cluster/files` returns the full cluster manifest (supports `?database=` filter).
+- Replication status and catch-up progress are surfaced via `/api/v1/cluster/status`.
+- Zero overhead for OSS / standalone deployments.
 
-Building on the cluster file manifest, Arc Enterprise now replicates **actual Parquet bytes** between cluster nodes. When a writer flushes a file, readers automatically pull the bytes from the origin peer over the existing coordinator TCP protocol and write them to their own local storage backend. This unlocks bare-metal, VM, and edge deployments where each node has its own local SSDs and shared storage (S3, MinIO, Azure) is not available — on-prem, aerospace, defense, and edge use cases.
+**Configuration** (`ARC_CLUSTER_REPLICATION_*` env vars or `cluster.replication_*` in `arc.toml`):
 
-**How it works:**
-- Every flushed Parquet file is SHA-256 hashed on the writer (on the in-memory buffer, before writing to the backend) and the hash is committed into the Raft manifest alongside the file metadata. Every node in the cluster learns the authoritative hash as soon as the Raft log replicates.
-- On each non-origin node, an `onFileRegistered` callback fires from the FSM when a new entry commits. A background `Puller` worker pool enqueues a fetch, skipping files that originated on the local node or already exist on the local backend.
-- Workers dial the origin peer using the cluster's existing TLS-wrapped coordinator connection and send a new `MsgFetchFile` request, authenticated with an HMAC that binds `{nonce, nodeID, clusterName, path, timestamp}` — including the path prevents a stolen MAC from being replayed to fetch a different file within the freshness window.
-- The origin validates the HMAC, sanitizes the path, confirms the file is in the cluster manifest (so peers cannot request arbitrary local files), and streams the body directly over the connection.
-- The puller streams body bytes through an `io.MultiWriter` tee into a `sha256.New()` hasher while writing into the local backend via `WriteReader`, and compares the computed hash against the manifest hash before accepting the file. On mismatch the partial file is deleted and the fetch retries.
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `replication_enabled` | `false` | Master switch; requires `shared_secret` |
+| `replication_pull_workers` | `4` | Concurrent fetch workers per node |
+| `replication_queue_size` | `1024` | Bounded queue; excess entries reconciled on restart |
+| `replication_fetch_timeout_ms` | `60000` | Per-fetch timeout (puller side) |
+| `replication_serve_timeout_ms` | `120000` | Body-stream timeout (origin side) |
+| `replication_retry_max_attempts` | `3` | Retry attempts before dropping an entry |
+| `replication_catchup_enabled` | `true` | Startup catch-up; disable for emergency |
+| `replication_catchup_barrier_timeout_ms` | `10000` | Raft barrier timeout before walking |
 
-**Configuration** (defaults shown, set via `ARC_CLUSTER_REPLICATION_*` env vars or `cluster.replication_*` in `arc.toml`):
-- `replication_enabled` — master switch; requires `cluster.shared_secret` to be set
-- `replication_pull_workers = 4` — concurrent fetch workers per node
-- `replication_queue_size = 1024` — bounded queue; excess entries are dropped with a rate-limited warning and reconciled later
-- `replication_fetch_timeout_ms = 60000` — puller-side per-fetch timeout
-- `replication_serve_timeout_ms = 120000` — origin-side body-stream timeout; raise for large Parquet files or slow links
-- `replication_retry_max_attempts = 3` — immediate retry attempts before dropping the entry
+### Dedicated Compactor Role with Automatic Failover (Enterprise)
 
-**Security:**
-- Peer replication is gated by `FeatureClustering` — a user without an enterprise license cannot construct the puller.
-- Shared secret is required at startup; Arc refuses to boot if `replication_enabled=true` and `shared_secret` is empty.
-- All fetch traffic flows over the cluster coordinator port (not the public API port), physically isolating replication bytes from client traffic.
-- When `cluster.tls_enabled=true`, the fetch client reuses the cluster TLS config for end-to-end encryption.
+In clustered deployments, compaction now runs on exactly one node to prevent duplicate outputs on shared storage and eliminate redundant CPU/IO work across nodes.
 
-**Scope of Phase 2:** async replication only. Phase 2 does **not** include: resume via HTTP Range, catch-up for nodes joining with existing data, quorum durability, multi-peer fanout, or compaction-aware routing. These land in Phases 3–5.
+- Set `ARC_CLUSTER_ROLE=compactor` on one node. Writers and readers automatically gate their compaction schedulers. OSS deployments are unaffected — compaction runs unconditionally.
+- Compacted outputs are registered in the Raft manifest and replicated to all peers automatically.
+- **Automatic failover**: when `cluster.failover_enabled=true`, the Raft leader monitors the active compactor and reassigns it to another healthy node after ~30s of unresponsiveness. No restart required. Prefers compactor-role nodes, falls back to writers. 60s cooldown prevents rapid cycling.
+- Health warnings surface when no compactor is elected or when multiple compactors are configured (misconfiguration that re-introduces duplicate outputs).
 
-**Design inspiration:** ClickHouse's ReplicatedMergeTree model — a Raft-equivalent op log + HTTP-pull-based file transfer. Research compared InfluxDB Enterprise (anti-entropy + HHQ), ClickHouse (log + HTTP pull), TimescaleDB (deprecated multi-node), Apache Pinot (peer fetcher fallback), and Apache Druid (metadata-driven assignment). ClickHouse's model is the cleanest fit for Arc's existing Raft + coordinator TCP infrastructure.
+**Compaction configuration** (`ARC_COMPACTION_*` env vars):
 
-### Peer File Replication — Catch-up on Join (Enterprise — Phase 3)
-
-Phase 2 replicated files reactively — a node only pulled files that committed to Raft while its puller was running. That left two fatal gaps on Kubernetes: (1) a node that was down when a file was flushed never got the callback and had the file missing on restart, and (2) a brand-new reader joining a cluster with existing data received the Raft log but couldn't pull anything because `entry.OriginNodeID` often pointed to a pod that had been rescheduled and no longer existed. Queries against such nodes silently returned incomplete results.
-
-Phase 3 closes both gaps with a **startup reconciliation walker** and a **multi-peer fallback resolver**. A node that comes online now converges on the manifest within a bounded time, regardless of whether the original writer is still in the cluster.
-
-**How it works:**
-- After the puller starts, the coordinator spawns a background goroutine — guarded by `sync.Once` so it runs exactly once per coordinator lifetime — that waits for a Raft leader, issues a new `Node.Barrier` wrapper over `hraft.Raft.Barrier` so the local FSM reflects every committed entry, then feeds `fsm.GetAllFiles()` through a new `Puller.RunCatchUp` method. On `WaitForLeader` or `Barrier` timeout the walker proceeds against the follower's possibly-stale view — better a partial walk than no walk, and the reactive FSM callback path catches anything the walker missed as it applies.
-- The walker enqueues each manifest entry through the existing Phase 2 worker pool, so all the Phase 2 retry, backoff, checksum verification, and metrics apply automatically — catch-up is data flowing through the same code path as reactive pulls.
-- A per-path **inflight set** on the puller deduplicates enqueues: if the walker and a reactive FSM callback both try to enqueue path X during a write committing mid-walk, only the first call queues the entry and the rest are counted as `skipped_dup`. The slot is released via `defer` inside `processEntry` so the set stays bounded even on worker panic.
-- **Queue-depth backpressure** — when the queue is above `replication_catchup_queue_high_water` (default 0.8), the walker sleeps 50ms between enqueues to let workers drain. Prevents thundering-herd drop storms on large manifests without needing a second worker pool.
-
-**Multi-peer fallback resolver:** the Phase 2 `PeerResolver` interface returned a single `(addr, ok)` pair for the origin. Phase 3 changes it to `ResolvePeers(originNodeID, path string) []string` — the resolver takes just the two fields it needs (no `*raft.FileEntry` coupling), and returns an **ordered list**: origin first (if still healthy), then every other healthy peer excluding self. The `path` parameter is part of the signature so Phase 4+ can add shard-aware or compactor-aware routing without changing the interface; Phase 3 ignores it.
-
-The puller iterates the list within a single attempt and falls through to the next candidate on any per-peer failure **except** checksum mismatch. A corrupt body from peer-1 is a data integrity signal, not a "try another peer" signal — if the puller fell through on checksum mismatch it would pull-and-corrupt from every healthy peer in turn. `ErrChecksumMismatch` breaks out of the per-attempt peer loop and the attempt-level retry handles it via the existing delete-and-redownload path.
-
-**Typed ack error codes** — the ack header gained a new `protocol.AckErrorCode` typed field with constants (`AckCodeNotFound`, `AckCodeManifest`, `AckCodeAuth`, `AckCodeBackend`, `AckCodeRaft`, `AckCodeInvalidPath`) so the puller can distinguish "peer doesn't have this file" from "peer rejected me" without substring matching:
-
-| Code | Puller behavior |
-|---|---|
-| `not_found` / `manifest` | Fall through to next peer |
-| `auth` / `backend` / `raft` / `invalid_path` | Fail attempt (don't fall through) |
-
-The `Code` field is a JSON `omitempty` addition — **backward compatible** with Phase 2 peers. When `Code` is empty (Phase 2 peer), the client falls back to **exact-match** (not substring — an adversary can't craft an error string like `"file not found on local backend: /etc/passwd"` to confuse the check) against `protocol.ErrMsgFileNotInManifest` / `protocol.ErrMsgFileNotFound`. Both the typed codes and the Phase 2 fallback strings live together in `internal/cluster/protocol/messages.go` so a refactor of either touches both sites at once.
-
-**Configuration** (set via `ARC_CLUSTER_REPLICATION_CATCHUP_*` env vars or `cluster.replication_catchup_*` in `arc.toml`):
-- `replication_catchup_enabled = true` — master switch; disable as an emergency kill-switch on pathologically large manifests
-- `replication_catchup_barrier_timeout_ms = 10000` — Raft barrier timeout before walking
-- `replication_catchup_queue_high_water = 0.8` — walker pauses enqueueing when the queue is above this fraction
-
-No new worker-count knob — catch-up shares the Phase 2 `replication_pull_workers` pool.
-
-**Observability:** `Puller.Stats()` grew new counters surfaced through the coordinator:
-- `catchup_started_at` / `catchup_completed_at` (unix seconds; the latter goes non-zero once the walker has finished its pass, not once all queued pulls have drained)
-- `catchup_entries_walked` / `catchup_enqueued` / `catchup_skipped_local`
-- `skipped_dup` (new — counts Phase 3 dedup skips)
-
-New `Coordinator.ReplicationCatchUpStatus()` returns the catch-up-specific stats as a JSON-serializable map intended for `/api/v1/cluster/status`. New `Coordinator.ReplicationReady()` returns `true` once the walker has completed its pass — not currently consumed (queries can hit a node during catch-up and see eventually-consistent results), but Phase 5 will use it to hard-gate the query path so the accessor lands now and avoids another coordinator surface change later. Operators can use the status endpoint for external readiness probes in the meantime.
-
-**Security review:**
-- Multi-peer fallback expands the set of trusted peers from `OriginNodeID` to any healthy cluster member — but all peers are already mutually authenticated via shared secret + TLS, and the Phase 2 path-bound HMAC is preserved so a stolen MAC still can't fetch a different file. Regression-tested.
-- Checksum mismatch short-circuit is tested explicitly (`TestPullerMultiPeerChecksumMismatchDoesNotFallThrough`) to lock in the "one corrupt peer can't force every reader to pull-and-corrupt" invariant.
-- Every `sendFetchError` call site uses a typed `AckErrorCode` constant — no path where user input flows into `Code`.
-
-**Scope of Phase 3:** startup-only reconciliation with any-peer fallback. Phase 3 does **not** include: periodic reconciliation (reactive callbacks handle steady-state drift), orphan detection (Phase 4 compaction concern), paginated FSM walks (accepted O(N) snapshot copy — emergency kill-switch exists for 10M+ file deployments), hard query gating (Phase 5), bandwidth caps (Phase 5), or HTTP Range resume (Phase 5).
-
-**What's coming next** (separate PRs):
-- Phase 5: Optional write quorum for strong durability, hard query gating on catch-up, paginated FSM iteration, periodic reconciliation, bandwidth caps, resumable transfers via Range, automatic compactor failover, and proper leader forwarding for non-leader compactors.
-
-### Peer File Replication — Dedicated Compactor Role (Enterprise — Phase 4)
-
-Phase 2 and 3 replicated files correctly, but compaction still ran independently on every cluster node. On shared-storage deployments (S3, MinIO, Azure) this was a real correctness bug: two nodes picking up the same hour of source files would produce two distinct compacted outputs with unique filenames, both would land in the bucket, and queries would double-count rows until retention cleaned up. On local-storage deployments it was "only" wasteful — every node ran the same DuckDB merge on its own copy of the files, burning N× CPU and I/O for identical work.
-
-**Phase 4 introduces a dedicated `RoleCompactor`** that runs compaction on exactly one node per cluster, and wires the compacted output into the existing Raft manifest so Phase 2/3 replication automatically distributes it.
-
-**How it works:**
-- When `ARC_CLUSTER_ROLE=compactor` is set on a node, the compaction scheduler starts as today. On any other role (`writer`, `reader`) the scheduler logs `"Compaction scheduler gated: node role does not have CanCompact capability"` at Info and stays idle. OSS and standalone deployments pass no gate and are unaffected — compaction runs unconditionally, preserving the OSS feature contract.
-- Compaction still runs in a subprocess for memory isolation. Phase 4 adds a **completion-manifest handoff** on local disk at `{temp_directory}/.completion/pending/{job_id}.json`. The subprocess atomically writes the manifest in state `output_written` immediately after upload succeeds (the critical durability point), then advances it to `sources_deleted` once the source files are removed from storage.
-- A parent-side **`CompletionWatcher`** polls the directory on a 1-second tick, reads each pending manifest, and translates it to `RegisterFile` / `DeleteFile` Raft commands via a new `CompactionBridge`. Successful apply removes the manifest. Failure (including the leader-flap case) leaves the manifest in place for the next poll — Raft FSM handlers are already idempotent, so retries are safe.
-- The bridge checks `IsLeader()` before every Raft command and returns a new `ErrNotLeader` sentinel when the local compactor is not the Raft leader. The watcher recognizes this as a transient retry condition (not logged as an error). By the time leadership stabilizes (sub-second in practice), the retry succeeds.
-- On readers, the existing Phase 2/3 `onFileRegistered` callback fires automatically when the compacted file lands in the manifest, and the puller pulls the bytes from the compactor. No changes to the replication layer.
-- Phase 4 also activates the previously-logging-only `onFileDeleted` callback to **delete local copies** of source files after a 500ms grace period (giving in-flight queries time to finish reading). Local-storage readers shed their stale source copies; shared-storage deployments skip this entirely because the compactor already removed the shared object.
-
-**Two operator-visible health warnings** surface rate-limited (once per minute) via the cluster health checker when `cluster.enabled && cluster.replication_enabled && compaction.enabled`:
-
-```
-No compactor elected: compacted files will accumulate.
-  Set ARC_CLUSTER_ROLE=compactor on one node and restart.
-
-Multiple compactors elected (N): shared storage may see
-  duplicate outputs. Only one node should have
-  ARC_CLUSTER_ROLE=compactor.
-```
-
-Both are `Warn` (not Error) — Arc keeps running, queries still work, but operators should fix the configuration. The second warning is the Phase 4 safety net for the exact misconfiguration the feature is designed to prevent.
-
-**Configuration knobs** (all default to sensible values):
-- `compaction.completion_watcher_interval_ms = 1000` — how often the watcher scans for pending manifests
-- `compaction.completion_dir` (auto-derived from `compaction.temp_directory` when empty)
-- `compaction.completion_orphan_timeout_ms = 600000` — sweep `writing_output` manifests older than this on startup (indicates a crashed subprocess; later states are never swept)
-
-**No license flag for compaction.** Gating compaction would follow InfluxDB's well-known path and is explicitly rejected. The compactor-coordination mechanism is scoped under `FeatureClustering` because the `CompletionWatcher` and `CompactionBridge` only activate when clustering + peer replication are both enabled.
-
-**Known Phase 4 limitations, all targeted by Phase 5:**
-- **Single point of failure**: if the compactor node dies, compaction stalls until an operator sets another node's role to `compactor` and restarts. No automatic failover.
-- **Leader-flap stalls**: if the compactor is not the Raft leader, the bridge short-circuits with `ErrNotLeader` and the watcher retries. Prolonged leader elections pause compaction progress until leadership stabilizes. Phase 5 will add proper leader forwarding.
-- **Orphan compacted files**: if the subprocess crashes in the narrow window between `WriteReader` and writing the completion manifest (~1ms), a compacted file may exist in storage without a corresponding manifest entry. Operator cleanup required until Phase 5 adds automatic reconciliation.
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `completion_watcher_interval_ms` | `1000` | How often the watcher scans for pending manifests |
+| `completion_dir` | auto-derived | Local directory for subprocess → parent handoff |
+| `completion_orphan_timeout_ms` | `600000` | Sweep stale manifests from crashed subprocesses |
 
 ### Cluster TLS Encryption and Shared Secret Authentication (Enterprise)
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -953,6 +953,9 @@ func main() {
 								// Phase 5: wire OnBecomeCompactor / OnLoseCompactor
 								// callbacks so the scheduler and watcher activate/deactivate
 								// dynamically when the compactor lease moves between nodes.
+								// Dedicated compactor nodes (CanCompact=true) keep the watcher
+								// running regardless of lease state to process orphaned manifests.
+								isDedicatedCompactor := capabilities.CanCompact
 								clusterCoordinator.SetCompactorCallbacks(
 									func() {
 										// OnBecomeCompactor: start scheduler + watcher
@@ -967,7 +970,9 @@ func main() {
 												log.Error().Err(err).Msg("Failed to start daily scheduler after failover")
 											}
 										}
-										watcher.Start(context.Background())
+										if !isDedicatedCompactor {
+											watcher.Start(context.Background())
+										}
 									},
 									func() {
 										// OnLoseCompactor: stop scheduler + watcher
@@ -978,7 +983,9 @@ func main() {
 										if dailyScheduler != nil {
 											dailyScheduler.Stop()
 										}
-										watcher.Stop()
+										if !isDedicatedCompactor {
+											watcher.Stop()
+										}
 									},
 								)
 							}

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -899,29 +899,26 @@ func main() {
 						}, shutdown.PriorityBuffer)
 						log.Info().Msg("Cluster file manifest registrar enabled")
 
-						// Phase 4: start the compaction completion watcher on nodes that
-						// carry the compactor role. The watcher polls the local
-						// .completion/pending/ dir that compaction subprocesses write
-						// their handoff manifests to, and applies RegisterFile +
-						// DeleteFile to the Raft manifest via CompactionBridge.
+						// Phase 5: wire the dynamic compaction gate to the coordinator
+						// so CanCompact() checks the FSM's active compactor lease
+						// when failover is configured.
+						if compactionGate != nil {
+							if gate, ok := compactionGate.(*compactionClusterGate); ok {
+								gate.setCoordinator(clusterCoordinator)
+							}
+						}
+
+						// Phase 4+5: start the compaction completion watcher on
+						// nodes that can potentially compact. With Phase 5 failover,
+						// any node may become the active compactor at runtime, so we
+						// construct the watcher and schedulers on every node but only
+						// start them when the node holds the compactor lease.
 						//
-						// Only the compactor runs compaction, so only the compactor needs
-						// the watcher. Readers and writers that see an empty .completion
-						// dir do nothing, but we don't bother starting the watcher there
-						// because it would be a permanent no-op.
-						//
-						// Shutdown ordering: watcher stops at PriorityCompaction - 1 so
-						// it drains any pending manifests BEFORE the cluster coordinator
-						// tears down Raft. If the watcher stopped after Raft, the final
-						// RegisterFile calls would fail against a dead Raft node and the
-						// manifests would be lost.
-						if capabilities.CanCompact && completionDir != "" && cfg.Compaction.Enabled {
+						// Shutdown ordering: watcher stops at PriorityCompaction - 1
+						// so it drains any pending manifests BEFORE the coordinator
+						// tears down Raft.
+						if completionDir != "" && cfg.Compaction.Enabled {
 							bridge := cluster.NewCompactionBridge(clusterCoordinator)
-							// Honor the configured poll interval; fall back to 1s if
-							// the operator didn't set it (or set it to 0/negative).
-							// The watcher's NewCompletionWatcher also clamps defaults
-							// internally, but we prefer an explicit default here so
-							// the startup log reflects the effective value.
 							pollInterval := time.Duration(cfg.Compaction.CompletionWatcherIntervalMS) * time.Millisecond
 							if pollInterval <= 0 {
 								pollInterval = 1 * time.Second
@@ -936,15 +933,54 @@ func main() {
 							if werr != nil {
 								log.Warn().Err(werr).Msg("Failed to construct compaction completion watcher")
 							} else {
-								watcher.Start(context.Background())
+								// If this node is already the active compactor (static
+								// RoleCompactor with no failover, or failover already
+								// assigned us), start immediately. Otherwise the FSM
+								// callback will start it dynamically.
+								if capabilities.CanCompact || clusterCoordinator.IsActiveCompactor() {
+									watcher.Start(context.Background())
+									log.Info().
+										Str("completion_dir", completionDir).
+										Dur("poll_interval", pollInterval).
+										Msg("Phase 4 compaction completion watcher started")
+								}
+
 								shutdownCoordinator.RegisterHook("compaction-completion-watcher", func(ctx context.Context) error {
 									watcher.Stop()
 									return nil
 								}, shutdown.PriorityCompaction-1)
-								log.Info().
-									Str("completion_dir", completionDir).
-									Dur("poll_interval", pollInterval).
-									Msg("Phase 4 compaction completion watcher started")
+
+								// Phase 5: wire OnBecomeCompactor / OnLoseCompactor
+								// callbacks so the scheduler and watcher activate/deactivate
+								// dynamically when the compactor lease moves between nodes.
+								clusterCoordinator.SetCompactorCallbacks(
+									func() {
+										// OnBecomeCompactor: start scheduler + watcher
+										log.Info().Msg("Phase 5: this node became the active compactor — starting compaction")
+										if hourlyScheduler != nil {
+											if err := hourlyScheduler.Start(); err != nil {
+												log.Error().Err(err).Msg("Failed to start hourly scheduler after failover")
+											}
+										}
+										if dailyScheduler != nil {
+											if err := dailyScheduler.Start(); err != nil {
+												log.Error().Err(err).Msg("Failed to start daily scheduler after failover")
+											}
+										}
+										watcher.Start(context.Background())
+									},
+									func() {
+										// OnLoseCompactor: stop scheduler + watcher
+										log.Info().Msg("Phase 5: this node lost the active compactor lease — stopping compaction")
+										if hourlyScheduler != nil {
+											hourlyScheduler.Stop()
+										}
+										if dailyScheduler != nil {
+											dailyScheduler.Stop()
+										}
+										watcher.Stop()
+									},
+								)
 							}
 						}
 					}
@@ -1699,19 +1735,21 @@ func runCompactSubcommand(args []string) {
 	}
 }
 
-// compactionClusterGate implements compaction.ClusterGate by parsing the
-// local node's cluster role from config. It's constructed once at startup
-// with the role string — cfg.Cluster.Role — and the CanCompact check
-// consults the NodeRole capabilities the cluster package already exposes.
+// compactionClusterGate implements compaction.ClusterGate. When the
+// coordinator has a compactor failover manager (Phase 5), it checks the
+// FSM's active compactor lease instead of the static role. When failover
+// is not configured (no coordinator, or coordinator without failover),
+// it falls back to the static role check from Phase 4.
 //
-// This type sits in main.go (not in the cluster or compaction package) so
-// the compaction package has no compile-time dependency on the cluster
-// package, and the cluster package doesn't need to know about the
-// compaction scheduler. Both packages stay independent and the glue
-// lives at the one spot that already imports both — main.go.
+// This type sits in main.go so the compaction package has no compile-time
+// dependency on the cluster package.
 type compactionClusterGate struct {
 	role         cluster.NodeRole
 	capabilities cluster.RoleCapabilities
+	// coordinator is non-nil when clustering is enabled. When the
+	// coordinator has a compactor failover manager, CanCompact checks
+	// the FSM lease instead of the static role.
+	coordinator *cluster.Coordinator
 }
 
 func newCompactionClusterGate(roleString string) *compactionClusterGate {
@@ -1722,15 +1760,26 @@ func newCompactionClusterGate(roleString string) *compactionClusterGate {
 	}
 }
 
-// CanCompact reports whether the local node's role has the compact
-// capability. Only RoleCompactor returns true in cluster mode — writers
-// and readers return false and the scheduler stays idle on those nodes.
+// setCoordinator enables the dynamic FSM lease check for Phase 5 failover.
+// Called after the coordinator is created and started.
+func (g *compactionClusterGate) setCoordinator(c *cluster.Coordinator) {
+	g.coordinator = c
+}
+
+// CanCompact reports whether this node should run compaction.
+//
+// Phase 5 (failover enabled): checks the FSM's active compactor lease.
+// Phase 4 (no failover): checks the static role capability.
 func (g *compactionClusterGate) CanCompact() bool {
+	if g.coordinator != nil && g.coordinator.GetActiveCompactorID() != "" {
+		// Failover system is active — use the FSM lease.
+		return g.coordinator.IsActiveCompactor()
+	}
+	// No failover or no lease assigned yet — fall back to static role.
 	return g.capabilities.CanCompact
 }
 
-// Role returns the node's role string for log messages. Never used for
-// authorization — CanCompact is authoritative.
+// Role returns the node's role string for log messages.
 func (g *compactionClusterGate) Role() string {
 	return string(g.role)
 }

--- a/internal/cluster/compactor_failover.go
+++ b/internal/cluster/compactor_failover.go
@@ -199,24 +199,30 @@ func (m *CompactorFailoverManager) checkCompactorHealth() {
 }
 
 // tryInitialAssignment attempts to assign a compactor when none is active.
-// Prefers nodes with RoleCompactor; falls back to RoleWriter.
+// Runs the Raft Apply asynchronously to avoid blocking the check loop.
 func (m *CompactorFailoverManager) tryInitialAssignment() {
 	newID := m.selectNewCompactor("")
 	if newID == "" {
-		// No eligible node — the health checker's "No compactor elected"
-		// warning handles operator visibility.
 		return
 	}
+
+	m.failoverInProg = true
 
 	m.logger.Info().
 		Str("node_id", newID).
 		Msg("Assigning initial compactor lease")
 
-	if err := m.cfg.RaftNode.AssignCompactor(newID, "", m.cfg.FailoverTimeout); err != nil {
-		m.logger.Error().Err(err).
-			Str("node_id", newID).
-			Msg("Failed to assign initial compactor")
-	}
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		err := m.cfg.RaftNode.AssignCompactor(newID, "", m.cfg.FailoverTimeout)
+		if err != nil {
+			m.logger.Error().Err(err).
+				Str("node_id", newID).
+				Msg("Failed to assign initial compactor")
+		}
+		m.completeFailover(newID, err == nil)
+	}()
 }
 
 // triggerFailoverLocked initiates failover (must hold m.mu).
@@ -306,8 +312,8 @@ func (m *CompactorFailoverManager) selectNewCompactor(excludeNodeID string) stri
 func (m *CompactorFailoverManager) completeFailover(newCompactorID string, success bool) {
 	m.mu.Lock()
 	m.failoverInProg = false
-	m.lastFailoverAt = time.Now()
 	if success {
+		m.lastFailoverAt = time.Now()
 		m.consecutiveFails = 0
 	}
 	completeCb := m.onFailoverComplete

--- a/internal/cluster/compactor_failover.go
+++ b/internal/cluster/compactor_failover.go
@@ -1,0 +1,370 @@
+package cluster
+
+// CompactorFailoverManager monitors the active compactor's health and
+// automatically reassigns the compactor lease to another healthy node
+// when the current holder becomes unhealthy. Only the Raft leader runs
+// the check loop — all other nodes observe the resulting
+// CommandAssignCompactor via the FSM callback.
+//
+// The compactor lease is tracked in the FSM's activeCompactorID field,
+// separate from the operator-configured NodeRole. This means:
+//   - RoleCompactor nodes are preferred for the initial claim
+//   - On failover, a RoleWriter can hold the lease without restarting
+//   - When the original compactor returns, the current holder keeps it
+//     (no preemption — the lease is stable once assigned)
+//
+// Pattern mirrors WriterFailoverManager in writer_failover.go.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	arcRaft "github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/rs/zerolog"
+)
+
+// CompactorFailoverConfig holds configuration for the compactor failover manager.
+type CompactorFailoverConfig struct {
+	// Registry provides access to cluster node state.
+	Registry *Registry
+
+	// RaftNode for applying AssignCompactor commands via consensus.
+	RaftNode *arcRaft.Node
+
+	// RaftFSM to read the current activeCompactorID.
+	RaftFSM *arcRaft.ClusterFSM
+
+	// CheckInterval is how often the leader checks compactor health.
+	// Default: 10s (compaction is less latency-sensitive than writes).
+	CheckInterval time.Duration
+
+	// FailoverTimeout bounds the Raft Apply for AssignCompactor.
+	FailoverTimeout time.Duration
+
+	// CooldownPeriod prevents repeated failovers within this window.
+	CooldownPeriod time.Duration
+
+	// UnhealthyThreshold is consecutive unhealthy checks before triggering
+	// failover. At 10s interval, threshold=3 means ~30s detection time.
+	UnhealthyThreshold int
+
+	Logger zerolog.Logger
+}
+
+// CompactorFailoverManager monitors compactor health and reassigns the
+// compactor lease on failure. Only active on the Raft leader.
+type CompactorFailoverManager struct {
+	cfg      *CompactorFailoverConfig
+	mu       sync.RWMutex
+	logger   zerolog.Logger
+	ctx      context.Context
+	cancelFn context.CancelFunc
+	running  atomic.Bool
+	wg       sync.WaitGroup
+
+	// State tracking
+	consecutiveFails int
+	failoverInProg   bool
+	lastFailoverAt   time.Time
+
+	// Callbacks
+	onFailoverStart    func(oldCompactorID, newCompactorID string)
+	onFailoverComplete func(newCompactorID string, success bool)
+}
+
+// NewCompactorFailoverManager creates a new compactor failover manager.
+func NewCompactorFailoverManager(cfg *CompactorFailoverConfig) *CompactorFailoverManager {
+	if cfg.CheckInterval == 0 {
+		cfg.CheckInterval = 10 * time.Second
+	}
+	if cfg.FailoverTimeout == 0 {
+		cfg.FailoverTimeout = 30 * time.Second
+	}
+	if cfg.CooldownPeriod == 0 {
+		cfg.CooldownPeriod = 60 * time.Second
+	}
+	if cfg.UnhealthyThreshold == 0 {
+		cfg.UnhealthyThreshold = 3
+	}
+
+	return &CompactorFailoverManager{
+		cfg:    cfg,
+		logger: cfg.Logger.With().Str("component", "compactor-failover").Logger(),
+	}
+}
+
+// SetCallbacks sets callbacks for failover events.
+func (m *CompactorFailoverManager) SetCallbacks(
+	onStart func(oldCompactorID, newCompactorID string),
+	onComplete func(newCompactorID string, success bool),
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onFailoverStart = onStart
+	m.onFailoverComplete = onComplete
+}
+
+// Start begins the compactor failover manager.
+func (m *CompactorFailoverManager) Start(ctx context.Context) error {
+	m.ctx, m.cancelFn = context.WithCancel(ctx)
+	m.running.Store(true)
+
+	m.wg.Add(1)
+	go m.checkLoop()
+
+	m.logger.Info().
+		Dur("check_interval", m.cfg.CheckInterval).
+		Dur("cooldown_period", m.cfg.CooldownPeriod).
+		Int("unhealthy_threshold", m.cfg.UnhealthyThreshold).
+		Msg("Compactor failover manager started")
+
+	return nil
+}
+
+// Stop gracefully shuts down the compactor failover manager.
+func (m *CompactorFailoverManager) Stop() error {
+	if !m.running.Load() {
+		return nil
+	}
+
+	m.running.Store(false)
+	m.cancelFn()
+	m.wg.Wait()
+
+	m.logger.Info().Msg("Compactor failover manager stopped")
+	return nil
+}
+
+// checkLoop periodically checks the active compactor's health.
+func (m *CompactorFailoverManager) checkLoop() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.cfg.CheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkCompactorHealth()
+		}
+	}
+}
+
+// checkCompactorHealth verifies the active compactor is still healthy.
+// Only the Raft leader acts — other nodes observe the FSM callback.
+func (m *CompactorFailoverManager) checkCompactorHealth() {
+	// Only the Raft leader coordinates failover.
+	if m.cfg.RaftNode == nil || !m.cfg.RaftNode.IsLeader() {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.failoverInProg {
+		return
+	}
+
+	activeID := m.cfg.RaftFSM.GetActiveCompactorID()
+
+	// No active compactor — try to assign one.
+	if activeID == "" {
+		m.tryInitialAssignment()
+		return
+	}
+
+	// Check if the active compactor is still healthy.
+	node, ok := m.cfg.Registry.Get(activeID)
+	if !ok || node.GetState() != StateHealthy {
+		m.consecutiveFails++
+		m.logger.Warn().
+			Str("compactor_id", activeID).
+			Int("consecutive_fails", m.consecutiveFails).
+			Int("threshold", m.cfg.UnhealthyThreshold).
+			Msg("Active compactor unhealthy")
+
+		if m.consecutiveFails >= m.cfg.UnhealthyThreshold {
+			m.triggerFailoverLocked(activeID)
+		}
+		return
+	}
+
+	// Compactor is healthy — reset counter.
+	m.consecutiveFails = 0
+}
+
+// tryInitialAssignment attempts to assign a compactor when none is active.
+// Prefers nodes with RoleCompactor; falls back to RoleWriter.
+func (m *CompactorFailoverManager) tryInitialAssignment() {
+	newID := m.selectNewCompactor("")
+	if newID == "" {
+		// No eligible node — the health checker's "No compactor elected"
+		// warning handles operator visibility.
+		return
+	}
+
+	m.logger.Info().
+		Str("node_id", newID).
+		Msg("Assigning initial compactor lease")
+
+	if err := m.cfg.RaftNode.AssignCompactor(newID, "", m.cfg.FailoverTimeout); err != nil {
+		m.logger.Error().Err(err).
+			Str("node_id", newID).
+			Msg("Failed to assign initial compactor")
+	}
+}
+
+// triggerFailoverLocked initiates failover (must hold m.mu).
+func (m *CompactorFailoverManager) triggerFailoverLocked(oldCompactorID string) {
+	// Check cooldown.
+	if !m.lastFailoverAt.IsZero() && time.Since(m.lastFailoverAt) < m.cfg.CooldownPeriod {
+		m.logger.Warn().
+			Dur("cooldown_remaining", m.cfg.CooldownPeriod-time.Since(m.lastFailoverAt)).
+			Msg("Compactor failover skipped — cooldown period active")
+		return
+	}
+
+	m.failoverInProg = true
+
+	m.logger.Info().
+		Str("old_compactor", oldCompactorID).
+		Msg("Initiating compactor failover")
+
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		m.executeFailover(oldCompactorID)
+	}()
+}
+
+// executeFailover performs the actual failover operation.
+func (m *CompactorFailoverManager) executeFailover(oldCompactorID string) {
+	newCompactorID := m.selectNewCompactor(oldCompactorID)
+	if newCompactorID == "" {
+		m.logger.Error().
+			Str("old_compactor", oldCompactorID).
+			Msg("No healthy node available for compactor failover")
+		m.completeFailover("", false)
+		return
+	}
+
+	// Notify callback.
+	m.mu.RLock()
+	startCb := m.onFailoverStart
+	m.mu.RUnlock()
+	if startCb != nil {
+		startCb(oldCompactorID, newCompactorID)
+	}
+
+	m.logger.Info().
+		Str("old_compactor", oldCompactorID).
+		Str("new_compactor", newCompactorID).
+		Msg("Assigning compactor lease to new node")
+
+	if err := m.cfg.RaftNode.AssignCompactor(newCompactorID, oldCompactorID, m.cfg.FailoverTimeout); err != nil {
+		m.logger.Error().Err(err).
+			Str("new_compactor", newCompactorID).
+			Msg("Failed to assign compactor via Raft")
+		m.completeFailover(newCompactorID, false)
+		return
+	}
+
+	m.logger.Info().
+		Str("new_compactor", newCompactorID).
+		Str("old_compactor", oldCompactorID).
+		Msg("Compactor failover completed successfully")
+
+	m.completeFailover(newCompactorID, true)
+}
+
+// selectNewCompactor picks the best node to receive the compactor lease.
+// Priority: healthy RoleCompactor nodes (other than the failed one), then
+// healthy RoleWriter nodes. Readers are excluded because they typically
+// don't have write access to shared storage.
+func (m *CompactorFailoverManager) selectNewCompactor(excludeNodeID string) string {
+	// Prefer nodes that were deployed as compactors.
+	for _, node := range m.cfg.Registry.GetCompactors() {
+		if node.ID != excludeNodeID && node.GetState() == StateHealthy {
+			return node.ID
+		}
+	}
+	// Fall back to healthy writers.
+	for _, node := range m.cfg.Registry.GetWriters() {
+		if node.ID != excludeNodeID && node.GetState() == StateHealthy {
+			return node.ID
+		}
+	}
+	return ""
+}
+
+// completeFailover marks failover as complete.
+func (m *CompactorFailoverManager) completeFailover(newCompactorID string, success bool) {
+	m.mu.Lock()
+	m.failoverInProg = false
+	m.lastFailoverAt = time.Now()
+	if success {
+		m.consecutiveFails = 0
+	}
+	completeCb := m.onFailoverComplete
+	m.mu.Unlock()
+
+	if completeCb != nil {
+		completeCb(newCompactorID, success)
+	}
+}
+
+// TriggerManualFailover triggers a manual compactor failover.
+func (m *CompactorFailoverManager) TriggerManualFailover() error {
+	m.mu.Lock()
+
+	if m.failoverInProg {
+		m.mu.Unlock()
+		return fmt.Errorf("compactor failover already in progress")
+	}
+
+	activeID := m.cfg.RaftFSM.GetActiveCompactorID()
+	if activeID == "" {
+		m.mu.Unlock()
+		return fmt.Errorf("no active compactor to failover from")
+	}
+
+	m.failoverInProg = true
+	m.mu.Unlock()
+
+	m.logger.Info().
+		Str("current_compactor", activeID).
+		Msg("Manual compactor failover initiated")
+
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		m.executeFailover(activeID)
+	}()
+
+	return nil
+}
+
+// Stats returns failover manager statistics.
+func (m *CompactorFailoverManager) Stats() map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	stats := map[string]interface{}{
+		"running":              m.running.Load(),
+		"active_compactor_id":  m.cfg.RaftFSM.GetActiveCompactorID(),
+		"consecutive_fails":    m.consecutiveFails,
+		"failover_in_progress": m.failoverInProg,
+		"cooldown_period":      m.cfg.CooldownPeriod.String(),
+	}
+
+	if !m.lastFailoverAt.IsZero() {
+		stats["last_failover_at"] = m.lastFailoverAt.Format(time.RFC3339)
+	}
+
+	return stats
+}

--- a/internal/cluster/compactor_failover_test.go
+++ b/internal/cluster/compactor_failover_test.go
@@ -1,0 +1,240 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	arcRaft "github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/rs/zerolog"
+)
+
+// stubFailoverFSM is a minimal ClusterFSM for failover tests.
+func stubFailoverFSM() *arcRaft.ClusterFSM {
+	return arcRaft.NewClusterFSM(zerolog.Nop())
+}
+
+// TestCompactorFailover_InitialAssignment verifies that when no active
+// compactor is set and a healthy compactor-role node exists, the failover
+// manager assigns the lease within a check cycle.
+func TestCompactorFailover_InitialAssignment(t *testing.T) {
+	registry := NewRegistry(&RegistryConfig{Logger: zerolog.Nop()})
+	fsm := stubFailoverFSM()
+
+	// Add a healthy compactor node to the registry.
+	compactor := NewNode("compactor-1", "compactor-1", RoleCompactor, "test-cluster")
+	compactor.UpdateState(StateHealthy)
+	if err := registry.Register(compactor); err != nil {
+		t.Fatal(err)
+	}
+
+	// We can't use a real Raft node in unit tests, so we verify the
+	// selectNewCompactor logic directly.
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry:           registry,
+		RaftFSM:            fsm,
+		CheckInterval:      100 * time.Millisecond,
+		UnhealthyThreshold: 1,
+		Logger:             zerolog.Nop(),
+	})
+
+	// selectNewCompactor should pick the healthy compactor.
+	selected := mgr.selectNewCompactor("")
+	if selected != "compactor-1" {
+		t.Errorf("selectNewCompactor: got %q, want compactor-1", selected)
+	}
+}
+
+// TestCompactorFailover_SelectPreference verifies that RoleCompactor nodes
+// are preferred over RoleWriter nodes.
+func TestCompactorFailover_SelectPreference(t *testing.T) {
+	registry := NewRegistry(&RegistryConfig{Logger: zerolog.Nop()})
+
+	writer := NewNode("writer-1", "writer-1", RoleWriter, "test-cluster")
+	writer.UpdateState(StateHealthy)
+	registry.Register(writer)
+
+	compactor := NewNode("compactor-1", "compactor-1", RoleCompactor, "test-cluster")
+	compactor.UpdateState(StateHealthy)
+	registry.Register(compactor)
+
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry: registry,
+		RaftFSM:  stubFailoverFSM(),
+		Logger:   zerolog.Nop(),
+	})
+
+	selected := mgr.selectNewCompactor("")
+	if selected != "compactor-1" {
+		t.Errorf("selectNewCompactor should prefer RoleCompactor, got %q", selected)
+	}
+}
+
+// TestCompactorFailover_FallbackToWriter verifies that when no healthy
+// RoleCompactor nodes exist, RoleWriter is selected.
+func TestCompactorFailover_FallbackToWriter(t *testing.T) {
+	registry := NewRegistry(&RegistryConfig{Logger: zerolog.Nop()})
+
+	writer := NewNode("writer-1", "writer-1", RoleWriter, "test-cluster")
+	writer.UpdateState(StateHealthy)
+	registry.Register(writer)
+
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry: registry,
+		RaftFSM:  stubFailoverFSM(),
+		Logger:   zerolog.Nop(),
+	})
+
+	selected := mgr.selectNewCompactor("")
+	if selected != "writer-1" {
+		t.Errorf("selectNewCompactor should fall back to writer, got %q", selected)
+	}
+}
+
+// TestCompactorFailover_ExcludeFailedNode verifies that the failed
+// compactor is excluded from the candidate list.
+func TestCompactorFailover_ExcludeFailedNode(t *testing.T) {
+	registry := NewRegistry(&RegistryConfig{Logger: zerolog.Nop()})
+
+	compactor1 := NewNode("compactor-1", "compactor-1", RoleCompactor, "test-cluster")
+	compactor1.UpdateState(StateHealthy)
+	registry.Register(compactor1)
+
+	writer := NewNode("writer-1", "writer-1", RoleWriter, "test-cluster")
+	writer.UpdateState(StateHealthy)
+	registry.Register(writer)
+
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry: registry,
+		RaftFSM:  stubFailoverFSM(),
+		Logger:   zerolog.Nop(),
+	})
+
+	// Excluding compactor-1 should fall back to writer-1.
+	selected := mgr.selectNewCompactor("compactor-1")
+	if selected != "writer-1" {
+		t.Errorf("selectNewCompactor excluding compactor-1: got %q, want writer-1", selected)
+	}
+}
+
+// TestCompactorFailover_NoCandidate verifies that when no healthy nodes
+// exist, selectNewCompactor returns empty.
+func TestCompactorFailover_NoCandidate(t *testing.T) {
+	registry := NewRegistry(&RegistryConfig{Logger: zerolog.Nop()})
+
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry: registry,
+		RaftFSM:  stubFailoverFSM(),
+		Logger:   zerolog.Nop(),
+	})
+
+	selected := mgr.selectNewCompactor("")
+	if selected != "" {
+		t.Errorf("selectNewCompactor with no nodes: got %q, want empty", selected)
+	}
+}
+
+// TestCompactorFailover_CooldownPreventsRapidCycling verifies that the
+// cooldown period prevents repeated failovers.
+func TestCompactorFailover_CooldownPreventsRapidCycling(t *testing.T) {
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry:       NewRegistry(&RegistryConfig{Logger: zerolog.Nop()}),
+		RaftFSM:        stubFailoverFSM(),
+		CooldownPeriod: 1 * time.Hour,
+		Logger:         zerolog.Nop(),
+	})
+
+	// Simulate a completed failover.
+	mgr.lastFailoverAt = time.Now()
+
+	// triggerFailoverLocked should skip due to cooldown.
+	mgr.mu.Lock()
+	mgr.triggerFailoverLocked("old-compactor")
+	inProg := mgr.failoverInProg
+	mgr.mu.Unlock()
+
+	if inProg {
+		t.Error("failover should be skipped during cooldown period")
+	}
+}
+
+// TestCompactorFailover_StartStop verifies clean lifecycle.
+func TestCompactorFailover_StartStop(t *testing.T) {
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry:      NewRegistry(&RegistryConfig{Logger: zerolog.Nop()}),
+		RaftFSM:       stubFailoverFSM(),
+		CheckInterval: 50 * time.Millisecond,
+		Logger:        zerolog.Nop(),
+	})
+
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !mgr.running.Load() {
+		t.Error("expected running=true after Start")
+	}
+
+	if err := mgr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if mgr.running.Load() {
+		t.Error("expected running=false after Stop")
+	}
+}
+
+// TestCompactorFailover_ManualFailoverNoCompactor verifies that manual
+// failover returns an error when no active compactor exists.
+func TestCompactorFailover_ManualFailoverNoCompactor(t *testing.T) {
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry: NewRegistry(&RegistryConfig{Logger: zerolog.Nop()}),
+		RaftFSM:  stubFailoverFSM(),
+		Logger:   zerolog.Nop(),
+	})
+
+	err := mgr.TriggerManualFailover()
+	if err == nil {
+		t.Error("expected error when no active compactor")
+	}
+}
+
+// TestCompactorFailover_Stats verifies Stats returns expected fields.
+func TestCompactorFailover_Stats(t *testing.T) {
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry: NewRegistry(&RegistryConfig{Logger: zerolog.Nop()}),
+		RaftFSM:  stubFailoverFSM(),
+		Logger:   zerolog.Nop(),
+	})
+
+	stats := mgr.Stats()
+	if _, ok := stats["running"]; !ok {
+		t.Error("Stats missing 'running' field")
+	}
+	if _, ok := stats["active_compactor_id"]; !ok {
+		t.Error("Stats missing 'active_compactor_id' field")
+	}
+	if _, ok := stats["cooldown_period"]; !ok {
+		t.Error("Stats missing 'cooldown_period' field")
+	}
+}
+
+// TestCompactorFailover_DefaultConfig verifies sensible defaults.
+func TestCompactorFailover_DefaultConfig(t *testing.T) {
+	mgr := NewCompactorFailoverManager(&CompactorFailoverConfig{
+		Registry: NewRegistry(&RegistryConfig{Logger: zerolog.Nop()}),
+		RaftFSM:  stubFailoverFSM(),
+		Logger:   zerolog.Nop(),
+	})
+
+	if mgr.cfg.CheckInterval != 10*time.Second {
+		t.Errorf("CheckInterval: got %v, want 10s", mgr.cfg.CheckInterval)
+	}
+	if mgr.cfg.FailoverTimeout != 30*time.Second {
+		t.Errorf("FailoverTimeout: got %v, want 30s", mgr.cfg.FailoverTimeout)
+	}
+	if mgr.cfg.CooldownPeriod != 60*time.Second {
+		t.Errorf("CooldownPeriod: got %v, want 60s", mgr.cfg.CooldownPeriod)
+	}
+	if mgr.cfg.UnhealthyThreshold != 3 {
+		t.Errorf("UnhealthyThreshold: got %d, want 3", mgr.cfg.UnhealthyThreshold)
+	}
+}

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -725,7 +725,9 @@ func (c *Coordinator) sendHeartbeatToNode(addr string, hb *protocol.Heartbeat) {
 	}
 	defer conn.Close()
 
-	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	if err := conn.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		return
+	}
 	msg := protocol.NewHeartbeat(hb)
 	if err := protocol.SendMessage(conn, msg, 3*time.Second); err != nil {
 		c.logger.Debug().Err(err).Str("peer", addr).Msg("Failed to send heartbeat")

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -434,6 +434,12 @@ func (c *Coordinator) Start() error {
 		go c.discoveryLoop()
 	}
 
+	// Start heartbeat sender — periodically sends heartbeat messages to
+	// all known peers so the health checker can detect node failures.
+	// Without this, all nodes show last_heartbeat=zero and the health
+	// checker never marks anyone as unhealthy.
+	go c.heartbeatLoop()
+
 	c.running = true
 	c.localNode.MarkJoined()
 
@@ -655,6 +661,80 @@ func (c *Coordinator) runDeleteWorker() {
 // Close implements the shutdown.Shutdownable interface.
 func (c *Coordinator) Close() error {
 	return c.Stop()
+}
+
+// heartbeatLoop periodically sends heartbeat messages to all known peers.
+// Without this, the health checker has no heartbeat timestamps to check
+// and can never detect node failures. Each tick dials each peer's
+// coordinator address, sends a Heartbeat, and closes the connection.
+func (c *Coordinator) heartbeatLoop() {
+	interval := time.Duration(c.cfg.HealthCheckInterval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			c.sendHeartbeats()
+		}
+	}
+}
+
+// sendHeartbeats sends a heartbeat to each known peer (excluding self).
+func (c *Coordinator) sendHeartbeats() {
+	nodes := c.registry.GetAll()
+	local := c.registry.Local()
+
+	isLeader := false
+	if c.raftNode != nil {
+		isLeader = c.raftNode.IsLeader()
+	}
+
+	hb := &protocol.Heartbeat{
+		NodeID:    c.localNode.ID,
+		State:     string(c.localNode.GetState()),
+		IsLeader:  isLeader,
+		Timestamp: time.Now(),
+	}
+
+	for _, node := range nodes {
+		if local != nil && node.ID == local.ID {
+			continue
+		}
+		if node.Address == "" {
+			continue
+		}
+		go c.sendHeartbeatToNode(node.Address, hb)
+	}
+}
+
+// sendHeartbeatToNode sends a single heartbeat to a peer. Best-effort:
+// failures are expected when peers are down. Dial errors are silent
+// (common during failover); send errors are logged at Debug.
+func (c *Coordinator) sendHeartbeatToNode(addr string, hb *protocol.Heartbeat) {
+	conn, err := security.Dial("tcp", addr, 3*time.Second, c.tlsConfig)
+	if err != nil {
+		// Peer is likely down — expected during failover scenarios.
+		// Not logged to avoid noise during normal operation.
+		return
+	}
+	defer conn.Close()
+
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	msg := protocol.NewHeartbeat(hb)
+	if err := protocol.SendMessage(conn, msg, 3*time.Second); err != nil {
+		c.logger.Debug().Err(err).Str("peer", addr).Msg("Failed to send heartbeat")
+		return
+	}
+	// Read ack — confirms the peer processed the heartbeat.
+	if _, err := protocol.ReceiveMessage(conn, 3*time.Second); err != nil {
+		c.logger.Debug().Err(err).Str("peer", addr).Msg("Failed to read heartbeat ack")
+	}
 }
 
 // discoveryLoop periodically discovers and connects to peer nodes.
@@ -1069,12 +1149,8 @@ func (c *Coordinator) sendJoinSuccess(conn net.Conn) {
 
 // handleHeartbeat processes a heartbeat from a peer.
 func (c *Coordinator) handleHeartbeat(conn net.Conn, hb *protocol.Heartbeat) {
-	// Update the node's last heartbeat time
-	if node, exists := c.registry.Get(hb.NodeID); exists {
-		// Record heartbeat with empty stats (stats could be added to heartbeat message later)
-		node.RecordHeartbeat(NodeStats{})
-		node.UpdateState(NodeState(hb.State))
-	}
+	// Update the real node's LastHeartbeat in the registry (not a clone).
+	c.registry.RecordHeartbeat(hb.NodeID, NodeStats{})
 
 	// Send acknowledgment
 	ack := protocol.NewHeartbeatAck(&protocol.HeartbeatAck{
@@ -1692,6 +1768,9 @@ func (c *Coordinator) onWriterPromoted(newPrimaryID, oldPrimaryID string) {
 // onCompactorAssigned is the FSM callback fired when a CommandAssignCompactor
 // is applied. It notifies main.go via the registered hooks so the scheduler
 // and watcher can be dynamically activated or deactivated.
+//
+// Callbacks are invoked asynchronously (go func) because this runs on the
+// Raft FSM Apply path — blocking here stalls all cluster state updates.
 func (c *Coordinator) onCompactorAssigned(newCompactorID, oldCompactorID string) {
 	c.logger.Info().
 		Str("new_compactor", newCompactorID).
@@ -1699,11 +1778,11 @@ func (c *Coordinator) onCompactorAssigned(newCompactorID, oldCompactorID string)
 		Str("local_node", c.localNode.ID).
 		Msg("Compactor lease assignment applied")
 
-	// If we just became the active compactor, start compaction.
-	if newCompactorID == c.localNode.ID {
+	// If we just became the active compactor (and weren't before), start compaction.
+	if newCompactorID == c.localNode.ID && oldCompactorID != c.localNode.ID {
 		c.logger.Info().Msg("This node is now the active compactor")
 		if c.onBecomeCompactor != nil {
-			c.onBecomeCompactor()
+			go c.onBecomeCompactor()
 		}
 	}
 
@@ -1711,7 +1790,7 @@ func (c *Coordinator) onCompactorAssigned(newCompactorID, oldCompactorID string)
 	if oldCompactorID == c.localNode.ID && newCompactorID != c.localNode.ID {
 		c.logger.Info().Msg("This node is no longer the active compactor")
 		if c.onLoseCompactor != nil {
-			c.onLoseCompactor()
+			go c.onLoseCompactor()
 		}
 	}
 }

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1151,8 +1151,10 @@ func (c *Coordinator) sendJoinSuccess(conn net.Conn) {
 
 // handleHeartbeat processes a heartbeat from a peer.
 func (c *Coordinator) handleHeartbeat(conn net.Conn, hb *protocol.Heartbeat) {
-	// Update the real node's LastHeartbeat in the registry (not a clone).
+	// Update the real node's LastHeartbeat and self-reported state in the
+	// registry (not a clone).
 	c.registry.RecordHeartbeat(hb.NodeID, NodeStats{})
+	c.registry.UpdateNodeState(hb.NodeID, NodeState(hb.State))
 
 	// Send acknowledgment
 	ack := protocol.NewHeartbeatAck(&protocol.HeartbeatAck{

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -71,6 +71,14 @@ type Coordinator struct {
 	// Writer failover (Phase 3)
 	writerFailoverMgr *WriterFailoverManager
 
+	// Compactor failover (Phase 5)
+	compactorFailoverMgr *CompactorFailoverManager
+
+	// Phase 5: callbacks set by main.go for dynamic compaction activation.
+	// Fired from the FSM's onCompactorAssigned callback on the local node.
+	onBecomeCompactor func()
+	onLoseCompactor   func()
+
 	// WAL Replication (Phase 3.3)
 	replicationSender   *replication.Sender   // Writer only: sends entries to readers
 	replicationReceiver *replication.Receiver // Reader only: receives entries from writer
@@ -291,6 +299,34 @@ func NewCoordinator(cfg *CoordinatorConfig) (*Coordinator, error) {
 		}
 	}
 
+	// Initialize compactor failover manager (Phase 5) — reuses the same
+	// FailoverEnabled toggle and license gate as writer failover.
+	if cfg.Config.FailoverEnabled && c.raftNode != nil {
+		if cfg.LicenseClient == nil || !cfg.LicenseClient.CanUseWriterFailover() {
+			c.logger.Warn().Msg("Compactor failover enabled but license does not include writer_failover feature — compactor failover disabled")
+		} else {
+			c.compactorFailoverMgr = NewCompactorFailoverManager(&CompactorFailoverConfig{
+				Registry:        registry,
+				RaftNode:        c.raftNode,
+				RaftFSM:         c.raftFSM,
+				FailoverTimeout: time.Duration(cfg.Config.FailoverTimeoutSeconds) * time.Second,
+				CooldownPeriod:  time.Duration(cfg.Config.FailoverCooldownSeconds) * time.Second,
+				Logger:          cfg.Logger,
+			})
+
+			// Wire FSM compactor assignment callback.
+			c.raftFSM.SetCompactorAssignedCallback(func(newCompactorID, oldCompactorID string) {
+				c.onCompactorAssigned(newCompactorID, oldCompactorID)
+			})
+
+			c.logger.Info().Msg("Compactor failover manager initialized")
+
+			// Wire the FSM into the health checker so checkCompactorElected
+			// can check the active compactor lease (Phase 5).
+			c.healthChecker.SetRaftFSM(c.raftFSM)
+		}
+	}
+
 	c.logger.Info().
 		Str("node_id", nodeID).
 		Str("role", string(role)).
@@ -383,6 +419,13 @@ func (c *Coordinator) Start() error {
 		})
 		if err := c.writerFailoverMgr.Start(context.Background()); err != nil {
 			c.logger.Error().Err(err).Msg("Failed to start writer failover manager")
+		}
+	}
+
+	// Start compactor failover manager if configured (Phase 5)
+	if c.compactorFailoverMgr != nil {
+		if err := c.compactorFailoverMgr.Start(context.Background()); err != nil {
+			c.logger.Error().Err(err).Msg("Failed to start compactor failover manager")
 		}
 	}
 
@@ -504,6 +547,13 @@ func (c *Coordinator) Stop() error {
 	if c.writerFailoverMgr != nil {
 		if err := c.writerFailoverMgr.Stop(); err != nil {
 			c.logger.Error().Err(err).Msg("Error stopping writer failover manager")
+		}
+	}
+
+	// Stop compactor failover manager (Phase 5)
+	if c.compactorFailoverMgr != nil {
+		if err := c.compactorFailoverMgr.Stop(); err != nil {
+			c.logger.Error().Err(err).Msg("Error stopping compactor failover manager")
 		}
 	}
 
@@ -1637,6 +1687,56 @@ func (c *Coordinator) onWriterPromoted(newPrimaryID, oldPrimaryID string) {
 		Str("new_primary", newPrimaryID).
 		Str("old_primary", oldPrimaryID).
 		Msg("Writer promotion applied to registry")
+}
+
+// onCompactorAssigned is the FSM callback fired when a CommandAssignCompactor
+// is applied. It notifies main.go via the registered hooks so the scheduler
+// and watcher can be dynamically activated or deactivated.
+func (c *Coordinator) onCompactorAssigned(newCompactorID, oldCompactorID string) {
+	c.logger.Info().
+		Str("new_compactor", newCompactorID).
+		Str("old_compactor", oldCompactorID).
+		Str("local_node", c.localNode.ID).
+		Msg("Compactor lease assignment applied")
+
+	// If we just became the active compactor, start compaction.
+	if newCompactorID == c.localNode.ID {
+		c.logger.Info().Msg("This node is now the active compactor")
+		if c.onBecomeCompactor != nil {
+			c.onBecomeCompactor()
+		}
+	}
+
+	// If we just lost the compactor lease, stop compaction.
+	if oldCompactorID == c.localNode.ID && newCompactorID != c.localNode.ID {
+		c.logger.Info().Msg("This node is no longer the active compactor")
+		if c.onLoseCompactor != nil {
+			c.onLoseCompactor()
+		}
+	}
+}
+
+// SetCompactorCallbacks sets the callbacks for dynamic compaction activation.
+// Called from main.go before Start() so the FSM callback has hooks to invoke.
+func (c *Coordinator) SetCompactorCallbacks(onBecome, onLose func()) {
+	c.onBecomeCompactor = onBecome
+	c.onLoseCompactor = onLose
+}
+
+// IsActiveCompactor returns true if this node currently holds the compactor lease.
+func (c *Coordinator) IsActiveCompactor() bool {
+	if c.raftFSM == nil {
+		return false
+	}
+	return c.raftFSM.GetActiveCompactorID() == c.localNode.ID
+}
+
+// GetActiveCompactorID returns the node ID currently holding the compactor lease.
+func (c *Coordinator) GetActiveCompactorID() string {
+	if c.raftFSM == nil {
+		return ""
+	}
+	return c.raftFSM.GetActiveCompactorID()
 }
 
 // GetRouter returns the request router.

--- a/internal/cluster/health.go
+++ b/internal/cluster/health.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/basekick-labs/arc/internal/cluster/raft"
 	"github.com/rs/zerolog"
 )
 
@@ -39,6 +40,12 @@ type HealthChecker struct {
 	warnIfNoCompactor         bool
 	lastNoCompactorWarnAt     atomic.Int64 // unix nanos; throttles "no compactor elected"
 	lastMultiCompactorWarnAt  atomic.Int64 // unix nanos; throttles "multiple compactors elected"
+
+	// Phase 5: raftFSM is set when compactor failover is configured. When
+	// non-nil, checkCompactorElected also checks the FSM's activeCompactorID
+	// to suppress the "no compactor" warning when failover has assigned
+	// the lease to a non-RoleCompactor node (e.g. a writer after failover).
+	raftFSM *raft.ClusterFSM
 
 	running bool
 	stopCh  chan struct{}
@@ -198,12 +205,25 @@ func (h *HealthChecker) checkAllNodes() {
 // CAS race silence the other for the whole interval — an operator
 // watching a log-tail could see only "no compactor" while "multiple
 // compactors" was the more recent condition.
+// SetRaftFSM wires the Raft FSM so checkCompactorElected can check the
+// Phase 5 active compactor lease. Called from coordinator wiring.
+func (h *HealthChecker) SetRaftFSM(fsm *raft.ClusterFSM) {
+	h.raftFSM = fsm
+}
+
 func (h *HealthChecker) checkCompactorElected() {
 	compactors := h.registry.GetCompactors()
-	if len(compactors) == 1 {
-		// Correctly configured. Reset BOTH timers so the next
-		// misconfiguration of either kind fires immediately without
-		// waiting the full interval.
+
+	// Phase 5: if the FSM has an active compactor lease assigned (via
+	// failover), that counts as "a compactor is elected" even if no
+	// RoleCompactor nodes are in the registry (e.g. a writer took over).
+	activeCompactorID := ""
+	if h.raftFSM != nil {
+		activeCompactorID = h.raftFSM.GetActiveCompactorID()
+	}
+
+	if len(compactors) == 1 || (len(compactors) == 0 && activeCompactorID != "") {
+		// Correctly configured (or failover is handling it).
 		h.lastNoCompactorWarnAt.Store(0)
 		h.lastMultiCompactorWarnAt.Store(0)
 		return
@@ -215,7 +235,8 @@ func (h *HealthChecker) checkCompactorElected() {
 		}
 		h.logger.Warn().
 			Msg("No compactor elected: compacted files will accumulate. " +
-				"Set ARC_CLUSTER_ROLE=compactor on one node and restart.")
+				"Set ARC_CLUSTER_ROLE=compactor on one node and restart, " +
+				"or enable automatic failover (cluster.failover_enabled).")
 		return
 	}
 

--- a/internal/cluster/health.go
+++ b/internal/cluster/health.go
@@ -283,9 +283,11 @@ func (h *HealthChecker) checkNode(node *Node) {
 
 	healthy := h.performHealthCheck(ctx, node)
 
-	// Use atomic state transition to prevent race conditions
+	// Process the health check against the REAL node in the registry (not
+	// the clone we received from GetAll). The clone's LastHeartbeat is a
+	// snapshot — the real node's LastHeartbeat is updated by handleHeartbeat.
 	deadThreshold := h.unhealthyThreshold * 2
-	transition := node.ProcessHealthCheckResult(healthy, h.unhealthyThreshold, deadThreshold)
+	transition := h.registry.ProcessHealthCheck(node.ID, healthy, h.unhealthyThreshold, deadThreshold)
 
 	// Handle state transitions
 	if transition != nil {
@@ -320,28 +322,20 @@ func (h *HealthChecker) checkNode(node *Node) {
 // For Phase 2, this checks heartbeat freshness.
 // Phase 3 will add active HTTP health endpoint checks.
 func (h *HealthChecker) performHealthCheck(ctx context.Context, node *Node) bool {
-	// Check if context is already cancelled
 	select {
 	case <-ctx.Done():
 		return false
 	default:
 	}
 
-	// Check heartbeat freshness
-	// Consider healthy if heartbeat within 3x check interval
-	lastHeartbeat := node.GetLastHeartbeat()
+	// Read the REAL node's LastHeartbeat from the registry, not the
+	// clone's snapshot. The heartbeat sender updates the real node
+	// via registry.RecordHeartbeat; the clone is stale by the time
+	// we run the health check.
+	lastHeartbeat := h.registry.GetLastHeartbeat(node.ID)
 	threshold := 3 * h.checkInterval
 
-	if time.Since(lastHeartbeat) < threshold {
-		return true
-	}
-
-	// TODO (Phase 3): Add active health check
-	// - HTTP GET to node's /health endpoint
-	// - TCP connection test to coordinator port
-	// - gRPC health check if using gRPC
-
-	return false
+	return !lastHeartbeat.IsZero() && time.Since(lastHeartbeat) < threshold
 }
 
 // CheckNow performs an immediate health check on a specific node.

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -273,9 +273,11 @@ func (n *Node) ProcessHealthCheckResult(healthy bool, unhealthyThreshold, deadTh
 	oldState := n.State
 
 	if healthy {
-		// Reset failed checks and mark healthy
+		// Reset failed checks. LastHeartbeat is updated by the heartbeat
+		// sender (RecordHeartbeat), not here — updating it here would
+		// create a self-sustaining loop where the health check keeps
+		// the heartbeat fresh even when no real heartbeats arrive.
 		n.FailedChecks = 0
-		n.LastHeartbeat = time.Now()
 
 		if oldState != StateHealthy && oldState != StateJoining {
 			n.State = StateHealthy

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -31,6 +31,9 @@ const (
 	CommandRegisterFile
 	// CommandDeleteFile removes a file from the cluster manifest.
 	CommandDeleteFile
+	// CommandAssignCompactor designates a node as the active compactor.
+	// Used by the CompactorFailoverManager for automatic failover.
+	CommandAssignCompactor
 )
 
 // Command represents a command to be applied to the FSM.
@@ -112,11 +115,18 @@ type DeleteFilePayload struct {
 	Reason string `json:"reason,omitempty"` // "retention", "compaction", "manual"
 }
 
+// AssignCompactorPayload is the payload for CommandAssignCompactor.
+type AssignCompactorPayload struct {
+	NodeID         string `json:"node_id"`
+	OldCompactorID string `json:"old_compactor_id,omitempty"`
+}
+
 // FSMSnapshot represents a snapshot of the FSM state.
 type FSMSnapshot struct {
-	Nodes           map[string]*NodeInfo  `json:"nodes"`
-	PrimaryWriterID string                `json:"primary_writer_id,omitempty"`
-	Files           map[string]*FileEntry `json:"files,omitempty"` // File manifest (peer replication)
+	Nodes              map[string]*NodeInfo  `json:"nodes"`
+	PrimaryWriterID    string                `json:"primary_writer_id,omitempty"`
+	ActiveCompactorID  string                `json:"active_compactor_id,omitempty"`
+	Files              map[string]*FileEntry `json:"files,omitempty"` // File manifest (peer replication)
 }
 
 // ClusterFSM implements the raft.FSM interface for cluster state management.
@@ -124,8 +134,9 @@ type FSMSnapshot struct {
 type ClusterFSM struct {
 	mu              sync.RWMutex
 	nodes           map[string]*NodeInfo
-	primaryWriterID string                // ID of the current primary writer node
-	files           map[string]*FileEntry // File manifest (path → entry) for peer replication
+	primaryWriterID   string                // ID of the current primary writer node
+	activeCompactorID string                // ID of the node currently holding the compactor lease
+	files             map[string]*FileEntry // File manifest (path → entry) for peer replication
 	// Secondary index: database → set of file paths. Maintained alongside
 	// the primary `files` map on register/delete to avoid O(N) scans when
 	// filtering by database.
@@ -136,9 +147,10 @@ type ClusterFSM struct {
 	onNodeAdded      func(*NodeInfo)
 	onNodeRemoved    func(string)
 	onNodeUpdated    func(*NodeInfo)
-	onWriterPromoted func(newPrimaryID, oldPrimaryID string)
-	onFileRegistered func(*FileEntry)
-	onFileDeleted    func(path string, reason string)
+	onWriterPromoted   func(newPrimaryID, oldPrimaryID string)
+	onCompactorAssigned func(newCompactorID, oldCompactorID string)
+	onFileRegistered   func(*FileEntry)
+	onFileDeleted      func(path string, reason string)
 }
 
 // NewClusterFSM creates a new cluster FSM.
@@ -165,6 +177,20 @@ func (f *ClusterFSM) SetWriterPromotedCallback(cb func(newPrimaryID, oldPrimaryI
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.onWriterPromoted = cb
+}
+
+// SetCompactorAssignedCallback sets the callback for compactor assignment events.
+func (f *ClusterFSM) SetCompactorAssignedCallback(cb func(newCompactorID, oldCompactorID string)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.onCompactorAssigned = cb
+}
+
+// GetActiveCompactorID returns the node ID currently holding the compactor lease.
+func (f *ClusterFSM) GetActiveCompactorID() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.activeCompactorID
 }
 
 // SetFileCallbacks sets the callbacks for file manifest events (peer replication).
@@ -208,6 +234,8 @@ func (f *ClusterFSM) Apply(log *raft.Log) interface{} {
 		return f.applyRegisterFile(cmd.Payload, log.Index)
 	case CommandDeleteFile:
 		return f.applyDeleteFile(cmd.Payload)
+	case CommandAssignCompactor:
+		return f.applyAssignCompactor(cmd.Payload)
 	default:
 		return fmt.Errorf("unknown command type: %d", cmd.Type)
 	}
@@ -500,6 +528,34 @@ func (f *ClusterFSM) applyDeleteFile(payload []byte) interface{} {
 	return nil
 }
 
+func (f *ClusterFSM) applyAssignCompactor(payload []byte) interface{} {
+	var p AssignCompactorPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("failed to unmarshal assign compactor payload: %w", err)
+	}
+
+	if p.NodeID == "" {
+		return fmt.Errorf("assign compactor: node_id is required")
+	}
+
+	f.mu.Lock()
+	oldCompactorID := f.activeCompactorID
+	f.activeCompactorID = p.NodeID
+	callback := f.onCompactorAssigned
+	f.mu.Unlock()
+
+	f.logger.Info().
+		Str("new_compactor", p.NodeID).
+		Str("old_compactor", oldCompactorID).
+		Msg("Compactor lease assigned")
+
+	if callback != nil {
+		callback(p.NodeID, oldCompactorID)
+	}
+
+	return nil
+}
+
 // Snapshot returns a snapshot of the FSM state.
 func (f *ClusterFSM) Snapshot() (raft.FSMSnapshot, error) {
 	f.mu.RLock()
@@ -519,7 +575,7 @@ func (f *ClusterFSM) Snapshot() (raft.FSMSnapshot, error) {
 		files[path] = &fileCopy
 	}
 
-	return &fsmSnapshot{nodes: nodes, primaryWriterID: f.primaryWriterID, files: files}, nil
+	return &fsmSnapshot{nodes: nodes, primaryWriterID: f.primaryWriterID, activeCompactorID: f.activeCompactorID, files: files}, nil
 }
 
 // Restore restores the FSM from a snapshot.
@@ -534,6 +590,7 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 	f.mu.Lock()
 	f.nodes = snapshot.Nodes
 	f.primaryWriterID = snapshot.PrimaryWriterID
+	f.activeCompactorID = snapshot.ActiveCompactorID
 	if snapshot.Files != nil {
 		f.files = snapshot.Files
 	} else {
@@ -555,6 +612,7 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 		Int("node_count", len(snapshot.Nodes)).
 		Int("file_count", len(snapshot.Files)).
 		Str("primary_writer", snapshot.PrimaryWriterID).
+		Str("active_compactor", snapshot.ActiveCompactorID).
 		Msg("FSM restored from snapshot")
 
 	return nil
@@ -676,17 +734,19 @@ func (f *ClusterFSM) FileCount() int {
 
 // fsmSnapshot implements raft.FSMSnapshot.
 type fsmSnapshot struct {
-	nodes           map[string]*NodeInfo
-	primaryWriterID string
-	files           map[string]*FileEntry
+	nodes             map[string]*NodeInfo
+	primaryWriterID   string
+	activeCompactorID string
+	files             map[string]*FileEntry
 }
 
 // Persist writes the snapshot to the given sink.
 func (s *fsmSnapshot) Persist(sink raft.SnapshotSink) error {
 	snapshot := FSMSnapshot{
-		Nodes:           s.nodes,
-		PrimaryWriterID: s.primaryWriterID,
-		Files:           s.files,
+		Nodes:             s.nodes,
+		PrimaryWriterID:   s.primaryWriterID,
+		ActiveCompactorID: s.activeCompactorID,
+		Files:             s.files,
 	}
 
 	data, err := json.Marshal(snapshot)

--- a/internal/cluster/raft/node.go
+++ b/internal/cluster/raft/node.go
@@ -569,6 +569,22 @@ func (n *Node) DeleteFile(path, reason string, timeout time.Duration) error {
 	return n.Apply(cmd, timeout)
 }
 
+// AssignCompactor designates a node as the active compactor via Raft consensus.
+// Used by the CompactorFailoverManager for automatic failover.
+func (n *Node) AssignCompactor(nodeID, oldCompactorID string, timeout time.Duration) error {
+	payload, err := json.Marshal(AssignCompactorPayload{NodeID: nodeID, OldCompactorID: oldCompactorID})
+	if err != nil {
+		return fmt.Errorf("failed to marshal assign compactor payload: %w", err)
+	}
+
+	cmd := &Command{
+		Type:    CommandAssignCompactor,
+		Payload: payload,
+	}
+
+	return n.Apply(cmd, timeout)
+}
+
 // LeaderCh returns a channel that signals leadership changes.
 // True means this node became leader, false means it lost leadership.
 func (n *Node) LeaderCh() <-chan bool {

--- a/internal/cluster/registry.go
+++ b/internal/cluster/registry.go
@@ -172,6 +172,16 @@ func (r *Registry) RecordHeartbeat(nodeID string, stats NodeStats) bool {
 	return true
 }
 
+// UpdateNodeState updates the state of the real node in the registry.
+// Called from handleHeartbeat to propagate the peer's self-reported state.
+func (r *Registry) UpdateNodeState(nodeID string, state NodeState) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if node, exists := r.nodes[nodeID]; exists {
+		node.UpdateState(state)
+	}
+}
+
 // GetLastHeartbeat returns the LastHeartbeat timestamp of the real node in
 // the registry. Returns zero time if the node doesn't exist.
 func (r *Registry) GetLastHeartbeat(nodeID string) time.Time {

--- a/internal/cluster/registry.go
+++ b/internal/cluster/registry.go
@@ -157,6 +157,45 @@ func (r *Registry) Get(nodeID string) (*Node, bool) {
 	return node.Clone(), true
 }
 
+// RecordHeartbeat updates the LastHeartbeat on the real node in the registry
+// (not a clone). This is called from handleHeartbeat when a peer sends us
+// a heartbeat message. Node.RecordHeartbeat is thread-safe via the node's
+// internal mutex.
+func (r *Registry) RecordHeartbeat(nodeID string, stats NodeStats) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	node, exists := r.nodes[nodeID]
+	if !exists {
+		return false
+	}
+	node.RecordHeartbeat(stats)
+	return true
+}
+
+// GetLastHeartbeat returns the LastHeartbeat timestamp of the real node in
+// the registry. Returns zero time if the node doesn't exist.
+func (r *Registry) GetLastHeartbeat(nodeID string) time.Time {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	node, exists := r.nodes[nodeID]
+	if !exists {
+		return time.Time{}
+	}
+	return node.GetLastHeartbeat()
+}
+
+// ProcessHealthCheck runs a health check result against the real node in the
+// registry (not a clone). Returns the state transition if any occurred.
+func (r *Registry) ProcessHealthCheck(nodeID string, healthy bool, unhealthyThreshold, deadThreshold int) *StateTransition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	node, exists := r.nodes[nodeID]
+	if !exists {
+		return nil
+	}
+	return node.ProcessHealthCheckResult(healthy, unhealthyThreshold, deadThreshold)
+}
+
 // filterNodes returns cloned nodes that match the predicate.
 // This is a helper to reduce code duplication across Get* methods.
 func (r *Registry) filterNodes(predicate func(*Node) bool) []*Node {


### PR DESCRIPTION
## Summary
- Automatic compactor failover: Raft leader monitors compactor health and reassigns the lease to another healthy node after ~30s of unresponsiveness
- Dynamic compaction activation: new compactor starts schedulers and watcher without restart
- Release notes rewrite: consolidated 6 phase-based sections into 2 concise feature-based sections, removed all internal phase numbering

## Test plan
- [x] 10 unit tests for CompactorFailoverManager (initial assignment, selection priority, fallback to writer, exclusion, no candidate, cooldown, lifecycle, manual failover, stats, defaults)
- [x] All existing cluster + compaction tests pass (8 packages)
- [x] Enterprise review agents passed (security, license gating, code elegance)
- [x] 3-node docker test: kill compactor, verify failover within 30-60s
- [x] Fence test: original compactor returns, verify no double-compaction