### PR TITLE
feat(cluster): writer-only retention with Raft manifest propagation

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -149,6 +149,14 @@ Directories containing sensitive data (auth database, continuous query definitio
 
 Applied defense-in-depth SQL escaping to DuckDB `SET memory_limit` (single-quote escaping) and compaction `ORDER BY` sort key names (double-quote identifier escaping). Both already had config-level validation, but the runtime escaping provides an additional safety layer.
 
+### Cluster-Safe Retention Policy Execution (Enterprise)
+
+In clustered deployments, retention policies now run exclusively on the primary writer node and propagate file deletions through the Raft manifest to all peers.
+
+- **Writer-only execution**: The retention scheduler checks a cluster gate before starting. Only the primary writer node runs — reader and compactor nodes stay idle and log a clear message. On writer failover, the newly promoted primary picks up on the next cron tick. Standalone deployments are unaffected.
+- **Cluster manifest updates**: After each file is deleted from storage, the retention handler commits the deletion into the Raft log via `DeleteFileFromManifest`. This keeps the manifest consistent and prevents orphaned entries from interfering with peer replication catch-up.
+- **Reader node cleanup (local storage)**: The `onFileDeleted` FSM callback and delete-worker pool (shared with compaction) handle retention-triggered deletes on reader nodes, removing their local copy of the file and preventing unbounded disk growth on per-node storage deployments.
+
 ## Bug Fixes
 
 ### Row-Format MessagePack Flush Hardening

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1763,7 +1763,11 @@ func newRetentionClusterGate(c *cluster.Coordinator) *retentionClusterGate {
 }
 
 func (g *retentionClusterGate) CanRunRetention() bool {
-	return g.coordinator.GetLocalNode().IsPrimaryWriter()
+	node := g.coordinator.GetLocalNode()
+	if node == nil {
+		return false
+	}
+	return node.IsPrimaryWriter()
 }
 
 func (g *retentionClusterGate) Role() string {

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1320,7 +1320,7 @@ func main() {
 	var retentionHandler *api.RetentionHandler
 	if cfg.Retention.Enabled {
 		var err error
-		retentionHandler, err = api.NewRetentionHandler(storageBackend, db, &cfg.Retention, authManager, logger.Get("retention"))
+		retentionHandler, err = api.NewRetentionHandler(storageBackend, db, &cfg.Retention, licenseClient, authManager, logger.Get("retention"))
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to initialize retention handler")
 		}

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1325,6 +1325,9 @@ func main() {
 			log.Fatal().Err(err).Msg("Failed to initialize retention handler")
 		}
 		retentionHandler.RegisterRoutes(server.GetApp())
+		if clusterCoordinator != nil {
+			retentionHandler.SetCoordinator(clusterCoordinator)
+		}
 		shutdownCoordinator.RegisterHook("retention", func(ctx context.Context) error {
 			return retentionHandler.Close()
 		}, shutdown.PriorityDatabase)
@@ -1388,9 +1391,14 @@ func main() {
 	if cfg.Retention.Enabled && retentionHandler != nil {
 		if licenseClient != nil && licenseClient.CanUseRetentionScheduler() {
 			var err error
+			var retentionGate scheduler.RetentionClusterGate
+			if clusterCoordinator != nil {
+				retentionGate = newRetentionClusterGate(clusterCoordinator)
+			}
 			retentionScheduler, err = scheduler.NewRetentionScheduler(&scheduler.RetentionSchedulerConfig{
 				RetentionHandler: retentionHandler,
 				LicenseClient:    licenseClient,
+				ClusterGate:      retentionGate,
 				Schedule:         cfg.Scheduler.RetentionSchedule,
 				Logger:           logger.Get("retention-scheduler"),
 			})
@@ -1740,6 +1748,26 @@ func runCompactSubcommand(args []string) {
 		fmt.Fprintf(os.Stderr, "error: failed to encode result: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// retentionClusterGate implements scheduler.RetentionClusterGate.
+// Only the primary writer node runs retention to prevent races on shared
+// or per-node storage. This type sits in main.go to avoid a compile-time
+// dependency between the scheduler and cluster packages.
+type retentionClusterGate struct {
+	coordinator *cluster.Coordinator
+}
+
+func newRetentionClusterGate(c *cluster.Coordinator) *retentionClusterGate {
+	return &retentionClusterGate{coordinator: c}
+}
+
+func (g *retentionClusterGate) CanRunRetention() bool {
+	return g.coordinator.GetLocalNode().IsPrimaryWriter()
+}
+
+func (g *retentionClusterGate) Role() string {
+	return string(g.coordinator.GetRole())
 }
 
 // compactionClusterGate implements compaction.ClusterGate. When the

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -18,12 +18,20 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// RetentionCoordinator is the minimal cluster interface retention needs to
+// propagate file deletes to the Raft manifest. Using a minimal interface
+// avoids a compile-time dependency on the cluster package.
+type RetentionCoordinator interface {
+	DeleteFileFromManifest(path, reason string) error
+}
+
 // RetentionHandler handles retention policy operations
 type RetentionHandler struct {
 	storage     storage.Backend
 	config      *config.RetentionConfig
-	db          *sql.DB          // SQLite for policy metadata
-	duckdb      *database.DuckDB // Shared DuckDB for parquet queries
+	db          *sql.DB               // SQLite for policy metadata
+	duckdb      *database.DuckDB      // Shared DuckDB for parquet queries
+	coordinator RetentionCoordinator  // nil in standalone mode
 	authManager *auth.AuthManager
 	logger      zerolog.Logger
 }
@@ -114,6 +122,12 @@ func NewRetentionHandler(storage storage.Backend, duckdb *database.DuckDB, cfg *
 	}
 
 	return h, nil
+}
+
+// SetCoordinator wires the cluster coordinator for manifest updates.
+// Called after construction when cluster mode is enabled.
+func (h *RetentionHandler) SetCoordinator(c RetentionCoordinator) {
+	h.coordinator = c
 }
 
 // initTables creates the retention policy tables
@@ -758,6 +772,13 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 					continue
 				}
 				deletedFilePaths = append(deletedFilePaths, relativePath)
+				if h.coordinator != nil {
+					if err := h.coordinator.DeleteFileFromManifest(relativePath, "retention"); err != nil {
+						// Non-fatal: file is already gone from storage; manifest will
+						// self-heal on next compaction or node restart.
+						h.logger.Warn().Err(err).Str("file", relativePath).Msg("Failed to update cluster manifest after retention delete")
+					}
+				}
 			}
 
 			deletedRows += rowCount

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -807,8 +807,8 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 		subRows := eligibleRows[i:end]
 		if h.coordinator != nil {
 			ops = make([]raft.BatchFileOp, 0, len(chunk))
-			subPaths = subPaths[:0:0] // reset; will be rebuilt in parallel with ops
-			subRows = subRows[:0:0]
+			subPaths = make([]string, 0, len(chunk))
+			subRows = make([]int64, 0, len(chunk))
 			for j, p := range chunk {
 				payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: "retention"})
 				if err != nil {

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -747,10 +747,10 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 
 	var deletedRows int64
 	var deletedFiles int
-	var deletedFilePaths []string
+	var eligiblePaths []string // paths eligible for deletion (used for manifest + storage ops)
+	var eligibleRows []int64   // row counts parallel to eligiblePaths
 
 	for _, relativePath := range parquetFiles {
-		// Build full path for DuckDB to read (s3://, azure://, or local path)
 		fullPath := h.buildParquetPath(relativePath)
 
 		maxTime, rowCount, err := h.getFileMaxTimeAndRowCount(ctx, fullPath)
@@ -759,7 +759,6 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 			continue
 		}
 
-		// If ALL rows in file are older than cutoff, delete the file
 		if maxTime.Before(cutoffDate) {
 			h.logger.Info().
 				Str("file", filepath.Base(relativePath)).
@@ -769,32 +768,35 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 				Msg("File eligible for deletion")
 
 			if !dryRun {
-				if err := h.storage.Delete(ctx, relativePath); err != nil {
-					h.logger.Error().Err(err).Str("file", relativePath).Msg("Failed to delete file")
-					continue
-				}
-				deletedFilePaths = append(deletedFilePaths, relativePath)
+				eligiblePaths = append(eligiblePaths, relativePath)
+				eligibleRows = append(eligibleRows, rowCount)
+			} else {
+				deletedRows += rowCount
+				deletedFiles++
 			}
-
-			deletedRows += rowCount
-			deletedFiles++
 		}
 	}
 
-	// Batch-update the cluster manifest in chunks of 1000. Chunking prevents
-	// a single oversized Raft log entry when retention removes a large number
-	// of files. If a chunk fails, those paths become orphaned in the manifest
-	// (files are already gone from storage). There is no automatic reconciliation
-	// today — Phase 5 will add periodic manifest-vs-storage reconciliation to
-	// clean these up.
+	if dryRun || len(eligiblePaths) == 0 {
+		return deletedRows, deletedFiles, nil
+	}
+
+	// Step 1 — update the cluster manifest before touching storage. Chunked at
+	// 1000 ops to keep individual Raft log entries within a reasonable size.
+	// Ordering matters: if the manifest update fails, the file still exists in
+	// storage and the next retention run will retry it. The reverse order (delete
+	// storage first) would leave permanent orphan entries with no retry path.
+	// On manifest failure we abort the whole cycle — a Raft quorum loss is not
+	// transient, and continuing would produce more orphans for the same underlying
+	// cause. Phase 5 will add periodic manifest-vs-storage reconciliation.
 	const manifestBatchSize = 1000
-	if !dryRun && h.coordinator != nil && len(deletedFilePaths) > 0 {
-		for i := 0; i < len(deletedFilePaths); i += manifestBatchSize {
+	if h.coordinator != nil {
+		for i := 0; i < len(eligiblePaths); i += manifestBatchSize {
 			end := i + manifestBatchSize
-			if end > len(deletedFilePaths) {
-				end = len(deletedFilePaths)
+			if end > len(eligiblePaths) {
+				end = len(eligiblePaths)
 			}
-			chunk := deletedFilePaths[i:end]
+			chunk := eligiblePaths[i:end]
 			ops := make([]raft.BatchFileOp, 0, len(chunk))
 			for _, p := range chunk {
 				payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: "retention"})
@@ -809,13 +811,28 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 			}
 			if err := h.coordinator.BatchFileOpsInManifest(ops); err != nil {
 				h.logger.Error().Err(err).Int("count", len(ops)).Int("chunk_start", i).
-					Msg("Failed to update cluster manifest after retention delete; affected files are orphaned in manifest until Phase 5 reconciliation")
+					Msg("Failed to update cluster manifest; aborting retention cycle to avoid orphaned manifest entries")
+				return deletedRows, deletedFiles, fmt.Errorf("failed to update cluster manifest: %w", err)
 			}
 		}
 	}
 
+	// Step 2 — delete from storage. If a delete fails the file is now a harmless
+	// ghost: invisible to the cluster (manifest entry is gone) but still on disk.
+	// It will be cleaned up by the next compaction pass or operator action.
+	var deletedFilePaths []string
+	for i, relativePath := range eligiblePaths {
+		if err := h.storage.Delete(ctx, relativePath); err != nil {
+			h.logger.Error().Err(err).Str("file", relativePath).Msg("Failed to delete file from storage")
+			continue
+		}
+		deletedFilePaths = append(deletedFilePaths, relativePath)
+		deletedRows += eligibleRows[i]
+		deletedFiles++
+	}
+
 	// Clean up empty directories after deletion (only for local storage)
-	if !dryRun && len(deletedFilePaths) > 0 {
+	if len(deletedFilePaths) > 0 {
 		h.cleanupEmptyDirectories(ctx, deletedFilePaths)
 	}
 

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -420,6 +420,10 @@ func (h *RetentionHandler) ExecutePolicy(ctx context.Context, policyID int64) (*
 
 	for _, measurement := range measurements {
 		deleted, filesDeleted, err := h.deleteOldFiles(ctx, policy.Database, measurement, cutoffDate, false, fmt.Sprintf("retention:%d", policyID))
+		// Accumulate before error check: deleteOldFiles returns partial progress
+		// on abort so the execution record reflects all completed work accurately.
+		totalDeleted += deleted
+		totalFilesDeleted += filesDeleted
 		if err != nil {
 			h.logger.Error().Err(err).Str("measurement", measurement).Msg("Failed to process measurement")
 			// Abort on any error — manifest failures are non-transient (Raft quorum loss)
@@ -429,8 +433,6 @@ func (h *RetentionHandler) ExecutePolicy(ctx context.Context, policyID int64) (*
 			}
 			return nil, fmt.Errorf("retention aborted for policy %d: %w", policyID, err)
 		}
-		totalDeleted += deleted
-		totalFilesDeleted += filesDeleted
 	}
 
 	// Clear DuckDB parquet metadata/data cache and release memory back to OS.
@@ -576,6 +578,8 @@ func (h *RetentionHandler) handleExecute(c *fiber.Ctx) error {
 
 	for _, measurement := range measurements {
 		deleted, filesDeleted, err := h.deleteOldFiles(c.Context(), policy.Database, measurement, cutoffDate, req.DryRun, fmt.Sprintf("retention:%d", policyID))
+		totalDeleted += deleted
+		totalFilesDeleted += filesDeleted
 		if err != nil {
 			h.logger.Error().Err(err).Str("measurement", measurement).Msg("Failed to process measurement")
 			if !req.DryRun && executionID > 0 {
@@ -585,8 +589,6 @@ func (h *RetentionHandler) handleExecute(c *fiber.Ctx) error {
 				"error": fmt.Sprintf("retention aborted at measurement %q: %s", measurement, err.Error()),
 			})
 		}
-		totalDeleted += deleted
-		totalFilesDeleted += filesDeleted
 	}
 
 	// Clear DuckDB parquet metadata/data cache — dry runs also populate the cache via

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/cluster/raft"
 	"github.com/basekick-labs/arc/internal/config"
 	"github.com/basekick-labs/arc/internal/database"
 	"github.com/basekick-labs/arc/internal/storage"
@@ -22,7 +24,7 @@ import (
 // propagate file deletes to the Raft manifest. Using a minimal interface
 // avoids a compile-time dependency on the cluster package.
 type RetentionCoordinator interface {
-	DeleteFileFromManifest(path, reason string) error
+	BatchFileOpsInManifest(ops []raft.BatchFileOp) error
 }
 
 // RetentionHandler handles retention policy operations
@@ -772,17 +774,31 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 					continue
 				}
 				deletedFilePaths = append(deletedFilePaths, relativePath)
-				if h.coordinator != nil {
-					if err := h.coordinator.DeleteFileFromManifest(relativePath, "retention"); err != nil {
-						// Non-fatal: file is already gone from storage; manifest will
-						// self-heal on next compaction or node restart.
-						h.logger.Warn().Err(err).Str("file", relativePath).Msg("Failed to update cluster manifest after retention delete")
-					}
-				}
 			}
 
 			deletedRows += rowCount
 			deletedFiles++
+		}
+	}
+
+	// Batch-update the cluster manifest for all deleted files in a single
+	// Raft proposal instead of one proposal per file.
+	if !dryRun && h.coordinator != nil && len(deletedFilePaths) > 0 {
+		ops := make([]raft.BatchFileOp, 0, len(deletedFilePaths))
+		for _, p := range deletedFilePaths {
+			payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: "retention"})
+			if err != nil {
+				h.logger.Warn().Err(err).Str("file", p).Msg("Failed to marshal manifest delete op")
+				continue
+			}
+			ops = append(ops, raft.BatchFileOp{Type: raft.CommandDeleteFile, Payload: payload})
+		}
+		if len(ops) > 0 {
+			if err := h.coordinator.BatchFileOpsInManifest(ops); err != nil {
+				// Non-fatal: files are already gone from storage; manifest
+				// will self-heal on next compaction or node restart.
+				h.logger.Warn().Err(err).Int("count", len(ops)).Msg("Failed to batch-update cluster manifest after retention delete")
+			}
 		}
 	}
 

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -799,15 +799,25 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 		}
 		chunk := eligiblePaths[i:end]
 
+		// subPaths/subRows track only the files that were successfully marshalled
+		// into ops. The storage delete loop uses this subset so a marshal failure
+		// never causes a file to be deleted from storage without a manifest entry.
+		var ops []raft.BatchFileOp
+		subPaths := chunk          // default: all chunk paths (no coordinator)
+		subRows := eligibleRows[i:end]
 		if h.coordinator != nil {
-			ops := make([]raft.BatchFileOp, 0, len(chunk))
-			for _, p := range chunk {
+			ops = make([]raft.BatchFileOp, 0, len(chunk))
+			subPaths = subPaths[:0:0] // reset; will be rebuilt in parallel with ops
+			subRows = subRows[:0:0]
+			for j, p := range chunk {
 				payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: "retention"})
 				if err != nil {
-					h.logger.Warn().Err(err).Str("file", p).Msg("Failed to marshal manifest delete op")
+					h.logger.Warn().Err(err).Str("file", p).Msg("Failed to marshal manifest delete op; skipping file")
 					continue
 				}
 				ops = append(ops, raft.BatchFileOp{Type: raft.CommandDeleteFile, Payload: payload})
+				subPaths = append(subPaths, p)
+				subRows = append(subRows, eligibleRows[i+j])
 			}
 			if len(ops) > 0 {
 				if err := h.coordinator.BatchFileOpsInManifest(ops); err != nil {
@@ -821,13 +831,13 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 			}
 		}
 
-		for j, relativePath := range chunk {
+		for j, relativePath := range subPaths {
 			if err := h.storage.Delete(ctx, relativePath); err != nil {
 				h.logger.Error().Err(err).Str("file", relativePath).Msg("Failed to delete file from storage")
 				continue
 			}
 			deletedFilePaths = append(deletedFilePaths, relativePath)
-			deletedRows += eligibleRows[i+j]
+			deletedRows += subRows[j]
 			deletedFiles++
 		}
 	}

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -22,10 +22,16 @@ import (
 )
 
 // RetentionCoordinator is the minimal cluster interface retention needs to
-// propagate file deletes to the Raft manifest. Using a minimal interface
-// avoids a compile-time dependency on the cluster package.
+// propagate file deletes to the Raft manifest and gate execution to the
+// primary writer. Using a minimal interface avoids a compile-time dependency
+// on the cluster package.
 type RetentionCoordinator interface {
 	BatchFileOpsInManifest(ops []raft.BatchFileOp) error
+	// CanRunRetention reports whether this node may execute retention.
+	// Returns true unconditionally for standalone (coordinator is nil).
+	CanRunRetention() bool
+	// Role returns a human-readable role string for log messages.
+	Role() string
 }
 
 // RetentionHandler handles retention policy operations
@@ -518,6 +524,14 @@ func (h *RetentionHandler) handleExecute(c *fiber.Ctx) error {
 	if !req.DryRun && !req.Confirm {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Confirmation required for retention policy execution. Set confirm=true",
+		})
+	}
+
+	// In cluster mode, only the primary writer may execute retention — reader
+	// nodes must not race with the writer over shared or local storage.
+	if !req.DryRun && h.coordinator != nil && !h.coordinator.CanRunRetention() {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": fmt.Sprintf("retention rejected: node role %q is not primary writer", h.coordinator.Role()),
 		})
 	}
 

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -781,22 +781,25 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 		return deletedRows, deletedFiles, nil
 	}
 
