### PR TITLE
fix(query): break streaming loop on Flush error so DuckDB result buffers free on client disconnect

### DIFF
--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -112,6 +112,28 @@ The eliminated +72 MB-during-idle growth is the customer's exact symptom — RSS
 
 **Note on `MALLOC_ARENA_MAX=2`.** A separate experiment with `MALLOC_ARENA_MAX=2` cut residue further but caused 25–100% latency regression across the standard query suite, so it was not adopted. The 30s throttle on `ReleaseToOS()` keeps allocator-lock contention bounded without restricting glibc's per-thread arena count.
 
+### Query Path: Abort Streaming on Client Disconnect (PR #TBD)
+
+The Arrow-based streaming query handlers (`/api/v1/query` and `/api/v1/query/arrow`) write results to the client via Fiber's async `SetBodyStreamWriter`. When a client closed the connection mid-stream — closing a Grafana panel, killing a browser tab, Cmd-W on a dashboard — the streaming goroutine had no way to learn the client had gone away. fasthttp's `RequestCtx.Done()` only fires on server shutdown, not per-request disconnect ([fasthttp@v1.51.0/server.go:2719-2745](https://github.com/valyala/fasthttp/blob/v1.51.0/server.go#L2719-L2745)), and the streaming code used `context.Background()` deliberately because `c.UserContext()` is cancelled when the handler returns (before the async stream writer runs).
+
+The streaming loop would keep calling `reader.Next()` on the Arrow record reader, draining DuckDB result batches into a buffer nobody was reading, until either the query naturally completed or the per-request `queryTimeout` (default 300s) fired. For heavy time-bucket aggregations and wide GROUP BYs on long time ranges, that's tens of MB of result-set memory held per cancelled query.
+
+The fix is mechanical: capture the error from `bufio.Writer.Flush()` and break the streaming loop on the first failed flush, which is the canonical signal in fasthttp's streaming model that the underlying TCP connection has been closed. Six lines of change per handler in [internal/api/query_arrow.go](internal/api/query_arrow.go) and [internal/api/query_arrow_json.go](internal/api/query_arrow_json.go). Regression test in `query_arrow_json_test.go` uses an `io.Writer` that fails after N bytes and asserts the loop breaks before draining the full result set.
+
+This is **complementary to but distinct from** the #420 retention/delete leak: that fix targeted DuckDB native heap residue after S3 reads; this one targets in-flight Arrow record batches held on the goroutine stack when the client abandons a query mid-stream.
+
+### S3 Endpoint Scheme Normalization for DuckDB (PR #422)
+
+The AWS SDK Go v2 accepts `s3_endpoint` with or without an `http(s)://` prefix; DuckDB's `httpfs` extension expects a bare `host:port` and prepends scheme based on `s3_use_ssl`. With `s3_endpoint = "http://host:port"` in `arc.toml` (matching the AWS SDK convention), DuckDB built malformed URLs of the form `http://http://host:port/...` and every `read_parquet()` against S3 failed with `Could not resolve hostname`.
+
+Added a small `stripURLScheme` helper in [internal/database/duckdb.go](internal/database/duckdb.go), called at both `SET GLOBAL s3_endpoint` sites (startup and runtime reconfigure for tiered storage). Case-insensitive, also trims whitespace and trailing slashes — accepts `http://host:port`, `https://host:port/`, `HTTP://host:port`, ` host:port `, and the bare `host:port` form transparently. 18 unit test cases.
+
+### DELETE Rewrite on Non-TLS S3 (PR #423)
+
+The DELETE API rewrites parquet files to remove rows matching a WHERE clause and uploads them back to S3. Against plain-HTTP S3 (MinIO, Garage), every rewrite failed with `compute input header checksum failed, unseekable stream is not supported without TLS and trailing checksum`. AWS SDK Go v2 (`aws-sdk-go-v2/service/s3 v1.99.0`, post-Feb 2025) requires either TLS or a seekable body for the mandatory request checksum, and the previous `io.TeeReader` single-pass SHA256+upload pattern lost the underlying `*os.File`'s seekability.
+
+Replaced the TeeReader with a two-step "hash, then seek-and-upload": `io.Copy` into the SHA256 hasher, `Seek(0, io.SeekStart)`, pass the seekable `*os.File` directly to `storage.WriteReader`. The second read hits OS page cache so disk I/O is unchanged. Validated against MinIO over plain HTTP: 199/199 files rewritten (pre-fix: 0/200).
+
 ---
 
 _Maintainer notes: keep this file at the repo root (per [memory/project_release_strategy.md](memory/project_release_strategy.md)); do not write to `docs/RELEASE_NOTES_*` (that path is stale)._

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -115,6 +115,25 @@ var arrowJSONQueryFunc func(h *QueryHandler, c *fiber.Ctx, ctx context.Context, 
 // stream failures (genuine bug, log at Error).
 var errClientDisconnected = errors.New("client disconnected mid-stream")
 
+// isClientError reports whether err originated from the client side — either
+// the connection was closed mid-stream, the request's deadline elapsed, or
+// the request context was cancelled. These are expected operational events
+// and should be logged at Warn, not Error.
+func isClientError(err error) bool {
+	return errors.Is(err, errClientDisconnected) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled)
+}
+
+// streamErrEvent picks the right zerolog level for a stream-truncation
+// error: Warn for client-side events, Error for server-side failures.
+func (h *QueryHandler) streamErrEvent(err error) *zerolog.Event {
+	if isClientError(err) {
+		return h.logger.Warn()
+	}
+	return h.logger.Error()
+}
+
 // isIdentChar returns true if c is a valid SQL identifier character (a-z, A-Z, 0-9, _)
 func isIdentChar(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
@@ -1544,13 +1563,7 @@ localProcessing:
 				// Warn for client-disconnect / context expiry (headers already
 				// committed, partial result was delivered). Error for genuine
 				// server-side failures (scanner, db iteration).
-				ev := h.logger.Error()
-				if errors.Is(streamErr, errClientDisconnected) ||
-					errors.Is(streamErr, context.DeadlineExceeded) ||
-					errors.Is(streamErr, context.Canceled) {
-					ev = h.logger.Warn()
-				}
-				ev.Err(streamErr).
+				h.streamErrEvent(streamErr).Err(streamErr).
 					Int("rows_sent", rowCount).
 					Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 					Msg("Query stream truncated after headers committed; client received partial result")
@@ -1738,13 +1751,7 @@ localProcessing:
 				// Warn for client-disconnect / context expiry (headers already
 				// committed, partial result was delivered). Error for genuine
 				// server-side failures (scanner, db iteration).
-				ev := h.logger.Error()
-				if errors.Is(streamErr, errClientDisconnected) ||
-					errors.Is(streamErr, context.DeadlineExceeded) ||
-					errors.Is(streamErr, context.Canceled) {
-					ev = h.logger.Warn()
-				}
-				ev.Err(streamErr).
+				h.streamErrEvent(streamErr).Err(streamErr).
 					Int("rows_sent", rowCount).
 					Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 					Msg("Query stream truncated after headers committed; client received partial result")
@@ -3446,13 +3453,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 			// Warn for client-disconnect / context expiry (headers already
 			// committed, partial result was delivered). Error for genuine
 			// server-side failures.
-			ev := h.logger.Error()
-			if errors.Is(streamErr, errClientDisconnected) ||
-				errors.Is(streamErr, context.DeadlineExceeded) ||
-				errors.Is(streamErr, context.Canceled) {
-				ev = h.logger.Warn()
-			}
-			ev.Err(streamErr).
+			h.streamErrEvent(streamErr).Err(streamErr).
 				Str("measurement", measurement).
 				Int("rows_sent", rowCount).
 				Msg("queryMeasurement stream truncated after headers committed")

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1533,7 +1533,7 @@ localProcessing:
 						h.queryRegistry.Fail(queryID, streamErr.Error())
 					}
 				}
-				h.logger.Error().Err(streamErr).
+				h.logger.Warn().Err(streamErr).
 					Int("rows_sent", rowCount).
 					Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 					Msg("Query stream truncated after headers committed; client received partial result")
@@ -1718,7 +1718,7 @@ localProcessing:
 						h.queryRegistry.Fail(queryID, streamErr.Error())
 					}
 				}
