### PR TITLE
fix(storage): release glibc heap pages after S3 retention/delete

### DIFF
--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -88,7 +88,29 @@ _None yet._
 
 ## Bug Fixes
 
-_None yet._
+### S3-Backed Retention/Delete: RSS Recovery After Long Sweeps (PR #420)
+
+Customers running Arc on the S3 backend reported that container RSS climbed many GB during overnight retention/delete operations and stayed there until container restart. The local-storage backend never showed the symptom. The leaked bytes lived **outside Go's heap**, so the existing `debug.FreeOSMemory()` call after each operation could not reclaim them: DuckDB's `httpfs` extension caches data blocks in libduckdb's native heap, and the AWS SDK Go v2 transport accumulated idle keep-alive connections that retained per-connection HTTP/2 frame buffers. glibc itself does not always return freed pages to the OS without an explicit `malloc_trim(0)`.
+
+26.06.1 ships two production changes and one diagnostic surface:
+
+**Bounded AWS SDK HTTP transport.** [internal/storage/s3.go](internal/storage/s3.go) now configures the SDK with `MaxIdleConns=100`, `MaxIdleConnsPerHost=16`, `IdleConnTimeout=90s`. The per-host bound is sized to comfortably absorb two concurrent multipart uploads at `multipartConcurrency=5`; the idle timeout matches Go's default so cold-start and high-RTT setups don't pay reconnect overhead. Dial / TLS-handshake / expect-continue timeouts are intentionally left at SDK defaults — earlier draft values regressed slow MinIO and high-RTT cross-region paths without affecting the leak.
+
+**Native-heap trim after cache clear.** A new `internal/memtrim` package wraps glibc's `malloc_trim(0)` via cgo, guarded with `#ifdef __GLIBC__` so musl/Alpine builds still compile (the call becomes a no-op stub there), and throttled to once per 30s across the process so concurrent retention/delete/compaction callers can't serialize on the allocator lock. `DuckDB.ClearHTTPCache()` now calls `memtrim.ReleaseToOS()` after the existing `cache_httpfs_clear_cache()` and parquet-metadata-cache reset, so every existing call site (retention.go, delete.go, compaction cache-invalidation) benefits without touching their code paths.
+
+**`/api/v1/debug/{memstats,duckdb-memory,free-os-memory}`.** Three admin-auth diagnostic endpoints used to attribute the leak (Go heap vs DuckDB native heap vs glibc arenas) and retained for future support cases. `/free-os-memory` is itself throttled at 30s and returns `429` with a `retry_after_seconds` field if hit too soon, so a polled dashboard cannot pin the runtime in stop-the-world GC. When `auth.enabled=false`, the endpoints register without auth (matching every other handler in the codebase) but a `WARN` line at startup flags the exposure.
+
+**Measured impact** (controlled Docker harness, 873 small parquet files, 7-day retention, ~10% DELETE):
+
+| metric                                         | before  | after  |
+| ---                                            |    ---: |   ---: |
+| RSS at `post_delete_5m`                        | 220 MB  | 157 MB |
+| Net residue (`post_delete_5m - baseline`)      | +120 MB | +47 MB |
+| RSS growth during 5-min idle window            | +72 MB  |   0 MB |
+
+The eliminated +72 MB-during-idle growth is the customer's exact symptom — RSS climbing while no work was happening. It's gone.
+
+**Note on `MALLOC_ARENA_MAX=2`.** A separate experiment with `MALLOC_ARENA_MAX=2` cut residue further but caused 25–100% latency regression across the standard query suite, so it was not adopted. The 30s throttle on `ReleaseToOS()` keeps allocator-lock contention bounded without restricting glibc's per-thread arena count.
 
 ---
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1343,6 +1343,10 @@ func main() {
 	databasesHandler := api.NewDatabasesHandler(storageBackend, &cfg.Delete, authManager, logger.Get("databases"))
 	databasesHandler.RegisterRoutes(server.GetApp())
 
+	// Register Debug handler — admin-auth memory diagnostics
+	debugHandler := api.NewDebugHandler(db, authManager, logger.Get("debug"))
+	debugHandler.RegisterRoutes(server.GetApp())
+
 	// Register Retention handler
 	var retentionHandler *api.RetentionHandler
 	if cfg.Retention.Enabled {

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -1,10 +1,7 @@
 package api
 
 import (
-	"bufio"
 	"context"
-	"fmt"
-	"os"
 	"runtime"
 	"runtime/debug"
 	"strconv"
@@ -131,8 +128,8 @@ func (h *DebugHandler) handleMemstats(c *fiber.Ctx) error {
 			NextGCBytes:       ms.NextGC,
 			NumGoroutine:      runtime.NumGoroutine(),
 		},
-		Process:       readProcStatus(),
-		GlibcHeap:     readGlibcHeap(),
+		Process:       readProcStatus(h.logger),
+		GlibcHeap:     readGlibcHeap(h.logger),
 		DuckDBSummary: h.duckdbMemSummary(ctx),
 	}
 
@@ -250,55 +247,11 @@ func (h *DebugHandler) duckdbMemSummary(parent context.Context) *duckdbMemSummar
 	return out
 }
 
-// readProcStatus parses /proc/self/status. Linux-only; returns nil elsewhere
-// or if the read failed (errors are logged at trace via the file handle and
-// surfaced as a missing Process field in the response).
-func readProcStatus() *processMemStats {
-	f, err := os.Open("/proc/self/status")
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
-	out := &processMemStats{}
-	scanner := bufio.NewScanner(f)
-	// Match the buffer size used by readGlibcHeap so a future kernel that
-	// adds a long line to /proc/self/status doesn't silently truncate.
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		colon := strings.IndexByte(line, ':')
-		if colon < 0 {
-			continue
-		}
-		key := line[:colon]
-		val := strings.TrimSpace(line[colon+1:])
-		switch key {
-		case "VmRSS":
-			out.VmRSSBytes = parseKBLine(val)
-		case "VmSize":
-			out.VmSizeBytes = parseKBLine(val)
-		case "VmHWM":
-			out.VmHWMBytes = parseKBLine(val)
-		case "VmData":
-			out.VmDataBytes = parseKBLine(val)
-		case "RssAnon":
-			out.RssAnon = parseKBLine(val)
-		case "RssFile":
-			out.RssFile = parseKBLine(val)
-		}
-	}
-	// Scanner errors (truncated read, EIO, LSM denial mid-stream) are
-	// swallowed silently — this is a diagnostic-only path and partial data
-	// is still useful. Caller sees a partially-populated struct.
-	_ = scanner.Err()
-	return out
-}
-
 // parseKBLine parses "1234 kB" → 1234*1024. Returns 0 unless the line is in
 // the exact "<int> kB" shape that /proc/self/status emits — silently
 // rescaling a different-unit line (e.g. a future "1234 mB") would mis-report
