### PR TITLE
fix(query): mask bare FROM inside EXTRACT/SUBSTRING/TRIM/OVERLAY + Arrow IPC exec-time trailer

### DIFF
--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -2,6 +2,59 @@
 
 > **Status:** In progress. Entries are added as PRs land.
 
+## Bug fixes
+
+### Parser no longer mis-resolves bare `time` column inside `EXTRACT(YEAR FROM time)`
+
+The regex-based query rewriter previously matched the `FROM` keyword inside `EXTRACT(YEAR FROM time)` (and the same shape in `SUBSTRING(s FROM 1 FOR 3)`, `TRIM(LEADING '0' FROM x)`, `OVERLAY(s PLACING 'x' FROM 2)`) and rewrote the column reference as a measurement, producing:
+
+```
+Binder Error: Function "read_parquet" is a table function but it was used as a scalar function.
+LINE 1: SELECT EXTRACT(YEAR FROM read_parquet('/app/data/arc/.../time/**/*.parquet'...
+```
+
+`time` is the canonical column name across InfluxDB / Telegraf / Prometheus-derived schemas, so every customer migrating from those systems hit this. Workarounds were `YEAR(time)`, `date_trunc('year', time)`, or quoting / qualifying the column.
+
+26.06.1 adds a pre-pass that masks `FROM` keywords inside the argument list of `EXTRACT`, `SUBSTRING`, `TRIM`, and `OVERLAY` before the table-rewrite regex runs, then restores them afterwards. The masker tracks paren depth so nested calls like `EXTRACT(YEAR FROM CAST(t AS DATE))` are handled correctly. Both the standard and `x-arc-database` header-optimized rewriter paths are covered, and the fast paths bail to the masking path when these functions are present. The single-table query optimization continues to apply for queries that don't use these functions.
+
+**Overhead** (per cache-miss query — cached queries skip the entire rewriter): ~350 ns and **0 allocations** for queries that don't use these functions (the common case); ~625 ns and ~900 bytes for queries that do. The rewriter cache absorbs repeated identical queries, so this is paid once per unique SQL string. Bench numbers from `internal/sql/mask_test.go` on an M3 Max:
+
+```
+BenchmarkContainsFromKeywordFunction_Miss        348 ns/op      0 B/op   0 allocs/op
+BenchmarkContainsFromKeywordFunction_Hit          21 ns/op      0 B/op   0 allocs/op
+BenchmarkMaskFromKeywordsInFunctionBodies_Miss   348 ns/op      0 B/op   0 allocs/op
+BenchmarkMaskFromKeywordsInFunctionBodies_Hit    316 ns/op    336 B/op   4 allocs/op
+BenchmarkUnmaskFromKeywordsInFunctionBodies      285 ns/op    560 B/op   3 allocs/op
+```
+
+Tests added: `TestMaskFromKeywordsInFunctionBodies`, `TestUnmaskAfterLengthChangingRewrite`, `TestContainsFromKeywordFunction` in `internal/sql/mask_test.go`; `TestConvertSQLToStoragePaths_FromKeywordFunctions`, `TestConvertSQLToStoragePaths_ExtractAfterFrom`, `TestConvertSQLToStoragePathsWithHeaderDB_FromKeywordFunctions` in `internal/api/query_test.go`.
+
+This is a narrow regex pre-pass, not a full SQL-parser swap. The fix triggered an evaluation of replacing the regex rewriter with a real SQL parser — no Go SQL parser currently handles DuckDB's full syntax (lambdas `x -> y`, list literals `[1,2,3]`, `QUALIFY`, `EXCLUDE`/`REPLACE`, FROM-first, `:=` named args, `PIVOT`/`UNPIVOT`). A proper parser migration is tracked as a separate, larger initiative.
+
+### Arrow IPC responses now carry server-side execution time
+
+The HTTP/JSON query endpoint already reports `execution_time_ms` in the response body, but the Arrow IPC endpoint (`/api/v1/query/arrow`) exposed no server-side timing. Clients had to rely on wall-clock measurement, which overstates Arc's actual performance when the network is in the way — a 2,830ms server-side aggregation looked like 4,014ms from Costa Rica against a US-hosted demo box.
+
+26.06.1 publishes an `Arc-Execution-Time-Ms` HTTP response trailer at the end of every Arrow IPC stream. The trailer carries the same integer that the server logs internally. Clients consume the full Arrow stream and then read the trailer — e.g. in Python:
+
+```python
+import pyarrow as pa, requests
+r = requests.post(
+    "http://arc:8000/api/v1/query/arrow",
+    json={"sql": "SELECT count(*) FROM cpu WHERE time >= now() - INTERVAL 1 DAY"},
+    headers={"Authorization": f"Bearer {TOKEN}", "x-arc-database": "default"},
+    stream=True,
+)
+reader = pa.ipc.open_stream(r.raw)
+for batch in reader:
+    ...
+print("server-side ms:", r.headers.get("Arc-Execution-Time-Ms"))
+```
+
+The trailer is also emitted on the error path (with time-until-failure) so partial-stream timing is still observable. Trailers require HTTP/1.1 chunked transfer or HTTP/2 — both already in use by Arc's fasthttp-backed Fiber stack. Clients that ignore trailers degrade gracefully to wall-clock measurement.
+
+The JSON path (`/api/v1/query`) is unchanged — `execution_time_ms` was already in the response body.
+
 ## Hardening
 
 ### Hard Query Gating During Replication Catch-Up (Enterprise, opt-in) — closes #392

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1903,9 +1903,10 @@ func (h *QueryHandler) getTransformedSQLForParallel(sql string, headerDB string)
 		return transformed, nil, cached
 	}
 
-	// Check for features that prevent fast path
+	// Bail to slow path for features the fast path can't handle. EXTRACT/
+	// SUBSTRING/TRIM/OVERLAY need the slow path's FROM-keyword mask.
 	features := scanSQLFeatures(sql)