-				h.logger.Error().Err(streamErr).
+				h.logger.Warn().Err(streamErr).
 					Int("rows_sent", rowCount).
 					Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 					Msg("Query stream truncated after headers committed; client received partial result")
@@ -3417,7 +3417,10 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 
 		if streamErr != nil {
 			m.IncQueryErrors()
-			h.logger.Error().Err(streamErr).
+			// Warn (not Error): headers were already committed when this
+			// fired, so the client got a partial result. The common cause
+			// is client disconnect mid-stream (expected ops noise).
+			h.logger.Warn().Err(streamErr).
 				Str("measurement", measurement).
 				Int("rows_sent", rowCount).
 				Msg("queryMeasurement stream truncated after headers committed")

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -107,6 +107,14 @@ var (
 // Returns (rowCount, handled). If handled is false, the caller falls back to database/sql.
 var arrowJSONQueryFunc func(h *QueryHandler, c *fiber.Ctx, ctx context.Context, cancel context.CancelFunc, convertedSQL string, profileMode bool, governanceMaxRows int, start time.Time, timestamp string, onComplete func(int), onFail func(string), onTimeout func()) (int, bool)
 
+// errClientDisconnected is wrapped into streamErr by the streaming query
+// handlers when bufio.Writer.Write or Flush fails mid-stream — the canonical
+// signal in fasthttp's streaming model that the underlying TCP connection
+// has been closed by the client. Callers use errors.Is to disambiguate
+// client-side disconnect (operational noise, log at Warn) from server-side
+// stream failures (genuine bug, log at Error).
+var errClientDisconnected = errors.New("client disconnected mid-stream")
+
 // isIdentChar returns true if c is a valid SQL identifier character (a-z, A-Z, 0-9, _)
 func isIdentChar(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
@@ -1533,7 +1541,16 @@ localProcessing:
 						h.queryRegistry.Fail(queryID, streamErr.Error())
 					}
 				}
-				h.logger.Warn().Err(streamErr).
+				// Warn for client-disconnect / context expiry (headers already
+				// committed, partial result was delivered). Error for genuine
+				// server-side failures (scanner, db iteration).
+				ev := h.logger.Error()
+				if errors.Is(streamErr, errClientDisconnected) ||
+					errors.Is(streamErr, context.DeadlineExceeded) ||
+					errors.Is(streamErr, context.Canceled) {
+					ev = h.logger.Warn()
+				}
+				ev.Err(streamErr).
 					Int("rows_sent", rowCount).
 					Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 					Msg("Query stream truncated after headers committed; client received partial result")
@@ -1718,7 +1735,16 @@ localProcessing:
 						h.queryRegistry.Fail(queryID, streamErr.Error())
 					}
 				}