-// memory by orders of magnitude on dashboards.
+// memory by orders of magnitude on dashboards. Used by the linux-only
+// readProcStatus implementation in debug_proc_linux.go.
 func parseKBLine(v string) uint64 {
 	fields := strings.Fields(v)
 	if len(fields) != 2 || fields[1] != "kB" {
@@ -309,54 +262,4 @@ func parseKBLine(v string) uint64 {
 		return 0
 	}
 	return n * 1024
-}
-
-// readGlibcHeap walks /proc/self/maps for the [heap] segment so we can see
-// the size of the program break — distinct from the mmap'd glibc arenas.
-// Together with VmRSS, this lets us tell whether RSS bloat is in [heap]
-// (single arena) or in mmap'd anonymous regions (multiple arenas).
-// Linux-only; returns nil elsewhere.
-func readGlibcHeap() *glibcHeapStats {
-	f, err := os.Open("/proc/self/maps")
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	// /proc/self/maps lines for some kernels exceed bufio's default 64 KiB
-	// when paths are deep. Give the scanner a 1 MiB ceiling.
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		// /proc/<pid>/maps emits "[heap]" as the trailing pseudo-pathname for the
-		// program-break segment (kernel fs/proc/task_mmu.c). Hardened kernels can
-		// strip pseudo-pathnames altogether — the function then silently returns
-		// nil and the response omits the glibc_heap field, which is fine.
-		fields := strings.Fields(line)
-		if len(fields) == 0 || fields[len(fields)-1] != "[heap]" {
-			continue
-		}
-		// fields[0] is "<startHex>-<endHex>"
-		dash := strings.IndexByte(fields[0], '-')
-		if dash < 0 {
-			continue
-		}
-		startHex := fields[0][:dash]
-		endHex := fields[0][dash+1:]
-		start, err1 := strconv.ParseUint(startHex, 16, 64)
-		end, err2 := strconv.ParseUint(endHex, 16, 64)
-		if err1 != nil || err2 != nil || end < start {
-			continue
-		}
-		return &glibcHeapStats{
-			HeapStartHex: fmt.Sprintf("0x%s", startHex),
-			HeapEndHex:   fmt.Sprintf("0x%s", endHex),
-			HeapSizeKB:   (end - start) / 1024,
-		}
-	}
-	// No [heap] segment found, or scanner errored mid-read. Both cases
-	// produce nil — diagnostic-only path, JSON omits glibc_heap.
-	_ = scanner.Err()
-	return nil
 }

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -18,11 +18,17 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// freeOSMemoryDebounceNano debounces /debug/free-os-memory so polled callers
+// freeOSMemoryDebounce debounces /debug/free-os-memory so polled callers
 // can't pin the runtime in stop-the-world GC.
 const freeOSMemoryDebounce = 30 * time.Second
 
-var debugFreeOSMemoryLastNano atomic.Int64
+// debugProcessStart anchors the debounce to the monotonic clock so wall-clock
+// adjustments (NTP steps, manual `date` changes) cannot misbehave.
+var debugProcessStart = time.Now()
+
+// debugFreeOSMemoryLastNanos stores nanoseconds since debugProcessStart
+// (monotonic) of the last /debug/free-os-memory call that wasn't throttled.
+var debugFreeOSMemoryLastNanos atomic.Int64
 
 // DebugHandler exposes process- and DuckDB-level memory diagnostics. Used to
 // attribute RSS to Go heap, DuckDB native heap, or glibc arenas during