-	// Step 1 — update the cluster manifest before touching storage. Chunked at
-	// 1000 ops to keep individual Raft log entries within a reasonable size.
-	// Ordering matters: if the manifest update fails, the file still exists in
-	// storage and the next retention run will retry it. The reverse order (delete
-	// storage first) would leave permanent orphan entries with no retry path.
-	// On manifest failure we abort the whole cycle — a Raft quorum loss is not
-	// transient, and continuing would produce more orphans for the same underlying
-	// cause. Phase 5 will add periodic manifest-vs-storage reconciliation.
+	// Process in chunks of 1000: update manifest first, then delete from storage.
+	// Interleaving per-chunk limits orphan blast radius — a mid-run manifest
+	// failure only affects the current chunk, not all remaining files.
+	// Manifest-before-storage ordering ensures failures are retryable: if the
+	// manifest update fails, the file still exists in storage and the next
+	// retention run will pick it up. A storage delete failure after a successful
+	// manifest update leaves a harmless ghost on disk (compaction will clean it).
+	// On manifest failure we abort — a Raft quorum loss is not transient.
+	// Phase 5 will add periodic manifest-vs-storage reconciliation.
 	const manifestBatchSize = 1000
-	if h.coordinator != nil {
-		for i := 0; i < len(eligiblePaths); i += manifestBatchSize {
-			end := i + manifestBatchSize
-			if end > len(eligiblePaths) {
-				end = len(eligiblePaths)
-			}
-			chunk := eligiblePaths[i:end]
+	var deletedFilePaths []string
+	for i := 0; i < len(eligiblePaths); i += manifestBatchSize {
+		end := i + manifestBatchSize
+		if end > len(eligiblePaths) {
+			end = len(eligiblePaths)
+		}
+		chunk := eligiblePaths[i:end]
+
+		if h.coordinator != nil {
 			ops := make([]raft.BatchFileOp, 0, len(chunk))
 			for _, p := range chunk {
 				payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: "retention"})
@@ -806,32 +809,29 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 				}
 				ops = append(ops, raft.BatchFileOp{Type: raft.CommandDeleteFile, Payload: payload})
 			}
-			if len(ops) == 0 {
+			if len(ops) > 0 {
+				if err := h.coordinator.BatchFileOpsInManifest(ops); err != nil {
+					h.logger.Error().Err(err).Int("count", len(ops)).Int("chunk_start", i).
+						Msg("Failed to update cluster manifest; aborting retention cycle")
+					if len(deletedFilePaths) > 0 {
+						h.cleanupEmptyDirectories(ctx, deletedFilePaths)
+					}
+					return deletedRows, deletedFiles, fmt.Errorf("failed to update cluster manifest: %w", err)
+				}
+			}
+		}
+
+		for j, relativePath := range chunk {
+			if err := h.storage.Delete(ctx, relativePath); err != nil {
+				h.logger.Error().Err(err).Str("file", relativePath).Msg("Failed to delete file from storage")
 				continue
 			}
-			if err := h.coordinator.BatchFileOpsInManifest(ops); err != nil {
-				h.logger.Error().Err(err).Int("count", len(ops)).Int("chunk_start", i).
-					Msg("Failed to update cluster manifest; aborting retention cycle to avoid orphaned manifest entries")
-				return deletedRows, deletedFiles, fmt.Errorf("failed to update cluster manifest: %w", err)
-			}
+			deletedFilePaths = append(deletedFilePaths, relativePath)
+			deletedRows += eligibleRows[i+j]
+			deletedFiles++
 		}
 	}
 