-				h.logger.Warn().Err(streamErr).
+				// Warn for client-disconnect / context expiry (headers already
+				// committed, partial result was delivered). Error for genuine
+				// server-side failures (scanner, db iteration).
+				ev := h.logger.Error()
+				if errors.Is(streamErr, errClientDisconnected) ||
+					errors.Is(streamErr, context.DeadlineExceeded) ||
+					errors.Is(streamErr, context.Canceled) {
+					ev = h.logger.Warn()
+				}
+				ev.Err(streamErr).
 					Int("rows_sent", rowCount).
 					Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 					Msg("Query stream truncated after headers committed; client received partial result")
@@ -3417,10 +3443,16 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 
 		if streamErr != nil {
 			m.IncQueryErrors()
-			// Warn (not Error): headers were already committed when this
-			// fired, so the client got a partial result. The common cause
-			// is client disconnect mid-stream (expected ops noise).
-			h.logger.Warn().Err(streamErr).
+			// Warn for client-disconnect / context expiry (headers already
+			// committed, partial result was delivered). Error for genuine
+			// server-side failures.
+			ev := h.logger.Error()
+			if errors.Is(streamErr, errClientDisconnected) ||
+				errors.Is(streamErr, context.DeadlineExceeded) ||
+				errors.Is(streamErr, context.Canceled) {
+				ev = h.logger.Warn()
+			}
+			ev.Err(streamErr).
 				Str("measurement", measurement).
 				Int("rows_sent", rowCount).
 				Msg("queryMeasurement stream truncated after headers committed")

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -5,6 +5,7 @@ package api
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -137,6 +138,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		ipcWriter := ipc.NewWriter(w, ipc.WithSchema(schema))
 
 		var totalRows int64
+		var streamErr error
 	streamLoop:
 		for reader.Next() {
 			// Per-batch ctx check: a timeout firing or client disconnect
@@ -146,10 +148,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			// break is the idiomatic Go cancellation pattern (gemini r1).
 			select {
 			case <-streamCtx.Done():
-				h.logger.Warn().
-					Err(streamCtx.Err()).
-					Int64("rows_sent", totalRows).
-					Msg("Arrow IPC stream cancelled mid-stream")
+				streamErr = fmt.Errorf("arrow IPC stream cancelled at row %d: %w", totalRows, streamCtx.Err())
 				break streamLoop
 			default:
 			}
@@ -174,8 +173,8 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 				var castErr error
 				castedBatch, castErr = castDecimalBatch(batch, castInfo)
 				if castErr != nil {
-					h.logger.Error().Err(castErr).Msg("Failed to cast decimal columns in Arrow batch")
-					break
+					streamErr = fmt.Errorf("failed to cast decimal columns at row %d: %w", totalRows, castErr)
+					break streamLoop
 				}
 				batch = castedBatch
 			}
@@ -185,32 +184,32 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 				castedBatch.Release()
 			}
 			if err != nil {
-				h.logger.Error().Err(err).Msg("Failed to write Arrow batch")
-				break
+				streamErr = fmt.Errorf("failed to write arrow batch at row %d: %w", totalRows, err)
+				break streamLoop
 			}
 			// Capture Flush error: fasthttp's RequestCtx.Done() only fires on
 			// server shutdown (not per-request client disconnect), so the
 			// underlying bufio.Writer's error on the closed connection is our
