### PR TITLE
feat(delete): cluster-safe DELETE endpoint — writer gate + Raft manifest

### DIFF
--- a/RELEASE_NOTES_2026.05.1.md
+++ b/RELEASE_NOTES_2026.05.1.md
@@ -157,6 +157,14 @@ In clustered deployments, retention policies now run exclusively on the primary 
 - **Cluster manifest updates**: After each file is deleted from storage, the retention handler commits the deletion into the Raft log via `DeleteFileFromManifest`. This keeps the manifest consistent and prevents orphaned entries from interfering with peer replication catch-up.
 - **Reader node cleanup (local storage)**: The `onFileDeleted` FSM callback and delete-worker pool (shared with compaction) handle retention-triggered deletes on reader nodes, removing their local copy of the file and preventing unbounded disk growth on per-node storage deployments.
 
+### Cluster-Safe DELETE Endpoint (Enterprise)
+
+The `POST /api/v1/delete` endpoint is now cluster-aware. Reader nodes reject delete requests with `503 Service Unavailable` — only the primary writer may execute mutations.
+
+- **Writer-only gate**: Checked before any storage scan, so reader nodes are rejected immediately without running expensive DuckDB queries.
+- **Manifest-before-storage for full-file deletes**: When a DELETE removes an entire file (all rows match the WHERE clause), the path is committed to the Raft manifest before `storage.Delete`. All peer nodes learn about the removal via the `onFileDeleted` FSM hook and clean up their local copies. Partial rewrites (file overwritten in-place, path unchanged) require no manifest entry.
+- **Path traversal hardening**: `database` and `measurement` inputs are now validated to reject `..`, `/`, and `\` characters.
+
 ## Bug Fixes
 
 ### Row-Format MessagePack Flush Hardening

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1303,6 +1303,9 @@ func main() {
 	// Register Delete handler
 	deleteHandler := api.NewDeleteHandler(db, storageBackend, &cfg.Delete, authManager, logger.Get("delete"))
 	deleteHandler.RegisterRoutes(server.GetApp())
+	if clusterCoordinator != nil {
+		deleteHandler.SetCoordinator(clusterCoordinator)
+	}
 	if cfg.Delete.Enabled {
 		log.Info().
 			Int("confirmation_threshold", cfg.Delete.ConfirmationThreshold).

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1765,7 +1765,7 @@ func newRetentionClusterGate(c *cluster.Coordinator) *retentionClusterGate {
 	return &retentionClusterGate{coordinator: c}
 }
 
-func (g *retentionClusterGate) CanRunRetention() bool {
+func (g *retentionClusterGate) IsPrimaryWriter() bool {
 	node := g.coordinator.GetLocalNode()
 	if node == nil {
 		return false

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -859,7 +859,13 @@ func (h *DeleteHandler) updateManifestAfterRewrite(relativePath string) error {
 	entry := *existing // copy all fields to preserve immutable metadata
 
 	if lb, ok := h.storage.(*storage.LocalBackend); ok {
-		fullPath := filepath.Join(lb.GetBasePath(), relativePath)
+		basePath := lb.GetBasePath()
+		fullPath := filepath.Join(basePath, relativePath)
+		// Containment check: relativePath is already validated upstream, but
+		// guard here too since fileMetadata opens the file for reading.
+		if !strings.HasPrefix(fullPath, basePath+string(filepath.Separator)) {
+			return fmt.Errorf("path escapes storage root: %s", relativePath)
+		}
 		size, sha, err := fileMetadata(fullPath)
 		if err != nil {
 			return fmt.Errorf("failed to read rewritten file metadata: %w", err)

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -23,10 +25,12 @@ import (
 )
 
 // DeleteCoordinator is the minimal cluster interface the delete handler needs
-// to gate execution to the primary writer and propagate full-file deletes to
-// the Raft manifest. nil = standalone mode (no gate, manifest not updated).
+// to gate execution to the primary writer and propagate file manifest changes.
+// nil = standalone mode (no gate, manifest not updated).
 type DeleteCoordinator interface {
 	BatchFileOpsInManifest(ops []raft.BatchFileOp) error
+	UpdateFileInManifest(file raft.FileEntry) error
+	GetFileEntry(path string) (*raft.FileEntry, bool)
 	IsPrimaryWriter() bool
 	Role() string
 }
@@ -43,6 +47,21 @@ const parquetRowGroupSize = 122880
 // DuckDB read_parquet() calls, which do not support parameterized queries.
 func escapeDuckDBPath(path string) string {
 	return strings.ReplaceAll(path, "'", "''")
+}
+
+// fileMetadata returns the byte size and hex-encoded SHA-256 of the file at path.
+func fileMetadata(path string) (sizeBytes int64, sha256hex string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return 0, "", err
+	}
+	return n, fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
 // lastFreeOSMemoryNano is the last time freeOSMemoryThrottled fired, used to debounce GC calls.
@@ -672,12 +691,27 @@ func (h *DeleteHandler) rewriteFileWithoutDeletedRows(ctx context.Context, query
 	}
 
 	// For S3, we need to write to a temp file locally, then upload
+	var rewroteDeleted int64
+	var rewriteErr error
 	if h.isS3Backend() {
-		return h.rewriteS3File(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
+		rewroteDeleted, rewriteErr = h.rewriteS3File(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
+	} else {
+		rewroteDeleted, rewriteErr = h.rewriteLocalFile(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
+	}
+	if rewriteErr != nil {
+		return 0, rewriteErr
 	}
 
-	// Local storage: use atomic rename strategy
-	return h.rewriteLocalFile(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
+	// Notify the cluster manifest that this file's content changed. Non-fatal:
+	// the rewrite succeeded in storage; a stale manifest entry is eventually
+	// consistent and does not affect query correctness.
+	if h.coordinator != nil {
+		if err := h.updateManifestAfterRewrite(relativePath); err != nil {
+			h.logger.Warn().Err(err).Str("file", relativePath).Msg("Failed to update manifest after partial rewrite")
+		}
+	}
+
+	return rewroteDeleted, nil
 }
 
 // rewriteLocalFile handles file rewrite for local storage using atomic rename
@@ -801,4 +835,41 @@ func (h *DeleteHandler) getQueryPath(relativePath string) string {
 func (h *DeleteHandler) isS3Backend() bool {
 	_, ok := h.storage.(*storage.S3Backend)
 	return ok
+}
+
+// updateManifestAfterRewrite updates the cluster manifest entry for a partially
+// rewritten file. It reads the existing entry to preserve all immutable fields
+// (database, measurement, origin node, tier, etc.) and updates only the mutable
+// metadata: SizeBytes and SHA256.
+//
+// For local storage, the new size and checksum are computed from the rewritten
+// file on disk. For S3, size/checksum are not re-read (would require an extra
+// round-trip) — the manifest entry is still re-committed so peers know the file
+// changed, but SizeBytes and SHA256 will be stale until the next register.
+//
+// Failure is non-fatal: the rewrite already succeeded in storage; a stale
+// manifest entry is eventually consistent and does not affect query correctness.
+func (h *DeleteHandler) updateManifestAfterRewrite(relativePath string) error {
+	existing, ok := h.coordinator.GetFileEntry(relativePath)
+	if !ok {
+		// File not in manifest (standalone-registered or pre-cluster file) — skip.
+		return nil
+	}
+
+	entry := *existing // copy all fields to preserve immutable metadata
+
+	if lb, ok := h.storage.(*storage.LocalBackend); ok {
+		fullPath := filepath.Join(lb.GetBasePath(), relativePath)
+		size, sha, err := fileMetadata(fullPath)
+		if err != nil {
+			return fmt.Errorf("failed to read rewritten file metadata: %w", err)
+		}
+		entry.SizeBytes = size
+		entry.SHA256 = sha
+	}
+	// For S3: SizeBytes/SHA256 remain from the original entry until the next
+	// explicit register. The manifest update still signals to peers that the
+	// file's content changed (LSN advances on apply).
+
+	return h.coordinator.UpdateFileInManifest(entry)
 }

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,12 +14,26 @@ import (
 	"time"
 
 	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/cluster/raft"
 	"github.com/basekick-labs/arc/internal/config"
 	"github.com/basekick-labs/arc/internal/database"
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
 )
+
+// DeleteCoordinator is the minimal cluster interface the delete handler needs
+// to gate execution to the primary writer and propagate full-file deletes to
+// the Raft manifest. nil = standalone mode (no gate, manifest not updated).
+type DeleteCoordinator interface {
+	BatchFileOpsInManifest(ops []raft.BatchFileOp) error
+	CanRunRetention() bool // "can run writer-only mutations"
+	Role() string
+}
+
+// errManifestFailure is returned when a Raft manifest update fails.
+// This is non-transient (e.g. Raft quorum loss) and aborts the delete operation.
+var errManifestFailure = errors.New("cluster manifest update failed")
 
 // parquetRowGroupSize is the row group size used for Parquet rewrites during delete operations.
 // Matches compaction's row group size to limit DuckDB's internal write buffer per group.
@@ -45,6 +61,7 @@ type DeleteHandler struct {
 	storage     storage.Backend
 	config      *config.DeleteConfig
 	authManager *auth.AuthManager
+	coordinator DeleteCoordinator // nil in standalone mode
 	logger      zerolog.Logger
 }
 
@@ -112,6 +129,12 @@ func NewDeleteHandler(db *database.DuckDB, storage storage.Backend, cfg *config.
 		authManager: authManager,
 		logger:      logger.With().Str("component", "delete-handler").Logger(),
 	}
+}
+
+// SetCoordinator wires the cluster coordinator for manifest updates and role
+// gating. Called after construction when cluster mode is enabled.
+func (h *DeleteHandler) SetCoordinator(c DeleteCoordinator) {
+	h.coordinator = c
 }
 
 // RegisterRoutes registers delete endpoints
@@ -207,7 +230,7 @@ func (h *DeleteHandler) handleDelete(c *fiber.Ctx) error {
 		Msg("Processing delete request")
 
 	// Find affected files
-	ctx := context.Background()
+	ctx := c.Context()
 	affected, err := h.findAffectedFiles(ctx, req.Database, req.Measurement, req.Where)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to find affected files")
@@ -282,6 +305,15 @@ func (h *DeleteHandler) handleDelete(c *fiber.Ctx) error {
 		})
 	}
 
+	// In cluster mode, only the primary writer may execute deletes — reader
+	// nodes must not race with the writer over shared or local storage.
+	if h.coordinator != nil && !h.coordinator.CanRunRetention() {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(DeleteResponse{
+			Success: false,
+			Error:   fmt.Sprintf("delete rejected: node role %q is not primary writer", h.coordinator.Role()),
+		})
+	}
+
 	// Execute actual deletion (rewrite files)
 	h.logger.Info().
 		Int("file_count", len(affected)).
@@ -295,13 +327,29 @@ func (h *DeleteHandler) handleDelete(c *fiber.Ctx) error {
 
 	for _, f := range affected {
 		deleted, err := h.rewriteFileWithoutDeletedRows(ctx, f.path, f.relativePath, req.Where)
+		totalDeleted += deleted
 		if err != nil {
 			h.logger.Error().Err(err).Str("file", f.path).Msg("Failed to rewrite file")
+			// Manifest failures are non-transient (Raft quorum loss) — abort the
+			// entire operation to avoid deleting files from storage without a
+			// corresponding manifest record.
+			if errors.Is(err, errManifestFailure) {
+				h.db.ClearHTTPCache()
+				freeOSMemoryThrottled()
+				return c.Status(fiber.StatusInternalServerError).JSON(DeleteResponse{
+					Success:         false,
+					Error:           "Delete aborted: " + err.Error(),
+					DeletedCount:    totalDeleted,
+					AffectedFiles:   len(affected),
+					RewrittenFiles:  rewrittenCount,
+					FilesProcessed:  processedFiles,
+					ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
+				})
+			}
 			failedFiles = append(failedFiles, filepath.Base(f.path))
 			continue
 		}
 
-		totalDeleted += deleted
 		rewrittenCount++
 		processedFiles = append(processedFiles, filepath.Base(f.path))
 
@@ -453,7 +501,7 @@ func (h *DeleteHandler) countMatchingRowsInFiles(ctx context.Context, files []fi
 
 	db := h.db.DB()
 
-	// Build array of file paths for DuckDB
+	// Build array of file paths for DuckDB, escaping single quotes in paths.
 	var pathList strings.Builder
 	pathList.WriteString("[")
 	for i, f := range files {
@@ -461,7 +509,7 @@ func (h *DeleteHandler) countMatchingRowsInFiles(ctx context.Context, files []fi
 			pathList.WriteString(", ")
 		}
 		pathList.WriteString("'")
-		pathList.WriteString(f.queryPath)
+		pathList.WriteString(strings.ReplaceAll(f.queryPath, "'", "''"))
 		pathList.WriteString("'")
 	}
 	pathList.WriteString("]")
@@ -532,7 +580,7 @@ func (h *DeleteHandler) countMatchingRowsIndividually(ctx context.Context, files
 	db := h.db.DB()
 
 	for _, f := range files {
-		query := fmt.Sprintf("SELECT COUNT(*) FROM read_parquet('%s') WHERE %s", f.queryPath, whereClause)
+		query := fmt.Sprintf("SELECT COUNT(*) FROM read_parquet('%s') WHERE %s", strings.ReplaceAll(f.queryPath, "'", "''"), whereClause)
 		var count int64
 		if err := db.QueryRowContext(ctx, query).Scan(&count); err != nil {
 			h.logger.Warn().Err(err).Str("file", f.relativePath).Msg("Failed to count matching rows, skipping file")
@@ -567,7 +615,7 @@ func (h *DeleteHandler) rewriteFileWithoutDeletedRows(ctx context.Context, query
 			COUNT(*) as total,
 			COUNT(*) FILTER (WHERE NOT (%s)) as remaining
 		FROM read_parquet('%s')`,