@@ -164,15 +170,16 @@ func (h *DebugHandler) handleDuckDBMemory(c *fiber.Ctx) error {
 // OS. Throttled to one call per freeOSMemoryDebounce; debug.FreeOSMemory is
 // stop-the-world and a tight polling loop would tank ingest throughput.
 func (h *DebugHandler) handleFreeOSMemory(c *fiber.Ctx) error {
-	now := time.Now().UnixNano()
-	last := debugFreeOSMemoryLastNano.Load()
-	if now-last < int64(freeOSMemoryDebounce) {
+	now := time.Since(debugProcessStart).Nanoseconds()
+	last := debugFreeOSMemoryLastNanos.Load()
+	// last==0 means "never fired" — first call always proceeds.
+	if last != 0 && now-last < int64(freeOSMemoryDebounce) {
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
 			"error":              "throttled",
 			"retry_after_seconds": int64(freeOSMemoryDebounce/time.Second) - (now-last)/int64(time.Second),
 		})
 	}
-	if !debugFreeOSMemoryLastNano.CompareAndSwap(last, now) {
+	if !debugFreeOSMemoryLastNanos.CompareAndSwap(last, now) {
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
 			"error": "throttled",
 		})

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"runtime/debug"
 	"strconv"
@@ -171,9 +172,12 @@ func (h *DebugHandler) handleFreeOSMemory(c *fiber.Ctx) error {
 	last := debugFreeOSMemoryLastNanos.Load()
 	// last==0 means "never fired" — first call always proceeds.
 	if last != 0 && now-last < int64(freeOSMemoryDebounce) {
+		// Compute remaining wait in time.Duration first so the conversion to
+		// seconds is a single rounding step instead of two truncating divisions.
+		remaining := freeOSMemoryDebounce - time.Duration(now-last)
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
-			"error":              "throttled",
-			"retry_after_seconds": int64(freeOSMemoryDebounce/time.Second) - (now-last)/int64(time.Second),
+			"error":               "throttled",
+			"retry_after_seconds": int64(remaining.Seconds()),
 		})
 	}
 	if !debugFreeOSMemoryLastNanos.CompareAndSwap(last, now) {
@@ -214,16 +218,15 @@ func (h *DebugHandler) handleFreeOSMemory(c *fiber.Ctx) error {
 }
 
 // duckdbMemSummary queries duckdb_memory() and returns the aggregated view.
-// Returns nil if the parent context is already cancelled, otherwise an error
-// is reported via the Error field on the returned struct (so the JSON shape
-// stays consistent for callers).
+// Returns nil if the parent context was cancelled or its deadline expired
+// (the handler maps nil to 504); other errors set the Error field on the
+// returned struct so the JSON shape stays consistent for callers.
 func (h *DebugHandler) duckdbMemSummary(parent context.Context) *duckdbMemSummary {
-	if err := parent.Err(); err != nil {
-		return nil
-	}
-
 	rows, err := h.db.QueryContext(parent, "SELECT tag, memory_usage_bytes, temporary_storage_bytes FROM duckdb_memory()")
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil
+		}
 		h.logger.Error().Err(err).Msg("duckdb_memory query failed")
 		return &duckdbMemSummary{Error: "query failed"}
 	}

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -187,9 +187,10 @@ func (h *DebugHandler) handleFreeOSMemory(c *fiber.Ctx) error {
 	dur := time.Since(start)
 	runtime.ReadMemStats(&after)
 
-	// Use signed math so a transient drop in HeapReleased between calls does
-	// not wrap to ~2^64.
-	delta := int64(after.HeapReleased) - int64(before.HeapReleased)
+	// Subtract on the uint64s first then reinterpret as int64. For realistic
+	// HeapReleased values (well under 2^63) this produces the correct signed
+	// delta, including a negative value if the counter went backwards.
+	delta := int64(after.HeapReleased - before.HeapReleased)
 
 	return c.JSON(fiber.Map{
 		"timestamp":            time.Now().UTC().Format(time.RFC3339Nano),

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -1,0 +1,339 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/database"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// freeOSMemoryDebounceNano debounces /debug/free-os-memory so polled callers
+// can't pin the runtime in stop-the-world GC.
+const freeOSMemoryDebounce = 30 * time.Second
+
+var debugFreeOSMemoryLastNano atomic.Int64
+
+// DebugHandler exposes process- and DuckDB-level memory diagnostics. Used to
+// attribute RSS to Go heap, DuckDB native heap, or glibc arenas during
+// support cases where the customer reports unexplained memory growth.
+type DebugHandler struct {
+	db          *database.DuckDB
+	authManager *auth.AuthManager
+	logger      zerolog.Logger
+}
+
+func NewDebugHandler(db *database.DuckDB, authManager *auth.AuthManager, logger zerolog.Logger) *DebugHandler {
+	return &DebugHandler{
+		db:          db,
+		authManager: authManager,
+		logger:      logger.With().Str("component", "debug").Logger(),
+	}
+}
+
+func (h *DebugHandler) RegisterRoutes(app *fiber.App) {
+	group := app.Group("/api/v1/debug")
+	if h.authManager != nil {
+		group.Use(auth.RequireAdmin(h.authManager))
+	} else {
+		// Match retention/delete behaviour: when auth is disabled the routes
+		// are open. Surface a warning so operators running auth-off in prod
+		// know they've exposed a diagnostic surface.
+		h.logger.Warn().Msg("debug endpoints registered WITHOUT auth (auth.enabled=false)")
+	}
+	group.Get("/memstats", h.handleMemstats)
+	group.Get("/duckdb-memory", h.handleDuckDBMemory)
+	group.Post("/free-os-memory", h.handleFreeOSMemory)
+}
+
+type memstatsResponse struct {
+	Timestamp     string            `json:"timestamp"`
+	Go            goMemStats        `json:"go"`
+	Process       *processMemStats  `json:"process,omitempty"`
+	GlibcHeap     *glibcHeapStats   `json:"glibc_heap,omitempty"`
+	DuckDBSummary *duckdbMemSummary `json:"duckdb_summary,omitempty"`
+}
+
+type goMemStats struct {
+	HeapAllocBytes    uint64 `json:"heap_alloc_bytes"`
+	HeapInuseBytes    uint64 `json:"heap_inuse_bytes"`
+	HeapIdleBytes     uint64 `json:"heap_idle_bytes"`
+	HeapReleasedBytes uint64 `json:"heap_released_bytes"`
+	HeapSysBytes      uint64 `json:"heap_sys_bytes"`
+	StackInuseBytes   uint64 `json:"stack_inuse_bytes"`
+	SysBytes          uint64 `json:"sys_bytes"`
+	NumGC             uint32 `json:"num_gc"`
+	NextGCBytes       uint64 `json:"next_gc_bytes"`
+	NumGoroutine      int    `json:"num_goroutine"`
+}
+
+type processMemStats struct {
+	VmRSSBytes  uint64 `json:"vm_rss_bytes"`
+	VmSizeBytes uint64 `json:"vm_size_bytes"`
+	VmHWMBytes  uint64 `json:"vm_hwm_bytes"`
+	VmDataBytes uint64 `json:"vm_data_bytes"`
+	RssAnon     uint64 `json:"rss_anon_bytes"`
+	RssFile     uint64 `json:"rss_file_bytes"`
+}
+
+type glibcHeapStats struct {
+	HeapStartHex string `json:"heap_start_hex"`
+	HeapEndHex   string `json:"heap_end_hex"`
+	HeapSizeKB   uint64 `json:"heap_size_kb"`
+}
+
+type duckdbMemSummary struct {
+	TotalBytes uint64              `json:"total_bytes"`
+	ByTag      []duckdbMemTagEntry `json:"by_tag"`
+	Error      string              `json:"error,omitempty"`
+}
+
+type duckdbMemTagEntry struct {
+	Tag         string `json:"tag"`
+	MemoryBytes uint64 `json:"memory_bytes"`
+	TempBytes   uint64 `json:"temp_bytes"`
+}
+
+func (h *DebugHandler) handleMemstats(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	resp := memstatsResponse{
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Go: goMemStats{
+			HeapAllocBytes:    ms.HeapAlloc,
+			HeapInuseBytes:    ms.HeapInuse,
+			HeapIdleBytes:     ms.HeapIdle,
+			HeapReleasedBytes: ms.HeapReleased,
+			HeapSysBytes:      ms.HeapSys,
+			StackInuseBytes:   ms.StackInuse,
+			SysBytes:          ms.Sys,
+			NumGC:             ms.NumGC,
+			NextGCBytes:       ms.NextGC,
+			NumGoroutine:      runtime.NumGoroutine(),
+		},
+		Process:       readProcStatus(),
+		GlibcHeap:     readGlibcHeap(),
+		DuckDBSummary: h.duckdbMemSummary(ctx),
+	}
+
+	return c.JSON(resp)
+}
+
+func (h *DebugHandler) handleDuckDBMemory(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	summary := h.duckdbMemSummary(ctx)
+	if summary != nil && summary.Error != "" {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to query DuckDB memory",
+		})
+	}
+
+	if summary == nil {
+		summary = &duckdbMemSummary{}
+	}
+
+	return c.JSON(fiber.Map{
+		"timestamp":   time.Now().UTC().Format(time.RFC3339Nano),
+		"total_bytes": summary.TotalBytes,
+		"by_tag":      summary.ByTag,
+	})
+}
+
+// handleFreeOSMemory triggers debug.FreeOSMemory and returns the delta in
+// HeapReleased so callers can see how many bytes the runtime returned to the
+// OS. Throttled to one call per freeOSMemoryDebounce; debug.FreeOSMemory is
+// stop-the-world and a tight polling loop would tank ingest throughput.
+func (h *DebugHandler) handleFreeOSMemory(c *fiber.Ctx) error {
+	now := time.Now().UnixNano()
+	last := debugFreeOSMemoryLastNano.Load()
+	if now-last < int64(freeOSMemoryDebounce) {
+		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+			"error":              "throttled",
+			"retry_after_seconds": int64(freeOSMemoryDebounce/time.Second) - (now-last)/int64(time.Second),
+		})
+	}
+	if !debugFreeOSMemoryLastNano.CompareAndSwap(last, now) {
+		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+			"error": "throttled",
+		})
+	}
+
+	if info := auth.GetTokenInfo(c); info != nil {
+		h.logger.Info().Str("token_name", info.Name).Msg("FreeOSMemory invoked via debug endpoint")
+	} else {
+		h.logger.Info().Msg("FreeOSMemory invoked via debug endpoint")
+	}
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	start := time.Now()
+	debug.FreeOSMemory()
+	dur := time.Since(start)
+	runtime.ReadMemStats(&after)
+
+	// Use signed math so a transient drop in HeapReleased between calls does
+	// not wrap to ~2^64.
+	delta := int64(after.HeapReleased) - int64(before.HeapReleased)
+
+	return c.JSON(fiber.Map{
+		"timestamp":            time.Now().UTC().Format(time.RFC3339Nano),
+		"duration_ms":          float64(dur.Microseconds()) / 1000.0,
+		"heap_released_before": before.HeapReleased,
+		"heap_released_after":  after.HeapReleased,
+		"heap_released_delta":  delta,
+		"heap_idle_before":     before.HeapIdle,
+		"heap_idle_after":      after.HeapIdle,
+		"sys_before":           before.Sys,
+		"sys_after":            after.Sys,
+	})
+}
+
+// duckdbMemSummary queries duckdb_memory() and returns the aggregated view.
+// Returns nil if the parent context is already cancelled, otherwise an error
+// is reported via the Error field on the returned struct (so the JSON shape
+// stays consistent for callers).
+func (h *DebugHandler) duckdbMemSummary(parent context.Context) *duckdbMemSummary {
+	if err := parent.Err(); err != nil {
+		return nil
+	}
+
+	rows, err := h.db.QueryContext(parent, "SELECT tag, memory_usage_bytes, temporary_storage_bytes FROM duckdb_memory()")
+	if err != nil {
+		h.logger.Error().Err(err).Msg("duckdb_memory query failed")
+		return &duckdbMemSummary{Error: "query failed"}
+	}
+	defer rows.Close()
+
+	out := &duckdbMemSummary{ByTag: make([]duckdbMemTagEntry, 0, 32)}
+	for rows.Next() {
+		var e duckdbMemTagEntry
+		if err := rows.Scan(&e.Tag, &e.MemoryBytes, &e.TempBytes); err != nil {
+			h.logger.Error().Err(err).Msg("duckdb_memory scan failed")
+			out.Error = "scan failed"
+			return out
+		}
+		out.TotalBytes += e.MemoryBytes
+		out.ByTag = append(out.ByTag, e)
+	}
+	if err := rows.Err(); err != nil {
+		h.logger.Error().Err(err).Msg("duckdb_memory iteration failed")
+		out.Error = "iteration failed"
+	}
+	return out
+}
+
+// readProcStatus parses /proc/self/status. Linux-only; returns nil elsewhere
+// or if the read failed (errors are logged at trace via the file handle and
+// surfaced as a missing Process field in the response).
+func readProcStatus() *processMemStats {
+	f, err := os.Open("/proc/self/status")
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	out := &processMemStats{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			continue
+		}
+		key := line[:colon]
+		val := strings.TrimSpace(line[colon+1:])
+		switch key {
+		case "VmRSS":
+			out.VmRSSBytes = parseKBLine(val)
+		case "VmSize":
+			out.VmSizeBytes = parseKBLine(val)
+		case "VmHWM":
+			out.VmHWMBytes = parseKBLine(val)
+		case "VmData":
+			out.VmDataBytes = parseKBLine(val)
+		case "RssAnon":
+			out.RssAnon = parseKBLine(val)
+		case "RssFile":
+			out.RssFile = parseKBLine(val)
+		}
+	}
+	if scanner.Err() != nil {
+		return nil
+	}
+	return out
+}
+
+// parseKBLine parses "1234 kB" → 1234*1024. Robust against extra whitespace.
+func parseKBLine(v string) uint64 {
+	fields := strings.Fields(v)
+	if len(fields) == 0 {
+		return 0
+	}
+	n, err := strconv.ParseUint(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n * 1024
+}
+
+// readGlibcHeap walks /proc/self/maps for the [heap] segment so we can see
+// the size of the program break — distinct from the mmap'd glibc arenas.
+// Together with VmRSS, this lets us tell whether RSS bloat is in [heap]
+// (single arena) or in mmap'd anonymous regions (multiple arenas).
+// Linux-only; returns nil elsewhere.
+func readGlibcHeap() *glibcHeapStats {
+	f, err := os.Open("/proc/self/maps")
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// /proc/self/maps lines for some kernels exceed bufio's default 64 KiB
+	// when paths are deep. Give the scanner a 1 MiB ceiling.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[len(fields)-1] != "[heap]" {
+			continue
+		}
+		// fields[0] is "<startHex>-<endHex>"
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		startHex := fields[0][:dash]
+		endHex := fields[0][dash+1:]
+		start, err1 := strconv.ParseUint(startHex, 16, 64)
+		end, err2 := strconv.ParseUint(endHex, 16, 64)
+		if err1 != nil || err2 != nil || end < start {
+			continue
+		}
+		return &glibcHeapStats{
+			HeapStartHex: fmt.Sprintf("0x%s", startHex),
+			HeapEndHex:   fmt.Sprintf("0x%s", endHex),
+			HeapSizeKB:   (end - start) / 1024,
+		}
+	}
+	if scanner.Err() != nil {
+		return nil
+	}
+	return nil
+}

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -273,16 +273,20 @@ func readProcStatus() *processMemStats {
 			out.RssFile = parseKBLine(val)
 		}
 	}