-			// signal that the client has gone away. Breaking here stops
-			// DuckDB from draining the rest of the result set into a buffer
-			// nobody reads — the per-batch memory pressure that the user
-			// reported on heavy GROUP BYs.
+			// signal that the client has gone away. Wrap with the sentinel so
+			// the caller logs at Warn (not Error) for this expected ops noise.
 			if err := w.Flush(); err != nil {
-				h.logger.Warn().Err(err).Int64("rows_sent", totalRows).Msg("Arrow IPC stream client disconnected mid-stream")
+				streamErr = fmt.Errorf("stream flush failed at row %d: %w: %w", totalRows, errClientDisconnected, err)
 				break streamLoop
 			}
 		}
 
-		if err := reader.Err(); err != nil {
-			h.logger.Error().Err(err).Msg("Error iterating Arrow batches")
+		if streamErr == nil {
+			if err := reader.Err(); err != nil {
+				streamErr = fmt.Errorf("arrow reader error after %d rows: %w", totalRows, err)
+			}
 		}
 
 		if err := ipcWriter.Close(); err != nil {
 			// Warn (not Error): when the loop broke because the client
 			// disconnected, ipcWriter.Close is guaranteed to fail flushing
 			// trailing IPC metadata over the already-closed connection.
-			// That's the same client-disconnect event we already logged at
-			// Warn — emitting Error here would defeat the ops-noise
+			// That's the same client-disconnect event already captured in
+			// streamErr — emitting Error here would defeat the ops-noise
 			// reduction.
 			h.logger.Warn().Err(err).Msg("Failed to close Arrow IPC writer")
 		}
@@ -218,6 +217,24 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		conn.Close()
 		if cancel != nil {
 			cancel()
+		}
+
+		if streamErr != nil {
+			m.IncQueryErrors()
+			// Warn for client-disconnect / timeout (expected ops noise);
+			// Error for everything else (real server-side problem worth
+			// alerting on).
+			ev := h.logger.Error()
+			if errors.Is(streamErr, errClientDisconnected) ||
+				errors.Is(streamErr, context.DeadlineExceeded) ||
+				errors.Is(streamErr, context.Canceled) {
+				ev = h.logger.Warn()
+			}
+			ev.Err(streamErr).
+				Int64("rows_sent", totalRows).
+				Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
+				Msg("Arrow IPC stream truncated after headers committed; client received partial result")
+			return
 		}
 
 		h.logger.Info().

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -5,7 +5,6 @@ package api
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -224,13 +223,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			// Warn for client-disconnect / timeout (expected ops noise);
 			// Error for everything else (real server-side problem worth
 			// alerting on).
-			ev := h.logger.Error()
-			if errors.Is(streamErr, errClientDisconnected) ||
-				errors.Is(streamErr, context.DeadlineExceeded) ||
-				errors.Is(streamErr, context.Canceled) {
-				ev = h.logger.Warn()
-			}
-			ev.Err(streamErr).
+			h.streamErrEvent(streamErr).Err(streamErr).
 				Int64("rows_sent", totalRows).
 				Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 				Msg("Arrow IPC stream truncated after headers committed; client received partial result")

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -206,7 +206,13 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		}
 
 		if err := ipcWriter.Close(); err != nil {
-			h.logger.Error().Err(err).Msg("Failed to close Arrow IPC writer")
+			// Warn (not Error): when the loop broke because the client
+			// disconnected, ipcWriter.Close is guaranteed to fail flushing
+			// trailing IPC metadata over the already-closed connection.
+			// That's the same client-disconnect event we already logged at
+			// Warn — emitting Error here would defeat the ops-noise
+			// reduction.
+			h.logger.Warn().Err(err).Msg("Failed to close Arrow IPC writer")
 		}
 		reader.Release()
 		conn.Close()

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -188,7 +188,17 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 				h.logger.Error().Err(err).Msg("Failed to write Arrow batch")
 				break
 			}