-		whereClause, queryPath)
+		whereClause, strings.ReplaceAll(queryPath, "'", "''"))
 
 	if err := db.QueryRowContext(ctx, countQuery).Scan(&rowsBefore, &rowsAfter); err != nil {
 		return 0, fmt.Errorf("failed to count rows: %w", err)
@@ -575,11 +623,29 @@ func (h *DeleteHandler) rewriteFileWithoutDeletedRows(ctx context.Context, query
 
 	deleted := rowsBefore - rowsAfter
 
-	// If all rows would be deleted, just delete the file
+	// If all rows would be deleted, remove the file entirely.
 	if rowsAfter == 0 {
 		h.logger.Info().Str("file", filepath.Base(relativePath)).Int64("deleted", deleted).Msg("All rows deleted, removing file")
+
+		// Manifest-before-storage: record the delete in the Raft manifest before
+		// removing from storage. If the manifest update fails (Raft quorum loss),
+		// abort — the file still exists in storage and the next delete will retry.
+		if h.coordinator != nil {
+			payload, err := json.Marshal(raft.DeleteFilePayload{Path: relativePath, Reason: "delete"})
+			if err != nil {
+				return 0, fmt.Errorf("%w: marshal failed for %s: %v", errManifestFailure, relativePath, err)
+			}
+			if err := h.coordinator.BatchFileOpsInManifest([]raft.BatchFileOp{{Type: raft.CommandDeleteFile, Payload: payload}}); err != nil {
+				return 0, fmt.Errorf("%w: %v", errManifestFailure, err)
+			}
+		}
+
 		if err := h.storage.Delete(ctx, relativePath); err != nil {
-			return 0, fmt.Errorf("failed to delete file: %w", err)
+			// Manifest is already committed — storage failure is transient (network
+			// blip, file already gone). Log as Warn and return the deleted count;
+			// Phase 5 reconciliation will clean up the orphaned storage entry.
+			h.logger.Warn().Err(err).Str("file", relativePath).Msg("Failed to delete file from storage after manifest update")
+			return deleted, nil
 		}
 		return deleted, nil
 	}
@@ -616,7 +682,7 @@ func (h *DeleteHandler) rewriteLocalFile(ctx context.Context, filePath, _, where
 			COMPRESSION ZSTD,
 			COMPRESSION_LEVEL 3,
 			ROW_GROUP_SIZE %d
-		)`, filePath, whereClause, tempFile, parquetRowGroupSize)
+		)`, strings.ReplaceAll(filePath, "'", "''"), whereClause, strings.ReplaceAll(tempFile, "'", "''"), parquetRowGroupSize)
 
 	if _, err := db.ExecContext(ctx, copyQuery); err != nil {
 		os.Remove(tempFile)
@@ -666,7 +732,7 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 			COMPRESSION ZSTD,
 			COMPRESSION_LEVEL 3,
 			ROW_GROUP_SIZE %d
-		)`, s3Path, whereClause, tempPath, parquetRowGroupSize)
+		)`, strings.ReplaceAll(s3Path, "'", "''"), whereClause, strings.ReplaceAll(tempPath, "'", "''"), parquetRowGroupSize)
 
 	if _, err := db.ExecContext(ctx, copyQuery); err != nil {
 		return 0, fmt.Errorf("failed to write filtered data: %w", err)

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -367,7 +367,6 @@ func (h *DeleteHandler) handleDelete(c *fiber.Ctx) error {
 
 	for _, f := range affected {
 		deleted, err := h.rewriteFileWithoutDeletedRows(ctx, f.path, f.relativePath, req.Where)
-		totalDeleted += deleted
 		if err != nil {
 			h.logger.Error().Err(err).Str("file", f.path).Msg("Failed to rewrite file")
 			// Manifest failures are non-transient (Raft quorum loss) — abort the
@@ -383,12 +382,14 @@ func (h *DeleteHandler) handleDelete(c *fiber.Ctx) error {
 					AffectedFiles:   len(affected),
 					RewrittenFiles:  rewrittenCount,
 					FilesProcessed:  processedFiles,
+					FailedFiles:     failedFiles,
 					ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 				})
 			}
 			failedFiles = append(failedFiles, filepath.Base(f.path))
 			continue
 		}
+		totalDeleted += deleted
 
 		rewrittenCount++
 		processedFiles = append(processedFiles, filepath.Base(f.path))
@@ -690,11 +691,11 @@ func (h *DeleteHandler) rewriteFileWithoutDeletedRows(ctx context.Context, query
 		return deleted, nil
 	}
 
-	// For S3, we need to write to a temp file locally, then upload
+	// For remote backends (S3, Azure), write to a local temp file then upload.
 	var rewroteDeleted int64
 	var s3Result *s3RewriteResult
 	var rewriteErr error
-	if h.isS3Backend() {
+	if h.isRemoteBackend() {
 		rewroteDeleted, s3Result, rewriteErr = h.rewriteS3File(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
 	} else {
 		rewroteDeleted, rewriteErr = h.rewriteLocalFile(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
@@ -800,23 +801,26 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 		return 0, nil, fmt.Errorf("failed to write filtered data: %w", err)
 	}
 
-	// Compute size and SHA256 from the local temp file before uploading.
-	// This is the only moment we have the file available locally for free.
-	sizeBytes, sha256hex, err := fileMetadata(tempPath)
-	if err != nil {
-		return 0, nil, fmt.Errorf("failed to compute temp file metadata: %w", err)
-	}
-
-	// Stream temp file to S3 (avoids loading entire file into memory)
+	// Open temp file, compute SHA256 and size while streaming the upload via
+	// io.TeeReader — single pass over the file instead of two.
 	uploadFile, err := os.Open(tempPath)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to open temp file for upload: %w", err)
 	}
 	defer uploadFile.Close()
 
-	if err := h.storage.WriteReader(ctx, relativePath, uploadFile, sizeBytes); err != nil {
-		return 0, nil, fmt.Errorf("failed to upload rewritten file to S3: %w", err)
+	info, err := uploadFile.Stat()
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to stat temp file: %w", err)
 	}
+	sizeBytes := info.Size()
+
+	h256 := sha256.New()
+	tee := io.TeeReader(uploadFile, h256)
+	if err := h.storage.WriteReader(ctx, relativePath, tee, sizeBytes); err != nil {
+		return 0, nil, fmt.Errorf("failed to upload rewritten file to remote storage: %w", err)
+	}
+	sha256hex := fmt.Sprintf("%x", h256.Sum(nil))
 
 	h.logger.Info().
 		Str("file", filepath.Base(relativePath)).
@@ -835,15 +839,21 @@ func (h *DeleteHandler) getQueryPath(relativePath string) string {
 		return filepath.Join(backend.GetBasePath(), relativePath)
 	case *storage.S3Backend:
 		return fmt.Sprintf("s3://%s/%s%s", backend.GetBucket(), backend.GetPrefix(), relativePath)
+	case *storage.AzureBlobBackend:
+		return fmt.Sprintf("azure://%s/%s", backend.GetContainer(), relativePath)
 	default:
 		return relativePath
 	}
 }
 
-// isS3Backend returns true if the storage backend is S3
-func (h *DeleteHandler) isS3Backend() bool {
-	_, ok := h.storage.(*storage.S3Backend)
-	return ok
+// isRemoteBackend returns true if the storage backend requires a remote rewrite
+// (download to local temp file, then re-upload). Covers S3 and Azure Blob.
+func (h *DeleteHandler) isRemoteBackend() bool {
+	switch h.storage.(type) {
+	case *storage.S3Backend, *storage.AzureBlobBackend:
+		return true
+	}
+	return false
 }
 
 // updateManifestAfterRewrite updates the cluster manifest entry for a partially

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -692,9 +692,10 @@ func (h *DeleteHandler) rewriteFileWithoutDeletedRows(ctx context.Context, query
 
 	// For S3, we need to write to a temp file locally, then upload
 	var rewroteDeleted int64
+	var s3Result *s3RewriteResult
 	var rewriteErr error
 	if h.isS3Backend() {
-		rewroteDeleted, rewriteErr = h.rewriteS3File(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
+		rewroteDeleted, s3Result, rewriteErr = h.rewriteS3File(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
 	} else {
 		rewroteDeleted, rewriteErr = h.rewriteLocalFile(ctx, queryPath, relativePath, whereClause, rowsBefore, rowsAfter)
 	}
@@ -706,7 +707,7 @@ func (h *DeleteHandler) rewriteFileWithoutDeletedRows(ctx context.Context, query
 	// the rewrite succeeded in storage; a stale manifest entry is eventually
 	// consistent and does not affect query correctness.
 	if h.coordinator != nil {
-		if err := h.updateManifestAfterRewrite(relativePath); err != nil {
+		if err := h.updateManifestAfterRewrite(relativePath, s3Result); err != nil {
 			h.logger.Warn().Err(err).Str("file", relativePath).Msg("Failed to update manifest after partial rewrite")
 		}
 	}
@@ -763,16 +764,22 @@ func (h *DeleteHandler) rewriteLocalFile(ctx context.Context, filePath, _, where
 	return deleted, nil
 }
 
+// s3RewriteResult holds the outcome of rewriteS3File for manifest update.
+type s3RewriteResult struct {
+	sizeBytes int64
+	sha256    string
+}
+
 // rewriteS3File handles file rewrite for S3 storage
 // DuckDB can read from S3 directly, then we write to a temp file and upload
-func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath, whereClause string, rowsBefore, rowsAfter int64) (int64, error) {
+func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath, whereClause string, rowsBefore, rowsAfter int64) (int64, *s3RewriteResult, error) {
 	db := h.db.DB()
 	deleted := rowsBefore - rowsAfter
 
 	// Create temp file locally for the rewritten data
 	tempFile, err := os.CreateTemp("", "arc-delete-*.parquet")
 	if err != nil {
-		return 0, fmt.Errorf("failed to create temp file: %w", err)
+		return 0, nil, fmt.Errorf("failed to create temp file: %w", err)
 	}
 	tempPath := tempFile.Name()
 	tempFile.Close()
@@ -790,23 +797,25 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 		)`, escapeDuckDBPath(s3Path), whereClause, escapeDuckDBPath(tempPath), parquetRowGroupSize)
 
 	if _, err := db.ExecContext(ctx, copyQuery); err != nil {
-		return 0, fmt.Errorf("failed to write filtered data: %w", err)
+		return 0, nil, fmt.Errorf("failed to write filtered data: %w", err)
+	}
+
+	// Compute size and SHA256 from the local temp file before uploading.
+	// This is the only moment we have the file available locally for free.
+	sizeBytes, sha256hex, err := fileMetadata(tempPath)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to compute temp file metadata: %w", err)
 	}
 
 	// Stream temp file to S3 (avoids loading entire file into memory)
 	uploadFile, err := os.Open(tempPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open temp file for upload: %w", err)
+		return 0, nil, fmt.Errorf("failed to open temp file for upload: %w", err)
 	}
 	defer uploadFile.Close()
 
-	info, err := uploadFile.Stat()
-	if err != nil {
-		return 0, fmt.Errorf("failed to stat temp file: %w", err)
-	}
-
-	if err := h.storage.WriteReader(ctx, relativePath, uploadFile, info.Size()); err != nil {
-		return 0, fmt.Errorf("failed to upload rewritten file to S3: %w", err)
+	if err := h.storage.WriteReader(ctx, relativePath, uploadFile, sizeBytes); err != nil {
+		return 0, nil, fmt.Errorf("failed to upload rewritten file to S3: %w", err)
 	}
 
 	h.logger.Info().
@@ -816,7 +825,7 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 		Int64("deleted", deleted).
 		Msg("Rewrote S3 file")
 
-	return deleted, nil
+	return deleted, &s3RewriteResult{sizeBytes: sizeBytes, sha256: sha256hex}, nil
 }
 
 // getQueryPath converts a storage-relative path to a DuckDB-compatible path
@@ -849,7 +858,7 @@ func (h *DeleteHandler) isS3Backend() bool {
 //
 // Failure is non-fatal: the rewrite already succeeded in storage; a stale
 // manifest entry is eventually consistent and does not affect query correctness.
-func (h *DeleteHandler) updateManifestAfterRewrite(relativePath string) error {
+func (h *DeleteHandler) updateManifestAfterRewrite(relativePath string, s3 *s3RewriteResult) error {
 	existing, ok := h.coordinator.GetFileEntry(relativePath)
 	if !ok {
 		// File not in manifest (standalone-registered or pre-cluster file) — skip.
@@ -872,10 +881,11 @@ func (h *DeleteHandler) updateManifestAfterRewrite(relativePath string) error {
 		}
 		entry.SizeBytes = size
 		entry.SHA256 = sha
+	} else if s3 != nil {
+		// For S3: size and SHA256 were computed from the local temp file before upload.
+		entry.SizeBytes = s3.sizeBytes
+		entry.SHA256 = s3.sha256
 	}
-	// For S3: SizeBytes/SHA256 remain from the original entry until the next
-	// explicit register. The manifest update still signals to peers that the
-	// file's content changed (LSN advances on apply).
 
 	return h.coordinator.UpdateFileInManifest(entry)
 }

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -27,7 +27,7 @@ import (
 // the Raft manifest. nil = standalone mode (no gate, manifest not updated).
 type DeleteCoordinator interface {
 	BatchFileOpsInManifest(ops []raft.BatchFileOp) error
-	CanRunRetention() bool // "can run writer-only mutations"
+	IsPrimaryWriter() bool
 	Role() string
 }
 
@@ -38,6 +38,12 @@ var errManifestFailure = errors.New("cluster manifest update failed")
 // parquetRowGroupSize is the row group size used for Parquet rewrites during delete operations.
 // Matches compaction's row group size to limit DuckDB's internal write buffer per group.
 const parquetRowGroupSize = 122880
+
+// escapeDuckDBPath escapes single quotes in a path for safe interpolation into
+// DuckDB read_parquet() calls, which do not support parameterized queries.
+func escapeDuckDBPath(path string) string {
+	return strings.ReplaceAll(path, "'", "''")
+}
 
 // lastFreeOSMemoryNano is the last time freeOSMemoryThrottled fired, used to debounce GC calls.
 var lastFreeOSMemoryNano atomic.Int64
@@ -197,6 +203,30 @@ func (h *DeleteHandler) handleDelete(c *fiber.Ctx) error {
 		})
 	}
 
+	// Reject path traversal in database/measurement names — these values are
+	// concatenated directly into storage prefixes and DuckDB paths.
+	if strings.ContainsAny(req.Database, "/\\") || strings.Contains(req.Database, "..") {
+		return c.Status(fiber.StatusBadRequest).JSON(DeleteResponse{
+			Success: false,
+			Error:   "database name contains invalid characters",
+		})
+	}
+	if strings.ContainsAny(req.Measurement, "/\\") || strings.Contains(req.Measurement, "..") {
+		return c.Status(fiber.StatusBadRequest).JSON(DeleteResponse{
+			Success: false,
+			Error:   "measurement name contains invalid characters",
+		})
+	}
+
+	// In cluster mode, only the primary writer may execute deletes. Check before
+	// findAffectedFiles to avoid running expensive DuckDB scans on reader nodes.
+	if !req.DryRun && h.coordinator != nil && !h.coordinator.IsPrimaryWriter() {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(DeleteResponse{
+			Success: false,
+			Error:   fmt.Sprintf("delete rejected: node role %q is not primary writer", h.coordinator.Role()),
+		})
+	}
+
 	// Validate WHERE clause
 	isFullTableDelete, err := h.validateWhereClause(req.Where)
 	if err != nil {
@@ -302,15 +332,6 @@ func (h *DeleteHandler) handleDelete(c *fiber.Ctx) error {
 			ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 			DryRun:          true,
 			FilesProcessed:  fileNames,
-		})
-	}
-
-	// In cluster mode, only the primary writer may execute deletes — reader
-	// nodes must not race with the writer over shared or local storage.
-	if h.coordinator != nil && !h.coordinator.CanRunRetention() {
-		return c.Status(fiber.StatusServiceUnavailable).JSON(DeleteResponse{
-			Success: false,
-			Error:   fmt.Sprintf("delete rejected: node role %q is not primary writer", h.coordinator.Role()),
 		})
 	}
 
@@ -509,7 +530,7 @@ func (h *DeleteHandler) countMatchingRowsInFiles(ctx context.Context, files []fi
 			pathList.WriteString(", ")
 		}
 		pathList.WriteString("'")
-		pathList.WriteString(strings.ReplaceAll(f.queryPath, "'", "''"))
+		pathList.WriteString(escapeDuckDBPath(f.queryPath))
 		pathList.WriteString("'")
 	}
 	pathList.WriteString("]")
@@ -580,7 +601,7 @@ func (h *DeleteHandler) countMatchingRowsIndividually(ctx context.Context, files
 	db := h.db.DB()
 
 	for _, f := range files {
-		query := fmt.Sprintf("SELECT COUNT(*) FROM read_parquet('%s') WHERE %s", strings.ReplaceAll(f.queryPath, "'", "''"), whereClause)
+		query := fmt.Sprintf("SELECT COUNT(*) FROM read_parquet('%s') WHERE %s", escapeDuckDBPath(f.queryPath), whereClause)
 		var count int64
 		if err := db.QueryRowContext(ctx, query).Scan(&count); err != nil {
 			h.logger.Warn().Err(err).Str("file", f.relativePath).Msg("Failed to count matching rows, skipping file")
@@ -615,7 +636,7 @@ func (h *DeleteHandler) rewriteFileWithoutDeletedRows(ctx context.Context, query
 			COUNT(*) as total,
 			COUNT(*) FILTER (WHERE NOT (%s)) as remaining
 		FROM read_parquet('%s')`,
-		whereClause, strings.ReplaceAll(queryPath, "'", "''"))
+		whereClause, escapeDuckDBPath(queryPath))
 
 	if err := db.QueryRowContext(ctx, countQuery).Scan(&rowsBefore, &rowsAfter); err != nil {
 		return 0, fmt.Errorf("failed to count rows: %w", err)
@@ -682,7 +703,7 @@ func (h *DeleteHandler) rewriteLocalFile(ctx context.Context, filePath, _, where
 			COMPRESSION ZSTD,
 			COMPRESSION_LEVEL 3,
 			ROW_GROUP_SIZE %d
-		)`, strings.ReplaceAll(filePath, "'", "''"), whereClause, strings.ReplaceAll(tempFile, "'", "''"), parquetRowGroupSize)
+		)`, escapeDuckDBPath(filePath), whereClause, escapeDuckDBPath(tempFile), parquetRowGroupSize)
 
 	if _, err := db.ExecContext(ctx, copyQuery); err != nil {
 		os.Remove(tempFile)
@@ -732,7 +753,7 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 			COMPRESSION ZSTD,
 			COMPRESSION_LEVEL 3,
 			ROW_GROUP_SIZE %d
-		)`, strings.ReplaceAll(s3Path, "'", "''"), whereClause, strings.ReplaceAll(tempPath, "'", "''"), parquetRowGroupSize)
+		)`, escapeDuckDBPath(s3Path), whereClause, escapeDuckDBPath(tempPath), parquetRowGroupSize)
 
 	if _, err := db.ExecContext(ctx, copyQuery); err != nil {
 		return 0, fmt.Errorf("failed to write filtered data: %w", err)

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -27,9 +27,9 @@ import (
 // on the cluster package.
 type RetentionCoordinator interface {
 	BatchFileOpsInManifest(ops []raft.BatchFileOp) error
-	// CanRunRetention reports whether this node may execute retention.
+	// IsPrimaryWriter reports whether this node may execute writer-only mutations.
 	// Returns true unconditionally for standalone (coordinator is nil).
-	CanRunRetention() bool
+	IsPrimaryWriter() bool
 	// Role returns a human-readable role string for log messages.
 	Role() string
 }
@@ -531,7 +531,7 @@ func (h *RetentionHandler) handleExecute(c *fiber.Ctx) error {
 
 	// In cluster mode, only the primary writer may execute retention — reader
 	// nodes must not race with the writer over shared or local storage.
-	if !req.DryRun && h.coordinator != nil && !h.coordinator.CanRunRetention() {
+	if !req.DryRun && h.coordinator != nil && !h.coordinator.IsPrimaryWriter() {
 		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
 			"error": fmt.Sprintf("retention rejected: node role %q is not primary writer", h.coordinator.Role()),
 		})

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1511,9 +1511,9 @@ func (c *Coordinator) GetRole() NodeRole {
 	return c.localNode.Role
 }
 
-// CanRunRetention implements api.RetentionCoordinator: reports whether this
-// node is the primary writer and therefore permitted to execute retention.
-func (c *Coordinator) CanRunRetention() bool {
+// IsPrimaryWriter implements api.RetentionCoordinator and api.DeleteCoordinator:
+// reports whether this node is the primary writer and may execute writer-only mutations.
+func (c *Coordinator) IsPrimaryWriter() bool {
 	node := c.GetLocalNode()
 	if node == nil {
 		return false

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -2707,6 +2707,41 @@ func (c *Coordinator) ctxOrBackground() context.Context {
 	return c.ctx
 }
 
+// UpdateFileInManifest updates an existing file's metadata in the cluster manifest
+// after a partial rewrite that changes size/checksum but keeps the same path.
+// Same leader-forwarding semantics as RegisterFileInManifest.
+func (c *Coordinator) UpdateFileInManifest(file raft.FileEntry) error {
+	if c.raftNode == nil {
+		return nil
+	}
+	if c.raftNode.IsLeader() {
+		if err := c.raftNode.UpdateFile(file, 5*time.Second); err != nil {
+			return fmt.Errorf("update file in manifest: %w", err)
+		}
+		return nil
+	}
+	payload, err := json.Marshal(raft.UpdateFilePayload{File: file})
+	if err != nil {
+		return fmt.Errorf("update file in manifest: marshal payload: %w", err)
+	}
+	cmd := &raft.Command{Type: raft.CommandUpdateFile, Payload: payload}
+	forwardCtx, cancel := context.WithTimeout(c.ctxOrBackground(), forwardApplyTimeout)
+	defer cancel()
+	if err := c.forwardApplyToLeader(forwardCtx, cmd); err != nil {
+		return fmt.Errorf("update file in manifest (forwarded): %w", err)
+	}
+	return nil
+}
+
+// GetFileEntry returns the manifest entry for a given relative path.
+// Returns false if the file is not in the manifest (standalone mode or pre-cluster file).
+func (c *Coordinator) GetFileEntry(path string) (*raft.FileEntry, bool) {
+	if c.raftFSM == nil {
+		return nil, false
+	}
+	return c.raftFSM.GetFile(path)
+}
+
 // GetFileManifest returns the current file manifest from the Raft FSM.
 // Returns nil if Raft is not initialized.
 func (c *Coordinator) GetFileManifest() []*raft.FileEntry {

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -585,6 +585,7 @@ func (f *ClusterFSM) applyUpdateFile(payload []byte) interface{} {
 		}
 		idx[entry.Path] = struct{}{}
 	}
+	callback := f.onFileRegistered
 	f.mu.Unlock()
 
 	f.logger.Debug().
@@ -593,8 +594,14 @@ func (f *ClusterFSM) applyUpdateFile(payload []byte) interface{} {
 		Str("sha256", entry.SHA256).
 		Msg("File updated in cluster manifest")
 
-	// No onFileRegistered callback — the file already exists on disk; peers
-	// do not need to pull it again. Only metadata (size/checksum) changed.
+	// Trigger onFileRegistered so reader nodes detect the content change and
+	// pull the updated file from the writer. The file path is the same but the
+	// content (and checksum) changed, so readers must re-fetch it.
+	if callback != nil {
+		entryCopy := entry
+		callback(&entryCopy)
+	}
+
 	return nil
 }
 

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -37,6 +37,9 @@ const (
 	// CommandBatchFileOps groups multiple RegisterFile and DeleteFile operations
 	// into a single Raft log entry — one apply per compaction manifest instead of O(N).
 	CommandBatchFileOps
+	// CommandUpdateFile replaces an existing file's metadata in the cluster manifest.
+	// Used after partial rewrites that change size/checksum but keep the same path.
+	CommandUpdateFile
 )
 
 // Command represents a command to be applied to the FSM.
@@ -118,6 +121,11 @@ type DeleteFilePayload struct {
 	Reason string `json:"reason,omitempty"` // "retention", "compaction", "manual"
 }
 
+// UpdateFilePayload is the payload for CommandUpdateFile.
+type UpdateFilePayload struct {
+	File FileEntry `json:"file"`
+}
+
 // AssignCompactorPayload is the payload for CommandAssignCompactor.
 type AssignCompactorPayload struct {
 	NodeID         string `json:"node_id"`
@@ -125,10 +133,10 @@ type AssignCompactorPayload struct {
 }
 
 // BatchFileOp is a single operation within a CommandBatchFileOps command.
-// Type must be CommandRegisterFile or CommandDeleteFile; any other value
-// causes the FSM to return an error when the batch is applied.
+// Type must be CommandRegisterFile, CommandDeleteFile, or CommandUpdateFile;
+// any other value causes the FSM to return an error when the batch is applied.
 type BatchFileOp struct {
-	Type    CommandType `json:"type"`    // CommandRegisterFile or CommandDeleteFile
+	Type    CommandType `json:"type"`    // CommandRegisterFile, CommandDeleteFile, or CommandUpdateFile
 	Payload []byte      `json:"payload"` // Same payload shape as the corresponding single command
 }
 
@@ -254,6 +262,8 @@ func (f *ClusterFSM) Apply(log *raft.Log) interface{} {
 		return f.applyAssignCompactor(cmd.Payload)
 	case CommandBatchFileOps:
 		return f.applyBatchFileOps(cmd.Payload, log.Index)
+	case CommandUpdateFile:
+		return f.applyUpdateFile(cmd.Payload)
 	default:
 		return fmt.Errorf("unknown command type: %d", cmd.Type)
 	}
@@ -546,6 +556,48 @@ func (f *ClusterFSM) applyDeleteFile(payload []byte) interface{} {
 	return nil
 }
 
+func (f *ClusterFSM) applyUpdateFile(payload []byte) interface{} {
+	var p UpdateFilePayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("failed to unmarshal update file payload: %w", err)
+	}
+	if p.File.Path == "" {
+		return fmt.Errorf("update file: path is required")
+	}
+
+	f.mu.Lock()
+	entry := p.File
+	// If the database changed (defensive), remove the old secondary index entry first.
+	if old, existed := f.files[entry.Path]; existed && old.Database != entry.Database {
+		if oldIdx, ok := f.filesByDB[old.Database]; ok {
+			delete(oldIdx, old.Path)
+			if len(oldIdx) == 0 {
+				delete(f.filesByDB, old.Database)
+			}
+		}
+	}
+	f.files[entry.Path] = &entry
+	if entry.Database != "" {
+		idx, ok := f.filesByDB[entry.Database]
+		if !ok {
+			idx = make(map[string]struct{})
+			f.filesByDB[entry.Database] = idx
+		}
+		idx[entry.Path] = struct{}{}
+	}
+	f.mu.Unlock()
+
+	f.logger.Debug().
+		Str("path", entry.Path).
+		Int64("size_bytes", entry.SizeBytes).
+		Str("sha256", entry.SHA256).
+		Msg("File updated in cluster manifest")
+
+	// No onFileRegistered callback — the file already exists on disk; peers
+	// do not need to pull it again. Only metadata (size/checksum) changed.
+	return nil
+}
+
 func (f *ClusterFSM) applyAssignCompactor(payload []byte) interface{} {
 	var p AssignCompactorPayload
 	if err := json.Unmarshal(payload, &p); err != nil {
@@ -587,6 +639,8 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 			result = f.applyRegisterFile(op.Payload, logIndex)
 		case CommandDeleteFile:
 			result = f.applyDeleteFile(op.Payload)
+		case CommandUpdateFile:
+			result = f.applyUpdateFile(op.Payload)
 		default:
 			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
 		}

--- a/internal/cluster/raft/node.go
+++ b/internal/cluster/raft/node.go
@@ -596,6 +596,16 @@ func (n *Node) BatchFileOps(ops []BatchFileOp, timeout time.Duration) error {
 	return n.Apply(&Command{Type: CommandBatchFileOps, Payload: payload}, timeout)
 }
 
+// UpdateFile updates an existing file's metadata in the cluster manifest.
+// Called after partial rewrites that change size/checksum but keep the same path.
+func (n *Node) UpdateFile(file FileEntry, timeout time.Duration) error {
+	payload, err := json.Marshal(UpdateFilePayload{File: file})
+	if err != nil {
+		return fmt.Errorf("failed to marshal update file payload: %w", err)
+	}
+	return n.Apply(&Command{Type: CommandUpdateFile, Payload: payload}, timeout)
+}
+
 // LeaderCh returns a channel that signals leadership changes.
 // True means this node became leader, false means it lost leadership.
 func (n *Node) LeaderCh() <-chan bool {

--- a/internal/scheduler/retention_scheduler.go
+++ b/internal/scheduler/retention_scheduler.go
@@ -18,7 +18,7 @@ import (
 type RetentionClusterGate interface {
 	// CanRunRetention reports whether the local node may execute retention.
 	// When false, the scheduler stays idle — not running, not an error.
-	CanRunRetention() bool
+	IsPrimaryWriter() bool
 	// Role returns a human-readable role string for log messages only.
 	Role() string
 }
@@ -151,7 +151,7 @@ func (s *RetentionScheduler) runRetention() {
 	// Cluster gate: checked on every tick so role transitions (failover,
 	// demotion) take effect without a restart. clusterGate is immutable
 	// after construction so no lock is needed here.
-	if s.clusterGate != nil && !s.clusterGate.CanRunRetention() {
+	if s.clusterGate != nil && !s.clusterGate.IsPrimaryWriter() {
 		s.logger.Debug().Str("role", s.clusterGate.Role()).Msg("Retention tick skipped: node is not primary writer")
 		return
 	}
@@ -236,7 +236,7 @@ func (s *RetentionScheduler) TriggerNow(ctx context.Context) error {
 	// The same gate applies to manual triggers — a reader node must not
 	// run retention on demand either. clusterGate is immutable after
 	// construction so no lock is needed.
-	if s.clusterGate != nil && !s.clusterGate.CanRunRetention() {
+	if s.clusterGate != nil && !s.clusterGate.IsPrimaryWriter() {
 		s.logger.Warn().
 			Str("role", s.clusterGate.Role()).
 			Msg("Manual retention trigger rejected: node is not primary writer")
@@ -337,7 +337,7 @@ func (s *RetentionScheduler) Status() map[string]interface{} {
 	}
 
 	if s.clusterGate != nil {
-		status["can_run"] = s.clusterGate.CanRunRetention()
+		status["can_run"] = s.clusterGate.IsPrimaryWriter()
 		status["gate_role"] = s.clusterGate.Role()
 	}
 


### PR DESCRIPTION
## Summary

- **Writer-only gate**: reader nodes return `503 Service Unavailable` before any mutation; dry-run is allowed on any node
- **Manifest-before-storage for full-file deletes**: when all rows in a file match the WHERE clause, `BatchFileOpsInManifest` is called before `storage.Delete`. Raft propagates the `CommandDeleteFile` to all nodes — reader nodes' `onFileDeleted` FSM callback cleans up local copies. Partial rewrites (file path unchanged) need no manifest entry.
- **Abort on manifest failure**: `errManifestFailure` sentinel causes the operation to abort and return 500; continuing would delete files from storage with no manifest record
- **Storage failure after committed manifest**: logged as Warn, treated as success — manifest is authoritative, orphan cleaned up by Phase 5 reconciliation
- **Single-quote escaping** on all `read_parquet()` path interpolations (SQL injection hardening)
- **`c.Context()` propagation**: replaces `context.Background()` so client disconnects cancel in-flight rewrites
- **Standalone mode unchanged**: coordinator is nil, all gates skipped

Mirrors the retention PR (#407) pattern exactly.

## Test plan

- [x] `go build ./cmd/... ./internal/...` — clean
- [x] `go test ./internal/api/... -v` — all pass
- [x] Standalone: issue a delete with `confirm=true` — files rewritten/deleted, no errors
- [x] Reader node (cluster): issue delete → expect `503` with role in error message
- [x] Full-delete (cluster): after deleting all rows in a file, confirm path absent from Raft manifest on all nodes
- [x] Failover: stop writer mid-operation, promote standby → next delete succeeds on new writer