### PR TITLE
style: gofmt query_arrow.go

### DIFF
--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -147,7 +147,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			// break is the idiomatic Go cancellation pattern (gemini r1).
 			select {
 			case <-streamCtx.Done():
-streamErr = fmt.Errorf("stream cancelled at row %d: %w", totalRows, streamCtx.Err())
+				streamErr = fmt.Errorf("stream cancelled at row %d: %w", totalRows, streamCtx.Err())
 				break streamLoop
 			default:
 			}


### PR DESCRIPTION
Restores tab indentation on the `streamErr` assignment at [internal/api/query_arrow.go:150](internal/api/query_arrow.go#L150) that was lost when applying gemini's suggestion via the GitHub UI during #424.

`gofmt -l internal/api/query_arrow.go` flagged the file pre-fix; clean post-fix. Single-line change, behaviour identical, build + tests green on both `duckdb_arrow` and default tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)