-			w.Flush()
+			// Capture Flush error: fasthttp's RequestCtx.Done() only fires on
+			// server shutdown (not per-request client disconnect), so the
+			// underlying bufio.Writer's error on the closed connection is our
+			// signal that the client has gone away. Breaking here stops
+			// DuckDB from draining the rest of the result set into a buffer
+			// nobody reads — the per-batch memory pressure that the user
+			// reported on heavy GROUP BYs.
+			if err := w.Flush(); err != nil {
+				h.logger.Warn().Err(err).Int64("rows_sent", totalRows).Msg("Arrow IPC stream client disconnected mid-stream")
+				break streamLoop
+			}
 		}
 
 		if err := reader.Err(); err != nil {

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -147,7 +147,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			// break is the idiomatic Go cancellation pattern (gemini r1).
 			select {
 			case <-streamCtx.Done():
-				streamErr = fmt.Errorf("arrow IPC stream cancelled at row %d: %w", totalRows, streamCtx.Err())
+streamErr = fmt.Errorf("stream cancelled at row %d: %w", totalRows, streamCtx.Err())
 				break streamLoop
 			default:
 			}

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -155,7 +155,12 @@ func executeArrowJSONQuery(
 			} else if onFail != nil {
 				onFail(streamErr.Error())
 			}
-			h.logger.Error().Err(streamErr).
+			// Warn (not Error): the response headers were already committed
+			// when this fired, so by definition the client got a partial
+			// result. The common cause is the client disconnecting mid-
+			// stream (Grafana panel close, browser tab kill). That's
+			// expected ops noise, not an Arc fault.
+			h.logger.Warn().Err(streamErr).
 				Int("rows_sent", rc).
 				Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 				Msg("Arrow JSON stream truncated after headers committed; client received partial result")
@@ -270,7 +275,16 @@ batchLoop:
 			rowCount++
 
 			if rowCount%jsonFlushInterval == 0 {
-				w.Flush()
+				// Capture Flush error: fasthttp's RequestCtx.Done() only fires
+				// on server shutdown (not per-request client disconnect), so
+				// the bufio.Writer's error on the closed connection is our
+				// signal that the client has gone away. Breaking out of both
+				// nested loops stops DuckDB from draining the rest of the
+				// result set into a buffer nobody reads.
+				if err := w.Flush(); err != nil {
+					streamErr = fmt.Errorf("stream flush failed at row %d (client likely disconnected): %w", rowCount, err)
+					break batchLoop
+				}
 			}
 		}
 	}

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -159,13 +159,7 @@ func executeArrowJSONQuery(
 			// — headers were already committed, the client got partial bytes).
 			// Error for everything else: scanner/reader failures are real
 			// server-side problems worth alerting on.
-			ev := h.logger.Error()
-			if errors.Is(streamErr, errClientDisconnected) ||
-				errors.Is(streamErr, context.DeadlineExceeded) ||
-				errors.Is(streamErr, context.Canceled) {
-				ev = h.logger.Warn()
-			}
-			ev.Err(streamErr).
+			h.streamErrEvent(streamErr).Err(streamErr).
 				Int("rows_sent", rc).
 				Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 				Msg("Arrow JSON stream truncated after headers committed; client received partial result")

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -155,12 +155,17 @@ func executeArrowJSONQuery(
 			} else if onFail != nil {
 				onFail(streamErr.Error())
 			}
-			// Warn (not Error): the response headers were already committed
-			// when this fired, so by definition the client got a partial
-			// result. The common cause is the client disconnecting mid-
-			// stream (Grafana panel close, browser tab kill). That's
-			// expected ops noise, not an Arc fault.
-			h.logger.Warn().Err(streamErr).
+			// Warn for client-disconnect / context expiry (expected ops noise
+			// — headers were already committed, the client got partial bytes).
+			// Error for everything else: scanner/reader failures are real
+			// server-side problems worth alerting on.
+			ev := h.logger.Error()
+			if errors.Is(streamErr, errClientDisconnected) ||
+				errors.Is(streamErr, context.DeadlineExceeded) ||
+				errors.Is(streamErr, context.Canceled) {
+				ev = h.logger.Warn()
+			}
+			ev.Err(streamErr).
 				Int("rows_sent", rc).
 				Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 				Msg("Arrow JSON stream truncated after headers committed; client received partial result")
@@ -280,9 +285,11 @@ batchLoop:
 				// the bufio.Writer's error on the closed connection is our
 				// signal that the client has gone away. Breaking out of both
 				// nested loops stops DuckDB from draining the rest of the
-				// result set into a buffer nobody reads.
+				// result set into a buffer nobody reads. The error is wrapped
+				// with errClientDisconnected so the caller can log at Warn
+				// (not Error) for this expected ops noise.
 				if err := w.Flush(); err != nil {
-					streamErr = fmt.Errorf("stream flush failed at row %d (client likely disconnected): %w", rowCount, err)
+					streamErr = fmt.Errorf("stream flush failed at row %d: %w: %w", rowCount, errClientDisconnected, err)
 					break batchLoop
 				}
 			}

--- a/internal/api/query_arrow_json_test.go
+++ b/internal/api/query_arrow_json_test.go
@@ -370,11 +370,12 @@ func TestStreamArrowJSON_FlushErrorBreaksLoop(t *testing.T) {
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
 	}, nil)
 
