### PR TITLE
feat(server): support binding to a specific host/address — closes #439

### DIFF
--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -203,6 +203,32 @@ go run benchmarks/query_suite/main.go --target arc-arrow  --measurement cpu --it
 
 ## Hardening
 
+### HTTP server now supports binding to a specific host/address — closes #439
+
+The HTTP listener has always bound the wildcard address (`":<port>"`), giving operators no way to restrict the bind from the config file. Deployments wanting loopback-only behavior (Arc fronted by a sidecar adapter on the same host) reached for `systemd` `IPAddressDeny`, `ufw`, or a reverse proxy. The `[server]` config block was missing the corresponding knob.
+
+26.06.1 adds `server.host` to the `[server]` config block, plumbed through to the Fiber listener via `net.JoinHostPort`. Any address Go's `net` package recognizes works — IPv4 literals, IPv6 literals (with correct bracketing), hostnames, the explicit IPv4 wildcard `0.0.0.0`, the explicit IPv6 wildcard `::`. The matching env override is `ARC_SERVER_HOST`.
+
+**Default is empty string** — the listener constructs `":<port>"`, byte-identical to the historical `fmt.Sprintf(":%d", port)`. This preserves Linux dual-stack wildcard behavior (IPv4 + IPv6 via IPv4-mapped addresses); explicit `"0.0.0.0"` would force IPv4-only and silently break IPv6 clients on upgrade, so it's an opt-in. **Zero behavioral change on the listener for operators who don't touch their config.**
+
+```toml
+[server]
+host = "127.0.0.1"   # loopback-only
+# host = "::1"        # IPv6 loopback
+# host = "192.0.2.10" # specific NIC
+# host = "0.0.0.0"    # explicit IPv4-only wildcard
+# host = "::"         # explicit IPv6-only wildcard
+# host = ""           # default; dual-stack wildcard (matches pre-26.06.1 behavior)
+```
+
+The startup log line now also reports the bound host, so `journalctl -u arc | grep 'Starting Arc server'` answers "what did we bind to?" without grepping config files:
+
+```
+INF Starting Arc server component=api-server host=127.0.0.1 port=8000 tls_enabled=false protocol=HTTP
+```
+
+Operators currently relying on the `systemd` `IPAddressDeny` workaround can keep it — `ss -ltnp` will now show the bind address Arc actually opened, but the systemd filter remains valid defense-in-depth.
+
 ### Hard Query Gating During Replication Catch-Up (Enterprise, opt-in) — closes #392
 
 Reader nodes in a clustered Arc Enterprise deployment previously accepted queries the moment they started, even while peer file replication was still pulling Parquet files the rest of the cluster already had. The Raft manifest knew about the missing files; the local storage didn't have them yet; `read_parquet()` globbed against local storage rather than the manifest. The result was **silent partial results** during the catch-up window. The Phase 3 release explicitly deferred this fix; 26.05.1 closed half the gap (WAL replication makes unflushed writer data queryable on readers within milliseconds), but flushed Parquet files still depended on async background pullers.

--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -207,7 +207,7 @@ go run benchmarks/query_suite/main.go --target arc-arrow  --measurement cpu --it
 
 The HTTP listener has always bound the wildcard address (`":<port>"`), giving operators no way to restrict the bind from the config file. Deployments wanting loopback-only behavior (Arc fronted by a sidecar adapter on the same host) reached for `systemd` `IPAddressDeny`, `ufw`, or a reverse proxy. The `[server]` config block was missing the corresponding knob.
 
