### PR TITLE
fix(delete): pass seekable file body to S3 upload for non-TLS PUT

### DIFF
--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -809,8 +809,16 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 		return 0, nil, fmt.Errorf("failed to write filtered data: %w", err)
 	}
 
-	// Open temp file, compute SHA256 and size while streaming the upload via
-	// io.TeeReader — single pass over the file instead of two.
+	// Compute SHA256 by full-reading the temp file, then Seek(0,0) and pass
+	// the seekable *os.File to the storage backend. Two reads of the same
+	// file, but the second hits OS page cache so disk is touched once.
+	//
+	// We can't use io.TeeReader here (one pass instead of two): AWS SDK Go v2
+	// requires either TLS or a seekable body to compute the mandatory request
+	// checksum. TeeReader-wrapping an *os.File is non-seekable and breaks
+	// uploads to plain-HTTP S3 (MinIO, Garage) with:
+	//   "compute input header checksum failed, unseekable stream is not
+	//    supported without TLS and trailing checksum"
 	uploadFile, err := os.Open(tempPath)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to open temp file for upload: %w", err)
@@ -824,11 +832,18 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 	sizeBytes := info.Size()
 
 	h256 := sha256.New()
-	tee := io.TeeReader(uploadFile, h256)
-	if err := h.storage.WriteReader(ctx, relativePath, tee, sizeBytes); err != nil {
-		return 0, nil, fmt.Errorf("failed to upload rewritten file to remote storage: %w", err)
+	if _, err := io.Copy(h256, uploadFile); err != nil {
+		return 0, nil, fmt.Errorf("failed to compute SHA256 of rewritten file: %w", err)
 	}
 	sha256hex := fmt.Sprintf("%x", h256.Sum(nil))
+
+	if _, err := uploadFile.Seek(0, io.SeekStart); err != nil {
+		return 0, nil, fmt.Errorf("failed to rewind rewritten file for upload: %w", err)
+	}
+
+	if err := h.storage.WriteReader(ctx, relativePath, uploadFile, sizeBytes); err != nil {
+		return 0, nil, fmt.Errorf("failed to upload rewritten file to remote storage: %w", err)
+	}
 
 	h.logger.Info().
 		Str("file", filepath.Base(relativePath)).


### PR DESCRIPTION
## Summary

- DELETE rewrites against plain-HTTP S3 (MinIO, Garage) consistently failed with \`compute input header checksum failed, unseekable stream is not supported without TLS and trailing checksum\`.
- AWS SDK Go v2 (\`aws-sdk-go-v2/service/s3 v1.99.0\`, post-Feb 2025) requires either TLS or a seekable body to compute the mandatory request checksum. The previous \`io.TeeReader\`-based single-pass approach loses seekability even though the underlying \`*os.File\` is seekable.
- Replace the TeeReader with a two-step "hash, then seek-and-upload": \`io.Copy\` to the SHA256 hasher, \`Seek(0, io.SeekStart)\`, then pass the seekable \`*os.File\` directly to \`storage.WriteReader\`. The second read hits OS page cache, so disk I/O is unchanged.

## Origin

This bug was caught empirically during the PR #420 memtest reproduction — every DELETE phase failed with the unseekable-stream error against MinIO. Customers running Garage over plain HTTP would hit it identically.

## Test plan

- [x] \`go build ./internal/api/... ./cmd/arc/...\` clean.
- [x] End-to-end memtest validation. Pre-fix DELETE phase: \`success: false, rewritten_files: 0, failed_files: 200\`, all with the unseekable-stream error. **Post-fix DELETE phase: \`success: true, rewritten_files: 199, deleted_count: 13553, execution_time_ms: 1486\`. No errors.**
- [x] Retention path unaffected — only DELETE goes through \`rewriteS3File\`. Retention timing in the validation run (2.3s for 658 files deleted) is identical to baseline.
- [x] Ingest path unaffected — ingest uses \`*bytes.Buffer\` which is already seekable.
- [ ] Spot-check on AWS S3 (TLS). The change is a strict improvement (TLS path was already working with TeeReader; non-TLS now works too), but worth a smoke test post-merge.

## What this PR explicitly does NOT do

- Doesn't touch \`internal/storage/backend.go\` interface — \`io.Reader\` is still the contract.
- Doesn't disable the SDK's request checksum (would drop a real integrity check).
- Doesn't change ingest write paths — they were never affected.

## Why two reads is fine

- The temp file is the rewritten parquet output of a DuckDB \`COPY\` — typically a few KB to a few MB per file.
- First read populates OS page cache; second read serves from cache.
- Net disk I/O: identical to the single-pass version.
- CPU: slightly higher (SHA256 done before any upload progress) but negligible against the upload latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)