-	// Need more than jsonFlushInterval (5000) rows total so the explicit
-	// Flush() is hit at row 5000. The errAfterNBytes failure point (256
-	// bytes) makes the failure happen sometime during the first batch,
-	// but bufio's internal 4 KiB buffer means the sticky error doesn't
-	// surface until the per-5000-row Flush() call.
+	// Need more than jsonFlushInterval rows total so the explicit Flush()
+	// fires at least once. The errAfterNBytes failure point (256 bytes)
+	// makes the failure happen sometime during the first batch, but
+	// bufio's internal 4 KiB buffer absorbs the sticky error until the
+	// next per-jsonFlushInterval Flush() returns it. With jsonFlushInterval
+	// = 1000 (see query_json_writer.go), 6 × 1024 = 6144 rows is plenty.
 	const (
 		batchRows  = 1024
 		numBatches = 6

--- a/internal/api/query_arrow_json_test.go
+++ b/internal/api/query_arrow_json_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -325,5 +326,93 @@ func TestStreamArrowJSON_SpecialChars(t *testing.T) {
 		if row[0].(string) != exp {
 			t.Errorf("row[%d] expected %q, got %q", i, exp, row[0])
 		}
+	}
+}
+
+// errAfterNBytes is an io.Writer that succeeds for the first n bytes then
+// returns an error. Models a TCP connection that the client closed mid-stream.
+type errAfterNBytes struct {
+	limit int
+	wrote int
+	err   error
+}
+
+func (e *errAfterNBytes) Write(p []byte) (int, error) {
+	if e.wrote >= e.limit {
+		return 0, e.err
+	}
+	remaining := e.limit - e.wrote
+	if len(p) <= remaining {
+		e.wrote += len(p)
+		return len(p), nil
+	}
+	e.wrote = e.limit
+	return remaining, e.err
+}
+
+// TestStreamArrowJSON_FlushErrorBreaksLoop verifies that when the underlying
+// connection fails (client disconnect mid-stream), streamArrowJSON stops
+// iterating record batches instead of draining the entire result set into a
+// buffer nobody is reading. Regression test for the fasthttp-RequestCtx.Done
+// limitation: that channel only fires on server shutdown, so Flush errors are
+// our only signal that the client has gone away.
+func TestStreamArrowJSON_FlushErrorBreaksLoop(t *testing.T) {
+	// Note: this test uses NewGoAllocator (not CheckedAllocator) to match
+	// the rest of the test file. The buildArrowBatch helper creates Arrow
+	// builders that aren't explicitly Released — CheckedAllocator would
+	// flag those as leaks, but they're pre-existing and out of scope for
+	// the disconnect-handling fix this test verifies. The actual code path
+	// being tested (streamArrowJSON's break-on-Flush-error) does not itself
+	// retain any Arrow memory beyond what simpleRecordReader.Release frees.
+	alloc := memory.NewGoAllocator()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	// Need more than jsonFlushInterval (5000) rows total so the explicit
+	// Flush() is hit at row 5000. The errAfterNBytes failure point (256
+	// bytes) makes the failure happen sometime during the first batch,
+	// but bufio's internal 4 KiB buffer means the sticky error doesn't
+	// surface until the per-5000-row Flush() call.
+	const (
+		batchRows  = 1024
+		numBatches = 6
+	)
+	records := make([]arrow.Record, numBatches)
+	for b := 0; b < numBatches; b++ {
+		rows := make([][]interface{}, batchRows)
+		for i := range rows {
+			rows[i] = []interface{}{int64(b*batchRows + i)}
+		}
+		records[b] = buildArrowBatch(alloc, schema, rows)
+	}
+	reader := newSimpleRecordReader(schema, records)
+	defer reader.Release()
+
+	sentinel := errors.New("client disconnected")
+	failingWriter := &errAfterNBytes{limit: 256, err: sentinel}
+	w := bufio.NewWriter(failingWriter)
+
+	rowCount, err := streamArrowJSON(
+		context.Background(), w, reader, 0, nil,
+		time.Now(), "2024-01-15T12:00:00Z",
+	)
+
+	if err == nil {
+		t.Fatalf("expected streamArrowJSON to return an error on client disconnect; got nil (rows=%d)", rowCount)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected error to wrap sentinel %v, got %v", sentinel, err)
+	}
+
+	// The break must fire at the next jsonFlushInterval boundary after
+	// the writer's 256-byte limit is exceeded — so rowCount should equal
+	// jsonFlushInterval (5000) when the first explicit Flush() returns
+	// the sticky error. Allow one extra batch of slack for bufio's
+	// internal 4 KiB buffer auto-flush timing.
+	const tighterBound = jsonFlushInterval + batchRows
+	if rowCount > tighterBound {
+		t.Errorf("loop did not break promptly on flush error: emitted %d rows, expected <= %d", rowCount, tighterBound)
 	}
 }

--- a/internal/api/query_arrow_json_test.go
+++ b/internal/api/query_arrow_json_test.go
@@ -402,16 +402,25 @@ func TestStreamArrowJSON_FlushErrorBreaksLoop(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected streamArrowJSON to return an error on client disconnect; got nil (rows=%d)", rowCount)
 	}
+	// The underlying I/O sentinel must be in the error chain so future
+	// debugging can identify the actual cause.
 	if !errors.Is(err, sentinel) {
-		t.Errorf("expected error to wrap sentinel %v, got %v", sentinel, err)
+		t.Errorf("expected error to wrap underlying I/O sentinel %v, got %v", sentinel, err)
+	}
+	// The errClientDisconnected sentinel must also be in the error chain
+	// so callers can use errors.Is to disambiguate this from genuine
+	// server-side stream failures (and log at Warn instead of Error).
+	if !errors.Is(err, errClientDisconnected) {
+		t.Errorf("expected error to wrap errClientDisconnected, got %v", err)
 	}
 
 	// The break must fire at the FIRST explicit Flush after the writer's
 	// 256-byte limit is exceeded. bufio's internal 4 KiB auto-flush hits