-	// Step 2 — delete from storage. If a delete fails the file is now a harmless
-	// ghost: invisible to the cluster (manifest entry is gone) but still on disk.
-	// It will be cleaned up by the next compaction pass or operator action.
-	var deletedFilePaths []string
-	for i, relativePath := range eligiblePaths {
-		if err := h.storage.Delete(ctx, relativePath); err != nil {
-			h.logger.Error().Err(err).Str("file", relativePath).Msg("Failed to delete file from storage")
-			continue
-		}
-		deletedFilePaths = append(deletedFilePaths, relativePath)
-		deletedRows += eligibleRows[i]
-		deletedFiles++
-	}
-
-	// Clean up empty directories after deletion (only for local storage)
 	if len(deletedFilePaths) > 0 {
 		h.cleanupEmptyDirectories(ctx, deletedFilePaths)
 	}
@@ -844,8 +844,10 @@ func (h *RetentionHandler) getFileMaxTimeAndRowCount(ctx context.Context, filePa
 	// Use the shared DuckDB connection to avoid memory retention from temporary connections
 	db := h.duckdb.DB()
 
-	// Get max time and count
-	query := fmt.Sprintf("SELECT MAX(time) as max_time, COUNT(*) as cnt FROM read_parquet('%s')", filePath)
+	// read_parquet() does not support parameterized queries, so escape single
+	// quotes in the path to prevent SQL injection via crafted file paths.
+	safePath := strings.ReplaceAll(filePath, "'", "''")
+	query := fmt.Sprintf("SELECT MAX(time) as max_time, COUNT(*) as cnt FROM read_parquet('%s')", safePath)
 	row := db.QueryRowContext(ctx, query)
 
 	var maxTime time.Time

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -781,23 +781,35 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 		}
 	}
 