-26.06.1 adds `server.host` to the `[server]` config block, plumbed through to the Fiber listener via `net.JoinHostPort`. Any address Go's `net` package recognizes works — IPv4 literals, IPv6 literals (with correct bracketing), hostnames, the explicit IPv4 wildcard `0.0.0.0`, the explicit IPv6 wildcard `::`. The matching env override is `ARC_SERVER_HOST`.
+26.06.1 adds `server.host` to the `[server]` config block, plumbed through to the Fiber listener via `net.JoinHostPort`. Any address Go's `net` package recognizes works — IPv4 literals, IPv6 literals (write them without brackets — the server adds them when constructing the listen address; surrounding brackets in user input are stripped defensively), hostnames, the explicit IPv4 wildcard `0.0.0.0`, the explicit IPv6 wildcard `::`. The matching env override is `ARC_SERVER_HOST`.
 
 **Default is empty string** — the listener constructs `":<port>"`, byte-identical to the historical `fmt.Sprintf(":%d", port)`. This preserves Linux dual-stack wildcard behavior (IPv4 + IPv6 via IPv4-mapped addresses); explicit `"0.0.0.0"` would force IPv4-only and silently break IPv6 clients on upgrade, so it's an opt-in. **Zero behavioral change on the listener for operators who don't touch their config.**
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -860,10 +860,15 @@ func main() {
 			if lic == nil || !lic.HasFeature(license.FeatureClustering) {
 				log.Warn().Msg("License does not include clustering feature - running in standalone mode")
 			} else {
-				// Determine API address for this node
-				apiAddr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
-				if cfg.Server.Host == "0.0.0.0" {
-					apiAddr = fmt.Sprintf(":%d", cfg.Server.Port)
+				// Determine API address for this node. Use api.ListenAddr
+				// so IPv6 literals are bracketed correctly (the previous
+				// fmt.Sprintf("%s:%d", …) produced "::1:8000" which is
+				// not a valid address). The 0.0.0.0 special-case keeps
+				// the historical advertise-address shape (":<port>") for
+				// operators who explicitly bound the IPv4 wildcard.
+				apiAddr := fmt.Sprintf(":%d", cfg.Server.Port)
+				if cfg.Server.Host != "" && cfg.Server.Host != "0.0.0.0" {
+					_, apiAddr = api.ListenAddr(cfg.Server.Host, cfg.Server.Port)
 				}
 
 				// Peer replication (Enterprise Phase 2) requires shared-secret auth

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1089,6 +1089,7 @@ func main() {
 
 	// Initialize HTTP server
 	serverConfig := &api.ServerConfig{
+		Host:            cfg.Server.Host,
 		Port:            cfg.Server.Port,
 		ReadTimeout:     time.Duration(cfg.Server.ReadTimeout) * time.Second,
 		WriteTimeout:    time.Duration(cfg.Server.WriteTimeout) * time.Second,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -64,6 +64,24 @@ func DefaultServerConfig() *ServerConfig {
 	}
 }
 
+// listenAddr returns the canonicalized host and the full host:port
+// string we hand to Fiber. Behavior:
+//
+//   - host="" preserves the historical wildcard (":<port>") so existing
+//     deployments keep dual-stack binding on Linux on upgrade.
+//   - net.JoinHostPort adds IPv6 brackets when needed; surrounding
+//     brackets in user input are stripped first so we never produce
+//     an invalid double-bracketed address like "[[::1]]:8000".
+//
+// The canonicalized host is returned alongside the address so callers
+// can use it for logging without re-parsing.
+func listenAddr(host string, port int) (string, string) {
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+	return host, net.JoinHostPort(host, strconv.Itoa(port))
+}
+
 // NewServer creates a new HTTP server with Fiber
 func NewServer(config *ServerConfig, logger zerolog.Logger) *Server {
 	if config == nil {
@@ -367,19 +385,22 @@ func (s *Server) Start() error {
 		protocol = "HTTPS"
 	}
 
-	// net.JoinHostPort("", "8000") returns ":8000" — byte-identical
-	// to the historical fmt.Sprintf(":%d", port), which preserves
-	// dual-stack wildcard binding on Linux. An explicit host
-	// ("127.0.0.1", "::1", "0.0.0.0", "192.0.2.1", …) is honored
-	// as-is, with correct IPv6 bracketing.
-	addr := net.JoinHostPort(s.host, strconv.Itoa(s.port))
+	host, addr := listenAddr(s.host, s.port)
 
-	// host="" reads better in logs as "wildcard (dual-stack)"; an
-	// explicit value is logged verbatim so ops can see what we
-	// actually bound to without having to grep config files.
-	loggedHost := s.host
-	if loggedHost == "" {
-		loggedHost = "* (wildcard)"
+	// Wildcard variants read differently in logs so an operator
+	// debugging "why can't IPv6 clients connect" can see at a
+	// glance whether they're on dual-stack, v4-only, or v6-only.
+	// Other values are logged verbatim.
+	var loggedHost string
+	switch host {
+	case "":
+		loggedHost = "* (wildcard, dual-stack)"
+	case "0.0.0.0":
+		loggedHost = "0.0.0.0 (wildcard, IPv4-only)"
+	case "::":
+		loggedHost = ":: (wildcard, IPv6-only)"
+	default:
+		loggedHost = host
 	}
 	s.logger.Info().
 		Str("host", loggedHost).

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"runtime"
@@ -23,6 +24,7 @@ import (
 type Server struct {
 	app            *fiber.App
 	logger         zerolog.Logger
+	host           string
 	port           int
 	maxPayloadSize int64
 	tlsEnabled     bool
@@ -32,6 +34,12 @@ type Server struct {
 
 // ServerConfig holds server configuration
 type ServerConfig struct {
+	// Host is the bind address. Empty preserves the historical
+	// dual-stack wildcard (":<port>" on Linux binds both IPv4 and
+	// IPv6 via IPv4-mapped addresses). Set to a specific address
+	// (e.g. "127.0.0.1", "::1", "192.0.2.10") to restrict the bind.
+	// Explicit "0.0.0.0" forces IPv4-only.
+	Host            string
 	Port            int
 	ReadTimeout     time.Duration
 	WriteTimeout    time.Duration
@@ -104,6 +112,7 @@ func NewServer(config *ServerConfig, logger zerolog.Logger) *Server {
 	return &Server{
 		app:            app,
 		logger:         logger.With().Str("component", "api-server").Logger(),
+		host:           config.Host,
 		port:           config.Port,
 		maxPayloadSize: config.MaxPayloadSize,
 		tlsEnabled:     config.TLSEnabled,
@@ -358,7 +367,22 @@ func (s *Server) Start() error {
 		protocol = "HTTPS"
 	}
 
+	// net.JoinHostPort("", "8000") returns ":8000" — byte-identical
+	// to the historical fmt.Sprintf(":%d", port), which preserves
+	// dual-stack wildcard binding on Linux. An explicit host
+	// ("127.0.0.1", "::1", "0.0.0.0", "192.0.2.1", …) is honored
+	// as-is, with correct IPv6 bracketing.
+	addr := net.JoinHostPort(s.host, strconv.Itoa(s.port))
+
+	// host="" reads better in logs as "wildcard (dual-stack)"; an
+	// explicit value is logged verbatim so ops can see what we
+	// actually bound to without having to grep config files.
+	loggedHost := s.host
+	if loggedHost == "" {
+		loggedHost = "* (wildcard)"
+	}
 	s.logger.Info().
+		Str("host", loggedHost).
 		Int("port", s.port).
 		Bool("tls_enabled", s.tlsEnabled).
 		Str("protocol", protocol).
@@ -366,9 +390,7 @@ func (s *Server) Start() error {
 
 	// Start server in goroutine
 	go func() {
-		addr := fmt.Sprintf(":%d", s.port)
 		var err error
-
 		if s.tlsEnabled {
 			s.logger.Info().
 				Str("cert_file", s.tlsCert).

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -395,8 +395,11 @@ func (s *Server) Start() error {
 
 	// Wildcard variants read differently in logs so an operator
 	// debugging "why can't IPv6 clients connect" can see at a
-	// glance whether they're on dual-stack, v4-only, or v6-only.
-	// Other values are logged verbatim.
+	// glance which wildcard is in effect. The "::" case binds
+	// platform-default (dual-stack on modern Linux with
+	// bindv6only=0, v6-only on systems where IPV6_V6ONLY is
+	// set) — don't overclaim the family. Other values are
+	// logged verbatim.
 	var loggedHost string
 	switch host {
 	case "":
@@ -404,7 +407,7 @@ func (s *Server) Start() error {
 	case "0.0.0.0":
 		loggedHost = "0.0.0.0 (wildcard, IPv4-only)"
 	case "::":
-		loggedHost = ":: (wildcard, IPv6-only)"
+		loggedHost = ":: (wildcard, platform default)"
 	default:
 		loggedHost = host
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -64,8 +64,11 @@ func DefaultServerConfig() *ServerConfig {
 	}
 }
 
-// listenAddr returns the canonicalized host and the full host:port
-// string we hand to Fiber. Behavior:
+// ListenAddr canonicalizes (host, port) into the host:port string
+// callers hand to a listener — Fiber on the HTTP path, the cluster
+// coordinator's advertise/peer logic on the cluster path.
+//
+// Behavior:
 //
 //   - host="" preserves the historical wildcard (":<port>") so existing
 //     deployments keep dual-stack binding on Linux on upgrade.
@@ -74,8 +77,11 @@ func DefaultServerConfig() *ServerConfig {
 //     an invalid double-bracketed address like "[[::1]]:8000".
 //
 // The canonicalized host is returned alongside the address so callers
-// can use it for logging without re-parsing.
-func listenAddr(host string, port int) (string, string) {
+// can use it for logging without re-parsing. Exported so non-api
+// callers (cmd/arc) format the same address shape this server does
+// — historically this was duplicated with fmt.Sprintf("%s:%d", …)
+// which mis-formatted IPv6 literals.
+func ListenAddr(host string, port int) (string, string) {
 	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
 		host = host[1 : len(host)-1]
 	}
@@ -385,7 +391,7 @@ func (s *Server) Start() error {
 		protocol = "HTTPS"
 	}
 
-	host, addr := listenAddr(s.host, s.port)
+	host, addr := ListenAddr(s.host, s.port)
 
 	// Wildcard variants read differently in logs so an operator
 	// debugging "why can't IPv6 clients connect" can see at a

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -74,9 +74,9 @@ func TestListenAddrForHost(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, got := listenAddr(tc.host, port)
+			_, got := ListenAddr(tc.host, port)
 			if got != tc.want {
-				t.Errorf("listenAddr(%q, %d) = %q; want %q", tc.host, port, got, tc.want)
+				t.Errorf("ListenAddr(%q, %d) = %q; want %q", tc.host, port, got, tc.want)
 			}
 		})
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// TestListenAddrForHost pins the listener-address construction shape. The
+// production listener uses net.JoinHostPort(s.host, strconv.Itoa(s.port))
+// at server.go's Start path; this test asserts the addresses produced
+// for every shape an operator might configure.
+//
+// The "" case is load-bearing for backward compatibility: it must
+// produce ":<port>" (byte-identical to the historical fmt.Sprintf(":%d",
+// port)) so existing deployments upgrade with zero behavioral change
+// on the listener — specifically preserving Linux dual-stack
+// (IPv4 + IPv6 via IPv4-mapped addresses) binding semantics.
+func TestListenAddrForHost(t *testing.T) {
+	const port = 8000
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "empty preserves historical wildcard (dual-stack)",
+			host: "",
+			want: ":8000",
+		},
+		{
+			name: "explicit ipv4 wildcard binds v4 only",
+			host: "0.0.0.0",
+			want: "0.0.0.0:8000",
+		},
+		{
+			name: "explicit ipv6 wildcard with bracketing",
+			host: "::",
+			want: "[::]:8000",
+		},
+		{
+			name: "ipv4 loopback",
+			host: "127.0.0.1",
+			want: "127.0.0.1:8000",
+		},
+		{
+			name: "ipv6 loopback bracketed correctly",
+			host: "::1",
+			want: "[::1]:8000",
+		},
+		{
+			name: "named host passed through",
+			host: "arc.internal",
+			want: "arc.internal:8000",
+		},
+		{
+			name: "specific ipv4 interface",
+			host: "192.0.2.10",
+			want: "192.0.2.10:8000",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := net.JoinHostPort(tc.host, strconv.Itoa(port))
+			if got != tc.want {
+				t.Errorf("net.JoinHostPort(%q, %q) = %q; want %q", tc.host, strconv.Itoa(port), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestServerCapturesHostFromConfig pins that NewServer threads
+// ServerConfig.Host through to the Server struct's host field —
+// without this, the listener at Start() would always see the zero
+// value and silently fall back to wildcard regardless of what the
+// operator configured.
+func TestServerCapturesHostFromConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+	}{
+		{"empty default", ""},
+		{"ipv4 loopback", "127.0.0.1"},
+		{"ipv6 loopback", "::1"},
+		{"explicit v4 wildcard", "0.0.0.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &ServerConfig{
+				Host:           tc.host,
+				Port:           0,
+				MaxPayloadSize: 1024 * 1024,
+			}
+			// NewServer's logger argument is required but we don't
+			// care about its output here — zerolog.Nop() is the
+			// convention used by every other test in this package.
+			s := NewServer(cfg, zerolog.Nop())
+			if s.host != tc.host {
+				t.Errorf("Server.host = %q; want %q (NewServer dropped Host on the floor)", s.host, tc.host)
+			}
+		})
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,23 +1,24 @@
 package api
 
 import (
-	"net"
-	"strconv"
 	"testing"
 
 	"github.com/rs/zerolog"
 )
 
-// TestListenAddrForHost pins the listener-address construction shape. The
-// production listener uses net.JoinHostPort(s.host, strconv.Itoa(s.port))
-// at server.go's Start path; this test asserts the addresses produced
-// for every shape an operator might configure.
+// TestListenAddrForHost pins the listener-address construction shape
+// the Start path uses. Every shape an operator might configure is
+// exercised here.
 //
 // The "" case is load-bearing for backward compatibility: it must
 // produce ":<port>" (byte-identical to the historical fmt.Sprintf(":%d",
 // port)) so existing deployments upgrade with zero behavioral change
 // on the listener — specifically preserving Linux dual-stack
 // (IPv4 + IPv6 via IPv4-mapped addresses) binding semantics.
+//
+// The bracketed-IPv6 case is the defensive strip: a user who follows
+// docs that show bracketed addresses (or copies one from `ss`/`netstat`
+// output) must not produce an invalid "[[::1]]:8000".
 func TestListenAddrForHost(t *testing.T) {
 	const port = 8000
 	cases := []struct {
@@ -51,6 +52,16 @@ func TestListenAddrForHost(t *testing.T) {
 			want: "[::1]:8000",
 		},
 		{
+			name: "already-bracketed ipv6 is stripped before joining",
+			host: "[::1]",
+			want: "[::1]:8000",
+		},
+		{
+			name: "already-bracketed ipv6 wildcard is stripped before joining",
+			host: "[::]",
+			want: "[::]:8000",
+		},
+		{
 			name: "named host passed through",
 			host: "arc.internal",
 			want: "arc.internal:8000",
@@ -63,9 +74,9 @@ func TestListenAddrForHost(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := net.JoinHostPort(tc.host, strconv.Itoa(port))
+			_, got := listenAddr(tc.host, port)
 			if got != tc.want {
-				t.Errorf("net.JoinHostPort(%q, %q) = %q; want %q", tc.host, strconv.Itoa(port), got, tc.want)
+				t.Errorf("listenAddr(%q, %d) = %q; want %q", tc.host, port, got, tc.want)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -728,8 +728,15 @@ func Load() (*Config, error) {
 }
 
 func setDefaults(v *viper.Viper) {
-	// Server defaults
-	v.SetDefault("server.host", "0.0.0.0")
+	// Server defaults.
+	//
+	// server.host default is empty (not "0.0.0.0") so the listener
+	// invocation builds ":<port>" via net.JoinHostPort and preserves
+	// today's dual-stack wildcard behavior on Linux (IPv4 + IPv6
+	// via IPv4-mapped addresses). Explicit "0.0.0.0" forces
+	// IPv4-only and would silently break IPv6 clients on upgrade —
+	// see internal/api/server.go.
+	v.SetDefault("server.host", "")
 	v.SetDefault("server.port", 8000)
 	v.SetDefault("server.read_timeout", 30)
 	v.SetDefault("server.write_timeout", 30)


### PR DESCRIPTION
## Summary

- Adds `server.host` config (and `ARC_SERVER_HOST` env var) so operators can bind Arc's HTTP listener to a specific interface — useful behind a reverse proxy where Arc should only be reachable on loopback (#439).
- Default is the empty string, which preserves the pre-26.06.1 wildcard behavior with Linux dual-stack semantics (IPv4 + IPv6 via IPv4-mapped addresses). `net.JoinHostPort(\"\", \"8000\")` produces `\":8000\"`, **byte-identical** to the historical `fmt.Sprintf(\":%d\", port)` — zero behavioral change for operators upgrading without setting `server.host`.
- Listener switches from `fmt.Sprintf(\":%d\", port)` to `net.JoinHostPort(host, port)` so IPv6 addresses are bracketed correctly (e.g. `[::1]:8000`).
- Finishes plumbing that was already half-wired: viper read `server.host` into `config.Server.Host` but `cmd/arc/main.go` dropped it on the floor when copying into `api.ServerConfig`.

### Why empty default and not `0.0.0.0`

Setting `0.0.0.0` forces **IPv4-only** binding — silent break for IPv6 clients. Empty string keeps dual-stack on Linux. Called out in the release notes and the docs.

## Test plan

- [x] `go build ./cmd/... ./internal/...` clean
- [x] `go build -tags=duckdb_arrow ./cmd/... ./internal/...` clean
- [x] `go test ./internal/api/` — new `TestListenAddrForHost` (7 cases) + `TestServerCapturesHostFromConfig` (4 cases) pass
- [x] `go test ./internal/config/` passes
- [x] Empirically verified `net.JoinHostPort(\"\", \"8000\") == \":8000\"` (byte-identical to historical `fmt.Sprintf`)
- [x] Manual smoke: `ARC_SERVER_HOST=127.0.0.1 arc` → listener bound to loopback only
- [x] Manual smoke: no env var set → listener bound to all interfaces (dual-stack on Linux)
- [x] Docs PR for `docs.basekick.net` already merged: documents the new setting

## Related

- Closes #439
- Docs: Basekick-Labs/docs.basekick.net@85b13e7

🤖 Generated with [Claude Code](https://claude.com/claude-code)