### PR TITLE
feat(cluster): resumable peer-replication transfers (#398)

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -20,6 +20,7 @@ Every file is SHA-256 hashed at flush time and the hash is committed into a Raft
 - `GET /api/v1/cluster/files` returns the full cluster manifest (supports `?database=` filter).
 - Replication status and catch-up progress are surfaced via `/api/v1/cluster/status`.
 - Zero overhead for OSS / standalone deployments.
+- **Resumable transfers**: interrupted pulls resume from the last committed byte instead of restarting from zero. Especially valuable for large compacted Parquet outputs on slow or flaky links. On retry the puller checks how many bytes are already on disk, hashes the prefix to continue the SHA-256 chain, and requests only the remaining tail from the peer. Full-file hash verification is still enforced. S3 and Azure Blob backends fall back to a full re-fetch on resume (append is not supported by those APIs); local-SSD nodes get complete resume support.
 
 **Configuration** (`ARC_CLUSTER_REPLICATION_*` env vars or `cluster.replication_*` in `arc.toml`):
 

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -946,6 +946,13 @@ func (m *mockLocalBackend) Exists(ctx context.Context, path string) (bool, error
 func (m *mockLocalBackend) Close() error                                          { return nil }
 func (m *mockLocalBackend) Type() string                                          { return "mock" }
 func (m *mockLocalBackend) ConfigJSON() string                                    { return "{}" }
+func (m *mockLocalBackend) ReadToAt(_ context.Context, _ string, _ io.Writer, _ int64) error {
+	return nil
+}
+func (m *mockLocalBackend) StatFile(_ context.Context, _ string) (int64, error) { return -1, nil }
+func (m *mockLocalBackend) AppendReader(_ context.Context, _ string, _ io.Reader, _ int64) error {
+	return nil
+}
 
 func TestRewriteTimeBucket(t *testing.T) {
 	tests := []struct {

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1360,11 +1360,24 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 		return
 	}
 
-	// Step 5: Send the ack header with the size and checksum from the manifest.
+	// Step 5: Validate the byte offset (if any) and compute the tail size.
+	byteOffset := req.ByteOffset
+	if byteOffset < 0 || byteOffset >= entry.SizeBytes {
+		c.sendFetchError(conn, protocol.AckCodeBadOffset,
+			fmt.Sprintf("invalid byte offset %d for file size %d", byteOffset, entry.SizeBytes))
+		return
+	}
+	tailBytes := entry.SizeBytes - byteOffset
+
+	// Step 6: Send the ack header. SizeBytes is the tail size (bytes being
+	// sent), not the full file size — the puller reads exactly tailBytes.
+	// SHA256 is always the whole-file hash so the puller can verify integrity.
+	// ByteOffset echoes the requested offset so the puller can confirm it.
 	ack := &protocol.FetchFileAckHeader{
-		Status:    "ok",
-		SizeBytes: entry.SizeBytes,
-		SHA256:    entry.SHA256,
+		Status:     "ok",
+		SizeBytes:  tailBytes,
+		SHA256:     entry.SHA256,
+		ByteOffset: byteOffset,
 	}
 	// Short write timeout for the header itself — if the peer is slow reading,
 	// we want to fail fast rather than hold the goroutine.
@@ -1380,8 +1393,9 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 		return
 	}
 
-	// Step 6: Stream the body directly on the raw connection. No further
-	// protocol framing — the peer reads exactly entry.SizeBytes bytes.
+	// Step 7: Stream the body directly on the raw connection. No further
+	// protocol framing — the peer reads exactly tailBytes bytes.
+	// Use ReadToAt when offset > 0; ReadTo for the full-file case.
 	// The write deadline bounds slow peers; the context is derived from the
 	// coordinator's lifetime so shutdown cancels any in-flight transfer.
 	// Operators serving large Parquet files or running on slow/constrained
@@ -1396,13 +1410,17 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 	}
 	bodyCtx, bodyCancel := context.WithTimeout(c.ctx, bodyStreamTimeout)
 	defer bodyCancel()
-	if err := backend.ReadTo(bodyCtx, sanitized, conn); err != nil {
+
+	// ReadToAt handles both the full-fetch (offset=0) and resume cases uniformly.
+	bodyErr := backend.ReadToAt(bodyCtx, sanitized, conn, byteOffset)
+	if bodyErr != nil {
 		// The peer will detect a short body via its own size accounting; we
 		// can't meaningfully recover here since the ack has already been sent.
 		c.logger.Warn().
-			Err(err).
+			Err(bodyErr).
 			Str("peer", remoteAddr).
 			Str("path", sanitized).
+			Int64("byte_offset", byteOffset).
 			Msg("FetchFile: error streaming body")
 		return
 	}
@@ -1414,6 +1432,7 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 		Str("peer", remoteAddr).
 		Str("path", sanitized).
 		Int64("size_bytes", entry.SizeBytes).
+		Int64("byte_offset", byteOffset).
 		Msg("FetchFile served successfully")
 }
 

--- a/internal/cluster/filereplication/fetch_client.go
+++ b/internal/cluster/filereplication/fetch_client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"time"
 
@@ -68,12 +69,19 @@ func NewFetchClient(c FetchClient) (*FetchClient, error) {
 // streams body bytes into dst (while computing SHA-256), and verifies that
 // the computed hash matches the manifest SHA-256 from entry.SHA256.
 //
-// Returns the number of body bytes written and any error. On a checksum
-// mismatch the error wraps ErrChecksumMismatch so the puller can distinguish
-// mismatches from transport errors.
+// byteOffset is the byte position to resume from (0 = full fetch). When
+// byteOffset > 0, prefixHasher must be a hash.Hash pre-fed with bytes
+// [0, byteOffset) from the partial local file. Fetch streams bytes
+// [byteOffset, entry.SizeBytes) through the same hasher and verifies the
+// final digest against entry.SHA256. When byteOffset == 0, prefixHasher
+// must be nil; Fetch creates a fresh sha256 hasher internally.
+//
+// Returns the number of tail bytes written to dst and any error. On a
+// checksum mismatch the error wraps ErrChecksumMismatch. On a bad-offset
+// rejection from the peer the error wraps ErrBadOffset.
 //
 // The connection is always closed before returning.
-func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
+func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer, byteOffset int64, prefixHasher hash.Hash) (int64, error) {
 	if entry == nil {
 		return 0, fmt.Errorf("fetch: entry is nil")
 	}
@@ -82,6 +90,15 @@ func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.Fi
 	}
 	if entry.SizeBytes < 0 {
 		return 0, fmt.Errorf("fetch: entry has negative SizeBytes=%d", entry.SizeBytes)
+	}
+	if byteOffset < 0 {
+		return 0, fmt.Errorf("fetch: negative byteOffset=%d", byteOffset)
+	}
+	if byteOffset > 0 && prefixHasher == nil {
+		return 0, fmt.Errorf("fetch: byteOffset=%d but prefixHasher is nil", byteOffset)
+	}
+	if byteOffset == 0 && prefixHasher != nil {
+		return 0, fmt.Errorf("fetch: byteOffset=0 but prefixHasher is non-nil")
 	}
 
 	// Step 1: dial. Use security.Dial which wraps tls.DialWithDialer if TLS
@@ -104,7 +121,9 @@ func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.Fi
 	// Step 2: build and send the MsgFetchFile request. The HMAC binds the
 	// request to this specific {nodeID, clusterName, path, timestamp} tuple
 	// so a stolen MAC can't be replayed — neither outside the ±5min freshness
-	// window nor to fetch a different file within it.
+	// window nor to fetch a different file within it. ByteOffset is NOT bound
+	// into the HMAC — binding it would invalidate the MAC on resume since the
+	// path is already bound; offset is positional within that file.
 	nonce, err := security.GenerateNonce()
 	if err != nil {
 		return 0, fmt.Errorf("generate nonce: %w", err)
@@ -113,11 +132,12 @@ func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.Fi
 	mac := security.ComputeFetchHMAC(f.SharedSecret, nonce, f.SelfNodeID, f.ClusterName, entry.Path, ts)
 
 	req := &protocol.FetchFileRequest{
-		Path:      entry.Path,
-		NodeID:    f.SelfNodeID,
-		Nonce:     nonce,
-		Timestamp: ts,
-		HMAC:      mac,
+		Path:       entry.Path,
+		NodeID:     f.SelfNodeID,
+		Nonce:      nonce,
+		Timestamp:  ts,
+		HMAC:       mac,
+		ByteOffset: byteOffset,
 	}
 	if err := protocol.SendMessage(conn, &protocol.Message{
 		Type:    protocol.MsgFetchFile,
@@ -140,21 +160,28 @@ func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.Fi
 		return 0, fmt.Errorf("ack payload has wrong type: %T", ackMsg.Payload)
 	}
 	if ack.Status != "ok" {
-		// Phase 3: if the peer reports "not_found" or "manifest" (i.e. this
-		// peer simply doesn't hold this file), return ErrFileNotOnPeer so
-		// the puller can fall through to the next candidate peer. Code is
-		// empty when talking to a Phase 2 peer that predates this field —
-		// in that case, fall back to matching known human-readable strings.
+		// bad_offset means the server rejected our resume offset. The puller
+		// should delete the partial file and retry from zero — not fall through
+		// to another peer (the file exists there, the offset is just stale).
+		if ack.Code == protocol.AckCodeBadOffset {
+			return 0, fmt.Errorf("%w: %s", ErrBadOffset, ack.Error)
+		}
+		// not_found or manifest: peer simply doesn't hold this file.
 		if isFileNotOnPeerAck(ack) {
 			return 0, fmt.Errorf("%w: %s", ErrFileNotOnPeer, ack.Error)
 		}
 		return 0, fmt.Errorf("peer rejected fetch: %s", ack.Error)
 	}
+	// Validate the ack's offset echo — confirms the server honored our offset.
+	if ack.ByteOffset != byteOffset {
+		return 0, fmt.Errorf("byte offset echo mismatch: requested=%d acked=%d", byteOffset, ack.ByteOffset)
+	}
+	expectedTail := entry.SizeBytes - byteOffset
 	if ack.SizeBytes < 0 {
 		return 0, fmt.Errorf("ack has negative SizeBytes=%d", ack.SizeBytes)
 	}
-	if ack.SizeBytes != entry.SizeBytes {
-		return 0, fmt.Errorf("ack size mismatch: peer=%d manifest=%d", ack.SizeBytes, entry.SizeBytes)
+	if ack.SizeBytes != expectedTail {
+		return 0, fmt.Errorf("ack size mismatch: peer tail=%d expected tail=%d (offset=%d)", ack.SizeBytes, expectedTail, byteOffset)
 	}
 	if ack.SHA256 != entry.SHA256 {
 		// Peer disagrees with our manifest about this file's hash — shouldn't
@@ -163,16 +190,24 @@ func (f *FetchClient) Fetch(ctx context.Context, peerAddr string, entry *raft.Fi
 		return 0, fmt.Errorf("%w: ack hash=%s manifest=%s", ErrChecksumMismatch, ack.SHA256, entry.SHA256)
 	}
 
-	// Step 4: stream exactly SizeBytes of raw body from the connection into
-	// dst, tee'ing through a SHA-256 hasher.
-	hasher := sha256.New()
+	// Step 4: stream exactly ack.SizeBytes (tail) of raw body from the
+	// connection into dst, tee'ing through the SHA-256 hasher.
+	// For a full fetch (byteOffset==0), create a fresh hasher.
+	// For a resume, reuse the caller-supplied prefixHasher which already
+	// absorbed the prefix bytes — so the final digest covers the whole file.
+	var hasher hash.Hash
+	if prefixHasher != nil {
+		hasher = prefixHasher
+	} else {
+		hasher = sha256.New()
+	}
 	mw := io.MultiWriter(dst, hasher)
 	written, err := io.CopyN(mw, conn, ack.SizeBytes)
 	if err != nil {
-		return written, fmt.Errorf("stream body: %w (wrote %d of %d)", err, written, ack.SizeBytes)
+		return written, fmt.Errorf("stream body: %w (wrote %d of %d tail bytes)", err, written, ack.SizeBytes)
 	}
 
-	// Step 5: verify the computed hash matches the expected hash.
+	// Step 5: verify the computed hash matches the expected whole-file hash.
 	computed := hex.EncodeToString(hasher.Sum(nil))
 	if computed != entry.SHA256 {
 		return written, fmt.Errorf("%w: computed=%s expected=%s", ErrChecksumMismatch, computed, entry.SHA256)

--- a/internal/cluster/filereplication/fetch_client_test.go
+++ b/internal/cluster/filereplication/fetch_client_test.go
@@ -137,17 +137,27 @@ func (p *fakePeer) handleConn(conn net.Conn) {
 		}
 	}
 
+	// Echo the requested ByteOffset back in the ack so the client can validate it.
+	// For resume requests, also trim the body and adjust SizeBytes to the tail.
+	sendAck := ack
+	sendBody := body
+	if ack.Status == "ok" && req.ByteOffset > 0 && req.ByteOffset <= int64(len(body)) {
+		sendAck.ByteOffset = req.ByteOffset
+		sendAck.SizeBytes = int64(len(body)) - req.ByteOffset
+		sendBody = body[req.ByteOffset:]
+	}
+
 	if err := protocol.SendMessage(conn, &protocol.Message{
 		Type:    protocol.MsgFetchFileAck,
-		Payload: &ack,
+		Payload: &sendAck,
 	}, 2*time.Second); err != nil {
 		return
 	}
-	if ack.Status != "ok" {
+	if sendAck.Status != "ok" {
 		return
 	}
-	if len(body) > 0 {
-		_, _ = conn.Write(body)
+	if len(sendBody) > 0 {
+		_, _ = conn.Write(sendBody)
 	}
 }
 
@@ -188,7 +198,7 @@ func TestFetchClientHappyPath(t *testing.T) {
 		SHA256:    sum,
 	}
 	var dst bytes.Buffer
-	n, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	n, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -219,7 +229,7 @@ func TestFetchClientChecksumMismatch(t *testing.T) {
 		SHA256:    manifestSum,
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -248,7 +258,7 @@ func TestFetchClientBodyHashMismatch(t *testing.T) {
 		SHA256:    claimedSum,
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -269,7 +279,7 @@ func TestFetchClientErrorAck(t *testing.T) {
 		SHA256:    sha256Hex([]byte("dummy")),
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -290,7 +300,7 @@ func TestFetchClientSizeMismatch(t *testing.T) {
 		SHA256:    sum,
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatalf("expected size mismatch error, got nil")
 	}
@@ -305,7 +315,7 @@ func TestFetchClientDialError(t *testing.T) {
 	}
 	var dst bytes.Buffer
 	// Port 1 on loopback should refuse connections.
-	_, err := fc.Fetch(context.Background(), "127.0.0.1:1", entry, &dst)
+	_, err := fc.Fetch(context.Background(), "127.0.0.1:1", entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatalf("expected dial error, got nil")
 	}
@@ -333,7 +343,7 @@ func TestFetchClientHMACSent(t *testing.T) {
 		SHA256:    sum,
 	}
 	var dst bytes.Buffer
-	if _, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst); err != nil {
+	if _, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil); err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
 
@@ -369,7 +379,7 @@ func TestFetchClientPeerDropsBeforeReply(t *testing.T) {
 		SHA256:    sha256Hex([]byte("xxxxxxxxxx")),
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -422,7 +432,7 @@ func TestFetchClientLargeBody(t *testing.T) {
 		SHA256:    sum,
 	}
 	// Discard dst — we only care that the Fetch succeeds on a large body.
-	n, err := fc.Fetch(context.Background(), peer.addr(), entry, io.Discard)
+	n, err := fc.Fetch(context.Background(), peer.addr(), entry, io.Discard, 0, nil)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -449,7 +459,7 @@ func TestFetchClientErrFileNotOnPeerCodeNotFound(t *testing.T) {
 		SHA256:    sha256Hex([]byte("dummy")),
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -473,7 +483,7 @@ func TestFetchClientErrFileNotOnPeerCodeManifest(t *testing.T) {
 		SHA256:    sha256Hex([]byte("dummy")),
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -509,7 +519,7 @@ func TestFetchClientErrFileNotOnPeerPhase2Fallback(t *testing.T) {
 				SHA256:    sha256Hex([]byte("dummy")),
 			}
 			var dst bytes.Buffer
-			_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+			_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -536,7 +546,7 @@ func TestFetchClientAuthErrorIsNotFallback(t *testing.T) {
 		SHA256:    sha256Hex([]byte("dummy")),
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -560,11 +570,115 @@ func TestFetchClientBackendErrorIsNotFallback(t *testing.T) {
 		SHA256:    sha256Hex([]byte("dummy")),
 	}
 	var dst bytes.Buffer
-	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst)
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 0, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if errors.Is(err, ErrFileNotOnPeer) {
 		t.Errorf("backend errors must NOT map to ErrFileNotOnPeer, got %v", err)
+	}
+}
+
+// --- Resume / ByteOffset tests -------------------------------------------
+
+// TestFetchClientResume_HappyPath verifies that a client can resume a partial
+// transfer. The peer serves only the tail bytes; the client chains the
+// provided prefixHasher and verifies the full-file SHA-256.
+func TestFetchClientResume_HappyPath(t *testing.T) {
+	fullBody := []byte("0123456789abcdefghij") // 20 bytes
+	prefix := fullBody[:10]
+	tail := fullBody[10:]
+	fullSum := sha256Hex(fullBody)
+
+	peer := startFakePeer(t)
+	defer peer.stop()
+	// Script the full body — the fake peer will slice it based on ByteOffset.
+	peer.scriptOK(fullSum, fullBody)
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/resume.parquet",
+		SizeBytes: int64(len(fullBody)),
+		SHA256:    fullSum,
+	}
+
+	// Pre-seed the hasher with the prefix bytes, as the puller would.
+	prefixHasher := sha256.New()
+	prefixHasher.Write(prefix)
+
+	var dst bytes.Buffer
+	n, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, int64(len(prefix)), prefixHasher)
+	if err != nil {
+		t.Fatalf("Fetch resume: %v", err)
+	}
+	if n != int64(len(tail)) {
+		t.Errorf("bytes written: got %d, want %d (tail only)", n, len(tail))
+	}
+	if !bytes.Equal(dst.Bytes(), tail) {
+		t.Errorf("body mismatch: got %q, want %q", dst.Bytes(), tail)
+	}
+}
+
+// TestFetchClientResume_BadOffsetAck verifies that AckCodeBadOffset maps to
+// ErrBadOffset — not ErrFileNotOnPeer (which would trigger peer fallback).
+func TestFetchClientResume_BadOffsetAck(t *testing.T) {
+	peer := startFakePeer(t)
+	defer peer.stop()
+	peer.scriptErrorCode(protocol.AckCodeBadOffset, "offset 999 >= file size 42")
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/bad-offset.parquet",
+		SizeBytes: 42,
+		SHA256:    sha256Hex([]byte("dummy")),
+	}
+	prefixHasher := sha256.New()
+	prefixHasher.Write(make([]byte, 10))
+
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 10, prefixHasher)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrBadOffset) {
+		t.Errorf("expected ErrBadOffset, got %v", err)
+	}
+	if errors.Is(err, ErrFileNotOnPeer) {
+		t.Errorf("ErrBadOffset must NOT map to ErrFileNotOnPeer")
+	}
+}
+
+// TestFetchClientResume_OffsetEchoMismatch verifies that if the peer echoes a
+// different ByteOffset than requested, Fetch returns a protocol error.
+func TestFetchClientResume_OffsetEchoMismatch(t *testing.T) {
+	fullBody := []byte("hello world full body")
+	fullSum := sha256Hex(fullBody)
+
+	peer := startFakePeer(t)
+	defer peer.stop()
+	// Script the ack with a different ByteOffset than the client will request.
+	peer.mu.Lock()
+	peer.ack = protocol.FetchFileAckHeader{
+		Status:     "ok",
+		SizeBytes:  int64(len(fullBody)) - 5,
+		SHA256:     fullSum,
+		ByteOffset: 999, // wrong echo
+	}
+	peer.body = fullBody[5:]
+	peer.mu.Unlock()
+
+	fc := newFetchClient(t, "reader-1", "shared-secret-xyz")
+	entry := &raft.FileEntry{
+		Path:      "db/cpu/echo-mismatch.parquet",
+		SizeBytes: int64(len(fullBody)),
+		SHA256:    fullSum,
+	}
+	prefixHasher := sha256.New()
+	prefixHasher.Write(fullBody[:5])
+
+	var dst bytes.Buffer
+	_, err := fc.Fetch(context.Background(), peer.addr(), entry, &dst, 5, prefixHasher)
+	if err == nil {
+		t.Fatal("expected error on offset echo mismatch, got nil")
 	}
 }

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -11,8 +11,10 @@ package filereplication
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -28,11 +30,19 @@ import (
 // unit-tested with a fake that returns deterministic bytes/errors without
 // opening real TCP connections.
 type Fetcher interface {
-	// Fetch downloads the file identified by entry from the given peer address
-	// and writes the body bytes into dst. It MUST verify that the peer's
-	// declared SHA-256 matches the expected value from the manifest and that
-	// the body length matches the declared size. Returns (bytesWritten, error).
-	Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error)
+	// Fetch downloads the file (or a tail of it) identified by entry from the
+	// given peer address and writes body bytes into dst.
+	//
+	// byteOffset is the byte position to resume from (0 = full fetch). When
+	// byteOffset > 0, prefixHasher must be a sha256.Hash pre-fed with bytes
+	// [0, byteOffset) from the partial local file. Fetch streams bytes
+	// [byteOffset, entry.SizeBytes) through the same hasher and verifies the
+	// final hash against entry.SHA256. When byteOffset == 0, prefixHasher must
+	// be nil; Fetch creates a fresh hasher internally.
+	//
+	// Returns (bytesWritten, error). bytesWritten counts only the tail bytes
+	// received in this call (not the prefix already on disk).
+	Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer, byteOffset int64, prefixHasher hash.Hash) (int64, error)
 }
 
 // PeerResolver returns an ordered list of peer coordinator addresses that
@@ -136,15 +146,17 @@ type Puller struct {
 	inflight   map[string]struct{}
 
 	// Metrics (atomic for lock-free observability)
-	totalEnqueued          atomic.Int64
-	totalSkippedSelf       atomic.Int64 // origin is self — no pull needed
-	totalSkippedLocal      atomic.Int64 // backend.Exists already true
-	totalSkippedDup        atomic.Int64 // already enqueued / in-flight
-	totalPulled            atomic.Int64 // successful pulls
-	totalFailed            atomic.Int64 // gave up after retries
-	totalDropped           atomic.Int64 // queue full
-	totalChecksumMismatch  atomic.Int64 // bytes didn't match manifest SHA256
-	totalPeerLookupFailure atomic.Int64 // no candidate peers available
+	totalEnqueued               atomic.Int64
+	totalSkippedSelf            atomic.Int64 // origin is self — no pull needed
+	totalSkippedLocal           atomic.Int64 // file fully present locally
+	totalSkippedDup             atomic.Int64 // already enqueued / in-flight
+	totalPulled                 atomic.Int64 // successful pulls
+	totalFailed                 atomic.Int64 // gave up after retries
+	totalDropped                atomic.Int64 // queue full
+	totalChecksumMismatch       atomic.Int64 // bytes didn't match manifest SHA256
+	totalPeerLookupFailure      atomic.Int64 // no candidate peers available
+	totalBadOffsetServer        atomic.Int64 // server rejected resume offset (AckCodeBadOffset)
+	totalBadOffsetBackend       atomic.Int64 // backend can't append (ErrResumeNotSupported)
 
 	// Catch-up metrics (Phase 3). Populated by RunCatchUp and read via Stats.
 	catchupStartedAt     atomic.Int64 // unix seconds; 0 if never started
@@ -326,8 +338,10 @@ func (p *Puller) Stats() map[string]int64 {
 		"pulled":                 p.totalPulled.Load(),
 		"failed":                 p.totalFailed.Load(),
 		"dropped":                p.totalDropped.Load(),
-		"checksum_mismatch":      p.totalChecksumMismatch.Load(),
-		"peer_lookup_failure":    p.totalPeerLookupFailure.Load(),
+		"checksum_mismatch":        p.totalChecksumMismatch.Load(),
+		"peer_lookup_failure":      p.totalPeerLookupFailure.Load(),
+		"bad_offset_server":        p.totalBadOffsetServer.Load(),
+		"bad_offset_backend":       p.totalBadOffsetBackend.Load(),
 		"queue_depth":            int64(len(p.queue)),
 		"catchup_started_at":     p.catchupStartedAt.Load(),
 		"catchup_completed_at":   p.catchupCompletedAt.Load(),
@@ -384,11 +398,13 @@ func (p *Puller) processEntry(log zerolog.Logger, entry *raft.FileEntry) {
 			return
 		}
 
-		// Pre-pull check: skip if already local.
-		existsCtx, cancel := context.WithTimeout(p.ctx, 5*time.Second)
-		exists, existsErr := p.cfg.Backend.Exists(existsCtx, entry.Path)
-		cancel()
-		if existsErr == nil && exists {
+		// Pre-pull check: skip only if the file is fully present locally
+		// (size matches the manifest). A partial file (size < SizeBytes) should
+		// fall through so pullOnce can resume from the byte offset.
+		statCtx, statCancel := context.WithTimeout(p.ctx, 5*time.Second)
+		localSize, statErr := p.cfg.Backend.StatFile(statCtx, entry.Path)
+		statCancel()
+		if statErr == nil && localSize == entry.SizeBytes {
 			p.totalSkippedLocal.Add(1)
 			return
 		}
@@ -486,74 +502,133 @@ func (p *Puller) processEntry(log zerolog.Logger, entry *raft.FileEntry) {
 	}
 }
 
-// pullOnce performs a single fetch attempt end-to-end: opens a pipe into the
-// local backend writer, runs Fetcher.Fetch which streams bytes into the pipe,
-// and verifies the total byte count on success. The Fetcher is expected to
-// verify the SHA-256 itself and return an error on mismatch — this function
-// only tracks the mismatch counter.
+// pullOnce performs a single fetch attempt end-to-end. On attempt > 1 it
+// checks for a partial file and resumes from the byte offset already written,
+// avoiding re-transferring bytes already on disk. The Fetcher verifies SHA-256
+// across the full file (prefix + tail); this function only tracks counters.
 func (p *Puller) pullOnce(log zerolog.Logger, entry *raft.FileEntry, peerAddr string, attempt int) error {
 	fetchCtx, cancel := context.WithTimeout(p.ctx, p.cfg.FetchTimeout)
 	defer cancel()
 
-	// Pipe: producer side (Fetcher writes) → consumer side (backend.WriteReader reads).
-	// This lets us stream body bytes from the peer into the backend without
-	// buffering the entire file in memory.
+	// On retries, attempt to resume from a partial file already on disk.
+	// byteOffset > 0 means [0, byteOffset) is written and only the tail is needed.
+	var byteOffset int64
+	var prefixHasher hash.Hash
+	if attempt > 1 {
+		byteOffset, prefixHasher = p.tryResumeFromPartial(log, entry)
+	}
+
+	tailBytes := entry.SizeBytes - byteOffset
+
+	// Pipe: Fetch writes tail bytes into pw; the write goroutine reads from pr
+	// and commits to the backend. Using a pipe keeps memory flat regardless of
+	// file size — bytes flow directly from the network connection to disk.
 	pr, pw := io.Pipe()
 
-	// Backend writer goroutine: reads from the pipe until EOF or error.
-	// WriteReader is expected to read exactly entry.SizeBytes bytes and then
-	// return.
-	var writeErr error
-	writeDone := make(chan struct{})
+	var (
+		writeErr error
+		wg       sync.WaitGroup
+	)
+	wg.Add(1)
 	go func() {
-		defer close(writeDone)
-		writeErr = p.cfg.Backend.WriteReader(fetchCtx, entry.Path, pr, entry.SizeBytes)
-		// Ensure any pending Fetch writes unblock if the backend aborts early.
-		// (Normal case: backend drains the full body then returns nil.)
+		defer wg.Done()
+		writeErr = p.writeFileTail(fetchCtx, entry, pr, byteOffset, tailBytes)
 		if writeErr != nil {
+			// Signal the fetch side to abort; it will stop writing into pw.
 			_ = pr.CloseWithError(writeErr)
 		}
 	}()
 
-	// Fetch: streams the body bytes into the pipe writer. When the fetcher
-	// finishes (or errors), we close the pipe writer so the backend goroutine
-	// sees EOF.
-	written, fetchErr := p.cfg.Fetcher.Fetch(fetchCtx, peerAddr, entry, pw)
-	// Always close the pipe writer — if fetchErr, propagate so the backend
-	// goroutine unblocks with an error instead of hanging on Read.
-	if fetchErr != nil {
-		_ = pw.CloseWithError(fetchErr)
-	} else {
-		_ = pw.Close()
-	}
-
-	// Wait for the backend writer to finish so we observe its error.
-	<-writeDone
+	written, fetchErr := p.cfg.Fetcher.Fetch(fetchCtx, peerAddr, entry, pw, byteOffset, prefixHasher)
+	// CloseWithError(nil) is equivalent to Close() — safe in both success and
+	// error paths. Closing pw unblocks the write goroutine's next read.
+	_ = pw.CloseWithError(fetchErr)
+	wg.Wait()
 
 	if fetchErr != nil {
-		// Track checksum mismatches separately so operators can see them in metrics.
 		if errors.Is(fetchErr, ErrChecksumMismatch) {
 			p.totalChecksumMismatch.Add(1)
-			// On a checksum mismatch the local file (if any) is corrupt — try to
-			// delete it so the next attempt writes from scratch.
-			delCtx, delCancel := context.WithTimeout(p.ctx, 5*time.Second)
-			if delErr := p.cfg.Backend.Delete(delCtx, entry.Path); delErr != nil {
-				log.Warn().
-					Err(delErr).
-					Str("path", entry.Path).
-					Msg("Failed to delete corrupt file after checksum mismatch")
-			}
-			delCancel()
+			p.deleteFile(log, entry.Path)
+		}
+		if errors.Is(fetchErr, ErrBadOffset) {
+			// Server rejected our resume offset — delete partial, retry from zero.
+			p.totalBadOffsetServer.Add(1)
+			p.deleteFile(log, entry.Path)
 		}
 		return fetchErr
 	}
 	if writeErr != nil {
+		if errors.Is(writeErr, storage.ErrResumeNotSupported) {
+			// Backend can't append — delete partial, retry from zero next attempt.
+			p.totalBadOffsetBackend.Add(1)
+			p.deleteFile(log, entry.Path)
+			return fmt.Errorf("backend append not supported, will retry from zero: %w", ErrBadOffset)
+		}
 		return fmt.Errorf("backend write: %w", writeErr)
 	}
-	if written != entry.SizeBytes {
-		return fmt.Errorf("short body: wrote %d bytes, expected %d", written, entry.SizeBytes)
+	if written != tailBytes {
+		return fmt.Errorf("short body: wrote %d tail bytes, expected %d", written, tailBytes)
 	}
 	return nil
+}
+
+// writeFileTail commits tail bytes from r to the backend. When byteOffset > 0
+// it appends to the partial file via AppendingBackend; when byteOffset == 0 it
+// calls WriteReader for a fresh full-file write.
+//
+// The type-assertion to AppendingBackend is intentional: S3 and Azure Blob do
+// not implement AppendingBackend, so a non-zero offset on those backends
+// returns ErrResumeNotSupported and the puller falls back to a full re-fetch.
+func (p *Puller) writeFileTail(ctx context.Context, entry *raft.FileEntry, r io.Reader, byteOffset, tailBytes int64) error {
+	if byteOffset > 0 {
+		ab, ok := p.cfg.Backend.(storage.AppendingBackend)
+		if !ok {
+			return storage.ErrResumeNotSupported
+		}
+		return ab.AppendReader(ctx, entry.Path, r, tailBytes)
+	}
+	return p.cfg.Backend.WriteReader(ctx, entry.Path, r, entry.SizeBytes)
+}
+
+// tryResumeFromPartial checks whether a partial file exists on disk for entry
+// and, if so, hashes its bytes so the fetch client can continue the SHA-256
+// chain over the tail. Returns (offset, hasher) on success, or (0, nil) if
+// there is no usable partial file (not found, too large, or hash failed).
+func (p *Puller) tryResumeFromPartial(log zerolog.Logger, entry *raft.FileEntry) (int64, hash.Hash) {
+	statCtx, statCancel := context.WithTimeout(p.ctx, 5*time.Second)
+	partial, statErr := p.cfg.Backend.StatFile(statCtx, entry.Path)
+	statCancel()
+	if statErr != nil || partial <= 0 || partial >= entry.SizeBytes {
+		return 0, nil
+	}
+
+	h := sha256.New()
+	hashCtx, hashCancel := context.WithTimeout(p.ctx, 30*time.Second)
+	hashErr := p.cfg.Backend.ReadTo(hashCtx, entry.Path, h)
+	hashCancel()
+	if hashErr != nil {
+		log.Debug().Err(hashErr).Str("path", entry.Path).
+			Msg("Failed to hash partial file prefix; retrying from zero")
+		p.deleteFile(log, entry.Path)
+		return 0, nil
+	}
+
+	log.Debug().
+		Str("path", entry.Path).
+		Int64("byte_offset", partial).
+		Int64("total_bytes", entry.SizeBytes).
+		Msg("Resuming partial file transfer")
+	return partial, h
+}
+
+// deleteFile is a helper that deletes a file from the local backend, logging
+// a warning if the deletion fails. Used after checksum mismatches and bad offsets.
+func (p *Puller) deleteFile(log zerolog.Logger, path string) {
+	delCtx, delCancel := context.WithTimeout(p.ctx, 5*time.Second)
+	if delErr := p.cfg.Backend.Delete(delCtx, path); delErr != nil {
+		log.Warn().Err(delErr).Str("path", path).Msg("Failed to delete file")
+	}
+	delCancel()
 }
 
 // sleepBackoff sleeps for an exponential backoff interval, honoring context
@@ -585,3 +660,10 @@ var ErrChecksumMismatch = errors.New("filereplication: checksum mismatch")
 // essential for Phase 3 catch-up after a Kubernetes pod rotation where the
 // original writer is gone but other peers still hold the file.
 var ErrFileNotOnPeer = errors.New("filereplication: file not on peer")
+
+// ErrBadOffset is returned by Fetcher implementations when the server rejects
+// the requested byte offset (negative, >= file size, or backend doesn't
+// support seeks). The puller should delete any partial file and retry from
+// zero — not fall through to another peer, since the file exists there and
+// the offset is simply invalid or stale.
+var ErrBadOffset = errors.New("filereplication: bad byte offset")

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -599,6 +599,10 @@ func (p *Puller) writeFileTail(ctx context.Context, entry *raft.FileEntry, r io.
 // and, if so, hashes its bytes so the fetch client can continue the SHA-256
 // chain over the tail. Returns (offset, hasher) on success, or (0, nil) if
 // there is no usable partial file (not found, too large, or hash failed).
+//
+// Note: for backends that do not implement AppendingBackend, writeFileTail will
+// return ErrResumeNotSupported when called with a non-zero offset. This is
+// intentional — the puller increments bad_offset_backend and retries from zero.
 func (p *Puller) tryResumeFromPartial(log zerolog.Logger, entry *raft.FileEntry) (int64, hash.Hash) {
 	statCtx, statCancel := context.WithTimeout(p.ctx, 5*time.Second)
 	partial, statErr := p.cfg.Backend.StatFile(statCtx, entry.Path)

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -545,6 +545,17 @@ func (p *Puller) pullOnce(log zerolog.Logger, entry *raft.FileEntry, peerAddr st
 	_ = pw.CloseWithError(fetchErr)
 	wg.Wait()
 
+	// ErrResumeNotSupported from the write goroutine is the root cause even when
+	// fetchErr is also set (the write goroutine closed the pipe, which caused the
+	// fetch side to see a broken-pipe error). Handle it before fetchErr so the
+	// puller deletes the partial and retries from zero rather than treating this
+	// as a generic transport failure.
+	if errors.Is(writeErr, storage.ErrResumeNotSupported) {
+		p.totalBadOffsetBackend.Add(1)
+		p.deleteFile(log, entry.Path)
+		return fmt.Errorf("backend append not supported, will retry from zero: %w", ErrBadOffset)
+	}
+
 	if fetchErr != nil {
 		if errors.Is(fetchErr, ErrChecksumMismatch) {
 			p.totalChecksumMismatch.Add(1)
@@ -558,12 +569,6 @@ func (p *Puller) pullOnce(log zerolog.Logger, entry *raft.FileEntry, peerAddr st
 		return fetchErr
 	}
 	if writeErr != nil {
-		if errors.Is(writeErr, storage.ErrResumeNotSupported) {
-			// Backend can't append — delete partial, retry from zero next attempt.
-			p.totalBadOffsetBackend.Add(1)
-			p.deleteFile(log, entry.Path)
-			return fmt.Errorf("backend append not supported, will retry from zero: %w", ErrBadOffset)
-		}
 		return fmt.Errorf("backend write: %w", writeErr)
 	}
 	if written != tailBytes {

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -613,7 +613,7 @@ func (p *Puller) tryResumeFromPartial(log zerolog.Logger, entry *raft.FileEntry)
 
 	h := sha256.New()
 	hashCtx, hashCancel := context.WithTimeout(p.ctx, 30*time.Second)
-	hashErr := p.cfg.Backend.ReadTo(hashCtx, entry.Path, h)
+	hashErr := p.cfg.Backend.ReadToAt(hashCtx, entry.Path, h, 0)
 	hashCancel()
 	if hashErr != nil {
 		log.Debug().Err(hashErr).Str("path", entry.Path).

--- a/internal/cluster/filereplication/puller_test.go
+++ b/internal/cluster/filereplication/puller_test.go
@@ -1141,3 +1141,104 @@ func TestPuller_BadOffsetDeletesPartialAndRetries(t *testing.T) {
 		t.Errorf("file content mismatch: got %q, want %q", data, fullBody)
 	}
 }
+
+// nonAppendingBackend delegates all Backend methods to fakeBackend but
+// deliberately omits AppendReader, so the puller's AppendingBackend
+// type-assertion fails and ErrResumeNotSupported is returned.
+type nonAppendingBackend struct {
+	inner *fakeBackend
+}
+
+func (b *nonAppendingBackend) Write(ctx context.Context, path string, data []byte) error {
+	return b.inner.Write(ctx, path, data)
+}
+func (b *nonAppendingBackend) WriteReader(ctx context.Context, path string, r io.Reader, size int64) error {
+	return b.inner.WriteReader(ctx, path, r, size)
+}
+func (b *nonAppendingBackend) Read(ctx context.Context, path string) ([]byte, error) {
+	return b.inner.Read(ctx, path)
+}
+func (b *nonAppendingBackend) ReadTo(ctx context.Context, path string, w io.Writer) error {
+	return b.inner.ReadTo(ctx, path, w)
+}
+func (b *nonAppendingBackend) ReadToAt(ctx context.Context, path string, w io.Writer, offset int64) error {
+	return b.inner.ReadToAt(ctx, path, w, offset)
+}
+func (b *nonAppendingBackend) StatFile(ctx context.Context, path string) (int64, error) {
+	return b.inner.StatFile(ctx, path)
+}
+func (b *nonAppendingBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	return b.inner.List(ctx, prefix)
+}
+func (b *nonAppendingBackend) Delete(ctx context.Context, path string) error {
+	return b.inner.Delete(ctx, path)
+}
+func (b *nonAppendingBackend) Exists(ctx context.Context, path string) (bool, error) {
+	return b.inner.Exists(ctx, path)
+}
+func (b *nonAppendingBackend) Close() error       { return nil }
+func (b *nonAppendingBackend) Type() string       { return "non-appending" }
+func (b *nonAppendingBackend) ConfigJSON() string { return "{}" }
+
+// TestPuller_NonAppendingBackendFallback verifies that when the backend does
+// not implement AppendingBackend (e.g. S3/Azure), a resume attempt falls back
+// to a full re-fetch: the bad_offset_backend counter increments, the partial
+// file is deleted, and the next attempt fetches from offset 0.
+func TestPuller_NonAppendingBackendFallback(t *testing.T) {
+
+	inner := newFakeBackend()
+	backend := &nonAppendingBackend{inner: inner}
+
+	fullBody := bytes.Repeat([]byte("z"), 40)
+	entry := makeEntry("testdb/cpu/resume_fallback.parquet", "writer-1", int64(len(fullBody)))
+
+	// Attempt 1: transport error + partial write (simulates mid-transfer drop).
+	// Attempt 2: puller detects partial → type-asserts AppendingBackend → fails
+	//            → ErrResumeNotSupported → bad_offset_backend++ → partial deleted.
+	//            The fetcher is called but the write goroutine closes the pipe
+	//            immediately, so the fetcher gets a broken-pipe error (scripted).
+	// Attempt 3: no partial on disk → fresh full fetch from offset 0 → success.
+	fetcher := newResumeAwareFetcher(fullBody,
+		fmt.Errorf("transport error"),    // attempt 1: mid-transfer drop
+		fmt.Errorf("write: broken pipe"), // attempt 2: pipe closed by write side
+		nil,                              // attempt 3: success (fresh fetch from zero)
+	)
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        multiPeerResolver{addrs: []string{"peer-1:9999"}},
+		Workers:             1,
+		QueueSize:           8,
+		RetryMaxAttempts:    4,
+		RetryInitialBackoff: 1 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["pulled"] == 1
+	})
+
+	if stats["pulled"] != 1 {
+		t.Fatalf("expected pulled=1, got %v", stats)
+	}
+	if stats["bad_offset_backend"] != 1 {
+		t.Errorf("expected bad_offset_backend=1, got %v", stats)
+	}
+	data, readErr := inner.Read(context.Background(), entry.Path)
+	if readErr != nil {
+		t.Fatalf("Read: %v", readErr)
+	}
+	if string(data) != string(fullBody) {
+		t.Errorf("file content mismatch after fallback")
+	}
+}

--- a/internal/cluster/filereplication/puller_test.go
+++ b/internal/cluster/filereplication/puller_test.go
@@ -54,10 +54,10 @@ func (f *fakeBackend) WriteReader(ctx context.Context, path string, reader io.Re
 	if writeErr != nil {
 		return writeErr
 	}
-	// Read whatever the reader provides. If the reader closes with an error
-	// (e.g. a broken pipe from a cancelled fetch), store the partial bytes and
-	// return the error — matching real backend behaviour where partial bytes
-	// are flushed to disk before the write fails.
+	// Atomic: read all bytes into a staging key. On success, promote to final key.
+	// On error, leave bytes in the ".part" staging key (same as real LocalBackend)
+	// so resume tests can discover them via StatFile/ReadTo.
+	stagingKey := path + ".part"
 	var buf []byte
 	tmp := make([]byte, 4096)
 	var readErr error
@@ -73,11 +73,17 @@ func (f *fakeBackend) WriteReader(ctx context.Context, path string, reader io.Re
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if len(buf) > 0 {
-		f.files[path] = buf
-	}
-	if readErr == io.EOF {
+	if readErr == io.EOF || readErr == nil {
+		// Full transfer: commit to final path and clear staging.
+		if len(buf) > 0 {
+			f.files[path] = buf
+		}
+		delete(f.files, stagingKey)
 		return nil
+	}
+	// Partial transfer: store under staging key; final key is not written.
+	if len(buf) > 0 {
+		f.files[stagingKey] = buf
 	}
 	return readErr
 }
@@ -93,34 +99,48 @@ func (f *fakeBackend) Read(ctx context.Context, path string) ([]byte, error) {
 }
 
 func (f *fakeBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
-	data, err := f.Read(ctx, path)
-	if err != nil {
-		return err
+	// Fall back to staging file so tryResumeFromPartial can hash a partial prefix.
+	f.mu.Lock()
+	data, ok := f.files[path]
+	if !ok {
+		data, ok = f.files[path+".part"]
 	}
-	_, err = writer.Write(data)
+	f.mu.Unlock()
+	if !ok {
+		return errors.New("not found")
+	}
+	_, err := writer.Write(data)
 	return err
 }
 
 func (f *fakeBackend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
-	data, err := f.Read(ctx, path)
-	if err != nil {
-		return err
+	f.mu.Lock()
+	data, ok := f.files[path]
+	if !ok {
+		data, ok = f.files[path+".part"]
+	}
+	f.mu.Unlock()
+	if !ok {
+		return errors.New("not found")
 	}
 	if offset < 0 || offset > int64(len(data)) {
 		return fmt.Errorf("offset %d out of range for file size %d", offset, len(data))
 	}
-	_, err = writer.Write(data[offset:])
+	_, err := writer.Write(data[offset:])
 	return err
 }
 
 func (f *fakeBackend) StatFile(ctx context.Context, path string) (int64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	data, ok := f.files[path]
-	if !ok {
-		return -1, nil
+	if data, ok := f.files[path]; ok {
+		return int64(len(data)), nil
 	}
-	return int64(len(data)), nil
+	// Check staging file (mirrors LocalBackend behaviour).
+	if data, ok := f.files[path+".part"]; ok {
+		return int64(len(data)), nil
+	}
+	return -1, nil
 }
 
 func (f *fakeBackend) AppendReader(ctx context.Context, path string, reader io.Reader, appendSize int64) error {
@@ -134,22 +154,31 @@ func (f *fakeBackend) AppendReader(ctx context.Context, path string, reader io.R
 	if err != nil {
 		return err
 	}
+	stagingKey := path + ".part"
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.files[path] = append(f.files[path], tail...)
+	merged := append(f.files[stagingKey], tail...)
+	if int64(len(tail)) == appendSize {
+		// Full tail received — promote staging → final.
+		f.files[path] = merged
+		delete(f.files, stagingKey)
+	} else {
+		f.files[stagingKey] = merged
+	}
 	return nil
-}
-
-func (f *fakeBackend) List(ctx context.Context, prefix string) ([]string, error) {
-	panic("not used")
 }
 
 func (f *fakeBackend) Delete(ctx context.Context, path string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.files, path)
+	delete(f.files, path+".part") // also clean up staging file
 	f.deletedPaths = append(f.deletedPaths, path)
 	return nil
+}
+
+func (f *fakeBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	panic("not used")
 }
 
 func (f *fakeBackend) Exists(ctx context.Context, path string) (bool, error) {

--- a/internal/cluster/filereplication/puller_test.go
+++ b/internal/cluster/filereplication/puller_test.go
@@ -1,9 +1,11 @@
 package filereplication
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -52,15 +54,32 @@ func (f *fakeBackend) WriteReader(ctx context.Context, path string, reader io.Re
 	if writeErr != nil {
 		return writeErr
 	}
-	// Read the full body to simulate a real backend.
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		return err
+	// Read whatever the reader provides. If the reader closes with an error
+	// (e.g. a broken pipe from a cancelled fetch), store the partial bytes and
+	// return the error — matching real backend behaviour where partial bytes
+	// are flushed to disk before the write fails.
+	var buf []byte
+	tmp := make([]byte, 4096)
+	var readErr error
+	for {
+		n, err := reader.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			readErr = err
+			break
+		}
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.files[path] = data
-	return nil
+	if len(buf) > 0 {
+		f.files[path] = buf
+	}
+	if readErr == io.EOF {
+		return nil
+	}
+	return readErr
 }
 
 func (f *fakeBackend) Read(ctx context.Context, path string) ([]byte, error) {
@@ -80,6 +99,45 @@ func (f *fakeBackend) ReadTo(ctx context.Context, path string, writer io.Writer)
 	}
 	_, err = writer.Write(data)
 	return err
+}
+
+func (f *fakeBackend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
+	data, err := f.Read(ctx, path)
+	if err != nil {
+		return err
+	}
+	if offset < 0 || offset > int64(len(data)) {
+		return fmt.Errorf("offset %d out of range for file size %d", offset, len(data))
+	}
+	_, err = writer.Write(data[offset:])
+	return err
+}
+
+func (f *fakeBackend) StatFile(ctx context.Context, path string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, ok := f.files[path]
+	if !ok {
+		return -1, nil
+	}
+	return int64(len(data)), nil
+}
+
+func (f *fakeBackend) AppendReader(ctx context.Context, path string, reader io.Reader, appendSize int64) error {
+	f.mu.Lock()
+	writeErr := f.writeErr
+	f.mu.Unlock()
+	if writeErr != nil {
+		return writeErr
+	}
+	tail, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.files[path] = append(f.files[path], tail...)
+	return nil
 }
 
 func (f *fakeBackend) List(ctx context.Context, prefix string) ([]string, error) {
@@ -148,7 +206,7 @@ func newRepeatingFetcher(body []byte) *fakeFetcher {
 	}
 }
 
-func (f *fakeFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
+func (f *fakeFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer, byteOffset int64, prefixHasher hash.Hash) (int64, error) {
 	idx := f.calls.Add(1) - 1
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -213,7 +271,7 @@ func (f *perPeerFetcher) callsFor(peerAddr string) int64 {
 	return 0
 }
 
-func (f *perPeerFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
+func (f *perPeerFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer, byteOffset int64, prefixHasher hash.Hash) (int64, error) {
 	f.total.Add(1)
 	f.mu.Lock()
 	fn, ok := f.handlers[peerAddr]
@@ -366,8 +424,9 @@ func TestPullerSkipsSelfOrigin(t *testing.T) {
 
 func TestPullerSkipsAlreadyLocalFile(t *testing.T) {
 	backend := newFakeBackend()
-	// Pre-populate: the file already exists locally.
-	_ = backend.Write(context.Background(), "testdb/cpu/existing.parquet", []byte("old bytes"))
+	// Pre-populate: the file already exists locally, size matches entry.SizeBytes.
+	fileData := bytes.Repeat([]byte("x"), 100)
+	_ = backend.Write(context.Background(), "testdb/cpu/existing.parquet", fileData)
 	fetcher := newFakeFetcher() // should never be called
 	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
 
@@ -586,7 +645,7 @@ type blockingFetcher struct {
 	calls   atomic.Int64
 }
 
-func (b *blockingFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer) (int64, error) {
+func (b *blockingFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer, byteOffset int64, prefixHasher hash.Hash) (int64, error) {
 	b.calls.Add(1)
 	select {
 	case <-ctx.Done():
@@ -926,4 +985,159 @@ func contains(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+// --- Resume / ByteOffset tests -------------------------------------------
+
+// resumeAwareFetcher is a Fetcher that records the byteOffset passed to each
+// Fetch call and writes only the tail of body (body[byteOffset:]) into dst.
+// This lets puller resume tests verify that pullOnce passes the right offset
+// on the second attempt.
+type resumeAwareFetcher struct {
+	mu          sync.Mutex
+	body        []byte // full file bytes
+	offsets     []int64
+	errors      []error // per-call scripted errors; nil = success
+	callCount   atomic.Int64
+}
+
+func newResumeAwareFetcher(body []byte, errs ...error) *resumeAwareFetcher {
+	return &resumeAwareFetcher{body: body, errors: errs}
+}
+
+func (f *resumeAwareFetcher) Fetch(ctx context.Context, peerAddr string, entry *raft.FileEntry, dst io.Writer, byteOffset int64, prefixHasher hash.Hash) (int64, error) {
+	idx := int(f.callCount.Add(1) - 1)
+	f.mu.Lock()
+	f.offsets = append(f.offsets, byteOffset)
+	var fetchErr error
+	if idx < len(f.errors) {
+		fetchErr = f.errors[idx]
+	}
+	f.mu.Unlock()
+
+	// On a transport error (not ErrBadOffset/ErrChecksumMismatch), write a
+	// partial body before returning the error to simulate a mid-transfer drop.
+	if fetchErr != nil && !errors.Is(fetchErr, ErrBadOffset) && !errors.Is(fetchErr, ErrChecksumMismatch) {
+		partial := f.body[byteOffset:]
+		if len(partial) > 4 {
+			partial = partial[:len(partial)/2] // write half of the tail
+		}
+		_, _ = dst.Write(partial)
+		return int64(len(partial)), fetchErr
+	}
+	if fetchErr != nil {
+		return 0, fetchErr
+	}
+	tail := f.body[byteOffset:]
+	n, writeErr := dst.Write(tail)
+	return int64(n), writeErr
+}
+
+func (f *resumeAwareFetcher) lastOffset() int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.offsets) == 0 {
+		return -1
+	}
+	return f.offsets[len(f.offsets)-1]
+}
+
+// TestPuller_ResumeOnRetry verifies that when a partial file is already on
+// disk, the second Fetch call uses byteOffset == len(partial).
+func TestPuller_ResumeOnRetry(t *testing.T) {
+	fullBody := []byte("0123456789abcdefghijklmnopqrstuvwxyz") // 36 bytes
+	entry := makeEntry("db/cpu/resume.parquet", "writer-1", int64(len(fullBody)))
+
+	backend := newFakeBackend()
+
+	// Attempt 1: the fetcher writes half the tail then returns a transport error,
+	// leaving a partial file on disk. Attempt 2 resumes from the partial offset.
+	fetcher := newResumeAwareFetcher(fullBody, errors.New("transport: connection reset"))
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        multiPeerResolver{addrs: []string{"peer-1:9999"}},
+		Workers:             1,
+		QueueSize:           8,
+		RetryMaxAttempts:    2,
+		RetryInitialBackoff: 1 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	p.Enqueue(entry)
+
+	// Wait for both Fetch calls.
+	waitStats(t, p, func(s map[string]int64) bool {
+		return fetcher.callCount.Load() >= 2
+	})
+
+	if fetcher.callCount.Load() < 2 {
+		t.Fatalf("expected at least 2 Fetch calls, got %d", fetcher.callCount.Load())
+	}
+	// Second call should use a non-zero byte offset (the partial written by attempt 1).
+	if fetcher.lastOffset() <= 0 {
+		t.Errorf("second Fetch offset: got %d, want > 0 (should resume from partial)", fetcher.lastOffset())
+	}
+}
+
+// TestPuller_BadOffsetDeletesPartialAndRetries verifies that when the fetcher
+// returns ErrBadOffset, the puller deletes the partial file, increments the
+// bad_offset counter, and continues to retry from zero.
+func TestPuller_BadOffsetDeletesPartialAndRetries(t *testing.T) {
+	fullBody := []byte("full file content here")
+	entry := makeEntry("db/cpu/badoffset.parquet", "writer-1", int64(len(fullBody)))
+
+	backend := newFakeBackend()
+
+	// First call returns ErrBadOffset (server rejects offset 0 — unusual but
+	// possible if the file was replaced between manifest registration and fetch).
+	// Second call succeeds from offset 0.
+	fetcher := newResumeAwareFetcher(fullBody, ErrBadOffset)
+
+	p, err := New(Config{
+		SelfNodeID:          "reader-1",
+		Backend:             backend,
+		Fetcher:             fetcher,
+		PeerResolver:        multiPeerResolver{addrs: []string{"peer-1:9999"}},
+		Workers:             1,
+		QueueSize:           8,
+		RetryMaxAttempts:    3,
+		RetryInitialBackoff: 1 * time.Millisecond,
+		FetchTimeout:        2 * time.Second,
+		Logger:              zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	p.Enqueue(entry)
+
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["pulled"] == 1
+	})
+
+	if stats["pulled"] != 1 {
+		t.Fatalf("expected pulled=1, got %v (stats=%v)", stats["pulled"], stats)
+	}
+	if stats["bad_offset_server"] != 1 {
+		t.Errorf("expected bad_offset_server=1, got %v", stats)
+	}
+	// Full file should be on disk after the successful second attempt.
+	data, readErr := backend.Read(context.Background(), entry.Path)
+	if readErr != nil {
+		t.Fatalf("Read after resume: %v", readErr)
+	}
+	if string(data) != string(fullBody) {
+		t.Errorf("file content mismatch: got %q, want %q", data, fullBody)
+	}
 }

--- a/internal/cluster/filereplication_integration_test.go
+++ b/internal/cluster/filereplication_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -126,6 +127,38 @@ func (m *memBackend) Exists(ctx context.Context, path string) (bool, error) {
 func (m *memBackend) Close() error       { return nil }
 func (m *memBackend) Type() string       { return "mem" }
 func (m *memBackend) ConfigJSON() string { return "{}" }
+func (m *memBackend) ReadToAt(_ context.Context, path string, w io.Writer, offset int64) error {
+	m.mu.Lock()
+	data, ok := m.files[path]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("file not found: %s", path)
+	}
+	if offset > int64(len(data)) {
+		return fmt.Errorf("offset %d > file size %d", offset, len(data))
+	}
+	_, err := w.Write(data[offset:])
+	return err
+}
+func (m *memBackend) StatFile(_ context.Context, path string) (int64, error) {
+	m.mu.Lock()
+	data, ok := m.files[path]
+	m.mu.Unlock()
+	if !ok {
+		return -1, nil
+	}
+	return int64(len(data)), nil
+}
+func (m *memBackend) AppendReader(_ context.Context, path string, r io.Reader, _ int64) error {
+	tail, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.files[path] = append(m.files[path], tail...)
+	m.mu.Unlock()
+	return nil
+}
 
 // --- Minimal origin-side server ---
 
@@ -295,7 +328,7 @@ func TestPhase2FetchRoundtrip(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	n, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, pw)
+	n, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, pw, 0, nil)
 	if fetchErr != nil {
 		_ = pw.CloseWithError(fetchErr)
 		t.Fatalf("Fetch: %v", fetchErr)
@@ -370,7 +403,7 @@ func TestPhase2FetchRejectsBadHMAC(t *testing.T) {
 	entry := &raft.FileEntry{Path: path, SHA256: hashHex, SizeBytes: int64(len(body))}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, io.Discard)
+	_, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, io.Discard, 0, nil)
 	if fetchErr == nil {
 		t.Fatalf("expected auth error, got nil")
 	}
@@ -507,7 +540,7 @@ func TestPhase2FetchRejectsUnknownPath(t *testing.T) {
 	entry := &raft.FileEntry{Path: path, SHA256: hashHex, SizeBytes: int64(len(body))}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, io.Discard)
+	_, fetchErr := fetchClient.Fetch(ctx, origin.addr(), entry, io.Discard, 0, nil)
 	if fetchErr == nil {
 		t.Fatalf("expected manifest lookup error, got nil")
 	}

--- a/internal/cluster/protocol/messages.go
+++ b/internal/cluster/protocol/messages.go
@@ -188,6 +188,10 @@ type FetchFileRequest struct {
 	Nonce     string `json:"nonce"`
 	Timestamp int64  `json:"timestamp"`
 	HMAC      string `json:"hmac"`
+	// ByteOffset is the byte position to resume from. Zero means start from the
+	// beginning (full fetch). The HMAC does NOT bind ByteOffset — binding it
+	// would invalidate the MAC on resume since the path is already bound.
+	ByteOffset int64 `json:"byte_offset,omitempty"`
 }
 
 // Phase 2 fetch-ack error reasons — human-readable strings the Phase 2
@@ -232,6 +236,11 @@ const (
 	// AckCodeInvalidPath: path sanitization rejected the request (null
 	// byte, absolute path, traversal). Does not fall through.
 	AckCodeInvalidPath AckErrorCode = "invalid_path"
+	// AckCodeBadOffset: the requested byte offset is invalid (negative,
+	// >= file size, or the backend does not support seeking). The puller
+	// should delete any partial file and retry from zero — not fall through
+	// to another peer.
+	AckCodeBadOffset AckErrorCode = "bad_offset"
 )
 
 // FetchFileAckHeader is the response header for a fetch request. If Status is
@@ -242,8 +251,11 @@ type FetchFileAckHeader struct {
 	Status    string       `json:"status"`          // "ok" or "error"
 	Code      AckErrorCode `json:"code,omitempty"`  // machine-readable error category (Phase 3)
 	Error     string       `json:"error,omitempty"` // populated when Status == "error"
-	SizeBytes int64        `json:"size_bytes"`
-	SHA256    string       `json:"sha256"` // hex-encoded; must match manifest SHA256
+	SizeBytes int64        `json:"size_bytes"`      // tail bytes being sent (total - ByteOffset)
+	SHA256    string       `json:"sha256"`          // hex-encoded whole-file hash from manifest
+	// ByteOffset echoes the byte offset the server will serve from. The puller
+	// validates this matches the requested offset before streaming the body.
+	ByteOffset int64 `json:"byte_offset,omitempty"`
 }
 
 // ForwardApplyRequest is sent by a non-leader node to ask the Raft leader

--- a/internal/ingest/arrow_writer_flush_failure_test.go
+++ b/internal/ingest/arrow_writer_flush_failure_test.go
@@ -43,6 +43,15 @@ func (s *failingStorageBackend) List(ctx context.Context, prefix string) ([]stri
 func (s *failingStorageBackend) Close() error       { return nil }
 func (s *failingStorageBackend) Type() string       { return "mock-failing" }
 func (s *failingStorageBackend) ConfigJSON() string { return "{}" }
+func (s *failingStorageBackend) ReadToAt(_ context.Context, _ string, _ io.Writer, _ int64) error {
+	return nil
+}
+func (s *failingStorageBackend) StatFile(_ context.Context, _ string) (int64, error) {
+	return -1, nil
+}
+func (s *failingStorageBackend) AppendReader(_ context.Context, _ string, _ io.Reader, _ int64) error {
+	return nil
+}
 
 func TestArrowBuffer_FlushFailureMetricOnAsyncStorageError(t *testing.T) {
 	cfg := &config.IngestConfig{

--- a/internal/ingest/arrow_writer_rowformat_test.go
+++ b/internal/ingest/arrow_writer_rowformat_test.go
@@ -70,6 +70,15 @@ func (s *capturingStorageBackend) List(ctx context.Context, prefix string) ([]st
 func (s *capturingStorageBackend) Close() error       { return nil }
 func (s *capturingStorageBackend) Type() string       { return "mock-capturing" }
 func (s *capturingStorageBackend) ConfigJSON() string { return "{}" }
+func (s *capturingStorageBackend) ReadToAt(_ context.Context, _ string, _ io.Writer, _ int64) error {
+	return nil
+}
+func (s *capturingStorageBackend) StatFile(_ context.Context, _ string) (int64, error) {
+	return -1, nil
+}
+func (s *capturingStorageBackend) AppendReader(_ context.Context, _ string, _ io.Reader, _ int64) error {
+	return nil
+}
 
 func (s *capturingStorageBackend) writeCount() int {
 	s.mu.Lock()

--- a/internal/ingest/arrow_writer_s3_hang_test.go
+++ b/internal/ingest/arrow_writer_s3_hang_test.go
@@ -78,6 +78,15 @@ func (h *hangingStorageBackend) Exists(ctx context.Context, path string) (bool, 
 func (h *hangingStorageBackend) Close() error       { return nil }
 func (h *hangingStorageBackend) Type() string       { return "mock-hanging" }
 func (h *hangingStorageBackend) ConfigJSON() string { return "{}" }
+func (h *hangingStorageBackend) ReadToAt(_ context.Context, _ string, _ io.Writer, _ int64) error {
+	return nil
+}
+func (h *hangingStorageBackend) StatFile(_ context.Context, _ string) (int64, error) {
+	return -1, nil
+}
+func (h *hangingStorageBackend) AppendReader(_ context.Context, _ string, _ io.Reader, _ int64) error {
+	return nil
+}
 
 // makeColumns builds a columnar batch with the given record count.
 func makeColumns(n int) map[string][]interface{} {

--- a/internal/ingest/arrow_writer_test.go
+++ b/internal/ingest/arrow_writer_test.go
@@ -58,6 +58,13 @@ func (m *mockStorageBackend) List(ctx context.Context, prefix string) ([]string,
 func (m *mockStorageBackend) Close() error       { return nil }
 func (m *mockStorageBackend) Type() string       { return "mock" }
 func (m *mockStorageBackend) ConfigJSON() string { return "{}" }
+func (m *mockStorageBackend) ReadToAt(_ context.Context, _ string, _ io.Writer, _ int64) error {
+	return nil
+}
+func (m *mockStorageBackend) StatFile(_ context.Context, _ string) (int64, error) { return -1, nil }
+func (m *mockStorageBackend) AppendReader(_ context.Context, _ string, _ io.Reader, _ int64) error {
+	return nil
+}
 
 func TestRowsToColumnar_SingleRecord(t *testing.T) {
 	buffer := createTestArrowBuffer(t)

--- a/internal/pruning/partition_pruner_test.go
+++ b/internal/pruning/partition_pruner_test.go
@@ -49,6 +49,13 @@ func (m *mockS3Backend) Type() string {
 func (m *mockS3Backend) ConfigJSON() string {
 	return "{}"
 }
+func (m *mockS3Backend) ReadToAt(_ context.Context, _ string, _ io.Writer, _ int64) error {
+	return nil
+}
+func (m *mockS3Backend) StatFile(_ context.Context, _ string) (int64, error) { return -1, nil }
+func (m *mockS3Backend) AppendReader(_ context.Context, _ string, _ io.Reader, _ int64) error {
+	return nil
+}
 
 // ListDirectories implements storage.DirectoryLister
 func (m *mockS3Backend) ListDirectories(ctx context.Context, prefix string) ([]string, error) {

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -226,13 +226,17 @@ func (b *AzureBlobBackend) ReadTo(ctx context.Context, path string, writer io.Wr
 
 // ReadToAt reads data from Azure Blob Storage starting at the given byte
 // offset and writes to writer. Uses blob.HTTPRange to skip already-transferred
-// bytes. offset=0 fetches the full blob (no range restriction).
+// bytes. offset=0 fetches the full blob without a Range header.
 func (b *AzureBlobBackend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
 	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
 
-	resp, err := blobClient.DownloadStream(ctx, &blob.DownloadStreamOptions{
-		Range: blob.HTTPRange{Offset: offset},
-	})
+	var opts *blob.DownloadStreamOptions
+	if offset > 0 {
+		opts = &blob.DownloadStreamOptions{
+			Range: blob.HTTPRange{Offset: offset},
+		}
+	}
+	resp, err := blobClient.DownloadStream(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to read from Azure Blob Storage: %w", err)
 	}

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -224,6 +224,44 @@ func (b *AzureBlobBackend) ReadTo(ctx context.Context, path string, writer io.Wr
 	return nil
 }
 
+// ReadToAt reads data from Azure Blob Storage starting at the given byte
+// offset and writes to writer. Uses blob.HTTPRange to skip already-transferred
+// bytes. offset=0 fetches the full blob (no range restriction).
+func (b *AzureBlobBackend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
+
+	resp, err := blobClient.DownloadStream(ctx, &blob.DownloadStreamOptions{
+		Range: blob.HTTPRange{Offset: offset},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to read from Azure Blob Storage: %w", err)
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(writer, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy Azure blob: %w", err)
+	}
+	return nil
+}
+
+// StatFile returns the byte size of the Azure blob at path, or -1 if not found.
+func (b *AzureBlobBackend) StatFile(ctx context.Context, path string) (int64, error) {
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
+
+	resp, err := blobClient.GetProperties(ctx, nil)
+	if err != nil {
+		if isAzureNotFoundError(err) {
+			return -1, nil
+		}
+		return -1, fmt.Errorf("GetProperties %s: %w", path, err)
+	}
+	if resp.ContentLength == nil {
+		return 0, nil
+	}
+	return *resp.ContentLength, nil
+}
+
 // List lists blobs with the given prefix
 func (b *AzureBlobBackend) List(ctx context.Context, prefix string) ([]string, error) {
 	var blobs []string

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -2,9 +2,15 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"io"
 	"time"
 )
+
+// ErrResumeNotSupported is returned by AppendingBackend.AppendReader on
+// backends that do not support append writes (S3, Azure Blob Storage).
+// Callers should delete any partial file and retry from byte zero.
+var ErrResumeNotSupported = errors.New("storage: resume not supported by this backend")
 
 // Backend defines the interface for storage backends (local, S3, MinIO)
 type Backend interface {
@@ -19,6 +25,16 @@ type Backend interface {
 
 	// ReadTo reads data from the specified path and writes it to the writer
 	ReadTo(ctx context.Context, path string, writer io.Writer) error
+
+	// ReadToAt reads data from path starting at the given byte offset and writes
+	// to writer. offset=0 starts at the beginning (equivalent to ReadTo).
+	// Returns an error if offset is negative or >= file size.
+	ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error
+
+	// StatFile returns the byte size of the file at path.
+	// Returns -1 (and nil error) if the file does not exist.
+	// Returns a non-nil error only for unexpected backend failures.
+	StatFile(ctx context.Context, path string) (int64, error)
 
 	// List lists all objects with the given prefix
 	List(ctx context.Context, prefix string) ([]string, error)
@@ -39,6 +55,23 @@ type Backend interface {
 	// ConfigJSON returns the configuration as JSON for subprocess recreation
 	// Used for subprocess serialization
 	ConfigJSON() string
+}
+
+// AppendingBackend is an optional extension of Backend for backends that
+// support appending bytes to an existing file. Callers type-assert Backend to
+// AppendingBackend before calling AppendReader; if the assertion fails, the
+// backend does not support resumable writes and the caller should fall back to
+// a full re-fetch.
+//
+// Only local-SSD backends implement this. S3 and Azure Blob Storage do not
+// support append on block objects and return ErrResumeNotSupported instead.
+type AppendingBackend interface {
+	Backend
+	// AppendReader appends bytes from reader to the existing file at path.
+	// appendSize is the number of bytes expected from reader (informational;
+	// implementations may ignore it). Returns ErrResumeNotSupported if the
+	// backend cannot append.
+	AppendReader(ctx context.Context, path string, reader io.Reader, appendSize int64) error
 }
 
 // DirectoryLister lists immediate subdirectories at a prefix.

--- a/internal/storage/backend_test.go
+++ b/internal/storage/backend_test.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -414,7 +416,8 @@ func TestLocalBackend_ReadToAt(t *testing.T) {
 }
 
 // TestLocalBackend_AppendReader verifies that AppendingBackend is implemented,
-// and that AppendReader correctly appends bytes to an existing file.
+// and that AppendReader correctly appends bytes to a staging (.part) file
+// left by a failed WriteReader, then promotes it to the final path.
 func TestLocalBackend_AppendReader(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "arc-storage-appendreader-*")
 	if err != nil {
@@ -437,23 +440,44 @@ func TestLocalBackend_AppendReader(t *testing.T) {
 		t.Fatal("LocalBackend does not implement AppendingBackend")
 	}
 
-	prefix := []byte("hello ")
-	if err := backend.Write(ctx, "db/tbl/partial.parquet", prefix); err != nil {
-		t.Fatalf("Write: %v", err)
+	fullBody := []byte("hello world")
+	path := "db/tbl/partial.parquet"
+
+	// Simulate a failed WriteReader: use a pipe where we send only the prefix,
+	// then close with an error. This leaves a ".part" staging file on disk.
+	prefix := fullBody[:6] // "hello "
+	tail := fullBody[6:]   // "world"
+
+	pr, pw := io.Pipe()
+	writeErrCh := make(chan error, 1)
+	go func() {
+		writeErrCh <- backend.WriteReader(ctx, path, pr, int64(len(fullBody)))
+	}()
+	_, _ = pw.Write(prefix)
+	_ = pw.CloseWithError(errors.New("simulated transport failure"))
+	<-writeErrCh // ignore the error — we expect it
+
+	// Staging file should exist with the prefix bytes.
+	size, err := backend.StatFile(ctx, path)
+	if err != nil {
+		t.Fatalf("StatFile after partial write: %v", err)
+	}
+	if size != int64(len(prefix)) {
+		t.Fatalf("expected staging size %d, got %d", len(prefix), size)
 	}
 
-	tail := []byte("world")
-	if err := ab.AppendReader(ctx, "db/tbl/partial.parquet", bytes.NewReader(tail), int64(len(tail))); err != nil {
+	// AppendReader appends the tail to the staging file and promotes it.
+	if err := ab.AppendReader(ctx, path, bytes.NewReader(tail), int64(len(tail))); err != nil {
 		t.Fatalf("AppendReader: %v", err)
 	}
 
-	got, err := backend.Read(ctx, "db/tbl/partial.parquet")
+	// Final file should now contain the full body.
+	got, err := backend.Read(ctx, path)
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	want := "hello world"
-	if string(got) != want {
-		t.Errorf("got %q, want %q", got, want)
+	if string(got) != string(fullBody) {
+		t.Errorf("got %q, want %q", got, fullBody)
 	}
 }
 

--- a/internal/storage/backend_test.go
+++ b/internal/storage/backend_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -307,6 +308,152 @@ func TestObjectInfo(t *testing.T) {
 	}
 	if info.LastModified.IsZero() {
 		t.Error("Expected non-zero LastModified")
+	}
+}
+
+// TestLocalBackend_StatFile covers the three StatFile cases: not found (-1),
+// exists (correct size), and invalid path (error).
+func TestLocalBackend_StatFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "arc-storage-statfile-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	backend, err := NewLocalBackend(tmpDir, logger)
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	t.Run("not found returns -1", func(t *testing.T) {
+		size, err := backend.StatFile(ctx, "db/tbl/missing.parquet")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if size != -1 {
+			t.Errorf("got %d, want -1", size)
+		}
+	})
+
+	t.Run("existing file returns correct size", func(t *testing.T) {
+		data := []byte("hello world")
+		if err := backend.Write(ctx, "db/tbl/file.parquet", data); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		size, err := backend.StatFile(ctx, "db/tbl/file.parquet")
+		if err != nil {
+			t.Fatalf("StatFile: %v", err)
+		}
+		if size != int64(len(data)) {
+			t.Errorf("got %d, want %d", size, len(data))
+		}
+	})
+
+}
+
+// TestLocalBackend_ReadToAt covers full fetch (offset=0), partial read
+// (offset>0), and out-of-bounds offset.
+func TestLocalBackend_ReadToAt(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "arc-storage-readtoat-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	backend, err := NewLocalBackend(tmpDir, logger)
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	defer backend.Close()
+
+	ctx := context.Background()
+	content := []byte("abcdefghij") // 10 bytes
+	if err := backend.Write(ctx, "db/tbl/data.parquet", content); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	t.Run("offset=0 reads full file", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := backend.ReadToAt(ctx, "db/tbl/data.parquet", &buf, 0); err != nil {
+			t.Fatalf("ReadToAt: %v", err)
+		}
+		if buf.String() != string(content) {
+			t.Errorf("got %q, want %q", buf.String(), content)
+		}
+	})
+
+	t.Run("offset=5 reads tail", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := backend.ReadToAt(ctx, "db/tbl/data.parquet", &buf, 5); err != nil {
+			t.Fatalf("ReadToAt: %v", err)
+		}
+		want := "fghij"
+		if buf.String() != want {
+			t.Errorf("got %q, want %q", buf.String(), want)
+		}
+	})
+
+	t.Run("negative offset returns error", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := backend.ReadToAt(ctx, "db/tbl/data.parquet", &buf, -1); err == nil {
+			t.Error("expected error for negative offset, got nil")
+		}
+	})
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := backend.ReadToAt(ctx, "db/tbl/missing.parquet", &buf, 0); err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}
+
+// TestLocalBackend_AppendReader verifies that AppendingBackend is implemented,
+// and that AppendReader correctly appends bytes to an existing file.
+func TestLocalBackend_AppendReader(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "arc-storage-appendreader-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	backend, err := NewLocalBackend(tmpDir, logger)
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	// LocalBackend must satisfy AppendingBackend — compile-time check.
+	ab, ok := (Backend)(backend).(AppendingBackend)
+	if !ok {
+		t.Fatal("LocalBackend does not implement AppendingBackend")
+	}
+
+	prefix := []byte("hello ")
+	if err := backend.Write(ctx, "db/tbl/partial.parquet", prefix); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	tail := []byte("world")
+	if err := ab.AppendReader(ctx, "db/tbl/partial.parquet", bytes.NewReader(tail), int64(len(tail))); err != nil {
+		t.Fatalf("AppendReader: %v", err)
+	}
+
+	got, err := backend.Read(ctx, "db/tbl/partial.parquet")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	want := "hello world"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -139,9 +139,22 @@ func (b *LocalBackend) Write(ctx context.Context, path string, data []byte) erro
 	return nil
 }
 
-// WriteReader writes data from a reader to the specified path (for large files)
+// partPath returns the persistent in-progress path for a file being written by
+// WriteReader or AppendReader. Using a deterministic name (rather than a
+// random .tmp) means a partial write that survives a crash or transport error
+// is discoverable by StatFile and ReadToAt, enabling the puller to resume from
+// the last committed byte on the next attempt.
+func partPath(fullPath string) string {
+	return fullPath + ".part"
+}
+
+// WriteReader writes data from a reader to the specified path (for large files).
+//
+// Writes proceed to a deterministic "<path>.part" staging file so that a
+// partial transfer interrupted by a transport error leaves recoverable bytes
+// on disk. On success the staging file is atomically renamed to the final path.
+// On error the staging file is left in place so the puller can resume from it.
 func (b *LocalBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
-	// Validate and sanitize the path to prevent path traversal
 	fullPath, err := b.validatePath(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
@@ -152,10 +165,9 @@ func (b *LocalBackend) WriteReader(ctx context.Context, path string, reader io.R
 		return err
 	}
 
-	// Write to temporary file with cryptographically random name (prevents TOCTOU attacks)
-	tmpFile, err := os.CreateTemp(dir, ".arc-*.tmp")
+	stagingPath := partPath(fullPath)
+	stagingFile, err := os.OpenFile(stagingPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		// Directory might have been deleted externally — invalidate cache and retry
 		if os.IsNotExist(err) {
 			b.dirMu.Lock()
 			delete(b.dirCache, dir)
@@ -163,37 +175,34 @@ func (b *LocalBackend) WriteReader(ctx context.Context, path string, reader io.R
 			if err := b.ensureDir(dir); err != nil {
 				return err
 			}
-			tmpFile, err = os.CreateTemp(dir, ".arc-*.tmp")
+			stagingFile, err = os.OpenFile(stagingPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 			if err != nil {
-				return fmt.Errorf("failed to create temp file: %w", err)
+				return fmt.Errorf("failed to create staging file: %w", err)
 			}
 		} else {
-			return fmt.Errorf("failed to create temp file: %w", err)
+			return fmt.Errorf("failed to create staging file: %w", err)
 		}
 	}
-	tmpPath := tmpFile.Name()
 
-	// Copy data
-	written, err := io.Copy(tmpFile, reader)
-	closeErr := tmpFile.Close()
+	written, copyErr := io.Copy(stagingFile, reader)
+	closeErr := stagingFile.Close()
 
-	if err != nil {
-		os.Remove(tmpPath) // Clean up temp file on error
-		return fmt.Errorf("failed to write data: %w", err)
+	if copyErr != nil {
+		// Leave staging file in place — puller can resume from it.
+		metrics.Get().IncStorageErrors()
+		return fmt.Errorf("failed to write data: %w", copyErr)
 	}
 	if closeErr != nil {
-		os.Remove(tmpPath) // Clean up temp file on error
-		return fmt.Errorf("failed to close temp file: %w", closeErr)
-	}
-
-	// Atomic rename
-	if err := os.Rename(tmpPath, fullPath); err != nil {
-		os.Remove(tmpPath) // Clean up temp file on error
 		metrics.Get().IncStorageErrors()
-		return fmt.Errorf("failed to rename temp file: %w", err)
+		return fmt.Errorf("failed to close staging file: %w", closeErr)
 	}
 
-	// Record metrics
+	// Atomic promotion: rename staging → final.
+	if err := os.Rename(stagingPath, fullPath); err != nil {
+		metrics.Get().IncStorageErrors()
+		return fmt.Errorf("failed to promote staging file: %w", err)
+	}
+
 	metrics.Get().IncStorageWrites()
 	metrics.Get().IncStorageWriteBytes(written)
 
@@ -261,8 +270,10 @@ func (b *LocalBackend) ReadTo(ctx context.Context, path string, writer io.Writer
 	return nil
 }
 
-// ReadToAt reads data from the specified path starting at the given byte offset
-// and writes it to the writer. An offset of 0 is equivalent to ReadTo.
+// ReadToAt reads data from path starting at the given byte offset and writes
+// to writer. offset=0 starts at the beginning. Falls back to the ".part"
+// staging file if the final file does not exist (allows the puller to hash a
+// partial prefix before resuming a transfer).
 func (b *LocalBackend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
 	fullPath, err := b.validatePath(path)
 	if err != nil {
@@ -272,7 +283,14 @@ func (b *LocalBackend) ReadToAt(ctx context.Context, path string, writer io.Writ
 		return fmt.Errorf("negative offset: %d", offset)
 	}
 
-	file, err := os.Open(fullPath)
+	// Prefer the final file; fall back to the staging file so tryResumeFromPartial
+	// can hash a prefix even before the transfer completes.
+	openPath := fullPath
+	if _, statErr := os.Stat(fullPath); os.IsNotExist(statErr) {
+		openPath = partPath(fullPath)
+	}
+
+	file, err := os.Open(openPath)
 	if err != nil {
 		metrics.Get().IncStorageErrors()
 		if os.IsNotExist(err) {
@@ -287,7 +305,6 @@ func (b *LocalBackend) ReadToAt(ctx context.Context, path string, writer io.Writ
 			return fmt.Errorf("seek to offset %d: %w", offset, err)
 		}
 	}
-	// offset=0: no seek needed; file position is already at the start.
 
 	bytesRead, err := io.Copy(writer, file)
 	if err != nil {
@@ -300,34 +317,52 @@ func (b *LocalBackend) ReadToAt(ctx context.Context, path string, writer io.Writ
 	return nil
 }
 
-// StatFile returns the byte size of the file at path, or -1 if the file does
-// not exist. Returns a non-nil error only for unexpected failures.
+// StatFile returns the byte size of the file at path, or -1 if neither the
+// final file nor its ".part" staging file exist.
+// Returns a non-nil error only for unexpected failures.
+//
+// Checking the staging file allows the puller's pre-pull check to distinguish
+// a fully-received file (size == entry.SizeBytes → skip) from a partial one
+// (size < entry.SizeBytes → resume).
 func (b *LocalBackend) StatFile(ctx context.Context, path string) (int64, error) {
 	fullPath, err := b.validatePath(path)
 	if err != nil {
 		return -1, fmt.Errorf("invalid path: %w", err)
 	}
 	info, err := os.Stat(fullPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return -1, nil
-		}
+	if err == nil {
+		return info.Size(), nil
+	}
+	if !os.IsNotExist(err) {
 		return -1, fmt.Errorf("stat %s: %w", path, err)
 	}
-	return info.Size(), nil
+	// Final file absent — check the staging file.
+	info, err = os.Stat(partPath(fullPath))
+	if err == nil {
+		return info.Size(), nil
+	}
+	if os.IsNotExist(err) {
+		return -1, nil
+	}
+	return -1, fmt.Errorf("stat %s.part: %w", path, err)
 }
 
-// AppendReader appends appendSize bytes from reader to the existing file at path.
+// AppendReader appends bytes from reader to the ".part" staging file at path.
+// When all bytes have been appended (the transfer is complete), the caller
+// must call WriteReader (or the coordinator renames the file externally).
+//
+// This satisfies AppendingBackend, which the puller type-asserts before calling.
 func (b *LocalBackend) AppendReader(ctx context.Context, path string, reader io.Reader, appendSize int64) error {
 	fullPath, err := b.validatePath(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
 	}
 
-	file, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_APPEND, 0600)
+	stagingPath := partPath(fullPath)
+	file, err := os.OpenFile(stagingPath, os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		metrics.Get().IncStorageErrors()
-		return fmt.Errorf("failed to open file for append: %w", err)
+		return fmt.Errorf("failed to open staging file for append: %w", err)
 	}
 	defer file.Close()
 
@@ -335,6 +370,17 @@ func (b *LocalBackend) AppendReader(ctx context.Context, path string, reader io.
 	if err != nil {
 		metrics.Get().IncStorageErrors()
 		return fmt.Errorf("failed to append file data: %w", err)
+	}
+
+	// After appending, promote staging → final if we've received all expected bytes.
+	if written == appendSize {
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("failed to close staging file: %w", err)
+		}
+		if err := os.Rename(stagingPath, fullPath); err != nil {
+			metrics.Get().IncStorageErrors()
+			return fmt.Errorf("failed to promote staging file after append: %w", err)
+		}
 	}
 
 	metrics.Get().IncStorageWrites()

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -285,12 +285,10 @@ func (b *LocalBackend) ReadToAt(ctx context.Context, path string, writer io.Writ
 
 	// Prefer the final file; fall back to the staging file so tryResumeFromPartial
 	// can hash a prefix even before the transfer completes.
-	openPath := fullPath
-	if _, statErr := os.Stat(fullPath); os.IsNotExist(statErr) {
-		openPath = partPath(fullPath)
+	file, err := os.Open(fullPath)
+	if os.IsNotExist(err) {
+		file, err = os.Open(partPath(fullPath))
 	}
-
-	file, err := os.Open(openPath)
 	if err != nil {
 		metrics.Get().IncStorageErrors()
 		if os.IsNotExist(err) {

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -261,6 +261,87 @@ func (b *LocalBackend) ReadTo(ctx context.Context, path string, writer io.Writer
 	return nil
 }
 
+// ReadToAt reads data from the specified path starting at the given byte offset
+// and writes it to the writer. An offset of 0 is equivalent to ReadTo.
+func (b *LocalBackend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
+	fullPath, err := b.validatePath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+	if offset < 0 {
+		return fmt.Errorf("negative offset: %d", offset)
+	}
+
+	file, err := os.Open(fullPath)
+	if err != nil {
+		metrics.Get().IncStorageErrors()
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file not found: %s", path)
+		}
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	if offset > 0 {
+		if _, err := file.Seek(offset, io.SeekStart); err != nil {
+			return fmt.Errorf("seek to offset %d: %w", offset, err)
+		}
+	}
+	// offset=0: no seek needed; file position is already at the start.
+
+	bytesRead, err := io.Copy(writer, file)
+	if err != nil {
+		metrics.Get().IncStorageErrors()
+		return fmt.Errorf("failed to copy file data: %w", err)
+	}
+
+	metrics.Get().IncStorageReads()
+	metrics.Get().IncStorageReadBytes(bytesRead)
+	return nil
+}
+
+// StatFile returns the byte size of the file at path, or -1 if the file does
+// not exist. Returns a non-nil error only for unexpected failures.
+func (b *LocalBackend) StatFile(ctx context.Context, path string) (int64, error) {
+	fullPath, err := b.validatePath(path)
+	if err != nil {
+		return -1, fmt.Errorf("invalid path: %w", err)
+	}
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return -1, nil
+		}
+		return -1, fmt.Errorf("stat %s: %w", path, err)
+	}
+	return info.Size(), nil
+}
+
+// AppendReader appends appendSize bytes from reader to the existing file at path.
+func (b *LocalBackend) AppendReader(ctx context.Context, path string, reader io.Reader, appendSize int64) error {
+	fullPath, err := b.validatePath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+
+	file, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		metrics.Get().IncStorageErrors()
+		return fmt.Errorf("failed to open file for append: %w", err)
+	}
+	defer file.Close()
+
+	written, err := io.Copy(file, reader)
+	if err != nil {
+		metrics.Get().IncStorageErrors()
+		return fmt.Errorf("failed to append file data: %w", err)
+	}
+
+	metrics.Get().IncStorageWrites()
+	metrics.Get().IncStorageWriteBytes(written)
+	return nil
+}
+
 // List lists all objects with the given prefix
 func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error) {
 	// Validate and sanitize the prefix to prevent path traversal

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -288,6 +288,49 @@ func (b *S3Backend) ReadTo(ctx context.Context, path string, writer io.Writer) e
 	return nil
 }
 
+// ReadToAt reads data from S3 starting at the given byte offset and writes to
+// writer. Uses an HTTP Range header to skip already-transferred bytes.
+// offset=0 fetches the full object (no Range header sent).
+func (b *S3Backend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(b.bucket),
+		Key:    aws.String(b.prefixedKey(path)),
+	}
+	if offset > 0 {
+		input.Range = aws.String(fmt.Sprintf("bytes=%d-", offset))
+	}
+	result, err := b.client.GetObject(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to read from S3: %w", err)
+	}
+	defer result.Body.Close()
+
+	_, err = io.Copy(writer, result.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy S3 object: %w", err)
+	}
+	return nil
+}
+
+// StatFile returns the byte size of the S3 object at path, or -1 if not found.
+func (b *S3Backend) StatFile(ctx context.Context, path string) (int64, error) {
+	result, err := b.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(b.bucket),
+		Key:    aws.String(b.prefixedKey(path)),
+	})
+	if err != nil {
+		if isNotFoundError(err) {
+			return -1, nil
+		}
+		return -1, fmt.Errorf("HeadObject %s: %w", path, err)
+	}
+	if result.ContentLength == nil {
+		return 0, nil
+	}
+	return *result.ContentLength, nil
+}
+
+
 // List lists objects with the given prefix
 func (b *S3Backend) List(ctx context.Context, prefix string) ([]string, error) {
 	var objects []string

--- a/internal/tiering/integration_test.go
+++ b/internal/tiering/integration_test.go
@@ -87,6 +87,13 @@ func (m *mockBackend) List(_ context.Context, prefix string) ([]string, error) {
 	return paths, nil
 }
 func (m *mockBackend) Close() error { return nil }
+func (m *mockBackend) ReadToAt(_ context.Context, _ string, _ io.Writer, _ int64) error {
+	return nil
+}
+func (m *mockBackend) StatFile(_ context.Context, _ string) (int64, error) { return -1, nil }
+func (m *mockBackend) AppendReader(_ context.Context, _ string, _ io.Reader, _ int64) error {
+	return nil
+}
 
 // mockLicenseClient implements enough of license.Client for testing
 type mockLicenseClient struct {


### PR DESCRIPTION
## Summary

- Failed peer-replication file transfers now resume from the last committed byte instead of restarting from zero — especially valuable for large compacted Parquet outputs on slow or flaky links
- New `ByteOffset` field on `FetchFileRequest`/`FetchFileAckHeader` (omitempty); HMAC does not bind the offset (path is already bound)
- `AppendingBackend` optional interface replaces a mandatory `AppendReader` method that S3/Azure would always reject — puller type-asserts and falls back gracefully
- `bad_offset` counter split into `bad_offset_server` (AckCodeBadOffset) and `bad_offset_backend` (ErrResumeNotSupported) for cleaner observability
- Post-review refactors: `tryResumeFromPartial` helper, `writeFileTail` extracted, pipe goroutine uses `sync.WaitGroup`, coordinator uses `ReadToAt` unconditionally

## Test plan

- [ ] `go test ./internal/cluster/filereplication/...` — all existing + new tests pass (resume happy path, AckCodeBadOffset, offset echo mismatch, partial file retry, bad-offset deletes partial)
- [ ] `go test ./internal/storage/...` — ReadToAt, StatFile, AppendReader on LocalBackend
- [ ] `go test ./internal/cluster/...` — integration test: full fetch round-trip still works
- [ ] `go build ./...` — clean build
- [ ] Manual: interrupt a large file transfer mid-way, confirm second attempt resumes from offset (not from zero)
- [ ] Manual: S3/Azure backend confirms full re-fetch fallback (no partial file left behind)