### PR TITLE
fix(ingest): harden row-format msgpack flush visibility

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -116,6 +116,16 @@ Applied defense-in-depth SQL escaping to DuckDB `SET memory_limit` (single-quote
 
 ## Bug Fixes
 
+### Row-Format MessagePack Flush Hardening
+
+Issue #401 reported that row-format MessagePack writes could be silently dropped at flush time with `no time data in batch`. The failure could not be reproduced end-to-end on current builds, but Arc now has explicit regression coverage for the affected path and better visibility if a future flush failure occurs.
+
+**Changes:**
+
+- Added end-to-end regression tests for row-format MessagePack writes covering direct row ingestion, decoder-driven ingestion, and age-based flush.
+- Added a dedicated Prometheus counter, `arc_buffer_flush_failures_total`, to surface flush failures that are preserved in WAL for recovery.
+- Exposed the new flush failure counter through the JSON metrics endpoints and internal time-series collector.
+
 ### RBACManager Goroutine Leak — No Close() Method
 
 The RBACManager background cache cleanup goroutine (`cacheCleanupLoop`) ran in an infinite loop with no shutdown mechanism, leaking a goroutine on every Arc restart.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -318,11 +318,12 @@ func (s *Server) endpointMetricsHandler(c *fiber.Ctx) error {
 			"latency_avg_ms": queryLatencyAvgMs,
 		},
 		"buffer": fiber.Map{
-			"records_buffered": snapshot["buffer_records_buffered"],
-			"records_written":  snapshot["buffer_records_written"],
-			"flushes_total":    snapshot["buffer_flushes_total"],
-			"errors_total":     snapshot["buffer_errors_total"],
-			"queue_depth":      snapshot["buffer_queue_depth"],
+			"records_buffered":     snapshot["buffer_records_buffered"],
+			"records_written":      snapshot["buffer_records_written"],
+			"flushes_total":        snapshot["buffer_flushes_total"],
+			"errors_total":         snapshot["buffer_errors_total"],
+			"flush_failures_total": snapshot["buffer_flush_failures_total"],
+			"queue_depth":          snapshot["buffer_queue_depth"],
 		},
 		"storage": fiber.Map{
 			"writes_total":      snapshot["storage_writes_total"],

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -744,12 +744,12 @@ type ArrowBuffer struct {
 	shardCount uint32
 
 	// Background flush
-	ctx             context.Context
-	cancel          context.CancelFunc
-	flushTimer      *time.Timer // self-adjusting: fires when the oldest buffer is due to expire
-	flushDeadline   time.Time   // absolute time when flushTimer will fire; updated whenever the timer is (re)set
-	newBufferCh     chan struct{} // signals periodicFlush that a new buffer was created (used for idle→active wake-up)
-	wg              sync.WaitGroup
+	ctx           context.Context
+	cancel        context.CancelFunc
+	flushTimer    *time.Timer   // self-adjusting: fires when the oldest buffer is due to expire
+	flushDeadline time.Time     // absolute time when flushTimer will fire; updated whenever the timer is (re)set
+	newBufferCh   chan struct{} // signals periodicFlush that a new buffer was created (used for idle→active wake-up)
+	wg            sync.WaitGroup
 
 	// OPTIMIZATION: Worker pool for bounded flush concurrency
 	// Prevents goroutine explosion under sustained load
@@ -818,6 +818,14 @@ func (b *ArrowBuffer) HasFlushFailure() bool {
 // Called after successful WAL recovery replay.
 func (b *ArrowBuffer) ResetFlushFailure() {
 	b.hasFlushFailure.Store(false)
+}
+
+// markFlushFailure records that buffered data could not be persisted and must
+// be recovered from WAL.
+func (b *ArrowBuffer) markFlushFailure() {
+	b.totalErrors.Add(1)
+	b.hasFlushFailure.Store(true)
+	metrics.Get().IncBufferFlushFailures()
 }
 
 // getSortKeys returns sort keys for a measurement.
@@ -898,25 +906,25 @@ func NewArrowBuffer(cfg *config.IngestConfig, storage storage.Backend, logger ze
 	}
 
 	buffer := &ArrowBuffer{
-		config:          cfg,
-		storage:         storage,
-		writer:          NewArrowWriter(cfg, logger),
-		shards:          make([]*bufferShard, shardCount),
-		shardCount:      uint32(shardCount),
-		ctx:             ctx,
-		cancel:          cancel,
-		flushTimer:      time.NewTimer(time.Duration(cfg.MaxBufferAgeMS) * time.Millisecond),
-		flushDeadline:   time.Now().UTC().Add(time.Duration(cfg.MaxBufferAgeMS) * time.Millisecond),
-		newBufferCh:     make(chan struct{}, 1),
-		flushQueue:      make(chan flushTask, queueSize),
-		flushWorkers:    flushWorkers,
-		flushTimeout:    flushTimeout,
-		maxBufferAge:    time.Duration(cfg.MaxBufferAgeMS) * time.Millisecond,
+		config:               cfg,
+		storage:              storage,
+		writer:               NewArrowWriter(cfg, logger),
+		shards:               make([]*bufferShard, shardCount),
+		shardCount:           uint32(shardCount),
+		ctx:                  ctx,
+		cancel:               cancel,
+		flushTimer:           time.NewTimer(time.Duration(cfg.MaxBufferAgeMS) * time.Millisecond),
+		flushDeadline:        time.Now().UTC().Add(time.Duration(cfg.MaxBufferAgeMS) * time.Millisecond),
+		newBufferCh:          make(chan struct{}, 1),
+		flushQueue:           make(chan flushTask, queueSize),
+		flushWorkers:         flushWorkers,
+		flushTimeout:         flushTimeout,
+		maxBufferAge:         time.Duration(cfg.MaxBufferAgeMS) * time.Millisecond,
 		sortKeysConfig:       sortKeysConfig,
-		defaultSortKeys:     defaultSortKeys,
+		defaultSortKeys:      defaultSortKeys,
 		decimalConfig:        decimalConfig,
 		defaultDecimalConfig: defaultDecimalConfig,
-		logger:          logger.With().Str("component", "arrow-buffer").Logger(),
+		logger:               logger.With().Str("component", "arrow-buffer").Logger(),
 	}
 
 	// Initialize shards
@@ -2062,8 +2070,7 @@ func (b *ArrowBuffer) flushRecordsAsync(ctx context.Context, bufferKey, database
 			Str("buffer_key", bufferKey).
 			Msg("Failed to merge batches during async flush")
 
-		b.totalErrors.Add(1)
-		b.hasFlushFailure.Store(true)
+		b.markFlushFailure()
 		// Data is already in WAL (written at ingest time) - no need to restore to buffer
 		// WAL will be replayed on restart or via periodic recovery
 		return
@@ -2076,8 +2083,7 @@ func (b *ArrowBuffer) flushRecordsAsync(ctx context.Context, bufferKey, database
 			Str("buffer_key", bufferKey).
 			Int("records", recordCount).
 			Msg("Failed to flush - data preserved in WAL for recovery")
-		b.totalErrors.Add(1)
-		b.hasFlushFailure.Store(true)
+		b.markFlushFailure()
 		// Data is already in WAL (written at ingest time) - no memory growth
 		// WAL will be replayed on restart or via periodic recovery
 	}
@@ -2275,6 +2281,7 @@ func (b *ArrowBuffer) flushBufferLocked(ctx context.Context, shard *bufferShard,
 	merged, err := b.mergeBatches(recordsToFlush)
 	if err != nil {
 		shard.mu.Lock() // Re-acquire lock for caller
+		b.markFlushFailure()
 		return fmt.Errorf("failed to merge batches: %w", err)
 	}
 
@@ -2282,6 +2289,7 @@ func (b *ArrowBuffer) flushBufferLocked(ctx context.Context, shard *bufferShard,
 	startTime := time.Now().UTC()
 	if err := b.flushBufferLockedDataTime(ctx, bufferKey, database, measurement, merged, recordCount, startTime); err != nil {
 		shard.mu.Lock() // Re-acquire lock for caller
+		b.markFlushFailure()
 		b.logger.Warn().
 			Err(err).
 			Str("buffer_key", bufferKey).

--- a/internal/ingest/arrow_writer_flush_failure_test.go
+++ b/internal/ingest/arrow_writer_flush_failure_test.go
@@ -1,0 +1,95 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/pkg/models"
+	"github.com/rs/zerolog"
+)
+
+type failingStorageBackend struct {
+	err error
+}
+
+func (s *failingStorageBackend) Write(ctx context.Context, path string, data []byte) error {
+	return s.err
+}
+
+func (s *failingStorageBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	return s.err
+}
+
+func (s *failingStorageBackend) Read(ctx context.Context, path string) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *failingStorageBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
+	return nil
+}
+
+func (s *failingStorageBackend) Delete(ctx context.Context, path string) error { return nil }
+func (s *failingStorageBackend) Exists(ctx context.Context, path string) (bool, error) {
+	return false, nil
+}
+func (s *failingStorageBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	return nil, nil
+}
+func (s *failingStorageBackend) Close() error       { return nil }
+func (s *failingStorageBackend) Type() string       { return "mock-failing" }
+func (s *failingStorageBackend) ConfigJSON() string { return "{}" }
+
+func TestArrowBuffer_FlushFailureMetricOnAsyncStorageError(t *testing.T) {
+	cfg := &config.IngestConfig{
+		MaxBufferSize:  1,
+		MaxBufferAgeMS: 60000,
+		Compression:    "snappy",
+		ShardCount:     4,
+		FlushWorkers:   1,
+		FlushQueueSize: 16,
+	}
+
+	buf := NewArrowBuffer(
+		cfg,
+		&failingStorageBackend{err: errors.New("storage unavailable")},
+		zerolog.New(io.Discard),
+	)
+	t.Cleanup(func() { _ = buf.Close() })
+
+	before := metrics.Get().Snapshot()["buffer_flush_failures_total"].(int64)
+
+	record := &models.Record{
+		Measurement: "flush_failure_test",
+		Time:        time.Now().UTC(),
+		Fields: map[string]interface{}{
+			"value": 1.0,
+		},
+		Tags: map[string]string{},
+	}
+
+	if err := buf.Write(context.Background(), "default", []interface{}{record}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if buf.HasFlushFailure() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !buf.HasFlushFailure() {
+		t.Fatal("expected flush failure flag after storage write error")
+	}
+
+	after := metrics.Get().Snapshot()["buffer_flush_failures_total"].(int64)
+	if after != before+1 {
+		t.Fatalf("expected buffer_flush_failures_total=%d, got %d", before+1, after)
+	}
+}

--- a/internal/ingest/arrow_writer_rowformat_test.go
+++ b/internal/ingest/arrow_writer_rowformat_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/basekick-labs/arc/internal/config"
 	"github.com/basekick-labs/arc/pkg/models"
 	"github.com/rs/zerolog"
-	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/basekick-labs/msgpack/v6"
 )
 
 // capturingStorageBackend records every Parquet write so tests can verify

--- a/internal/ingest/arrow_writer_rowformat_test.go
+++ b/internal/ingest/arrow_writer_rowformat_test.go
@@ -1,0 +1,241 @@
+package ingest
+
+// End-to-end tests for row-format MessagePack ingest path.
+//
+// Regression guard for issue #401 — row-format writes to /api/v1/write/msgpack
+// were silently dropped at flush with "no time data in batch" error.
+//
+// These tests exercise two flows:
+//   1. Direct: buffer.Write(ctx, db, []interface{}{*models.Record}) → flush
+//   2. Full:   raw msgpack bytes → decoder → buffer → flush
+//
+// The bug was not caught by existing rowsToColumnar unit tests because those
+// tests stopped at the ColumnarRecord produced by rowsToColumnar; they never
+// exercised the full buffer → flush pipeline or the decoder → buffer handoff.
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/pkg/models"
+	"github.com/rs/zerolog"
+	"github.com/Basekick-Labs/msgpack/v6"
+)
+
+// capturingStorageBackend records every Parquet write so tests can verify
+// that data made it through the flush pipeline.
+type capturingStorageBackend struct {
+	mu     sync.Mutex
+	writes [][]byte
+	paths  []string
+}
+
+func (s *capturingStorageBackend) Write(ctx context.Context, path string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.paths = append(s.paths, path)
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	s.writes = append(s.writes, cp)
+	return nil
+}
+
+func (s *capturingStorageBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	buf := bytes.NewBuffer(make([]byte, 0, size))
+	if _, err := io.Copy(buf, reader); err != nil {
+		return err
+	}
+	return s.Write(ctx, path, buf.Bytes())
+}
+
+func (s *capturingStorageBackend) Read(ctx context.Context, path string) ([]byte, error) {
+	return nil, nil
+}
+func (s *capturingStorageBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
+	return nil
+}
+func (s *capturingStorageBackend) Delete(ctx context.Context, path string) error { return nil }
+func (s *capturingStorageBackend) Exists(ctx context.Context, path string) (bool, error) {
+	return false, nil
+}
+func (s *capturingStorageBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	return nil, nil
+}
+func (s *capturingStorageBackend) Close() error       { return nil }
+func (s *capturingStorageBackend) Type() string       { return "mock-capturing" }
+func (s *capturingStorageBackend) ConfigJSON() string { return "{}" }
+
+func (s *capturingStorageBackend) writeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.writes)
+}
+
+func createE2EArrowBuffer(t *testing.T) (*ArrowBuffer, *capturingStorageBackend) {
+	t.Helper()
+	logger := zerolog.New(os.Stderr).Level(zerolog.DebugLevel)
+	cfg := &config.IngestConfig{
+		MaxBufferSize:  10,
+		MaxBufferAgeMS: 60000,
+		Compression:    "snappy",
+		ShardCount:     4,
+		FlushWorkers:   1,
+		FlushQueueSize: 16,
+	}
+	storage := &capturingStorageBackend{}
+	buf := NewArrowBuffer(cfg, storage, logger)
+	t.Cleanup(func() { buf.Close() })
+	return buf, storage
+}
+
+// TestArrowBuffer_WriteRowFormat_DirectRecord — direct path: construct
+// *models.Record manually, send through Write. This mirrors what decodeRow
+// produces.
+func TestArrowBuffer_WriteRowFormat_DirectRecord(t *testing.T) {
+	buf, storage := createE2EArrowBuffer(t)
+
+	now := time.Now().UTC()
+	records := []interface{}{
+		&models.Record{
+			Measurement: "row_test",
+			Time:        now,
+			Fields: map[string]interface{}{
+				"sensor": "temp-1",
+				"value":  22.5,
+			},
+			Tags: map[string]string{},
+		},
+	}
+
+	for i := 0; i < 15; i++ {
+		if err := buf.Write(context.Background(), "default", records); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && storage.writeCount() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if storage.writeCount() == 0 {
+		t.Fatal("No Parquet files written — direct path failed")
+	}
+}
+
+// TestArrowBuffer_WriteRowFormat_ViaDecoder — full path mirroring the HTTP
+// handler: raw msgpack → MessagePackDecoder.Decode → ArrowBuffer.Write →
+// flush. This is what the HTTP handler at /api/v1/write/msgpack does.
+// This is the actual issue #401 reproduction.
+func TestArrowBuffer_WriteRowFormat_ViaDecoder(t *testing.T) {
+	buf, storage := createE2EArrowBuffer(t)
+	logger := zerolog.New(os.Stderr).Level(zerolog.DebugLevel)
+	decoder := NewMessagePackDecoder(logger)
+
+	// Construct the exact payload from issue #401: single bare row map.
+	now := time.Now().UnixMicro()
+	payload := map[string]any{
+		"m": "row_test",
+		"t": now,
+		"fields": map[string]any{
+			"sensor": "temp-1",
+			"value":  22.5,
+		},
+	}
+
+	data, err := msgpack.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Decode exactly like the HTTP handler does.
+	records, err := decoder.Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	t.Logf("Decoded records type: %T", records)
+	if recList, ok := records.([]interface{}); ok {
+		t.Logf("Records count: %d", len(recList))
+		for i, r := range recList {
+			t.Logf("  Record[%d] type: %T, value: %+v", i, r, r)
+		}
+	}
+
+	// Write enough to trigger flush.
+	for i := 0; i < 15; i++ {
+		if err := buf.Write(context.Background(), "default", records); err != nil {
+			t.Fatalf("Write iter %d: %v", i, err)
+		}
+	}
+
+	// Wait for async flush.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && storage.writeCount() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if storage.writeCount() == 0 {
+		t.Fatal("No Parquet files written — decoder→buffer→flush path failed (issue #401)")
+	}
+	t.Logf("Parquet files written: %d", storage.writeCount())
+}
+
+// TestArrowBuffer_WriteRowFormat_ViaDecoder_SingleWrite — single write (no
+// size-based flush), rely on buffer-age flush.
+func TestArrowBuffer_WriteRowFormat_ViaDecoder_SingleWrite(t *testing.T) {
+	logger := zerolog.New(os.Stderr).Level(zerolog.DebugLevel)
+	cfg := &config.IngestConfig{
+		MaxBufferSize:  1000,
+		MaxBufferAgeMS: 200, // flush after 200ms
+		Compression:    "snappy",
+		ShardCount:     4,
+		FlushWorkers:   1,
+		FlushQueueSize: 16,
+	}
+	storage := &capturingStorageBackend{}
+	buf := NewArrowBuffer(cfg, storage, logger)
+	defer buf.Close()
+
+	decoder := NewMessagePackDecoder(logger)
+
+	now := time.Now().UnixMicro()
+	payload := map[string]any{
+		"m": "row_test",
+		"t": now,
+		"fields": map[string]any{
+			"sensor": "temp-1",
+			"value":  22.5,
+		},
+	}
+
+	data, err := msgpack.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	records, err := decoder.Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	if err := buf.Write(context.Background(), "default", records); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Wait for age-based flush (200ms + grace).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && storage.writeCount() == 0 {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if storage.writeCount() == 0 {
+		t.Fatal("No Parquet files written — age-based flush failed for single row (issue #401)")
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -55,6 +55,7 @@ type Metrics struct {
 	bufferRecordsWritten  atomic.Int64
 	bufferFlushesTotal    atomic.Int64
 	bufferErrorsTotal     atomic.Int64
+	bufferFlushFailures   atomic.Int64
 	bufferQueueDepth      atomic.Int64
 
 	// Storage metrics
@@ -100,10 +101,10 @@ type Metrics struct {
 	auditWriteErrors atomic.Int64
 
 	// WAL metrics
-	walRecordsPreserved  atomic.Int64 // Records preserved in WAL for recovery (flush failures)
-	walRecoveryTotal     atomic.Int64 // Successful WAL recovery operations
-	walRecoveryRecords   atomic.Int64 // Total records recovered from WAL
-	walDroppedEntries    atomic.Int64 // Entries dropped due to full WAL buffer
+	walRecordsPreserved atomic.Int64 // Records preserved in WAL for recovery (flush failures)
+	walRecoveryTotal    atomic.Int64 // Successful WAL recovery operations
+	walRecoveryRecords  atomic.Int64 // Total records recovered from WAL
+	walDroppedEntries   atomic.Int64 // Entries dropped due to full WAL buffer
 
 	// Decompression pool metrics
 	decompBufferDiscards atomic.Int64 // Oversized buffers not returned to pool
@@ -224,6 +225,7 @@ func (m *Metrics) SetBufferRecordsBuffered(count int64) { m.bufferRecordsBuffere
 func (m *Metrics) SetBufferRecordsWritten(count int64)  { m.bufferRecordsWritten.Store(count) }
 func (m *Metrics) SetBufferFlushes(count int64)         { m.bufferFlushesTotal.Store(count) }
 func (m *Metrics) SetBufferErrors(count int64)          { m.bufferErrorsTotal.Store(count) }
+func (m *Metrics) IncBufferFlushFailures()              { m.bufferFlushFailures.Add(1) }
 func (m *Metrics) SetBufferQueueDepth(depth int64)      { m.bufferQueueDepth.Store(depth) }
 
 // Storage Metrics
@@ -357,11 +359,12 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 		"query_latency_count":  m.queryLatencyCount.Load(),
 
 		// Buffer
-		"buffer_records_buffered": m.bufferRecordsBuffered.Load(),
-		"buffer_records_written":  m.bufferRecordsWritten.Load(),
-		"buffer_flushes_total":    m.bufferFlushesTotal.Load(),
-		"buffer_errors_total":     m.bufferErrorsTotal.Load(),
-		"buffer_queue_depth":      m.bufferQueueDepth.Load(),
+		"buffer_records_buffered":     m.bufferRecordsBuffered.Load(),
+		"buffer_records_written":      m.bufferRecordsWritten.Load(),
+		"buffer_flushes_total":        m.bufferFlushesTotal.Load(),
+		"buffer_errors_total":         m.bufferErrorsTotal.Load(),
+		"buffer_flush_failures_total": m.bufferFlushFailures.Load(),
+		"buffer_queue_depth":          m.bufferQueueDepth.Load(),
 
 		// Storage
 		"storage_writes_total":      m.storageWritesTotal.Load(),
@@ -561,6 +564,10 @@ func (m *Metrics) PrometheusFormat() string {
 	b = append(b, "# HELP arc_buffer_flushes_total Total buffer flushes\n"...)
 	b = append(b, "# TYPE arc_buffer_flushes_total counter\n"...)
 	b = appendMetric(b, "arc_buffer_flushes_total", float64(m.bufferFlushesTotal.Load()))
+
+	b = append(b, "# HELP arc_buffer_flush_failures_total Total buffer flush failures preserved for WAL recovery\n"...)
+	b = append(b, "# TYPE arc_buffer_flush_failures_total counter\n"...)
+	b = appendMetric(b, "arc_buffer_flush_failures_total", float64(m.bufferFlushFailures.Load()))
 
 	b = append(b, "# HELP arc_buffer_queue_depth Current flush queue depth\n"...)
 	b = append(b, "# TYPE arc_buffer_queue_depth gauge\n"...)

--- a/internal/metrics/timeseries.go
+++ b/internal/metrics/timeseries.go
@@ -152,9 +152,10 @@ func (c *TimeSeriesCollector) collect() {
 			"query_requests_total": m.queryRequestsTotal.Load(),
 			"query_rows_total":     m.queryRowsTotal.Load(),
 			// Buffer
-			"buffer_queue_depth":   m.bufferQueueDepth.Load(),
-			"buffer_flushes_total": m.bufferFlushesTotal.Load(),
-			"buffer_errors_total":  m.bufferErrorsTotal.Load(),
+			"buffer_queue_depth":          m.bufferQueueDepth.Load(),
+			"buffer_flushes_total":        m.bufferFlushesTotal.Load(),
+			"buffer_errors_total":         m.bufferErrorsTotal.Load(),
+			"buffer_flush_failures_total": m.bufferFlushFailures.Load(),
 			// Storage
 			"storage_writes_total":      m.storageWritesTotal.Load(),
 			"storage_write_bytes_total": m.storageWriteBytesTotal.Load(),

--- a/internal/metrics/timeseries_test.go
+++ b/internal/metrics/timeseries_test.go
@@ -182,6 +182,7 @@ func TestTimeSeriesCollector_CollectedMetrics(t *testing.T) {
 			"query_requests_total",
 			"buffer_queue_depth",
 			"buffer_flushes_total",
+			"buffer_flush_failures_total",
 			"storage_writes_total",
 			"storage_write_bytes_total",
 			"storage_reads_total",


### PR DESCRIPTION
## Summary
- issue #401 was not reproducible locally on current builds
- land end-to-end row-format MessagePack regression coverage
- expose dedicated flush failure visibility for WAL-preserved failures

## Key Changes
- add row-format end-to-end tests for direct writes, decoder-driven writes, and age-based flush
- add a dedicated buffer flush failure metric to Prometheus, JSON metrics, and time-series collection
- update release notes for the hardening work

## Test Plan
- [x] `go test ./internal/ingest ./internal/metrics ./internal/api`