-	// the failing writer well before row 5000, sets the sticky error, and
-	// subsequent WriteByte/WriteString calls silently no-op. At row 5000
-	// the explicit Flush() returns the stored error and the loop breaks.
-	// So rowCount should be EXACTLY jsonFlushInterval.
+	// the failing writer well before row jsonFlushInterval, sets the
+	// sticky error, and subsequent WriteByte/WriteString calls silently
+	// no-op. At row jsonFlushInterval the explicit Flush() returns the
+	// stored error and the loop breaks. So rowCount should be EXACTLY
+	// jsonFlushInterval.
 	if rowCount != jsonFlushInterval {
 		t.Errorf("loop did not break exactly at flush boundary: emitted %d rows, expected %d", rowCount, jsonFlushInterval)
 	}

--- a/internal/api/query_arrow_json_test.go
+++ b/internal/api/query_arrow_json_test.go
@@ -406,13 +406,13 @@ func TestStreamArrowJSON_FlushErrorBreaksLoop(t *testing.T) {
 		t.Errorf("expected error to wrap sentinel %v, got %v", sentinel, err)
 	}
 
-	// The break must fire at the next jsonFlushInterval boundary after
-	// the writer's 256-byte limit is exceeded — so rowCount should equal
-	// jsonFlushInterval (5000) when the first explicit Flush() returns
-	// the sticky error. Allow one extra batch of slack for bufio's
-	// internal 4 KiB buffer auto-flush timing.
-	const tighterBound = jsonFlushInterval + batchRows
-	if rowCount > tighterBound {
-		t.Errorf("loop did not break promptly on flush error: emitted %d rows, expected <= %d", rowCount, tighterBound)
+	// The break must fire at the FIRST explicit Flush after the writer's
+	// 256-byte limit is exceeded. bufio's internal 4 KiB auto-flush hits
+	// the failing writer well before row 5000, sets the sticky error, and
+	// subsequent WriteByte/WriteString calls silently no-op. At row 5000
+	// the explicit Flush() returns the stored error and the loop breaks.
+	// So rowCount should be EXACTLY jsonFlushInterval.
+	if rowCount != jsonFlushInterval {
+		t.Errorf("loop did not break exactly at flush boundary: emitted %d rows, expected %d", rowCount, jsonFlushInterval)
 	}
 }

--- a/internal/api/query_json_writer.go
+++ b/internal/api/query_json_writer.go
@@ -164,9 +164,16 @@ scanLoop:
 
 		rowCount++
 
