### PR TITLE
fix(storage): strip URL scheme from s3_endpoint before DuckDB

### DIFF
--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -44,6 +44,17 @@ func escapeSQLString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
 
+// stripURLScheme removes a leading "http://" or "https://" prefix.
+// DuckDB's httpfs extension expects a bare "host:port" in s3_endpoint and
+// prepends scheme based on s3_use_ssl. The AWS SDK accepts either form, so
+// users routinely include the scheme — passing it verbatim to DuckDB
+// produces "http://http://host:port/..." URLs that fail to resolve.
+func stripURLScheme(endpoint string) string {
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	return endpoint
+}
+
 // Config holds DuckDB configuration
 type Config struct {
 	MaxConnections int
@@ -195,7 +206,7 @@ func configureS3Access(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 
 	// Set custom endpoint for MinIO or S3-compatible services
 	if cfg.S3Endpoint != "" {
-		if _, err := db.Exec(fmt.Sprintf("SET GLOBAL s3_endpoint='%s'", escapeSQLString(cfg.S3Endpoint))); err != nil {
+		if _, err := db.Exec(fmt.Sprintf("SET GLOBAL s3_endpoint='%s'", escapeSQLString(stripURLScheme(cfg.S3Endpoint)))); err != nil {
 			return fmt.Errorf("failed to set s3_endpoint: %w", err)
 		}
 	}
@@ -325,7 +336,7 @@ func (d *DuckDB) ConfigureS3(s3cfg *S3Config) error {
 
 	// Set custom endpoint for MinIO or S3-compatible services
 	if s3cfg.Endpoint != "" {
-		if _, err := d.db.Exec(fmt.Sprintf("SET GLOBAL s3_endpoint='%s'", escapeSQLString(s3cfg.Endpoint))); err != nil {
+		if _, err := d.db.Exec(fmt.Sprintf("SET GLOBAL s3_endpoint='%s'", escapeSQLString(stripURLScheme(s3cfg.Endpoint)))); err != nil {
 			return fmt.Errorf("failed to set s3_endpoint: %w", err)
 		}
 	}

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -44,14 +44,21 @@ func escapeSQLString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
 
-// stripURLScheme removes a leading "http://" or "https://" prefix.
+// stripURLScheme removes a leading "http://" or "https://" prefix
+// (case-insensitive — RFC 3986 schemes are case-insensitive and users
+// routinely paste mixed-case from docs or IDE autocomplete).
 // DuckDB's httpfs extension expects a bare "host:port" in s3_endpoint and
 // prepends scheme based on s3_use_ssl. The AWS SDK accepts either form, so
 // users routinely include the scheme — passing it verbatim to DuckDB
 // produces "http://http://host:port/..." URLs that fail to resolve.
 func stripURLScheme(endpoint string) string {
-	endpoint = strings.TrimPrefix(endpoint, "https://")
-	endpoint = strings.TrimPrefix(endpoint, "http://")
+	lower := strings.ToLower(endpoint)
+	if strings.HasPrefix(lower, "https://") {
+		return endpoint[len("https://"):]
+	}
+	if strings.HasPrefix(lower, "http://") {
+		return endpoint[len("http://"):]
+	}
 	return endpoint
 }
 

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -44,22 +44,30 @@ func escapeSQLString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
 
-// stripURLScheme removes a leading "http://" or "https://" prefix
-// (case-insensitive — RFC 3986 schemes are case-insensitive and users
-// routinely paste mixed-case from docs or IDE autocomplete).
-// DuckDB's httpfs extension expects a bare "host:port" in s3_endpoint and
-// prepends scheme based on s3_use_ssl. The AWS SDK accepts either form, so
-// users routinely include the scheme — passing it verbatim to DuckDB
-// produces "http://http://host:port/..." URLs that fail to resolve.
+// stripURLScheme normalises an S3 endpoint into the bare "host:port" form
+// that DuckDB's httpfs extension expects. The AWS SDK accepts either
+// "host:port" or "scheme://host:port[/]"; DuckDB does not. Passing scheme'd
+// or trailing-slashed input through verbatim produces "http://http://..."
+// URLs that fail to resolve.
+//
+// Strips, in order:
+//  - leading and trailing whitespace (paste artefacts),
+//  - leading "http://" or "https://" (case-insensitive — RFC 3986 schemes
+//    are case-insensitive and users routinely paste mixed-case),
+//  - trailing slashes ("host:port/" → "host:port").
+//
+// The case of the remainder is preserved (bucket names and path components
+// can be case-sensitive depending on the S3 implementation).
 func stripURLScheme(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
 	lower := strings.ToLower(endpoint)
-	if strings.HasPrefix(lower, "https://") {
-		return endpoint[len("https://"):]
+	switch {
+	case strings.HasPrefix(lower, "https://"):
+		endpoint = endpoint[len("https://"):]
+	case strings.HasPrefix(lower, "http://"):
+		endpoint = endpoint[len("http://"):]
 	}
-	if strings.HasPrefix(lower, "http://") {
-		return endpoint[len("http://"):]
-	}
-	return endpoint
+	return strings.TrimRight(endpoint, "/")
 }
 
 // Config holds DuckDB configuration

--- a/internal/database/duckdb_test.go
+++ b/internal/database/duckdb_test.go
@@ -54,3 +54,56 @@ func TestEscapeSQLString(t *testing.T) {
 		})
 	}
 }
+
+func TestStripURLScheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "http scheme",
+			input:    "http://minio:9000",
+			expected: "minio:9000",
+		},
+		{
+			name:     "https scheme",
+			input:    "https://s3.amazonaws.com",
+			expected: "s3.amazonaws.com",
+		},
+		{
+			name:     "no scheme passthrough",
+			input:    "minio:9000",
+			expected: "minio:9000",
+		},
+		{
+			name:     "localhost no scheme",
+			input:    "localhost:9000",
+			expected: "localhost:9000",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "https with path",
+			input:    "https://garage.example.com:3900",
+			expected: "garage.example.com:3900",
+		},
+		{
+			name:     "scheme not at start does not match",
+			input:    "weird-host-http://name",
+			expected: "weird-host-http://name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripURLScheme(tt.input)
+			if result != tt.expected {
+				t.Errorf("stripURLScheme(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/database/duckdb_test.go
+++ b/internal/database/duckdb_test.go
@@ -87,7 +87,7 @@ func TestStripURLScheme(t *testing.T) {
 			expected: "",
 		},
 		{
-			name:     "https with path",
+			name:     "https with port",
 			input:    "https://garage.example.com:3900",
 			expected: "garage.example.com:3900",
 		},
@@ -120,6 +120,36 @@ func TestStripURLScheme(t *testing.T) {
 			name:     "preserve case in remainder",
 			input:    "http://MyBucket.example.com",
 			expected: "MyBucket.example.com",
+		},
+		{
+			name:     "trim trailing slash",
+			input:    "http://minio:9000/",
+			expected: "minio:9000",
+		},
+		{
+			name:     "trim multiple trailing slashes",
+			input:    "https://s3.amazonaws.com///",
+			expected: "s3.amazonaws.com",
+		},
+		{
+			name:     "trim trailing slash with no scheme",
+			input:    "minio:9000/",
+			expected: "minio:9000",
+		},
+		{
+			name:     "trim leading and trailing whitespace",
+			input:    "  http://minio:9000  ",
+			expected: "minio:9000",
+		},
+		{
+			name:     "trim whitespace and trailing slash combined",
+			input:    "  https://s3.amazonaws.com/  ",
+			expected: "s3.amazonaws.com",
+		},
+		{
+			name:     "whitespace only is empty",
+			input:    "   ",
+			expected: "",
 		},
 	}
 

--- a/internal/database/duckdb_test.go
+++ b/internal/database/duckdb_test.go
@@ -96,6 +96,31 @@ func TestStripURLScheme(t *testing.T) {
 			input:    "weird-host-http://name",
 			expected: "weird-host-http://name",
 		},
+		{
+			name:     "uppercase HTTP scheme",
+			input:    "HTTP://minio:9000",
+			expected: "minio:9000",
+		},
+		{
+			name:     "uppercase HTTPS scheme",
+			input:    "HTTPS://s3.amazonaws.com",
+			expected: "s3.amazonaws.com",
+		},
+		{
+			name:     "mixed case Http scheme",
+			input:    "Http://minio:9000",
+			expected: "minio:9000",
+		},
+		{
+			name:     "mixed case Https scheme",
+			input:    "Https://s3.amazonaws.com",
+			expected: "s3.amazonaws.com",
+		},
+		{
+			name:     "preserve case in remainder",
+			input:    "http://MyBucket.example.com",
+			expected: "MyBucket.example.com",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- The AWS SDK Go v2 accepts \`s3_endpoint\` with or without an \`http(s)://\` prefix and prepends the scheme if missing. DuckDB's \`httpfs\` extension expects a bare \`host:port\` and prepends scheme based on \`s3_use_ssl\`. The two consumers had OPPOSITE expectations.
- Result: when a user set \`s3_endpoint = "http://host:port"\` in \`arc.toml\` (matching the AWS SDK convention and \`deploy/docker-compose/oss-s3/docker-compose.yml:25\`), DuckDB built malformed URLs of the form \`http://http://host:port/...\` and every \`read_parquet()\` against S3 failed with \`Could not resolve hostname\`.
- Added a small \`stripURLScheme\` helper called at both DuckDB \`SET GLOBAL s3_endpoint\` sites: \`configureS3Access\` (startup) and \`ConfigureS3\` (runtime, for tiered storage). Either input format now works.

## Origin

This bug was caught empirically during the PR #420 memtest reproduction. Customers running Garage or other S3-compatible backends over plain HTTP would hit this if they ever set the scheme in \`arc.toml\`.

## Test plan

- [x] \`go build ./internal/database/... ./cmd/arc/...\` clean.
- [x] \`go test ./internal/database/... -run TestStripURLScheme\` — 7 cases passing (\`http://\` strip, \`https://\` strip, no-scheme passthrough, empty string, scheme-not-at-start no-match).
- [x] End-to-end memtest validation: set \`s3_endpoint = "http://minio:9000"\` in the memtest harness, ran retention against 871 small parquet files. **Pre-fix**: every \`read_parquet\` errored with \`Could not resolve hostname\`. **Post-fix**: retention completed cleanly in 2s, deleted 668 files (441,600 rows). No \`http://http://\` strings appear in the Arc logs.
- [ ] Spot-check on AWS S3 (TLS endpoint) — the path through \`stripURLScheme\` strips \`https://\` too, so this needs a sanity check post-merge.

## What this PR explicitly does NOT do

- Doesn't change SDK-side endpoint handling — that already accepts both forms correctly via the existing \`strings.HasPrefix\` check at \`internal/storage/s3.go:144\`.
- Doesn't update \`arc.toml\` comments or \`config.go\` docstrings — both forms now work, so the existing docs are no longer wrong; users who follow either convention get a working deployment.
- Doesn't add config-load validation — accepting any input the helper can normalise is the simpler contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)