-	// Batch-update the cluster manifest for all deleted files in a single
-	// Raft proposal instead of one proposal per file.
+	// Batch-update the cluster manifest in chunks of 1000. Chunking prevents
+	// a single oversized Raft log entry when retention removes a large number
+	// of files. If a chunk fails, those paths become orphaned in the manifest
+	// (files are already gone from storage). There is no automatic reconciliation
+	// today — Phase 5 will add periodic manifest-vs-storage reconciliation to
+	// clean these up.
+	const manifestBatchSize = 1000
 	if !dryRun && h.coordinator != nil && len(deletedFilePaths) > 0 {
-		ops := make([]raft.BatchFileOp, 0, len(deletedFilePaths))
-		for _, p := range deletedFilePaths {
-			payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: "retention"})
-			if err != nil {
-				h.logger.Warn().Err(err).Str("file", p).Msg("Failed to marshal manifest delete op")
+		for i := 0; i < len(deletedFilePaths); i += manifestBatchSize {
+			end := i + manifestBatchSize
+			if end > len(deletedFilePaths) {
+				end = len(deletedFilePaths)
+			}
+			chunk := deletedFilePaths[i:end]
+			ops := make([]raft.BatchFileOp, 0, len(chunk))
+			for _, p := range chunk {
+				payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: "retention"})
+				if err != nil {
+					h.logger.Warn().Err(err).Str("file", p).Msg("Failed to marshal manifest delete op")
+					continue
+				}
+				ops = append(ops, raft.BatchFileOp{Type: raft.CommandDeleteFile, Payload: payload})
+			}
+			if len(ops) == 0 {
 				continue
 			}