-		// Flush periodically to keep memory bounded
+		// Flush periodically to keep memory bounded. fasthttp's RequestCtx.Done
+		// only fires on server shutdown, so the bufio.Writer error on the closed
+		// connection is our only signal that the client has disconnected
+		// mid-stream. Break out so the underlying *sql.Rows isn't drained into
+		// a buffer nobody reads.
 		if rowCount%jsonFlushInterval == 0 {
-			w.Flush()
+			if err := w.Flush(); err != nil {
+				streamErr = fmt.Errorf("stream flush failed at row %d (client likely disconnected): %w", rowCount, err)
+				break scanLoop
+			}
 		}
 
 		if governanceMaxRows > 0 && rowCount >= governanceMaxRows {

--- a/internal/api/query_json_writer.go
+++ b/internal/api/query_json_writer.go
@@ -27,8 +27,13 @@ const (
 
 // jsonFlushInterval controls how often we flush the bufio.Writer to the
 // HTTP response during streaming. Flushing every N rows keeps memory bounded
-// while avoiding per-row flush overhead.
-const jsonFlushInterval = 5000
+// while avoiding per-row flush overhead. The Flush also doubles as the
+// client-disconnect detection point (see errClientDisconnected) — at 1000
+// rows the worst-case wasted formatting work after a disconnect is ~1000
+// rows of CPU, which is acceptable for typical query rates (~10-100µs).
+// Per-row Flush would be cleaner for fast disconnect detection but doubles
+// as forced syscalls on a healthy connection; 1000 is the compromise.
+const jsonFlushInterval = 1000
 
 // rowScanner is the interface satisfied by both *sql.Rows and *MergedRowIterator.
 type rowScanner interface {
@@ -168,10 +173,11 @@ scanLoop:
 		// only fires on server shutdown, so the bufio.Writer error on the closed
 		// connection is our only signal that the client has disconnected
 		// mid-stream. Break out so the underlying *sql.Rows isn't drained into
-		// a buffer nobody reads.
+		// a buffer nobody reads. Wrap with errClientDisconnected so the caller
+		// can log at Warn (not Error) for this expected ops noise.
 		if rowCount%jsonFlushInterval == 0 {
 			if err := w.Flush(); err != nil {
-				streamErr = fmt.Errorf("stream flush failed at row %d (client likely disconnected): %w", rowCount, err)
+				streamErr = fmt.Errorf("stream flush failed at row %d: %w: %w", rowCount, errClientDisconnected, err)
 				break scanLoop
 			}
 		}


### PR DESCRIPTION
## Summary

- Heavy queries against \`/api/v1/query\` (and \`/api/v1/query/arrow\`) hold DuckDB result-set memory until query completion or the 5-min timeout when the client disconnects mid-stream — Grafana panel close, browser tab kill, dashboard refresh. The streaming goroutine has no way to learn the client closed the TCP connection because fasthttp's \`RequestCtx.Done()\` only fires on server shutdown (\`server.go:2719-2745\`), and \`c.UserContext()\` is already cancelled by the time the async stream writer runs.
- The reliable signal in fasthttp's streaming model is the error returned by \`bufio.Writer.Flush()\` — when the underlying TCP connection is closed, the next flush surfaces EPIPE. The fix captures that error and breaks the streaming loop.
- Same pattern applied to the three streaming write paths: Arrow IPC (\`query_arrow.go\`), Arrow-to-JSON (\`query_arrow_json.go\` — what the default \`/query\` endpoint uses on \`-tags=duckdb_arrow\` builds), and the pure database/sql JSON fallback (\`query_json_writer.go\`).
- Aligned the four \"stream truncated after headers committed\" log sites to \`Warn\` (from \`Error\`). Headers are already committed when streamErr fires, so the client got a partial result — by definition the server worked. Client disconnect is expected ops noise.

## Origin

Filed in response to a user-reported pattern: heavy time-bucket aggregations and wide GROUP BYs cause RSS to climb during query execution. Investigation found multiple potential leak sources; this PR fixes the one with the clearest causal mechanism and reproducer (client-disconnect path).

A throttled \`DuckDB.ClearHTTPCache()\` from the query path (parquet_metadata_cache eviction) was investigated and tested in the same branch but **dropped from this PR** — at 1200 queries on a small local-backend dataset, the with-fix and without-fix runs were indistinguishable (both converged to ~180 MB RSS post-settle). Without empirical evidence at the test scale, shipping it would be cargo-cult. May revisit at production scale.

## Test plan

- [x] \`go build ./internal/api/... ./cmd/arc/...\` clean on both default and \`-tags=duckdb_arrow\` build configurations.
- [x] \`go test -tags=duckdb_arrow ./internal/api/...\` — all existing tests pass plus new \`TestStreamArrowJSON_FlushErrorBreaksLoop\` (7 tests in the Arrow JSON test file).
- [x] New regression test uses \`errAfterNBytes\` (an \`io.Writer\` that fails after N bytes) and asserts:
  - the returned error wraps the sentinel via \`errors.Is\`
  - the row count is bounded to within \`jsonFlushInterval + batchRows\` of the failure point (i.e. break fires at the next 5000-row Flush boundary, not later)
- [ ] **Spot-check on Grafana**: open a heavy panel against the \`/query\` endpoint, kill the browser tab mid-load. Pre-fix: DuckDB result reader keeps draining for up to 5 min. Post-fix: reader stops within the next flush window.

## Internal review

Four parallel reviewer agents (correctness, security, code-quality, performance) per the CLAUDE.md review protocol. Findings addressed:

- **Same bug in non-Arrow JSON path** (code-quality HIGH) → applied identical fix in \`query_json_writer.go:169\`.
- **Asymmetric severity Error vs Warn** (3 agents) → aligned all four streaming-truncation log sites to Warn.
- **Stale test comment + loose assertion** (multiple agents) → fixed comment, tightened bound to \`jsonFlushInterval + batchRows\` instead of \`>= totalRows\`.
- **No IPC-path test coverage** (code-quality MEDIUM) → noted as a follow-up. The IPC path uses structurally identical code to the JSON path that the test exercises. Extracting a testable helper from the Fiber handler is a separate refactor.

Pushed back on:
- **Convert reader.Release() to defer** (correctness MEDIUM) — pre-existing pattern, not introduced by this fix, separate hardening.
- **Short-circuit envelope-close on streamErr** (correctness HIGH) — the design is intentional (\"emit valid JSON regardless\" for clients parsing as bytes arrive); cost on disconnect is one no-op JSON marshal.
- **Cancel ctx immediately on flush-error break** (performance MEDIUM) — re-read the code, this is already correct: the cancel() at end of closure fires after the break, and \`reader.Next()\` isn't called again because we broke the loop.
- **Add sentinel error / metric** (multiple LOW) — separate observability PR.
- **Convert test to CheckedAllocator** (perf NIT) — the existing \`buildArrowBatch\` helper leaks builder allocations on every test (pre-existing bug); fixing it would scope-creep. Filed mentally as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)