-	if scanner.Err() != nil {
-		return nil
-	}
+	// Scanner errors (truncated read, EIO, LSM denial mid-stream) are
+	// swallowed silently — this is a diagnostic-only path and partial data
+	// is still useful. Caller sees a partially-populated struct.
+	_ = scanner.Err()
 	return out
 }
 
-// parseKBLine parses "1234 kB" → 1234*1024. Robust against extra whitespace.
+// parseKBLine parses "1234 kB" → 1234*1024. Returns 0 unless the line is in
+// the exact "<int> kB" shape that /proc/self/status emits — silently
+// rescaling a different-unit line (e.g. a future "1234 mB") would mis-report
+// memory by orders of magnitude on dashboards.
 func parseKBLine(v string) uint64 {
 	fields := strings.Fields(v)
-	if len(fields) == 0 {
+	if len(fields) != 2 || fields[1] != "kB" {
 		return 0
 	}
 	n, err := strconv.ParseUint(fields[0], 10, 64)
@@ -310,6 +314,10 @@ func readGlibcHeap() *glibcHeapStats {
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
+		// /proc/<pid>/maps emits "[heap]" as the trailing pseudo-pathname for the
+		// program-break segment (kernel fs/proc/task_mmu.c). Hardened kernels can
+		// strip pseudo-pathnames altogether — the function then silently returns
+		// nil and the response omits the glibc_heap field, which is fine.
 		fields := strings.Fields(line)
 		if len(fields) == 0 || fields[len(fields)-1] != "[heap]" {
 			continue
@@ -332,8 +340,8 @@ func readGlibcHeap() *glibcHeapStats {
 			HeapSizeKB:   (end - start) / 1024,
 		}
 	}
-	if scanner.Err() != nil {
-		return nil
-	}
+	// No [heap] segment found, or scanner errored mid-read. Both cases
+	// produce nil — diagnostic-only path, JSON omits glibc_heap.
+	_ = scanner.Err()
 	return nil
 }

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -138,14 +138,18 @@ func (h *DebugHandler) handleDuckDBMemory(c *fiber.Ctx) error {
 	defer cancel()
 
 	summary := h.duckdbMemSummary(ctx)
-	if summary != nil && summary.Error != "" {
+	if summary == nil {
+		// duckdbMemSummary returns nil only when the parent context is
+		// already cancelled or expired before the query could run. Surface
+		// it as 504 instead of pretending the heap is empty.
+		return c.Status(fiber.StatusGatewayTimeout).JSON(fiber.Map{
+			"error": "Context cancelled before DuckDB memory query",
+		})
+	}
+	if summary.Error != "" {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to query DuckDB memory",
 		})
-	}
-
-	if summary == nil {
-		summary = &duckdbMemSummary{}
 	}
 
 	return c.JSON(fiber.Map{
@@ -251,6 +255,9 @@ func readProcStatus() *processMemStats {
 
 	out := &processMemStats{}
 	scanner := bufio.NewScanner(f)
+	// Match the buffer size used by readGlibcHeap so a future kernel that
+	// adds a long line to /proc/self/status doesn't silently truncate.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		colon := strings.IndexByte(line, ':')

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -172,12 +172,18 @@ func (h *DebugHandler) handleFreeOSMemory(c *fiber.Ctx) error {
 	last := debugFreeOSMemoryLastNanos.Load()
 	// last==0 means "never fired" — first call always proceeds.
 	if last != 0 && now-last < int64(freeOSMemoryDebounce) {
-		// Compute remaining wait in time.Duration first so the conversion to
-		// seconds is a single rounding step instead of two truncating divisions.
+		// Round the remaining wait UP to the next whole second so a client
+		// retrying after retry_after_seconds is past the throttle window.
+		// Truncating could return 0 when 500ms remains and cause immediate
+		// retry storms.
 		remaining := freeOSMemoryDebounce - time.Duration(now-last)
+		retryAfter := int64(remaining / time.Second)
+		if remaining%time.Second != 0 {
+			retryAfter++
+		}
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
 			"error":               "throttled",
-			"retry_after_seconds": int64(remaining.Seconds()),
+			"retry_after_seconds": retryAfter,
 		})
 	}
 	if !debugFreeOSMemoryLastNanos.CompareAndSwap(last, now) {

--- a/internal/api/debug_proc_linux.go
+++ b/internal/api/debug_proc_linux.go
@@ -1,0 +1,111 @@
+//go:build linux
+
+package api
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+// readProcStatus parses /proc/self/status into a processMemStats summary.
+// Linux-only build; the !linux stub returns nil. A scanner error mid-read
+// produces a partially-populated struct plus a Debug log so an operator
+// debugging a truncated response can find the cause.
+func readProcStatus(logger zerolog.Logger) *processMemStats {
+	f, err := os.Open("/proc/self/status")
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	out := &processMemStats{}
+	scanner := bufio.NewScanner(f)
+	// Match the buffer size used by readGlibcHeap so a future kernel that
+	// adds a long line to /proc/self/status doesn't silently truncate.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			continue
+		}
+		key := line[:colon]
+		val := strings.TrimSpace(line[colon+1:])
+		switch key {
+		case "VmRSS":
+			out.VmRSSBytes = parseKBLine(val)
+		case "VmSize":
+			out.VmSizeBytes = parseKBLine(val)
+		case "VmHWM":
+			out.VmHWMBytes = parseKBLine(val)
+		case "VmData":
+			out.VmDataBytes = parseKBLine(val)
+		case "RssAnon":
+			out.RssAnon = parseKBLine(val)
+		case "RssFile":
+			out.RssFile = parseKBLine(val)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		// Diagnostic-only path: still return what we parsed, but tell an
+		// operator the read was truncated. Fires at most once per /memstats
+		// request so it cannot spam the log.
+		logger.Debug().Err(err).Msg("partial read of /proc/self/status")
+	}
+	return out
+}
+
+// readGlibcHeap walks /proc/self/maps for the [heap] segment so we can tell
+// whether RSS bloat lives in the program-break heap (single arena) or in
+// mmap'd anonymous regions (multiple per-thread arenas). Returns nil when
+// the [heap] line is absent — hardened kernels and some LSMs strip the
+// pseudo-pathname, in which case the response simply omits glibc_heap.
+func readGlibcHeap(logger zerolog.Logger) *glibcHeapStats {
+	f, err := os.Open("/proc/self/maps")
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// /proc/self/maps lines for some kernels exceed bufio's default 64 KiB
+	// when paths are deep. Give the scanner a 1 MiB ceiling.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// /proc/<pid>/maps emits "[heap]" as the trailing pseudo-pathname for the
+		// program-break segment (kernel fs/proc/task_mmu.c). Hardened kernels can
+		// strip pseudo-pathnames altogether — the function then silently returns
+		// nil and the response omits the glibc_heap field, which is fine.
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[len(fields)-1] != "[heap]" {
+			continue
+		}
+		// fields[0] is "<startHex>-<endHex>"
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		startHex := fields[0][:dash]
+		endHex := fields[0][dash+1:]
+		start, err1 := strconv.ParseUint(startHex, 16, 64)
+		end, err2 := strconv.ParseUint(endHex, 16, 64)
+		if err1 != nil || err2 != nil || end < start {
+			continue
+		}
+		return &glibcHeapStats{
+			HeapStartHex: fmt.Sprintf("0x%s", startHex),
+			HeapEndHex:   fmt.Sprintf("0x%s", endHex),
+			HeapSizeKB:   (end - start) / 1024,
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		logger.Debug().Err(err).Msg("partial read of /proc/self/maps")
+	}
+	return nil
+}

--- a/internal/api/debug_proc_other.go
+++ b/internal/api/debug_proc_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package api
+
+import "github.com/rs/zerolog"
+
+// readProcStatus is a no-op outside Linux. /proc/self/status doesn't exist
+// on darwin or windows, so the memstats response simply omits the process
+// field on those platforms.
+func readProcStatus(_ zerolog.Logger) *processMemStats { return nil }
+
+// readGlibcHeap is a no-op outside Linux. The [heap] pseudo-segment is a
+// linux-kernel concept; macOS uses libmalloc with different bookkeeping.
+func readGlibcHeap(_ zerolog.Logger) *glibcHeapStats { return nil }

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -64,18 +64,24 @@ func fileMetadata(path string) (sizeBytes int64, sha256hex string, err error) {
 	return n, fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-// lastFreeOSMemoryNano is the last time freeOSMemoryThrottled fired, used to debounce GC calls.
-var lastFreeOSMemoryNano atomic.Int64
+// freeOSMemoryProcessStart anchors the throttle to the monotonic clock so wall
+// clock adjustments (NTP steps, manual `date` changes) cannot misbehave.
+var freeOSMemoryProcessStart = time.Now()
+
+// lastFreeOSMemoryNanos is the time freeOSMemoryThrottled last fired, stored
+// as nanoseconds since freeOSMemoryProcessStart (monotonic).
+var lastFreeOSMemoryNanos atomic.Int64
 
 // freeOSMemoryThrottled fires debug.FreeOSMemory in a goroutine at most once every 30 seconds.
 // This prevents GC storms when multiple concurrent delete/retention requests complete together.
 func freeOSMemoryThrottled() {
-	now := time.Now().UnixNano()
-	last := lastFreeOSMemoryNano.Load()
-	if now-last < int64(30*time.Second) {
+	now := time.Since(freeOSMemoryProcessStart).Nanoseconds()
+	last := lastFreeOSMemoryNanos.Load()
+	// last==0 means "never fired" — first call always proceeds.
+	if last != 0 && now-last < int64(30*time.Second) {
 		return
 	}
-	if lastFreeOSMemoryNano.CompareAndSwap(last, now) {
+	if lastFreeOSMemoryNanos.CompareAndSwap(last, now) {
 		go debug.FreeOSMemory()
 	}
 }

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/basekick-labs/arc/internal/memtrim"
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/rs/zerolog"
 )
@@ -358,26 +359,27 @@ func (d *DuckDB) ConfigureS3(s3cfg *S3Config) error {
 }
 
 // ClearHTTPCache clears DuckDB's cache_httpfs and parquet_metadata_cache.
-// This should be called after compaction deletes files to prevent stale cache hits
-// (glob results, file metadata, and data blocks pointing to deleted parquet files).
-// Safe to call even if cache_httpfs is not loaded — the error is silently ignored.
+// Call after compaction/delete/retention so subsequent queries don't hit stale
+// cache entries pointing to files that no longer exist. Also asks glibc to
+// release native-heap pages — debug.FreeOSMemory only covers Go-managed memory;
+// CGo allocations from the DuckDB httpfs extension live outside it.
 func (d *DuckDB) ClearHTTPCache() {
-	// Clear cache_httpfs (glob results, data blocks, file handles, file metadata)
 	if _, err := d.db.Exec("SELECT cache_httpfs_clear_cache()"); err != nil {
 		d.logger.Debug().Err(err).Msg("cache_httpfs_clear_cache not available (extension may not be loaded)")
 	} else {
 		d.logger.Info().Msg("Cleared cache_httpfs cache")
 	}
 
-	// Reset parquet_metadata_cache by toggling off/on to clear cached schema for deleted files
 	if _, err := d.db.Exec("SET GLOBAL parquet_metadata_cache=false"); err != nil {
 		d.logger.Debug().Err(err).Msg("Failed to disable parquet_metadata_cache")
+	} else if _, err := d.db.Exec("SET GLOBAL parquet_metadata_cache=true"); err != nil {
+		d.logger.Warn().Err(err).Msg("Failed to re-enable parquet_metadata_cache")
 	} else {
-		if _, err := d.db.Exec("SET GLOBAL parquet_metadata_cache=true"); err != nil {
-			d.logger.Warn().Err(err).Msg("Failed to re-enable parquet_metadata_cache")
-		} else {
-			d.logger.Info().Msg("Reset parquet_metadata_cache")
-		}
+		d.logger.Info().Msg("Reset parquet_metadata_cache")
+	}
+
+	if memtrim.ReleaseToOS() {
+		d.logger.Info().Str("source", "clear_http_cache").Msg("Released glibc heap pages to OS")
 	}
 }
 

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -370,9 +370,13 @@ func (d *DuckDB) ClearHTTPCache() {
 		d.logger.Info().Msg("Cleared cache_httpfs cache")
 	}
 
+	// Toggle disable then re-enable — always attempt the re-enable even if
+	// disable failed, so a transient disable error doesn't leave the cache
+	// in an unintended off state on a connection.
 	if _, err := d.db.Exec("SET GLOBAL parquet_metadata_cache=false"); err != nil {
 		d.logger.Debug().Err(err).Msg("Failed to disable parquet_metadata_cache")
-	} else if _, err := d.db.Exec("SET GLOBAL parquet_metadata_cache=true"); err != nil {
+	}
+	if _, err := d.db.Exec("SET GLOBAL parquet_metadata_cache=true"); err != nil {
 		d.logger.Warn().Err(err).Msg("Failed to re-enable parquet_metadata_cache")
 	} else {
 		d.logger.Info().Msg("Reset parquet_metadata_cache")

--- a/internal/memtrim/memtrim_linux.go
+++ b/internal/memtrim/memtrim_linux.go
@@ -1,0 +1,45 @@
+//go:build linux && cgo
+
+package memtrim
+
+/*
+#ifdef __GLIBC__
+#include <malloc.h>
+#else
+// musl, uClibc, and other Linux libcs do not provide malloc_trim.
+// Treat as a no-op so cgo builds on Alpine etc. still compile.
+static int malloc_trim(size_t pad) { (void)pad; return 0; }
+#endif
+*/
+import "C"
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// minTrimInterval throttles ReleaseToOS so concurrent retention/delete/compaction
+// callers can't serialize the process under glibc's allocator lock.
+const minTrimInterval = 30 * time.Second
+
+var lastTrimNano atomic.Int64
+
+// ReleaseToOS asks glibc to return free heap pages to the OS via malloc_trim(0).
+// debug.FreeOSMemory only releases Go-managed memory; CGo allocations from the
+// DuckDB httpfs extension live in glibc arenas that need an explicit trim.
+//
+// Throttled to once per minTrimInterval across the whole process. Calls that
+// arrive inside the window return false without invoking the C function.
+// On non-glibc Linux libcs (musl, uClibc) the C call is a stub and always
+// returns 0; outside Linux see memtrim_other.go.
+func ReleaseToOS() bool {
+	now := time.Now().UnixNano()
+	last := lastTrimNano.Load()
+	if now-last < int64(minTrimInterval) {
+		return false
+	}
+	if !lastTrimNano.CompareAndSwap(last, now) {
+		return false
+	}
+	return C.malloc_trim(0) == 1
+}

--- a/internal/memtrim/memtrim_linux.go
+++ b/internal/memtrim/memtrim_linux.go
@@ -22,7 +22,13 @@ import (
 // callers can't serialize the process under glibc's allocator lock.
 const minTrimInterval = 30 * time.Second
 
-var lastTrimNano atomic.Int64
+// processStart anchors the throttle to the monotonic clock so wall-clock
+// adjustments (NTP steps, daylight saving, manual `date` changes) cannot
+// cause the throttle window to misbehave.
+var processStart = time.Now()
+
+// lastTrimNanos stores nanoseconds since processStart (monotonic).
+var lastTrimNanos atomic.Int64
 
 // ReleaseToOS asks glibc to return free heap pages to the OS via malloc_trim(0).
 // debug.FreeOSMemory only releases Go-managed memory; CGo allocations from the
@@ -33,12 +39,15 @@ var lastTrimNano atomic.Int64
 // On non-glibc Linux libcs (musl, uClibc) the C call is a stub and always
 // returns 0; outside Linux see memtrim_other.go.
 func ReleaseToOS() bool {
-	now := time.Now().UnixNano()
-	last := lastTrimNano.Load()
-	if now-last < int64(minTrimInterval) {
+	now := time.Since(processStart).Nanoseconds()
+	last := lastTrimNanos.Load()
+	// last==0 means "never fired" — that's not a real moment in monotonic
+	// time on a process that has been alive for any nonzero duration, so
+	// we treat it as eligible.
+	if last != 0 && now-last < int64(minTrimInterval) {
 		return false
 	}
-	if !lastTrimNano.CompareAndSwap(last, now) {
+	if !lastTrimNanos.CompareAndSwap(last, now) {
 		return false
 	}
 	return C.malloc_trim(0) == 1

--- a/internal/memtrim/memtrim_other.go
+++ b/internal/memtrim/memtrim_other.go
@@ -1,0 +1,7 @@
+//go:build !(linux && cgo)
+
+package memtrim
+
+// ReleaseToOS is a no-op outside Linux+cgo. The bug it addresses (glibc malloc
+// arenas holding pages after CGo frees) does not exist on darwin's allocator.
+func ReleaseToOS() bool { return false }

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -37,8 +37,10 @@ const (
 // not touch dial / handshake / response timeouts: those are already correct at
 // SDK defaults, and shortening them regresses cold-start and high-RTT setups.
 const (
-	// Total idle-conn cap across all hosts. Default Go is 100; we lower to bound
-	// memory growth on multi-bucket deployments.
+	// Total idle-conn cap across all hosts. Matches Go's http.DefaultTransport
+	// default — the actual leak is bounded by MaxIdleConnsPerHost+IdleConnTimeout
+	// below; this is set explicitly so the bounds are self-documenting on the
+	// transport we ship rather than inherited from a future Go default change.
 	s3MaxIdleConns = 100
 	// Per-host idle-conn cap. Sized to comfortably accommodate two concurrent
 	// multipart uploads (each at multipartConcurrency=5) without churning the

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/rs/zerolog"
 )
 
@@ -27,6 +29,23 @@ const (
 	multipartPartSize = 16 * 1024 * 1024
 	// Concurrency for multipart upload
 	multipartConcurrency = 5
+)
+
+// HTTP transport bounds for the AWS SDK client. These cap the per-process
+// idle-connection state — the leak we care about is HTTP/2 frame buffers and
+// keep-alive metadata accumulating across long retention/delete sweeps. We do
+// not touch dial / handshake / response timeouts: those are already correct at
+// SDK defaults, and shortening them regresses cold-start and high-RTT setups.
+const (
+	// Total idle-conn cap across all hosts. Default Go is 100; we lower to bound
+	// memory growth on multi-bucket deployments.
+	s3MaxIdleConns = 100
+	// Per-host idle-conn cap. Sized to comfortably accommodate two concurrent
+	// multipart uploads (each at multipartConcurrency=5) without churning the
+	// pool — at least 2*multipartConcurrency, with headroom.
+	s3MaxIdleConnsPerHost = 16
+	// How long an idle connection survives in the pool. Matches Go default.
+	s3IdleConnTimeout = 90 * time.Second
 )
 
 // S3Backend implements the Backend interface for S3 and MinIO storage
@@ -94,6 +113,18 @@ func NewS3Backend(cfg *S3Config, logger zerolog.Logger) (*S3Backend, error) {
 	} else {
 		log.Info().Msg("Using default credential chain for S3 (environment, IAM role, etc.)")
 	}
+
+	// Bounded HTTP transport: caps the idle-connection pool so per-connection
+	// HTTP/2 frame buffers and keep-alive metadata don't accumulate across
+	// long retention/delete sweeps. Honours AWS_CA_BUNDLE / proxy env vars
+	// because awshttp.NewBuildableClient builds on http.DefaultTransport.
+	httpClient := awshttp.NewBuildableClient().
+		WithTransportOptions(func(t *http.Transport) {
+			t.MaxIdleConns = s3MaxIdleConns
+			t.MaxIdleConnsPerHost = s3MaxIdleConnsPerHost
+			t.IdleConnTimeout = s3IdleConnTimeout
+		})
+	opts = append(opts, config.WithHTTPClient(httpClient))
 
 	// Load AWS config
 	awsCfg, err := config.LoadDefaultConfig(context.Background(), opts...)


### PR DESCRIPTION
## Summary

- S3-backed retention/delete leaks RSS that `debug.FreeOSMemory()` cannot reclaim because the bytes live in DuckDB httpfs's native heap and AWS SDK Go v2 transport state, not Go's heap. Local backend never showed the symptom.
- Bound the AWS SDK HTTP transport pool (`MaxIdleConns=100`, `MaxIdleConnsPerHost=16`, `IdleConnTimeout=90s`) so idle keep-alive connections don't accumulate HTTP/2 frame buffers across long sweeps.
- Add an `internal/memtrim` cgo wrapper around `malloc_trim(0)`, glibc-guarded so musl/Alpine still compiles, throttled to once per 30s so concurrent retention/delete/compaction callers can't serialize on the allocator lock. Called from `DuckDB.ClearHTTPCache()`.
- Add admin-auth `/api/v1/debug/{memstats,duckdb-memory,free-os-memory}` endpoints — these were the diagnostic surface used to attribute the leak and are retained for future support cases. `/free-os-memory` is itself throttled so a polled dashboard can't pin the runtime in stop-the-world GC.

## Reproduction & validation

Controlled Docker harness (Arc + MinIO, 873 small parquet files, 7-day retention policy, ~10% DELETE):

| metric                                   | before | after |
| ---                                      |   ---: |  ---: |
| RSS at `post_delete_5m`                  | 220 MB | 157 MB |
| Net residue (`post_delete_5m - baseline`) | +120 MB | +47 MB |
| RSS growth during 5-min idle             | +72 MB | 0 MB |

A separate experiment with `MALLOC_ARENA_MAX=2` cut residue further but caused 25–100% latency regression across the standard query suite, so it was not adopted.

## Test plan

- [x] `go build ./internal/... ./cmd/arc/...` clean on macOS arm64.
- [x] Linux/amd64 docker image builds cleanly with the in-tree Dockerfile.
- [x] Memtest harness on linux/arm64 docker shows no idle-time RSS growth (5-min wait flat at 157 MB).
- [x] Retention policy execution time unchanged (2.0s before, 2.1s after on 873 files).
- [x] `/api/v1/debug/memstats` returns expected JSON shape on Linux (with `process` and `glibc_heap` fields populated) and on macOS dev (with those fields omitted).
- [x] `POST /api/v1/debug/free-os-memory` returns 429 when called within 30s of the last successful invocation.
- [x] `internal/memtrim` builds cleanly with `CGO_ENABLED=0` (no-op fallback selected).
- [ ] Spot-check on real S3 (not MinIO) post-merge — the customer who reported the issue runs Garage; ask them to validate.

## Internal review

Four parallel review agents run before commit (correctness/failure-modes, security, Go idioms, perf/observability) — findings addressed in this commit:

- `malloc_trim` throttled at 30s in `internal/memtrim/memtrim_linux.go`
- glibc-only header guard for musl/Alpine compatibility
- Dialer/TLS handshake/expect-continue timeouts removed from SDK transport (matched defaults; misleading)
- `IdleConnTimeout` raised from 30s → 90s (Go default; over-tuning regressed cold-start)
- `MaxIdleConnsPerHost` raised from 10 → 16 (>2× `multipartConcurrency`)
- All transport bounds lifted to named constants alongside `multipart*`
- `/api/v1/debug/*` error responses no longer leak `err.Error()` to clients
- `bufio.Scanner.Err()` checked on `/proc/self/{status,maps}` reads
- `/proc/self/maps` `[heap]` parsing uses `strings.Fields` instead of `HasSuffix`
- `heap_released_delta` uses signed math to avoid uint64 underflow wrap
- Duplicate `duckdb_memory()` query loops collapsed to one helper
- Package moved from `internal/runtime/memtrim` (shadows stdlib) to `internal/memtrim`
- `Trim()` renamed to `ReleaseToOS()` for clarity

## Follow-ups (separate PRs)

Two related S3-only bugs surfaced during this work and will ship in their own PRs:
1. Double-`http://` when `s3_endpoint` already has a scheme (DuckDB receives `http://http://host:port`).
2. DELETE rewrite fails on non-TLS S3 with `compute input header checksum failed, unseekable stream is not supported without TLS and trailing checksum` — AWS SDK Go v2 needs a seekable body for the new mandatory checksum, but our `rewriteS3File` wraps `*os.File` in `io.TeeReader` for SHA256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)