-			ops = append(ops, raft.BatchFileOp{Type: raft.CommandDeleteFile, Payload: payload})
-		}
-		if len(ops) > 0 {
 			if err := h.coordinator.BatchFileOpsInManifest(ops); err != nil {
-				// Non-fatal: files are already gone from storage; manifest
-				// will self-heal on next compaction or node restart.
-				h.logger.Warn().Err(err).Int("count", len(ops)).Msg("Failed to batch-update cluster manifest after retention delete")
+				h.logger.Error().Err(err).Int("count", len(ops)).Int("chunk_start", i).
+					Msg("Failed to update cluster manifest after retention delete; affected files are orphaned in manifest until Phase 5 reconciliation")
 			}
 		}
 	}

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -419,7 +419,7 @@ func (h *RetentionHandler) ExecutePolicy(ctx context.Context, policyID int64) (*
 	var totalFilesDeleted int
 
 	for _, measurement := range measurements {
-		deleted, filesDeleted, err := h.deleteOldFiles(ctx, policy.Database, measurement, cutoffDate, false)
+		deleted, filesDeleted, err := h.deleteOldFiles(ctx, policy.Database, measurement, cutoffDate, false, fmt.Sprintf("retention:%d", policyID))
 		if err != nil {
 			h.logger.Error().Err(err).Str("measurement", measurement).Msg("Failed to process measurement")
 			// Abort on any error — manifest failures are non-transient (Raft quorum loss)
@@ -575,7 +575,7 @@ func (h *RetentionHandler) handleExecute(c *fiber.Ctx) error {
 	var totalFilesDeleted int
 
 	for _, measurement := range measurements {
-		deleted, filesDeleted, err := h.deleteOldFiles(c.Context(), policy.Database, measurement, cutoffDate, req.DryRun)
+		deleted, filesDeleted, err := h.deleteOldFiles(c.Context(), policy.Database, measurement, cutoffDate, req.DryRun, fmt.Sprintf("retention:%d", policyID))
 		if err != nil {
 			h.logger.Error().Err(err).Str("measurement", measurement).Msg("Failed to process measurement")
 			if !req.DryRun && executionID > 0 {
@@ -759,7 +759,7 @@ func (h *RetentionHandler) getMeasurementsToProcess(ctx context.Context, policy 
 
 // deleteOldFiles deletes Parquet files where ALL rows are older than cutoffDate
 // Supports all storage backends: local, S3, and Azure
-func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measurement string, cutoffDate time.Time, dryRun bool) (int64, int, error) {
+func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measurement string, cutoffDate time.Time, dryRun bool, reason string) (int64, int, error) {
 	// List all files for this measurement using storage backend
 	prefix := database + "/" + measurement + "/"
 	files, err := h.storage.List(ctx, prefix)
@@ -842,7 +842,7 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 			subPaths = make([]string, 0, len(chunk))
 			subRows = make([]int64, 0, len(chunk))
 			for j, p := range chunk {
-				payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: "retention"})
+				payload, err := json.Marshal(raft.DeleteFilePayload{Path: p, Reason: reason})
 				if err != nil {
 					h.logger.Warn().Err(err).Str("file", p).Msg("Failed to marshal manifest delete op; skipping file")
 					continue
@@ -865,7 +865,9 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 
 		for j, relativePath := range subPaths {
 			if err := h.storage.Delete(ctx, relativePath); err != nil {
-				h.logger.Error().Err(err).Str("file", relativePath).Msg("Failed to delete file from storage")
+				// Storage errors are transient (network blip, file already gone) —
+				// log as Warn and continue so one bad file doesn't abort the cycle.
+				h.logger.Warn().Err(err).Str("file", relativePath).Msg("Failed to delete file from storage; skipping")
 				continue
 			}
 			deletedFilePaths = append(deletedFilePaths, relativePath)

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -14,6 +14,7 @@ import (
 	"github.com/basekick-labs/arc/internal/cluster/raft"
 	"github.com/basekick-labs/arc/internal/config"
 	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/license"
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/gofiber/fiber/v2"
 	_ "github.com/mattn/go-sqlite3"
@@ -29,13 +30,14 @@ type RetentionCoordinator interface {
 
 // RetentionHandler handles retention policy operations
 type RetentionHandler struct {
-	storage     storage.Backend
-	config      *config.RetentionConfig
-	db          *sql.DB               // SQLite for policy metadata
-	duckdb      *database.DuckDB      // Shared DuckDB for parquet queries
-	coordinator RetentionCoordinator  // nil in standalone mode
-	authManager *auth.AuthManager
-	logger      zerolog.Logger
+	storage       storage.Backend
+	config        *config.RetentionConfig
+	db            *sql.DB              // SQLite for policy metadata
+	duckdb        *database.DuckDB     // Shared DuckDB for parquet queries
+	coordinator   RetentionCoordinator // nil in standalone mode
+	licenseClient *license.Client      // nil when auth/licensing is disabled
+	authManager   *auth.AuthManager
+	logger        zerolog.Logger
 }
 
 // RetentionPolicy represents a retention policy
@@ -95,7 +97,7 @@ type RetentionExecution struct {
 }
 
 // NewRetentionHandler creates a new retention handler
-func NewRetentionHandler(storage storage.Backend, duckdb *database.DuckDB, cfg *config.RetentionConfig, authManager *auth.AuthManager, logger zerolog.Logger) (*RetentionHandler, error) {
+func NewRetentionHandler(storage storage.Backend, duckdb *database.DuckDB, cfg *config.RetentionConfig, licenseClient *license.Client, authManager *auth.AuthManager, logger zerolog.Logger) (*RetentionHandler, error) {
 	// Ensure directory exists
 	dir := filepath.Dir(cfg.DBPath)
 	if err := os.MkdirAll(dir, 0700); err != nil {
@@ -109,12 +111,13 @@ func NewRetentionHandler(storage storage.Backend, duckdb *database.DuckDB, cfg *
 	}
 
 	h := &RetentionHandler{
-		storage:     storage,
-		config:      cfg,
-		db:          db,
-		duckdb:      duckdb,
-		authManager: authManager,
-		logger:      logger.With().Str("component", "retention-handler").Logger(),
+		storage:       storage,
+		config:        cfg,
+		db:            db,
+		duckdb:        duckdb,
+		licenseClient: licenseClient,
+		authManager:   authManager,
+		logger:        logger.With().Str("component", "retention-handler").Logger(),
 	}
 
 	// Initialize tables
@@ -371,6 +374,11 @@ func (h *RetentionHandler) handleDelete(c *fiber.Ctx) error {
 func (h *RetentionHandler) ExecutePolicy(ctx context.Context, policyID int64) (*ExecuteRetentionResponse, error) {
 	start := time.Now()
 
+	// License check: guards direct programmatic calls that bypass the scheduler.
+	if h.licenseClient != nil && !h.licenseClient.CanUseRetentionScheduler() {
+		return nil, fmt.Errorf("valid enterprise license required for retention policy execution")
+	}
+
 	// Get policy
 	policy, err := h.getPolicy(policyID)
 	if err != nil {
@@ -408,6 +416,14 @@ func (h *RetentionHandler) ExecutePolicy(ctx context.Context, policyID int64) (*
 		deleted, filesDeleted, err := h.deleteOldFiles(ctx, policy.Database, measurement, cutoffDate, false)
 		if err != nil {
 			h.logger.Error().Err(err).Str("measurement", measurement).Msg("Failed to process measurement")
+			// Manifest failures are non-transient (e.g. Raft quorum loss) — abort
+			// the entire policy to avoid creating more orphaned manifest entries.
+			if h.coordinator != nil {
+				if executionID > 0 {
+					h.recordExecutionComplete(executionID, "failed", totalDeleted, float64(time.Since(start).Milliseconds()), err.Error())
+				}
+				return nil, fmt.Errorf("retention aborted for policy %d: %w", policyID, err)
+			}
 			continue
 		}
 		totalDeleted += deleted

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -416,15 +416,12 @@ func (h *RetentionHandler) ExecutePolicy(ctx context.Context, policyID int64) (*
 		deleted, filesDeleted, err := h.deleteOldFiles(ctx, policy.Database, measurement, cutoffDate, false)
 		if err != nil {
 			h.logger.Error().Err(err).Str("measurement", measurement).Msg("Failed to process measurement")
-			// Manifest failures are non-transient (e.g. Raft quorum loss) — abort
-			// the entire policy to avoid creating more orphaned manifest entries.
-			if h.coordinator != nil {
-				if executionID > 0 {
-					h.recordExecutionComplete(executionID, "failed", totalDeleted, float64(time.Since(start).Milliseconds()), err.Error())
-				}
-				return nil, fmt.Errorf("retention aborted for policy %d: %w", policyID, err)
+			// Abort on any error — manifest failures are non-transient (Raft quorum loss)
+			// and continuing would produce orphaned manifest entries with no retry path.
+			if executionID > 0 {
+				h.recordExecutionComplete(executionID, "failed", totalDeleted, float64(time.Since(start).Milliseconds()), err.Error())
 			}
-			continue
+			return nil, fmt.Errorf("retention aborted for policy %d: %w", policyID, err)
 		}
 		totalDeleted += deleted
 		totalFilesDeleted += filesDeleted
@@ -564,10 +561,15 @@ func (h *RetentionHandler) handleExecute(c *fiber.Ctx) error {
 	var totalFilesDeleted int
 
 	for _, measurement := range measurements {
-		deleted, filesDeleted, err := h.deleteOldFiles(context.Background(), policy.Database, measurement, cutoffDate, req.DryRun)
+		deleted, filesDeleted, err := h.deleteOldFiles(c.Context(), policy.Database, measurement, cutoffDate, req.DryRun)
 		if err != nil {
 			h.logger.Error().Err(err).Str("measurement", measurement).Msg("Failed to process measurement")
-			continue
+			if !req.DryRun && executionID > 0 {
+				h.recordExecutionComplete(executionID, "failed", totalDeleted, float64(time.Since(start).Milliseconds()), err.Error())
+			}
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"error": fmt.Sprintf("retention aborted at measurement %q: %s", measurement, err.Error()),
+			})
 		}
 		totalDeleted += deleted
 		totalFilesDeleted += filesDeleted

--- a/internal/api/retention_test.go
+++ b/internal/api/retention_test.go
@@ -46,7 +46,7 @@ func setupTestRetentionHandler(t *testing.T) (*RetentionHandler, string) {
 		DBPath:  filepath.Join(tmpDir, "retention.db"),
 	}
 
-	handler, err := NewRetentionHandler(backend, duckdb, retentionCfg, nil, logger)
+	handler, err := NewRetentionHandler(backend, duckdb, retentionCfg, nil, nil, logger)
 	if err != nil {
 		duckdb.Close()
 		os.RemoveAll(tmpDir)

--- a/internal/api/retention_test.go
+++ b/internal/api/retention_test.go
@@ -199,7 +199,7 @@ func TestDeleteOldFiles_NoFiles(t *testing.T) {
 	handler, _ := setupTestRetentionHandler(t)
 
 	cutoff := time.Now().Add(-24 * time.Hour)
-	deletedRows, deletedFiles, err := handler.deleteOldFiles(context.Background(), "testdb", "nonexistent", cutoff, false)
+	deletedRows, deletedFiles, err := handler.deleteOldFiles(context.Background(), "testdb", "nonexistent", cutoff, false, "retention:test")
 
 	if err != nil {
 		t.Fatalf("deleteOldFiles() error = %v", err)
@@ -242,7 +242,7 @@ func TestDeleteOldFiles_DryRun(t *testing.T) {
 
 	// Run dry-run deletion with a cutoff date after the data
 	cutoff := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
-	deletedRows, deletedFiles, err := handler.deleteOldFiles(context.Background(), "testdb", "logs", cutoff, true)
+	deletedRows, deletedFiles, err := handler.deleteOldFiles(context.Background(), "testdb", "logs", cutoff, true, "retention:test")
 
 	if err != nil {
 		t.Fatalf("deleteOldFiles() error = %v", err)
@@ -295,7 +295,7 @@ func TestDeleteOldFiles_ActualDelete(t *testing.T) {
 
 	// Run actual deletion with a cutoff date after the data
 	cutoff := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
-	deletedRows, deletedFiles, err := handler.deleteOldFiles(context.Background(), "testdb", "logs", cutoff, false)
+	deletedRows, deletedFiles, err := handler.deleteOldFiles(context.Background(), "testdb", "logs", cutoff, false, "retention:test")
 
 	if err != nil {
 		t.Fatalf("deleteOldFiles() error = %v", err)
@@ -343,7 +343,7 @@ func TestDeleteOldFiles_KeepsRecentFiles(t *testing.T) {
 
 	// Run deletion with a cutoff date before the data
 	cutoff := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	deletedRows, deletedFiles, err := handler.deleteOldFiles(context.Background(), "testdb", "logs", cutoff, false)
+	deletedRows, deletedFiles, err := handler.deleteOldFiles(context.Background(), "testdb", "logs", cutoff, false, "retention:test")
 
 	if err != nil {
 		t.Fatalf("deleteOldFiles() error = %v", err)
@@ -397,7 +397,7 @@ func TestDeleteOldFiles_CleansUpEmptyDirectories(t *testing.T) {
 
 	// Run actual deletion with a cutoff date after the data
 	cutoff := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, _, err := handler.deleteOldFiles(context.Background(), "testdb", "logs", cutoff, false)
+	_, _, err := handler.deleteOldFiles(context.Background(), "testdb", "logs", cutoff, false, "retention:test")
 
 	if err != nil {
 		t.Fatalf("deleteOldFiles() error = %v", err)

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1511,6 +1511,22 @@ func (c *Coordinator) GetRole() NodeRole {
 	return c.localNode.Role
 }
 
+// CanRunRetention implements api.RetentionCoordinator: reports whether this
+// node is the primary writer and therefore permitted to execute retention.
+func (c *Coordinator) CanRunRetention() bool {
+	node := c.GetLocalNode()
+	if node == nil {
+		return false
+	}
+	return node.IsPrimaryWriter()
+}
+
+// Role implements api.RetentionCoordinator: returns a human-readable role
+// string for log messages.
+func (c *Coordinator) Role() string {
+	return string(c.GetRole())
+}
+
 // GetCapabilities returns the capabilities of the local node.
 func (c *Coordinator) GetCapabilities() RoleCapabilities {
 	return c.localNode.GetCapabilities()

--- a/internal/scheduler/retention_scheduler.go
+++ b/internal/scheduler/retention_scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -11,13 +12,30 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// RetentionClusterGate is the minimal interface the retention scheduler needs
+// to decide whether this node may run retention. A nil gate means no check
+// (standalone/OSS mode — retention always runs).
+type RetentionClusterGate interface {
+	// CanRunRetention reports whether the local node may execute retention.
+	// When false, the scheduler stays idle — not running, not an error.
+	CanRunRetention() bool
+	// Role returns a human-readable role string for log messages only.
+	Role() string
+}
+
+// ErrRetentionRoleGated is returned by TriggerNow when the node's role does
+// not permit running retention (e.g. it is a reader, not the primary writer).
+var ErrRetentionRoleGated = fmt.Errorf("retention: node role is not primary writer")
+
 // RetentionScheduler manages automatic execution of retention policies on a schedule
 type RetentionScheduler struct {
 	retentionHandler *api.RetentionHandler
 	licenseClient    *license.Client
+	clusterGate      RetentionClusterGate
 	schedule         string // Cron schedule (e.g., "0 3 * * *" = 3am daily)
 	cron             *cron.Cron
 	running          bool
+	roleGated        bool // true when Start found CanRunRetention=false
 	mu               sync.Mutex
 	logger           zerolog.Logger
 }
@@ -26,7 +44,8 @@ type RetentionScheduler struct {
 type RetentionSchedulerConfig struct {
 	RetentionHandler *api.RetentionHandler
 	LicenseClient    *license.Client
-	Schedule         string // Cron schedule string (e.g., "0 3 * * *")
+	ClusterGate      RetentionClusterGate // nil = standalone, no gate
+	Schedule         string               // Cron schedule string (e.g., "0 3 * * *")
 	Logger           zerolog.Logger
 }
 
@@ -47,6 +66,7 @@ func NewRetentionScheduler(cfg *RetentionSchedulerConfig) (*RetentionScheduler, 
 	s := &RetentionScheduler{
 		retentionHandler: cfg.RetentionHandler,
 		licenseClient:    cfg.LicenseClient,
+		clusterGate:      cfg.ClusterGate,
 		schedule:         schedule,
 		logger:           cfg.Logger.With().Str("component", "retention-scheduler").Logger(),
 	}
@@ -73,6 +93,17 @@ func (s *RetentionScheduler) Start() error {
 		s.logger.Warn().Msg("Valid enterprise license required for retention scheduler - not starting")
 		return nil
 	}
+
+	// Cluster gate: only the primary writer runs retention. Reader nodes
+	// stay idle so they don't race with the writer on shared or local storage.
+	if s.clusterGate != nil && !s.clusterGate.CanRunRetention() {
+		s.roleGated = true
+		s.logger.Info().
+			Str("role", s.clusterGate.Role()).
+			Msg("Retention scheduler gated: node is not primary writer. Scheduler idle.")
+		return nil
+	}
+	s.roleGated = false
 
 	// Create cron instance
 	s.cron = cron.New(cron.WithParser(cron.NewParser(
@@ -189,6 +220,18 @@ func (s *RetentionScheduler) runRetention() {
 
 // TriggerNow triggers retention execution immediately
 func (s *RetentionScheduler) TriggerNow(ctx context.Context) error {
+	// The same gate applies to manual triggers — a reader node must not
+	// run retention on demand either.
+	s.mu.Lock()
+	gate := s.clusterGate
+	s.mu.Unlock()
+	if gate != nil && !gate.CanRunRetention() {
+		s.logger.Warn().
+			Str("role", gate.Role()).
+			Msg("Manual retention trigger rejected: node is not primary writer")
+		return ErrRetentionRoleGated
+	}
+
 	s.logger.Info().Msg("Manual retention trigger")
 
 	// Check license - require valid license for retention scheduler
@@ -266,6 +309,11 @@ func (s *RetentionScheduler) Status() map[string]interface{} {
 
 	if s.running {
 		status["next_run"] = s.getNextRun().Format(time.RFC3339)
+	}
+
+	if s.clusterGate != nil {
+		status["role_gated"] = s.roleGated
+		status["gate_role"] = s.clusterGate.Role()
 	}
 
 	return status

--- a/internal/scheduler/retention_scheduler.go
+++ b/internal/scheduler/retention_scheduler.go
@@ -150,13 +150,10 @@ func (s *RetentionScheduler) runRetention() {
 	}
 
 	// Cluster gate: checked on every tick so role transitions (failover,
-	// demotion) take effect without a restart. A node that is not the
-	// primary writer silently skips this tick.
-	s.mu.Lock()
-	gate := s.clusterGate
-	s.mu.Unlock()
-	if gate != nil && !gate.CanRunRetention() {
-		s.logger.Debug().Str("role", gate.Role()).Msg("Retention tick skipped: node is not primary writer")
+	// demotion) take effect without a restart. clusterGate is immutable
+	// after construction so no lock is needed here.
+	if s.clusterGate != nil && !s.clusterGate.CanRunRetention() {
+		s.logger.Debug().Str("role", s.clusterGate.Role()).Msg("Retention tick skipped: node is not primary writer")
 		return
 	}
 
@@ -221,13 +218,11 @@ func (s *RetentionScheduler) runRetention() {
 // TriggerNow triggers retention execution immediately
 func (s *RetentionScheduler) TriggerNow(ctx context.Context) error {
 	// The same gate applies to manual triggers — a reader node must not
-	// run retention on demand either.
-	s.mu.Lock()
-	gate := s.clusterGate
-	s.mu.Unlock()
-	if gate != nil && !gate.CanRunRetention() {
+	// run retention on demand either. clusterGate is immutable after
+	// construction so no lock is needed.
+	if s.clusterGate != nil && !s.clusterGate.CanRunRetention() {
 		s.logger.Warn().
-			Str("role", gate.Role()).
+			Str("role", s.clusterGate.Role()).
 			Msg("Manual retention trigger rejected: node is not primary writer")
 		return ErrRetentionRoleGated
 	}

--- a/internal/scheduler/retention_scheduler.go
+++ b/internal/scheduler/retention_scheduler.go
@@ -243,13 +243,27 @@ func (s *RetentionScheduler) TriggerNow(ctx context.Context) error {
 		return ErrRetentionRoleGated
 	}
 
-	s.logger.Info().Msg("Manual retention trigger")
-
 	// Check license - require valid license for retention scheduler
 	if s.licenseClient == nil || !s.licenseClient.CanUseRetentionScheduler() {
 		s.logger.Warn().Msg("Valid enterprise license required for retention trigger")
 		return nil
 	}
+
+	s.mu.Lock()
+	if s.runningJob {
+		s.mu.Unlock()
+		s.logger.Warn().Msg("Manual retention trigger rejected: a cycle is already running")
+		return fmt.Errorf("retention cycle already in progress")
+	}
+	s.runningJob = true
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.runningJob = false
+		s.mu.Unlock()
+	}()
+
+	s.logger.Info().Msg("Manual retention trigger")
 
 	startTime := time.Now()
 

--- a/internal/scheduler/retention_scheduler.go
+++ b/internal/scheduler/retention_scheduler.go
@@ -34,9 +34,8 @@ type RetentionScheduler struct {
 	clusterGate      RetentionClusterGate
 	schedule         string // Cron schedule (e.g., "0 3 * * *" = 3am daily)
 	cron             *cron.Cron
-	running          bool
-	roleGated        bool // true when Start found CanRunRetention=false
-	mu               sync.Mutex
+	running bool
+	mu      sync.Mutex
 	logger           zerolog.Logger
 }
 
@@ -94,17 +93,6 @@ func (s *RetentionScheduler) Start() error {
 		return nil
 	}
 
-	// Cluster gate: only the primary writer runs retention. Reader nodes
-	// stay idle so they don't race with the writer on shared or local storage.
-	if s.clusterGate != nil && !s.clusterGate.CanRunRetention() {
-		s.roleGated = true
-		s.logger.Info().
-			Str("role", s.clusterGate.Role()).
-			Msg("Retention scheduler gated: node is not primary writer. Scheduler idle.")
-		return nil
-	}
-	s.roleGated = false
-
 	// Create cron instance
 	s.cron = cron.New(cron.WithParser(cron.NewParser(
 		cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow,
@@ -154,13 +142,25 @@ func (s *RetentionScheduler) Stop() {
 // runRetention runs one retention cycle for all active policies
 func (s *RetentionScheduler) runRetention() {
 	startTime := time.Now()
-	s.logger.Info().Msg("Triggering scheduled retention")
 
 	// Check license before execution
 	if s.licenseClient == nil || !s.licenseClient.CanUseRetentionScheduler() {
 		s.logger.Warn().Msg("Valid enterprise license required, skipping retention execution")
 		return
 	}
+
+	// Cluster gate: checked on every tick so role transitions (failover,
+	// demotion) take effect without a restart. A node that is not the
+	// primary writer silently skips this tick.
+	s.mu.Lock()
+	gate := s.clusterGate
+	s.mu.Unlock()
+	if gate != nil && !gate.CanRunRetention() {
+		s.logger.Debug().Str("role", gate.Role()).Msg("Retention tick skipped: node is not primary writer")
+		return
+	}
+
+	s.logger.Info().Msg("Triggering scheduled retention")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
@@ -312,7 +312,7 @@ func (s *RetentionScheduler) Status() map[string]interface{} {
 	}
 
 	if s.clusterGate != nil {
-		status["role_gated"] = s.roleGated
+		status["can_run"] = s.clusterGate.CanRunRetention()
 		status["gate_role"] = s.clusterGate.Role()
 	}
 

--- a/internal/scheduler/retention_scheduler.go
+++ b/internal/scheduler/retention_scheduler.go
@@ -34,9 +34,10 @@ type RetentionScheduler struct {
 	clusterGate      RetentionClusterGate
 	schedule         string // Cron schedule (e.g., "0 3 * * *" = 3am daily)
 	cron             *cron.Cron
-	running bool
-	mu      sync.Mutex
-	logger           zerolog.Logger
+	running    bool
+	runningJob bool // true while a retention cycle is in progress; prevents overlap
+	mu         sync.Mutex
+	logger     zerolog.Logger
 }
 
 // RetentionSchedulerConfig holds configuration for the retention scheduler
@@ -141,8 +142,6 @@ func (s *RetentionScheduler) Stop() {
 
 // runRetention runs one retention cycle for all active policies
 func (s *RetentionScheduler) runRetention() {
-	startTime := time.Now()
-
 	// Check license before execution
 	if s.licenseClient == nil || !s.licenseClient.CanUseRetentionScheduler() {
 		s.logger.Warn().Msg("Valid enterprise license required, skipping retention execution")
@@ -157,6 +156,23 @@ func (s *RetentionScheduler) runRetention() {
 		return
 	}
 
+	// Prevent concurrent execution: if a previous cycle is still running
+	// (e.g. slow storage or large dataset), skip this tick entirely.
+	s.mu.Lock()
+	if s.runningJob {
+		s.mu.Unlock()
+		s.logger.Warn().Msg("Retention tick skipped: previous cycle still running")
+		return
+	}
+	s.runningJob = true
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.runningJob = false
+		s.mu.Unlock()
+	}()
+
+	startTime := time.Now()
 	s.logger.Info().Msg("Triggering scheduled retention")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)


### PR DESCRIPTION
## Summary

- Only the primary writer node runs retention policies in cluster mode, preventing races on shared (S3/Azure/NFS) and per-node (local) storage
- After each file delete, `DeleteFileFromManifest` commits the removal into the Raft log, keeping the cluster manifest consistent
- Reader nodes clean up their local copies via the existing `onFileDeleted` FSM callback and delete-worker pool (shared with compaction — no new code needed)
- Standalone deployments are completely unaffected (nil gate = no check)

## Test plan

- [x] `go build ./cmd/... ./internal/...` passes clean
- [x] `go test ./internal/scheduler/... ./internal/api/... ./internal/cluster/...` all pass
- [x] Standalone: retention runs normally, no gate log messages
- [x] Cluster (3-node): only writer logs "Triggering scheduled retention"; readers log "Scheduler idle"
- [x] Cluster: after retention runs, `GET /api/v1/cluster/files` shows no orphaned entries for deleted files
- [x] Writer failover: new primary picks up retention on next cron tick