-	if features.hasQuotes || features.hasDashComment || features.hasBlockComment {
+	if features.hasQuotes || features.hasDashComment || features.hasBlockComment || sqlutil.ContainsFromKeywordFunction(sql) {
 		transformed, cached := h.getTransformedSQL(sql, headerDB)
 		return transformed, nil, cached
 	}
@@ -1954,6 +1955,11 @@ func (h *QueryHandler) convertSQLToStoragePaths(sql string) string {
 	// Phase 1: Mask string literals to prevent regex from matching inside them
 	// e.g., WHERE msg = 'SELECT * FROM mydb.cpu' should not convert the string content
 	sql, masks := sqlutil.MaskStringLiterals(sql, features.hasQuotes)
+
+	// Phase 1b: Mask bare FROM inside EXTRACT/SUBSTRING/TRIM/OVERLAY so the
+	// table-rewriter regex below does not treat e.g. `time` in
+	// `EXTRACT(YEAR FROM time)` as a measurement.
+	sql, fromMasks := sqlutil.MaskFromKeywordsInFunctionBodies(sql)
 
 	// Phase 2: Strip SQL comments (after masking to preserve comments inside strings)
 	// e.g., "-- FROM mydb.cpu" should not be converted
@@ -2051,7 +2057,10 @@ func (h *QueryHandler) convertSQLToStoragePaths(sql string) string {
 		return h.buildReadParquetExpr(path, originalSQL, "JOIN")
 	})
 
-	// Restore original string literals
+	// Restore masked FROM keywords and string literals. Both use content-
+	// addressed placeholders, so the intermediate length-changing regex
+	// rewrites above are safe.
+	sql = sqlutil.UnmaskFromKeywordsInFunctionBodies(sql, fromMasks)
 	sql = sqlutil.UnmaskStringLiterals(sql, masks)
 
 	return sql
@@ -2495,9 +2504,11 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(sql string, database
 		sqlLower = strings.ToLower(sql)
 	}
 
-	// FAST PATH: For simple single-table queries without special SQL features,
-	// skip all the regex machinery and use direct string manipulation
-	if isSingleTableQuery(sqlLower) && !strings.Contains(sqlLower, "with ") {
+	// FAST PATH: skip all regex machinery for simple single-table queries.
+	// Bail when the SQL has a bare FROM inside EXTRACT/SUBSTRING/TRIM/OVERLAY
+	// — `SELECT EXTRACT(YEAR FROM CURRENT_DATE)` slips past isSingleTableQuery
+	// with fromCount==1, so the slow path's mask helper must run.
+	if isSingleTableQuery(sqlLower) && !strings.Contains(sqlLower, "with ") && !sqlutil.ContainsFromKeywordFunction(sql) {
 		features := scanSQLFeatures(sql)
 		if !features.hasQuotes && !features.hasDashComment && !features.hasBlockComment {
 			// Also need to rewrite time functions if present
@@ -2522,6 +2533,9 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(sql string, database
 
 	// Phase 1: Mask string literals to prevent regex from matching inside them
 	sql, masks := sqlutil.MaskStringLiterals(sql, features.hasQuotes)
+
+	// Phase 1b: see convertSQLToStoragePaths.
+	sql, fromMasks := sqlutil.MaskFromKeywordsInFunctionBodies(sql)
 
 	// Phase 2: Strip SQL comments
 	sql = stripSQLComments(sql, features.hasDashComment || features.hasBlockComment)
@@ -2606,7 +2620,8 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(sql string, database
 		return h.buildReadParquetExpr(path, originalSQL, "JOIN")
 	})
 
-	// Restore original string literals
+	// Restore masked FROM keywords and original string literals.
+	sql = sqlutil.UnmaskFromKeywordsInFunctionBodies(sql, fromMasks)
 	sql = sqlutil.UnmaskStringLiterals(sql, masks)
 
 	return sql

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -144,14 +144,23 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 
 	c.Set("Content-Type", "application/vnd.apache.arrow.stream")
 
-	// Declare the execution-time trailer in the response head. fasthttp
-	// requires AddTrailer before the stream writer runs so the `Trailer:`
-	// response header is emitted before the chunked body starts. Clients
-	// that don't read trailers degrade gracefully to wall-clock timing.
-	// The Warn is sync.Once-gated because the trailer name is constant
-	// and a per-request log would be operational noise if a future
-	// fasthttp release ever rejects it.
-	if err := c.Context().Response.Header.AddTrailer(arrowExecutionTimeTrailer); err != nil {
+	// Capture the fasthttp RequestCtx once. c *fiber.Ctx is pooled and
+	// reset after this handler returns; the SetBodyStreamWriter callback
+	// runs asynchronously after the handler exits, so any call to
+	// c.Context() inside the closure observes a recycled context (nil
+	// pointer panic in practice — verified by integration test against
+	// clickbench). The fasthttp RequestCtx itself stays valid until the
+	// stream writer returns.
+	fctx := c.Context()
+	respHeader := &fctx.Response.Header
+
+	// Declare the execution-time trailer in the response head before
+	// SetBodyStreamWriter runs so the `Trailer:` response header is
+	// emitted before the chunked body starts. Clients that don't read
+	// trailers degrade gracefully to wall-clock timing. The Warn is
+	// sync.Once-gated against per-request log spam if a future fasthttp
+	// release ever rejects the trailer name.
+	if err := respHeader.AddTrailer(arrowExecutionTimeTrailer); err != nil {
 		arrowTrailerWarnOnce.Do(func() {
 			h.logger.Warn().Err(err).Str("trailer", arrowExecutionTimeTrailer).
 				Msg("Failed to register Arrow execution-time trailer; clients will not see server-side timing")
@@ -159,7 +168,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 	}
 
 	streamCtx := ctx
-	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+	fctx.SetBodyStreamWriter(func(w *bufio.Writer) {
 		ipcWriter := ipc.NewWriter(w, ipc.WithSchema(schema))
 
 		var totalRows int64
@@ -244,15 +253,15 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			cancel()
 		}
 
-		// Publish authoritative server-side timing to the client as a
-		// chunked-transfer trailer. The value is set even on the error
-		// path so clients see the time-until-failure for partial results
-		// (the trailer arrives after the truncated body, ahead of the
-		// connection close on a clean disconnect). On a hard client
-		// disconnect the trailer is silently dropped, same as any other
-		// post-body byte.
+		// Publish authoritative server-side timing as a chunked-transfer
+		// trailer. Set even on the error path so partial results carry
+		// time-until-failure. On a hard client disconnect the trailer is
+		// silently dropped, same as any other post-body byte.
+		//
+		// Use the captured respHeader, NOT c.Context().Response.Header —
+		// fiber.Ctx is pooled and reset before this closure runs.
 		execMs := time.Since(start).Milliseconds()
-		c.Context().Response.Header.Set(arrowExecutionTimeTrailer, strconv.FormatInt(execMs, 10))
+		respHeader.Set(arrowExecutionTimeTrailer, strconv.FormatInt(execMs, 10))
 
 		if streamErr != nil {
 			m.IncQueryErrors()

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -6,7 +6,9 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -17,6 +19,16 @@ import (
 	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/gofiber/fiber/v2"
 )
+
+// arrowTrailerWarnOnce gates the AddTrailer failure log so a fasthttp
+// upgrade that ever rejects the trailer name does not produce a Warn per
+// request.
+var arrowTrailerWarnOnce sync.Once
+
+// arrowExecutionTimeTrailer is the HTTP response trailer carrying server-
+// side query execution time (milliseconds) on the Arrow IPC endpoint.
+// Clients consume the full Arrow stream then read this trailer.
+const arrowExecutionTimeTrailer = "Arc-Execution-Time-Ms"
 
 // arrowBatchSize is the number of rows per Arrow record batch.
 // Smaller batches reduce peak memory usage and enable streaming.
@@ -132,6 +144,20 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 
 	c.Set("Content-Type", "application/vnd.apache.arrow.stream")
 
+	// Declare the execution-time trailer in the response head. fasthttp
+	// requires AddTrailer before the stream writer runs so the `Trailer:`
+	// response header is emitted before the chunked body starts. Clients
+	// that don't read trailers degrade gracefully to wall-clock timing.
+	// The Warn is sync.Once-gated because the trailer name is constant
+	// and a per-request log would be operational noise if a future
+	// fasthttp release ever rejects it.
+	if err := c.Context().Response.Header.AddTrailer(arrowExecutionTimeTrailer); err != nil {
+		arrowTrailerWarnOnce.Do(func() {
+			h.logger.Warn().Err(err).Str("trailer", arrowExecutionTimeTrailer).
+				Msg("Failed to register Arrow execution-time trailer; clients will not see server-side timing")
+		})
+	}
+
 	streamCtx := ctx
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		ipcWriter := ipc.NewWriter(w, ipc.WithSchema(schema))
@@ -218,6 +244,16 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			cancel()
 		}
 
+		// Publish authoritative server-side timing to the client as a
+		// chunked-transfer trailer. The value is set even on the error
+		// path so clients see the time-until-failure for partial results
+		// (the trailer arrives after the truncated body, ahead of the
+		// connection close on a clean disconnect). On a hard client
+		// disconnect the trailer is silently dropped, same as any other
+		// post-body byte.
+		execMs := time.Since(start).Milliseconds()
+		c.Context().Response.Header.Set(arrowExecutionTimeTrailer, strconv.FormatInt(execMs, 10))
+
 		if streamErr != nil {
 			m.IncQueryErrors()
 			// Warn for client-disconnect / timeout (expected ops noise);
@@ -225,14 +261,14 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			// alerting on).
 			h.streamErrEvent(streamErr).Err(streamErr).
 				Int64("rows_sent", totalRows).
-				Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
+				Int64("execution_time_ms", execMs).
 				Msg("Arrow IPC stream truncated after headers committed; client received partial result")
 			return
 		}
 
 		h.logger.Info().
 			Int64("row_count", totalRows).
-			Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
+			Int64("execution_time_ms", execMs).
 			Msg("Arrow streaming query completed")
 	})
 

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -457,6 +457,224 @@ func TestConvertSQLWithCTE(t *testing.T) {
 	}
 }
 
+// TestConvertSQLToStoragePaths_FromKeywordFunctions verifies that the table
+// rewriter no longer mis-resolves a column reference inside EXTRACT /
+// SUBSTRING / TRIM / OVERLAY as a measurement. Regression for the issue
+// where `SELECT EXTRACT(YEAR FROM time) FROM citibike_trips` produced
+// `Binder Error: read_parquet used as scalar`.
+func TestConvertSQLToStoragePaths_FromKeywordFunctions(t *testing.T) {
+	h := &QueryHandler{
+		storage: &mockLocalBackend{basePath: "./data"},
+		pruner:  pruning.NewPartitionPruner(zerolog.Nop()),
+		logger:  zerolog.Nop(),
+	}
+
+	tests := []struct {
+		name             string
+		input            string
+		shouldContain    []string
+		shouldNotContain []string
+	}{
+		{
+			name:  "EXTRACT(YEAR FROM time) FROM table",
+			input: "SELECT EXTRACT(YEAR FROM time) FROM citibike_trips",
+			shouldContain: []string{
+				"EXTRACT(YEAR FROM time)",                              // expression preserved verbatim
+				"read_parquet('./data/default/citibike_trips/**/*.parquet'", // outer FROM rewritten
+			},
+			shouldNotContain: []string{
+				"read_parquet('./data/default/time/", // inner FROM must NOT be rewritten
+			},
+		},
+		{
+			name:  "EXTRACT lowercase",
+			input: "select extract(year from time) from cpu",
+			shouldContain: []string{
+				"extract(year from time)",
+				"read_parquet('./data/default/cpu/**/*.parquet'",
+			},
+			shouldNotContain: []string{
+				"read_parquet('./data/default/time/",
+			},
+		},
+		{
+			name:  "SUBSTRING(s FROM 1 FOR 3)",
+			input: "SELECT SUBSTRING(name FROM 1 FOR 3) FROM users",
+			shouldContain: []string{
+				"SUBSTRING(name FROM 1 FOR 3)",
+				"read_parquet('./data/default/users/**/*.parquet'",
+			},
+		},
+		{
+			name:  "TRIM(LEADING '0' FROM x)",
+			input: "SELECT TRIM(LEADING '0' FROM zipcode) FROM addresses",
+			shouldContain: []string{
+				"TRIM(LEADING '0' FROM zipcode)",
+				"read_parquet('./data/default/addresses/**/*.parquet'",
+			},
+		},
+		{
+			name:  "OVERLAY(s PLACING 'x' FROM 2)",
+			input: "SELECT OVERLAY(label PLACING 'X' FROM 2) FROM items",
+			shouldContain: []string{
+				"OVERLAY(label PLACING 'X' FROM 2)",
+				"read_parquet('./data/default/items/**/*.parquet'",
+			},
+		},
+		{
+			name:  "nested EXTRACT + CAST",
+			input: "SELECT EXTRACT(YEAR FROM CAST(t AS DATE)) FROM trips",
+			shouldContain: []string{
+				"EXTRACT(YEAR FROM CAST(t AS DATE))",
+				"read_parquet('./data/default/trips/**/*.parquet'",
+			},
+			shouldNotContain: []string{
+				"read_parquet('./data/default/cast/",
+			},
+		},
+		{
+			name:  "measurement literally named extract still rewritten",
+			input: "SELECT * FROM extract",
+			shouldContain: []string{
+				"read_parquet('./data/default/extract/**/*.parquet'",
+			},
+		},
+		{
+			name:  "EXTRACT plus database-qualified table",
+			input: "SELECT EXTRACT(MONTH FROM time) FROM analytics.events",
+			shouldContain: []string{
+				"EXTRACT(MONTH FROM time)",
+				"read_parquet('./data/analytics/events/**/*.parquet'",
+			},
+			shouldNotContain: []string{
+				"read_parquet('./data/default/time/",
+			},
+		},
+		{
+			name:  "two EXTRACTs same query",
+			input: "SELECT EXTRACT(YEAR FROM time), EXTRACT(MONTH FROM time) FROM cpu WHERE host = 'a'",
+			shouldContain: []string{
+				"EXTRACT(YEAR FROM time)",
+				"EXTRACT(MONTH FROM time)",
+				"read_parquet('./data/default/cpu/**/*.parquet'",
+			},
+			shouldNotContain: []string{
+				"read_parquet('./data/default/time/",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.convertSQLToStoragePaths(tt.input)
+			for _, substr := range tt.shouldContain {
+				if !strings.Contains(result, substr) {
+					t.Errorf("Result should contain %q.\nInput:  %s\nResult: %s", substr, tt.input, result)
+				}
+			}
+			for _, substr := range tt.shouldNotContain {
+				if strings.Contains(result, substr) {
+					t.Errorf("Result should NOT contain %q.\nInput:  %s\nResult: %s", substr, tt.input, result)
+				}
+			}
+		})
+	}
+}
+
+// TestConvertSQLToStoragePaths_ExtractAfterFrom verifies the rewrite still
+// works when EXTRACT appears AFTER the outer FROM/JOIN — the position where
+// the table-rewrite regex would shift every downstream byte and (if the
+// mask helper restored by absolute pre-rewrite offsets) would corrupt the
+// rewritten read_parquet call. This was a security finding flagged by the
+// post-implementation review.
+func TestConvertSQLToStoragePaths_ExtractAfterFrom(t *testing.T) {
+	h := &QueryHandler{
+		storage: &mockLocalBackend{basePath: "./data"},
+		pruner:  pruning.NewPartitionPruner(zerolog.Nop()),
+		logger:  zerolog.Nop(),
+	}
+
+	tests := []struct {
+		name             string
+		input            string
+		shouldContain    []string
+		shouldNotContain []string
+	}{
+		{
+			name:  "EXTRACT in WHERE clause after FROM",
+			input: "SELECT * FROM cpu WHERE EXTRACT(YEAR FROM ts) = 2024",
+			shouldContain: []string{
+				"read_parquet('./data/default/cpu/**/*.parquet'",
+				"EXTRACT(YEAR FROM ts)",
+			},
+			shouldNotContain: []string{
+				"read_parquet('./data/default/ts/",
+			},
+		},
+		{
+			name:  "EXTRACT in HAVING after GROUP BY",
+			input: "SELECT host, count(*) FROM cpu GROUP BY host HAVING EXTRACT(HOUR FROM max(ts)) > 12",
+			shouldContain: []string{
+				"read_parquet('./data/default/cpu/**/*.parquet'",
+				"EXTRACT(HOUR FROM max(ts))",
+			},
+			shouldNotContain: []string{
+				"read_parquet('./data/default/ts/",
+			},
+		},
+		{
+			name:  "two FROMs then EXTRACT in WHERE",
+			input: "SELECT * FROM cpu, memory WHERE EXTRACT(YEAR FROM ts) = 2024",
+			shouldContain: []string{
+				"read_parquet('./data/default/cpu/**/*.parquet'",
+				"EXTRACT(YEAR FROM ts)",
+			},
+			shouldNotContain: []string{
+				"read_parquet('./data/default/ts/",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.convertSQLToStoragePaths(tt.input)
+			for _, substr := range tt.shouldContain {
+				if !strings.Contains(result, substr) {
+					t.Errorf("Result should contain %q.\nInput:  %s\nResult: %s", substr, tt.input, result)
+				}
+			}
+			for _, substr := range tt.shouldNotContain {
+				if strings.Contains(result, substr) {
+					t.Errorf("Result should NOT contain %q.\nInput:  %s\nResult: %s", substr, tt.input, result)
+				}
+			}
+		})
+	}
+}
+
+// TestConvertSQLToStoragePathsWithHeaderDB_FromKeywordFunctions covers the
+// same bug class on the header-DB optimized path.
+func TestConvertSQLToStoragePathsWithHeaderDB_FromKeywordFunctions(t *testing.T) {
+	h := &QueryHandler{
+		storage: &mockLocalBackend{basePath: "./data"},
+		pruner:  pruning.NewPartitionPruner(zerolog.Nop()),
+		logger:  zerolog.Nop(),
+	}
+
+	input := "SELECT EXTRACT(YEAR FROM time) FROM citibike_trips"
+	result := h.convertSQLToStoragePathsWithHeaderDB(input, "mydb")
+
+	if !strings.Contains(result, "EXTRACT(YEAR FROM time)") {
+		t.Errorf("inner EXTRACT expression was mutated.\nGot: %s", result)
+	}
+	if !strings.Contains(result, "read_parquet('./data/mydb/citibike_trips/**/*.parquet'") {
+		t.Errorf("outer FROM was not rewritten to header DB path.\nGot: %s", result)
+	}
+	if strings.Contains(result, "read_parquet('./data/mydb/time/") {
+		t.Errorf("inner FROM was incorrectly rewritten as measurement.\nGot: %s", result)
+	}
+}
+
 func TestJoinClausePatterns(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/sql/mask.go
+++ b/internal/sql/mask.go
@@ -3,6 +3,7 @@ package sql
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -91,6 +92,261 @@ func UnmaskStringLiterals(sql string, masks []StringMask) string {
 // This is a fast check to avoid unnecessary processing in MaskStringLiterals.
 func HasQuotes(sql string) bool {
 	return strings.ContainsAny(sql, "'\"")
+}
+
+// fromKeywordFunctions lists SQL builtins whose argument list contains a bare
+// FROM keyword that the table-rewriter regex would otherwise mis-match as a
+// `FROM <table>` reference:
+//
+//	EXTRACT(field FROM source)
+//	SUBSTRING(string FROM start FOR length)
+//	TRIM([LEADING|TRAILING|BOTH] chars FROM string)
+//	OVERLAY(string PLACING new FROM start [FOR length])
+//
+// POSITION(substring IN string) is intentionally NOT in this list — the IN
+// keyword does not collide with the FROM/JOIN rewrite regexes.
+var fromKeywordFunctions = [...]string{"extract", "substring", "trim", "overlay"}
+
+// FromMask records a FROM keyword that MaskFromKeywordsInFunctionBodies
+// replaced with a unique placeholder so the table-rewriter regex skips it.
+// Original preserves the source casing (FROM vs from vs From) so unmask
+// restores the user's SQL verbatim — DuckDB accepts any case, but tests
+// and downstream tooling pass through the rewriter expect bytewise fidelity.
+type FromMask struct {
+	Placeholder string
+	Original    string
+}
+
+// ContainsFromKeywordFunction reports whether sql calls any of the SQL
+// builtins whose argument list contains a bare FROM keyword (EXTRACT,
+// SUBSTRING, TRIM, OVERLAY). Word-boundary aware so a column literally
+// named `extracted` next to a real `EXTRACT(...)` does not hide the real
+// call from later passes. Case-insensitive via per-byte fold.
+func ContainsFromKeywordFunction(sql string) bool {
+	for _, name := range fromKeywordFunctions {
+		if findKeywordFunctionCall(sql, name) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// findKeywordFunctionCall returns the byte offset of the first whole-word
+// case-insensitive occurrence of `name` in sql that is immediately followed
+// (modulo whitespace) by `(`, or -1. The follow-by-paren check distinguishes
+// the builtin call site from a same-spelled column reference.
+func findKeywordFunctionCall(sql, name string) int {
+	n := len(name)
+	for i := 0; i+n <= len(sql); i++ {
+		if !equalFoldASCII(sql[i:i+n], name) {
+			continue
+		}
+		if i > 0 && isIdentByte(sql[i-1]) {
+			continue
+		}
+		j := i + n
+		if j < len(sql) && isIdentByte(sql[j]) {
+			continue
+		}
+		// Allow whitespace between the name and the `(` — `EXTRACT  (...)`.
+		for j < len(sql) && (sql[j] == ' ' || sql[j] == '\t' || sql[j] == '\n' || sql[j] == '\r') {
+			j++
+		}
+		if j < len(sql) && sql[j] == '(' {
+			return i
+		}
+	}
+	return -1
+}
+
+// MaskFromKeywordsInFunctionBodies replaces whole-word FROM tokens that appear
+// inside the argument list of EXTRACT, SUBSTRING, TRIM, or OVERLAY with unique
+// placeholders so the caller's table-rewriter regex (which would otherwise
+// match `FROM <ident>` greedily inside these expressions) skips them. The
+// placeholders contain only identifier characters and never satisfy
+// `\bFROM\b`.
+//
+// The mask is content-addressed via the placeholders, not offset-based —
+// callers may run arbitrary length-changing transformations between the
+// mask and unmask calls (e.g. the FROM/JOIN rewrites replace short
+// measurement names with `read_parquet('long/path/**/*.parquet')`).
+// UnmaskFromKeywordsInFunctionBodies restores the originals by simple
+// string replacement. The trailing `__` in `__FROM_MASK_N__` isolates
+// counters so unmask order is irrelevant (e.g. mask 1 cannot be a
+// substring of mask 10).
+//
+// PRECONDITION: string literals must already be masked by the caller via
+// MaskStringLiterals. The paren-depth scanner does not re-detect quotes,
+// so a literal `'... FROM ...'` inside a trigger-function arg would have
+// its FROM masked too if not pre-masked.
+//
+// Returns the original sql (no allocation) when no trigger function is
+// present.
+func MaskFromKeywordsInFunctionBodies(sql string) (string, []FromMask) {
+	if len(sql) == 0 {
+		return sql, nil
+	}
+	// Cheap pre-check skips the scanner allocation when no trigger
+	// function call is present. Round-2 reviewers asked if the
+	// pre-check is redundant; it is NOT — without it we'd build a
+	// strings.Builder and walk the entire SQL byte-by-byte for every
+	// uncached query, even the 99% that have no EXTRACT/SUBSTRING/
+	// TRIM/OVERLAY. The miss path is 0 allocs.
+	if !ContainsFromKeywordFunction(sql) {
+		return sql, nil
+	}
+
+	// stack holds the paren depths at which active mask frames were entered.
+	// A new frame is pushed when a `(` is preceded by a trigger function
+	// name; popped when paren depth drops back through that level. Nested
+	// non-trigger calls (e.g. EXTRACT(YEAR FROM CAST(t AS DATE))) inherit
+	// the outer mask because the outer frame stays on the stack until its
+	// matching `)`.
+	var stack []int
+	depth := 0
+
+	var b strings.Builder
+	b.Grow(len(sql))
+
+	var masks []FromMask
+	maskIndex := 0
+	// Reusable scratch buffer for placeholder generation — strconv.AppendInt
+	// writes into this byte slice so we avoid fmt.Sprintf's allocation per
+	// mask. "__FROM_MASK_" + max-19-digit int + "__" fits in 32 bytes.
+	var phBuf [32]byte
+	i := 0
+	for i < len(sql) {
+		c := sql[i]
+		switch c {
+		case '(':
+			if isFromKeywordFuncBeforeParen(sql, i) {
+				stack = append(stack, depth+1)
+			}
+			depth++
+			b.WriteByte(c)
+			i++
+		case ')':
+			depth--
+			if len(stack) > 0 && stack[len(stack)-1] > depth {
+				stack = stack[:len(stack)-1]
+			}
+			b.WriteByte(c)
+			i++
+		default:
+			if len(stack) > 0 && (c == 'f' || c == 'F') && isFromKeywordAt(sql, i) {
+				ph := strconv.AppendInt(append(phBuf[:0], "__FROM_MASK_"...), int64(maskIndex), 10)
+				ph = append(ph, '_', '_')
+				placeholder := string(ph)
+				masks = append(masks, FromMask{Placeholder: placeholder, Original: sql[i : i+4]})
+				b.WriteString(placeholder)
+				maskIndex++
+				i += 4
+				continue
+			}
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String(), masks
+}
+
+// UnmaskFromKeywordsInFunctionBodies restores FROM tokens that
+// MaskFromKeywordsInFunctionBodies replaced with placeholders. Safe to run
+// after arbitrary length-changing transformations on the masked SQL —
+// placeholders are unique strings, restored by string replace.
+func UnmaskFromKeywordsInFunctionBodies(sql string, masks []FromMask) string {
+	if len(masks) == 0 {
+		return sql
+	}
+	result := sql
+	for _, m := range masks {
+		result = strings.Replace(result, m.Placeholder, m.Original, 1)
+	}
+	return result
+}
+
+// isFromKeywordFuncBeforeParen reports whether the identifier immediately
+// preceding the `(` at sql[parenIdx] is one of the trigger SQL builtins
+// (EXTRACT, SUBSTRING, TRIM, OVERLAY). Skips ASCII whitespace between the
+// name and the paren. Rejects double-quoted identifiers — `"EXTRACT"(...)`
+// is a user column, not the builtin.
+//
+// Allocation-free: compares the byte range against fromKeywordFunctions
+// in place via equalFoldASCII, avoiding the prior toLowerASCII copy.
+func isFromKeywordFuncBeforeParen(sql string, parenIdx int) bool {
+	j := parenIdx - 1
+	for j >= 0 && (sql[j] == ' ' || sql[j] == '\t' || sql[j] == '\n' || sql[j] == '\r') {
+		j--
+	}
+	if j < 0 || sql[j] == '"' {
+		return false
+	}
+	end := j + 1
+	for j >= 0 && isIdentByte(sql[j]) {
+		j--
+	}
+	start := j + 1
+	if start >= end {
+		return false
+	}
+	ident := sql[start:end]
+	for _, name := range fromKeywordFunctions {
+		if equalFoldASCII(ident, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFromKeywordAt reports whether sql[i:i+4] is a whole-word case-insensitive
+// FROM keyword.
+func isFromKeywordAt(sql string, i int) bool {
+	if i+4 > len(sql) {
+		return false
+	}
+	c0, c1, c2, c3 := sql[i], sql[i+1], sql[i+2], sql[i+3]
+	if (c0 != 'f' && c0 != 'F') ||
+		(c1 != 'r' && c1 != 'R') ||
+		(c2 != 'o' && c2 != 'O') ||
+		(c3 != 'm' && c3 != 'M') {
+		return false
+	}
+	if i > 0 && isIdentByte(sql[i-1]) {
+		return false
+	}
+	if i+4 < len(sql) && isIdentByte(sql[i+4]) {
+		return false
+	}
+	return true
+}
+
+// isIdentByte returns true if c is a valid SQL identifier byte (a-z, A-Z,
+// 0-9, _). Mirrors internal/api.isIdentChar; redeclared here to keep this
+// package self-contained.
+func isIdentByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') || c == '_'
+}
+
+// equalFoldASCII compares a and b case-insensitively over ASCII. Faster than
+// strings.EqualFold for the all-ASCII function-name compare we need.
+func equalFoldASCII(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
 }
 
 // EscapeStringLiteral escapes single quotes for safe use as a DuckDB

--- a/internal/sql/mask.go
+++ b/internal/sql/mask.go
@@ -132,9 +132,11 @@ func ContainsFromKeywordFunction(sql string) bool {
 }
 
 // findKeywordFunctionCall returns the byte offset of the first whole-word
-// case-insensitive occurrence of `name` in sql that is immediately followed
-// (modulo whitespace) by `(`, or -1. The follow-by-paren check distinguishes
-// the builtin call site from a same-spelled column reference.
+// case-insensitive occurrence of `name` in sql that is followed (modulo
+// whitespace and inline SQL comments) by `(`, or -1. The follow-by-paren
+// check distinguishes the builtin call site from a same-spelled column
+// reference. Comment handling is required because the masker runs before
+// stripSQLComments, and `EXTRACT /* c */ (YEAR FROM x)` must still match.
 func findKeywordFunctionCall(sql, name string) int {
 	n := len(name)
 	for i := 0; i+n <= len(sql); i++ {
@@ -148,15 +150,46 @@ func findKeywordFunctionCall(sql, name string) int {
 		if j < len(sql) && isIdentByte(sql[j]) {
 			continue
 		}
-		// Allow whitespace between the name and the `(` — `EXTRACT  (...)`.
-		for j < len(sql) && (sql[j] == ' ' || sql[j] == '\t' || sql[j] == '\n' || sql[j] == '\r') {
-			j++
-		}
+		j = skipWhitespaceAndCommentsForward(sql, j)
 		if j < len(sql) && sql[j] == '(' {
 			return i
 		}
 	}
 	return -1
+}
+
+// skipWhitespaceAndCommentsForward walks forward from sql[i] over ASCII
+// whitespace and SQL comments (`/* ... */` block and `-- ...\n` line),
+// returning the index of the first non-skip byte (or len(sql) if the
+// scan reaches the end).
+func skipWhitespaceAndCommentsForward(sql string, i int) int {
+	for i < len(sql) {
+		c := sql[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i++
+			continue
+		}
+		if c == '/' && i+1 < len(sql) && sql[i+1] == '*' {
+			i += 2
+			for i+1 < len(sql) && !(sql[i] == '*' && sql[i+1] == '/') {
+				i++
+			}
+			if i+1 < len(sql) {
+				i += 2 // step past `*/`
+			} else {
+				i = len(sql) // unterminated comment; treat as end-of-input
+			}
+			continue
+		}
+		if c == '-' && i+1 < len(sql) && sql[i+1] == '-' {
+			for i < len(sql) && sql[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		break
+	}
+	return i
 }
 
 // MaskFromKeywordsInFunctionBodies replaces whole-word FROM tokens that appear
@@ -233,7 +266,13 @@ func MaskFromKeywordsInFunctionBodies(sql string) (string, []FromMask) {
 			b.WriteByte(c)
 			i++
 		default:
-			if len(stack) > 0 && (c == 'f' || c == 'F') && isFromKeywordAt(sql, i) {
+			// Only mask FROM at the trigger frame's own paren depth.
+			// `EXTRACT(YEAR FROM (SELECT t FROM cpu))` — the inner
+			// subquery's `FROM cpu` must be left alone so the regex
+			// rewriter can convert `cpu` to read_parquet(...). Without
+			// the depth-equality check, DuckDB fails with "Table cpu
+			// does not exist". (gemini-code-assist round 2.)
+			if len(stack) > 0 && depth == stack[len(stack)-1] && (c == 'f' || c == 'F') && isFromKeywordAt(sql, i) {
 				ph := strconv.AppendInt(append(phBuf[:0], "__FROM_MASK_"...), int64(maskIndex), 10)
 				ph = append(ph, '_', '_')
 				placeholder := string(ph)
@@ -254,31 +293,38 @@ func MaskFromKeywordsInFunctionBodies(sql string) (string, []FromMask) {
 // MaskFromKeywordsInFunctionBodies replaced with placeholders. Safe to run
 // after arbitrary length-changing transformations on the masked SQL —
 // placeholders are unique strings, restored by string replace.
+//
+// Uses strings.NewReplacer for a single-pass walk over sql; the old
+// loop-of-Replace allocated one intermediate string per mask
+// (gemini-code-assist round 2).
 func UnmaskFromKeywordsInFunctionBodies(sql string, masks []FromMask) string {
 	if len(masks) == 0 {
 		return sql
 	}
-	result := sql
+	pairs := make([]string, 0, len(masks)*2)
 	for _, m := range masks {
-		result = strings.Replace(result, m.Placeholder, m.Original, 1)
+		pairs = append(pairs, m.Placeholder, m.Original)
 	}
-	return result
+	return strings.NewReplacer(pairs...).Replace(sql)
 }
 
 // isFromKeywordFuncBeforeParen reports whether the identifier immediately
 // preceding the `(` at sql[parenIdx] is one of the trigger SQL builtins
-// (EXTRACT, SUBSTRING, TRIM, OVERLAY). Skips ASCII whitespace between the
-// name and the paren. Rejects double-quoted identifiers — `"EXTRACT"(...)`
-// is a user column, not the builtin.
+// (EXTRACT, SUBSTRING, TRIM, OVERLAY). Walks backwards over whitespace and
+// inline SQL comments (`/* ... */` and `--`-to-EOL) — required because the
+// masker runs before stripSQLComments, so `EXTRACT /* c */ (YEAR FROM x)`
+// must still be recognised.
+//
+// Rejects quoted identifiers — `"EXTRACT"(...)` or `` `EXTRACT`(...) `` is
+// a user column, not the builtin. DuckDB does not accept backticks for
+// identifiers in its default parser, but the check costs nothing and
+// matches gemini-code-assist's defensive guidance.
 //
 // Allocation-free: compares the byte range against fromKeywordFunctions
-// in place via equalFoldASCII, avoiding the prior toLowerASCII copy.
+// in place via equalFoldASCII.
 func isFromKeywordFuncBeforeParen(sql string, parenIdx int) bool {
-	j := parenIdx - 1
-	for j >= 0 && (sql[j] == ' ' || sql[j] == '\t' || sql[j] == '\n' || sql[j] == '\r') {
-		j--
-	}
-	if j < 0 || sql[j] == '"' {
+	j := skipWhitespaceAndCommentsBack(sql, parenIdx-1)
+	if j < 0 || sql[j] == '"' || sql[j] == '`' {
 		return false
 	}
 	end := j + 1
@@ -296,6 +342,69 @@ func isFromKeywordFuncBeforeParen(sql string, parenIdx int) bool {
 		}
 	}
 	return false
+}
+
+// skipWhitespaceAndCommentsBack walks backwards from sql[i] over ASCII
+// whitespace and SQL comments, returning the index of the first non-skip
+// byte (or -1 if the scan reaches before the start of the string).
+//
+// Handles:
+//   - whitespace: space, tab, CR, LF.
+//   - block comments `/* ... */` — the cursor is on `/` of the closing
+//     `*/`; we walk back to the matching `/*` (no nesting in standard SQL).
+//   - line comments `-- ... \n` — the closing newline is consumed as
+//     whitespace; once we land on the trailing char of a `-- ...` segment
+//     we must walk back to the `--` start. Detected by scanning the
+//     current line backwards to either start-of-string or `\n`, and
+//     checking if a `--` precedes the cursor position on that line.
+func skipWhitespaceAndCommentsBack(sql string, i int) int {
+	for i >= 0 {
+		c := sql[i]
+		// Skip whitespace.
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i--
+			continue
+		}
+		// Closing of a block comment `*/`: walk back to the matching `/*`.
+		if c == '/' && i > 0 && sql[i-1] == '*' {
+			i -= 2 // step past the `/` and `*` of `*/`
+			for i > 0 && !(sql[i-1] == '/' && sql[i] == '*') {
+				i--
+			}
+			// i now points at the `*` of `/*`; step past both bytes.
+			i -= 2
+			continue
+		}
+		// Possible end of a `-- ...` line comment: walk to start-of-line
+		// and check whether a `--` opens a comment that covers position i.
+		if dashStart, ok := findDashCommentStartBackward(sql, i); ok {
+			i = dashStart - 1
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+// findDashCommentStartBackward checks whether sql[i] is inside a
+// `-- ...`-style line comment that has not yet been terminated by `\n`.
+// If so, returns the index of the first `-` in the `--` opener (so the
+// caller can resume scanning at that-1). Otherwise returns (_, false).
+//
+// SQL `--` line comments run from `--` to the next `\n`. The caller has
+// already established sql[i] is non-whitespace; we walk back to either
+// start-of-string or `\n` and then forward looking for `--` on that line.
+func findDashCommentStartBackward(sql string, i int) (int, bool) {
+	lineStart := i
+	for lineStart > 0 && sql[lineStart-1] != '\n' {
+		lineStart--
+	}
+	for k := lineStart; k < i; k++ {
+		if sql[k] == '-' && k+1 < len(sql) && sql[k+1] == '-' {
+			return k, true
+		}
+	}
+	return 0, false
 }
 
 // isFromKeywordAt reports whether sql[i:i+4] is a whole-word case-insensitive

--- a/internal/sql/mask_test.go
+++ b/internal/sql/mask_test.go
@@ -103,6 +103,59 @@ func TestMaskFromKeywordsInFunctionBodies(t *testing.T) {
 			mustContainOuterFROM:    []string{"FROM cpu"},
 			mustNotContainInnerFROM: []string{"FROM ts"},
 		},
+		{
+			// Gemini finding: comment between function name and paren
+			// must not defeat the scanner. Verified to reproduce the
+			// original Binder Error against the live clickbench dataset
+			// before this fix.
+			name:                    "block comment between EXTRACT and paren",
+			input:                   "SELECT EXTRACT /* c */ (YEAR FROM ts) FROM cpu",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM cpu"},
+			mustNotContainInnerFROM: []string{"FROM ts"},
+		},
+		{
+			name:                    "block comment with newlines and trailing whitespace",
+			input:                   "SELECT EXTRACT\n\t/* multi-\n   line */ \t (YEAR FROM ts) FROM cpu",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM cpu"},
+			mustNotContainInnerFROM: []string{"FROM ts"},
+		},
+		{
+			name:                    "line comment between SUBSTRING and paren",
+			input:                   "SELECT SUBSTRING -- inline comment\n(s FROM 1 FOR 3) FROM t",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM t"},
+			mustNotContainInnerFROM: []string{"FROM 1"},
+		},
+		{
+			// Gemini finding: backtick-quoted identifier is a column,
+			// not the EXTRACT builtin. DuckDB itself rejects backticks
+			// today, but the defensive check costs nothing.
+			name:      "backticked EXTRACT identifier is a column, not the builtin",
+			input:     "SELECT `EXTRACT`(a, b) FROM t",
+			wantMasks: 0,
+		},
+		{
+			// Gemini finding (round 2): subquery inside the trigger's
+			// argument list — the inner FROM must NOT be masked, or
+			// the regex rewriter cannot convert `cpu` to read_parquet.
+			// Verified to reproduce a "Table with name cpu does not
+			// exist" Catalog Error against the live clickbench dataset
+			// before this fix.
+			name:                    "subquery FROM inside EXTRACT must not be masked",
+			input:                   "SELECT EXTRACT(YEAR FROM (SELECT MIN(ts) FROM cpu)) FROM events",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM cpu", "FROM events"},
+			mustNotContainInnerFROM: []string{"FROM (SELECT MIN(ts)"},
+		},
+		{
+			name:                    "deeply nested subquery — both inner FROMs survive",
+			input:                   "SELECT EXTRACT(YEAR FROM (SELECT a FROM (SELECT b FROM t))) FROM o",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM t", "FROM o", "FROM (SELECT b"},
+			mustNotContainInnerFROM: []string{"FROM (SELECT a"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/sql/mask_test.go
+++ b/internal/sql/mask_test.go
@@ -1,0 +1,253 @@
+package sql
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskFromKeywordsInFunctionBodies(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantMasks int
+		// After mask runs, the table-rewriter regex should NOT see "FROM x"
+		// where x is the inner column, but SHOULD still see the outer FROM.
+		mustContainOuterFROM     []string
+		mustNotContainInnerFROM  []string
+	}{
+		{
+			name:                    "EXTRACT(YEAR FROM time) FROM table",
+			input:                   "SELECT EXTRACT(YEAR FROM time) FROM cpu",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM cpu"},
+			mustNotContainInnerFROM: []string{"FROM time"},
+		},
+		{
+			name:                    "SUBSTRING(s FROM 1 FOR 3)",
+			input:                   "SELECT SUBSTRING(s FROM 1 FOR 3) FROM t",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM t"},
+			mustNotContainInnerFROM: []string{"FROM 1"},
+		},
+		{
+			name:                    "TRIM(LEADING '0' FROM x)",
+			input:                   "SELECT TRIM(LEADING '0' FROM x) FROM t",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM t"},
+			mustNotContainInnerFROM: []string{"FROM x"},
+		},
+		{
+			name:                    "OVERLAY(s PLACING 'x' FROM 2)",
+			input:                   "SELECT OVERLAY(s PLACING 'x' FROM 2) FROM t",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM t"},
+			mustNotContainInnerFROM: []string{"FROM 2"},
+		},
+		{
+			name:                    "nested EXTRACT + CAST",
+			input:                   "SELECT EXTRACT(YEAR FROM CAST(t AS DATE)) FROM trips",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM trips"},
+			mustNotContainInnerFROM: []string{"FROM CAST"},
+		},
+		{
+			name:                    "lowercase extract",
+			input:                   "SELECT extract(year from time) FROM cpu",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM cpu"},
+			mustNotContainInnerFROM: []string{"from time"},
+		},
+		{
+			name:      "no trigger function",
+			input:     "SELECT a, b FROM cpu WHERE x = 1",
+			wantMasks: 0,
+		},
+		{
+			name:                 "user column literally named extract",
+			input:                "SELECT extract FROM cpu",
+			wantMasks:            0,
+			mustContainOuterFROM: []string{"extract FROM cpu"},
+		},
+		{
+			name:      "MY_EXTRACT user function with bare FROM is not the builtin",
+			input:     "SELECT MY_EXTRACT(YEAR FROM x) FROM cpu",
+			wantMasks: 0,
+		},
+		{
+			name:                    "two EXTRACT calls",
+			input:                   "SELECT EXTRACT(YEAR FROM time), EXTRACT(MONTH FROM time) FROM cpu",
+			wantMasks:               2,
+			mustContainOuterFROM:    []string{"FROM cpu"},
+			mustNotContainInnerFROM: []string{"FROM time"},
+		},
+		{
+			// Correctness review finding: ContainsFromKeywordFunction
+			// used strings.Index which returns only the first match. A
+			// column literally named extract_col next to a real EXTRACT
+			// call would hide the real call. Verify both detection AND
+			// mask work here.
+			name:                    "column prefixed extract_col next to real EXTRACT call",
+			input:                   "SELECT extract_col FROM t WHERE EXTRACT(YEAR FROM time) = 2025",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM t"},
+			mustNotContainInnerFROM: []string{"FROM time"},
+		},
+		{
+			// Correctness review finding: EXTRACT appearing AFTER the
+			// outer FROM/JOIN is the offset-shift corruption scenario
+			// for offset-based unmask. The placeholder approach must
+			// roundtrip cleanly here.
+			name:                    "EXTRACT in WHERE after outer FROM",
+			input:                   "SELECT a FROM cpu WHERE EXTRACT(YEAR FROM ts) = 2024",
+			wantMasks:               1,
+			mustContainOuterFROM:    []string{"FROM cpu"},
+			mustNotContainInnerFROM: []string{"FROM ts"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			masked, masks := MaskFromKeywordsInFunctionBodies(tt.input)
+			if len(masks) != tt.wantMasks {
+				t.Errorf("masks count = %d, want %d (masked=%q)", len(masks), tt.wantMasks, masked)
+			}
+			for _, substr := range tt.mustContainOuterFROM {
+				if !strings.Contains(masked, substr) {
+					t.Errorf("masked SQL missing outer FROM substring %q.\nInput:  %s\nMasked: %s",
+						substr, tt.input, masked)
+				}
+			}
+			for _, substr := range tt.mustNotContainInnerFROM {
+				if strings.Contains(masked, substr) {
+					t.Errorf("masked SQL still contains inner FROM substring %q.\nInput:  %s\nMasked: %s",
+						substr, tt.input, masked)
+				}
+			}
+
+			restored := UnmaskFromKeywordsInFunctionBodies(masked, masks)
+			if restored != tt.input {
+				t.Errorf("roundtrip mismatch.\nGot:  %q\nWant: %q", restored, tt.input)
+			}
+		})
+	}
+}
+
+// TestUnmaskAfterLengthChangingRewrite is the critical regression test for
+// the offset-shift corruption bug found in post-implementation review. The
+// caller masks, then runs a length-changing transformation (simulating
+// patternSimpleTable rewriting `FROM cpu` → `FROM read_parquet('long/path')`),
+// then unmasks. With offset-based unmask this corrupts the rewrite output;
+// with placeholder-based unmask it must roundtrip cleanly.
+func TestUnmaskAfterLengthChangingRewrite(t *testing.T) {
+	input := "SELECT a FROM cpu WHERE EXTRACT(YEAR FROM time) = 2024"
+	masked, masks := MaskFromKeywordsInFunctionBodies(input)
+	if len(masks) != 1 {
+		t.Fatalf("expected 1 mask, got %d (masked=%q)", len(masks), masked)
+	}
+
+	// Simulate the table rewriter expanding `FROM cpu` into a much longer
+	// read_parquet call. This shifts every byte after the rewrite to the
+	// right, which is exactly the failure mode the placeholder approach
+	// must survive.
+	rewritten := strings.Replace(masked,
+		"FROM cpu",
+		"FROM read_parquet('./data/default/cpu/**/*.parquet', union_by_name=true)",
+		1)
+
+	restored := UnmaskFromKeywordsInFunctionBodies(rewritten, masks)
+
+	if !strings.Contains(restored, "EXTRACT(YEAR FROM time)") {
+		t.Errorf("inner EXTRACT was not restored.\nGot: %s", restored)
+	}
+	if !strings.Contains(restored, "read_parquet('./data/default/cpu/**/*.parquet'") {
+		t.Errorf("outer rewrite was corrupted.\nGot: %s", restored)
+	}
+	if strings.Contains(restored, "__FROM_MASK_") {
+		t.Errorf("placeholder leaked into restored SQL.\nGot: %s", restored)
+	}
+	// Specifically: corruption signature from the offset-based version
+	// was bytes like "deFROMt" or "cpFROM" landing inside the path.
+	if strings.Contains(restored, "deFROMt") || strings.Contains(restored, "cpFROM") {
+		t.Errorf("offset-based corruption detected.\nGot: %s", restored)
+	}
+}
+
+func TestContainsFromKeywordFunction(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"SELECT EXTRACT(YEAR FROM time) FROM cpu", true},
+		{"SELECT extract(year from time) FROM cpu", true},
+		{"SELECT EXTRACT  (YEAR FROM time) FROM cpu", true}, // whitespace before paren
+		{"SELECT * FROM cpu", false},
+		{"SELECT extract FROM cpu", false}, // bare identifier, no `(`
+		{"SELECT MY_EXTRACT(x) FROM cpu", false},
+		{"SELECT extracted FROM cpu", false},   // prefix collision
+		{"SELECT decomposition FROM x", false}, // substring containing position
+		// Regression: first-match-only bug would skip the real EXTRACT
+		// after a leading prefix collision.
+		{"SELECT extract_col FROM t WHERE EXTRACT(YEAR FROM time) = 2025", true},
+		{"SELECT SUBSTRING(s FROM 1 FOR 3) FROM t", true},
+		{"SELECT TRIM(LEADING '0' FROM x) FROM t", true},
+		{"SELECT OVERLAY(s PLACING 'x' FROM 2) FROM t", true},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ContainsFromKeywordFunction(tt.input); got != tt.want {
+				t.Errorf("ContainsFromKeywordFunction(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkContainsFromKeywordFunction_Miss(b *testing.B) {
+	sql := "SELECT a, b, c, d, e FROM cpu WHERE x = 1 AND y > 100 GROUP BY z ORDER BY a LIMIT 100"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ContainsFromKeywordFunction(sql)
+	}
+}
+
+func BenchmarkContainsFromKeywordFunction_Hit(b *testing.B) {
+	sql := "SELECT EXTRACT(YEAR FROM time), col FROM cpu WHERE x = 1 GROUP BY col ORDER BY a LIMIT 100"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ContainsFromKeywordFunction(sql)
+	}
+}
+
+func BenchmarkMaskFromKeywordsInFunctionBodies_Miss(b *testing.B) {
+	sql := "SELECT a, b, c, d, e FROM cpu WHERE x = 1 AND y > 100 GROUP BY z ORDER BY a LIMIT 100"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		MaskFromKeywordsInFunctionBodies(sql)
+	}
+}
+
+func BenchmarkMaskFromKeywordsInFunctionBodies_Hit(b *testing.B) {
+	sql := "SELECT EXTRACT(YEAR FROM time), col FROM cpu WHERE x = 1 GROUP BY col ORDER BY a LIMIT 100"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		MaskFromKeywordsInFunctionBodies(sql)
+	}
+}
+
+// BenchmarkUnmaskFromKeywordsInFunctionBodies measures the unmask path on
+// a post-rewrite SQL (after the FROM-table regex has expanded `FROM cpu`
+// into the longer `read_parquet(...)` form). Three masks is a realistic
+// upper bound for typical analytics SQL (one per EXTRACT clause).
+func BenchmarkUnmaskFromKeywordsInFunctionBodies(b *testing.B) {
+	input := "SELECT EXTRACT(YEAR FROM ts1), EXTRACT(MONTH FROM ts2), EXTRACT(DAY FROM ts3) FROM cpu WHERE host = 'a'"
+	masked, masks := MaskFromKeywordsInFunctionBodies(input)
+	// Simulate the table rewriter expanding the table reference.
+	rewritten := strings.Replace(masked,
+		"FROM cpu",
+		"FROM read_parquet('./data/default/cpu/**/*.parquet', union_by_name=true)",
+		1)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		UnmaskFromKeywordsInFunctionBodies(rewritten, masks)
+	}
+}


### PR DESCRIPTION
## Summary

- **Parser fix**: `SELECT EXTRACT(YEAR FROM time) FROM citibike_trips` (and `SUBSTRING(s FROM 1 FOR 3)`, `TRIM(LEADING '0' FROM x)`, `OVERLAY(s PLACING 'x' FROM 2)`) no longer produces a DuckDB `Binder Error: read_parquet is a table function but used as a scalar`. The regex rewriter previously matched the inner `FROM time` and rewrote `time` as a measurement. `time` is the canonical column name across InfluxDB/Telegraf/Prometheus-derived schemas — every customer migrating hit this.
- **Arrow exec time**: `/api/v1/query/arrow` now emits an `Arc-Execution-Time-Ms` HTTP response trailer so clients can report authoritative server-side timing instead of wall-clock (which overstates Arc perf when network is in the way — playground from Costa Rica saw 4,014 ms wall-clock vs 2,830 ms server-side).

## How it works

Pre-pass before the table-rewrite regexes: paren-depth scanner masks each bare `FROM` inside `EXTRACT/SUBSTRING/TRIM/OVERLAY` argument lists with a unique content-addressed placeholder `__FROM_MASK_<n>__`. The regex passes operate on the masked SQL, then `strings.Replace` restores the originals. Content-addressed (not offset-based) is essential — the original offset-based draft corrupted SQL whenever EXTRACT appeared after FROM/JOIN because the regex rewrite shifts every downstream byte. `TestUnmaskAfterLengthChangingRewrite` locks in that regression.

Helpers live in `internal/sql/mask.go` next to the existing `MaskStringLiterals` / `UnmaskStringLiterals` pair. Both single-table fast paths bail to the masking path when `EXTRACT/SUBSTRING/TRIM/OVERLAY` is detected.

## Overhead per cache-miss query

Cached queries skip the entire rewriter, so this is paid once per unique SQL string:

| Bench | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `ContainsFromKeywordFunction_Miss` | 348 | 0 | 0 |
| `ContainsFromKeywordFunction_Hit` | 21 | 0 | 0 |
| `MaskFromKeywordsInFunctionBodies_Miss` | 348 | 0 | 0 |
| `MaskFromKeywordsInFunctionBodies_Hit` | 316 | 336 | 4 |
| `UnmaskFromKeywordsInFunctionBodies` (3 masks) | 285 | 560 | 3 |

Miss path (the 99% of queries): ~350 ns, **0 allocations**. Hit path: ~625 ns, ~900 bytes total.

## Why not a real SQL parser

Evaluated `cockroachdb-parser`, `pg_query_go`, DuckDB's `json_serialize_sql`, and `auxten/postgresql-parser` before writing this fix. No Go SQL parser currently handles DuckDB's full syntax (lambdas `x -> y`, list literals `[1,2,3]`, `QUALIFY`, `EXCLUDE`/`REPLACE`, FROM-first, `:=` named args, `PIVOT`/`UNPIVOT`). The parser migration is tracked as a separate, larger initiative; this PR is a narrow regex pre-pass that closes the user-facing bug now.

## Review process

Two rounds of four parallel internal reviews (correctness/failure-modes, security, code-quality, perf/observability per CLAUDE.md). Round-1 caught a CRITICAL: the original offset-based unmask corrupted SQL when EXTRACT appeared after FROM. Switched to content-addressed placeholders. Round-2 returned ship-it across all four reviewers; remaining LOW/NIT items applied in this branch (allocation-free `isFromKeywordFuncBeforeParen`, `strconv.AppendInt` placeholder formatting, sync.Once-gated AddTrailer warn, dropped verbose comments).

## Test plan

- [x] `go test ./internal/sql/ ./internal/api/` — green
- [x] `go test -tags duckdb_arrow ./internal/sql/ ./internal/api/` — green
- [x] `go build ./cmd/... ./internal/...` — green
- [x] `go build -tags duckdb_arrow ./cmd/... ./internal/...` — green
- [x] `go test ./internal/sql/ -bench=. -benchmem` — numbers above
- [ ] Manual end-to-end against `h01-customers-basekick-net` demo:
  - [ ] `curl POST /api/v1/query` with `SELECT EXTRACT(YEAR FROM time) FROM citibike_trips LIMIT 1` returns one row, not a Binder Error
  - [ ] `curl POST /api/v1/query` with `SELECT SUBSTRING(s FROM 1 FOR 3)`, `TRIM(LEADING '0' FROM x)`, `OVERLAY(s PLACING 'x' FROM 2)` — all rewrite correctly
  - [ ] `curl POST /api/v1/query/arrow` followed by reading `r.headers['Arc-Execution-Time-Ms']` — matches server log `execution_time_ms` within ±1 ms
- [ ] Verify rewriter cache invalidation works for queries that now exercise the mask path
- [ ] Confirm no perf regression on the cache-hit path (rewriter cache should absorb identical queries)

## Discovered

May 12, 2026 during playground build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)