### PR TITLE
fix(security): validate Raft FSM manifest paths (closes GHSA-f85q-mvg8-qf37)

### DIFF
--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -108,6 +108,45 @@ Operator-facing changes:
 
 Tests added: `TestCompute{,Fetch,Forward,CacheInvalidate}HMAC_Determinism` (pin reference MACs for every cluster HMAC endpoint so any future format drift fails CI), `TestValidate_RejectsMalformedHexMAC` (pins fail-closed on non-hex receivedMAC across all four validators), `TestValidateCacheInvalidateHMAC_{Valid, WrongSecret, StaleTimestamp, FutureTimestamp, FieldBinding}`, `TestCacheInvalidateHMAC_LabelBinding_NoCrossEndpointReplay` (cross-endpoint replay protection, covers Forward + Fetch + Join in both directions), `TestNewCacheInvalidateHandler_RejectsInvalidConfig` (constructor panics on each kind of misconfiguration), and 9 handler tests asserting both the response status AND the onInvalidate callback fired-exactly-once / never. The positive-path test asserts 204 + callback invoked; `TestCacheInvalidate_NonceNotBurnedByBadMAC` pins the ordering invariant (nonce cache `Track()` runs AFTER HMAC validation, so an off-path attacker without the secret cannot consume nonce-cache slots).
 
+### Cluster FSM rejects malicious paths in manifest-registration proposals (Enterprise)
+
+Reported by [Alex Manson](https://neurowinter.com/) ([@NeuroWinter](https://github.com/NeuroWinter)) — closes audit finding X2 / [GHSA-f85q-mvg8-qf37](https://github.com/Basekick-Labs/arc/security/advisories/GHSA-f85q-mvg8-qf37). **Enterprise-only critical** (clustering requires Arc Enterprise license — OSS deployments do not construct the cluster FSM and are unaffected).
+
+Pre-26.06.1 the Raft FSM (`internal/cluster/raft/fsm.go:applyRegisterFile` + `applyUpdateFile`) only checked that the proposed file path was non-empty. An attacker with one valid cluster credential — or one compromised cluster node — could issue Raft proposals registering arbitrary paths into the authoritative cluster manifest:
+
+- `/etc/passwd` as a "cluster data file" — other nodes that fetch the file to serve queries read host-level files outside Arc's storage root.
+- `s3://attacker-controlled-bucket/poisoned.parquet` — every cluster reader pulls attacker-controlled data into query results.
+- `../../etc/shadow` via parent-traversal — depending on how the storage backend resolves the path.
+
+Combined with [audit X1](https://github.com/Basekick-Labs/arc/security/advisories/GHSA-wfgr-8x84-22q7) (no HMAC on `MsgReplicateSync`, fix tracked separately), this was a **cluster-wide worm primitive**: a single-node compromise propagated through the entire data plane.
+
+26.06.1 introduces shape-based path validation in `internal/cluster/raft/path_validation.go`. Every manifest entry passes through `ValidateManifestPath` before landing in the FSM. The validator rejects:
+
+- **URL schemes** — `s3://`, `http://`, `file://`, etc. Legitimate Arc paths are relative to the storage backend root; the scheme is added by the backend at read time, never stored.
+- **Absolute paths** — leading `/` (POSIX) or `C:\` / `C:/` (Windows drive prefix). Legitimate paths are always backend-relative.
+- **Parent-traversal segments** — any segment exactly equal to `..`, treating both `/` and `\` as separators in a single pass so mixed-separator paths like `db/..\etc` are caught. Filenames containing `..` as a substring inside a longer token (e.g. `metric_20260520..parquet`) are NOT false-positives — the check is on segment equality, not substring containment.
+- **NUL bytes** — `\x00` smuggles through C-string callers (everything before NUL evaluates, everything after silently drops). Never legitimate.
+- **Empty paths** — already rejected pre-PR; preserved.
+- **Paths longer than 4096 bytes** — typical POSIX `PATH_MAX`. A malicious sender could otherwise propose a multi-megabyte path string to inflate the FSM's in-memory map.
+
+Validator returns sentinel errors (`ErrPath{Empty, TooLong, Traversal, Absolute, Scheme, NullByte}`) so callers can branch on the rejection reason via `errors.Is`. Every code path that mutates the manifest — `applyRegisterFile`, `applyUpdateFile`, `applyBatchFileOps` (atomic pre-validation pass), and snapshot `Restore` — logs at `Error` with the path + rejection reason as structured fields.
+
+**How rejection interacts with hashicorp/raft.** It is important to be precise about what "Apply rejects" actually does — the worm primitive is killed by the FSM, not by Raft's commit machinery:
+
+- A proposer (Arc's `Node.RegisterFile` / `.UpdateFile` etc.) calls `raftNode.Apply(cmd, timeout)`. Inside hashicorp/raft, the leader writes the command to its local log AND ships it to follower replicators BEFORE `fsm.Apply` runs. By the time `fsm.Apply` returns an error, the entry is already in every node's Raft log and is committed at the cluster level.
+- The security property is that **every node's FSM independently refuses to put the malicious path into `f.files`**: each `applyRegisterFile` validates the path, increments `rejectedPaths`, logs at `Error`, and returns the validation error. The proposer sees the error via `future.Response()` and propagates it; during log replay the error is silently swallowed (`req.future == nil`), but the entry still doesn't land and the counter still increments.
+- The malicious entry stays in the Raft log until the next snapshot rotation, at which point `Snapshot()` drains `f.files` (which never contained the malicious entry) and writes a clean snapshot; older log entries past the snapshot are subsequently truncated by hashicorp/raft.
+
+**Operator alerting.** `ClusterFSM.RejectedPathsCount()` returns a monotonic atomic counter of every refused entry across snapshot `Restore`, runtime Apply, and log-replay Apply. A non-zero growth rate is the load-bearing signal that somebody — a peer, a stored snapshot, or a Raft log entry from before validation was enforced — proposed a path this FSM refused. Operators should scrape this counter (or the per-entry `manifest path validation failed` Error log lines) and alert on growth. The Raft `Node.Start` also emits an `Error`-level summary at end-of-boot if any snapshot entries were refused during `Restore`.
+
+**Snapshot Restore vs. log replay.** hashicorp/raft splits boot into two phases: snapshot restore (synchronous inside `NewRaft`) and log replay past the snapshot (asynchronous on the `runFSM` goroutine, post-NewRaft). The FSM treats both identically: `ValidateManifestPath` runs, the rejected entry doesn't land, the counter increments. The cluster never refuses to boot because of a malicious entry — boot continues with the offending entry refused and the operator alert raised.
+
+**Atomicity of batched ops.** `applyBatchFileOps` (the common compaction path) runs a pre-validation pass over every Register/Update path in the batch before any state mutation. If ANY op carries a malicious path, the entire batch is refused and NO ops have side-effects. Without this pre-pass, a batch containing `[legit, malicious]` would have applied the legit op before the malicious one was caught — the test `TestApplyBatchFileOps_RejectsMaliciousPath_AtomicPrevalidation` pins this invariant.
+
+Approach note: shape-based validation, not backend-aware prefix matching. The legitimate path format produced by Arc's writer (`internal/cluster/file_registrar.go`) and compactor (`internal/cluster/compaction_bridge.go`) is `{database}/{measurement}/{year}/{month}/{day}/{hour}/{filename}.parquet` — always relative, always scheme-less, no `..`. The shape check catches every malicious shape from the audit without requiring `*config.StorageConfig` to be plumbed into the FSM (which would expand security surface unnecessarily). Backend-aware prefix matching can land later as a tightening if a path is found that the shape check accepts but the backend should reject.
+
+Tests added in `internal/cluster/raft/path_validation_test.go`: table-driven rejection matrix covering every shape from the audit + close-shape variants, sentinel-error verification via `errors.Is`, and a positive set covering production writer/compaction output. In `internal/cluster/raft/fsm_test.go`: `TestApplyRegisterFile_RejectsMaliciousPath` (table-driven across every malicious shape, asserts error + counter + non-membership in `f.files`), `TestApplyRegisterFile_MixedBatchIsolatesMaliciousEntries` (sequential Apply calls with legit/malicious interleaved — legit lands, malicious refused, counter reflects all), `TestApplyUpdateFile_RejectsMaliciousPath`, `TestApplyBatchFileOps_RejectsMaliciousPath_AtomicPrevalidation` (atomic batch: legit op preceding malicious op MUST NOT land), and `TestFSMRestore_QuarantinesMaliciousSnapshotEntries` (snapshot round-trip: 3 legit + 2 malicious entries → only 3 legit land, counter = 2).
+
 ## Bug fixes
 
 ### Parser no longer mis-resolves bare `time` column inside `EXTRACT(YEAR FROM time)`

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -658,6 +658,16 @@ func (f *ClusterFSM) applyUpdateFileStruct(p UpdateFilePayload, logIndex uint64)
 	if err := ValidateManifestPath(p.File.Path); err != nil {
 		return f.rejectManifestPath("update", p.File.Path, logIndex, err)
 	}
+	if p.File.CreatedAt.IsZero() {
+		// Same reasoning as applyRegisterFileStruct: the caller is
+		// responsible for setting CreatedAt before appending to Raft.
+		// Apply MUST NOT stamp it from time.Now() because that would
+		// be non-deterministic across nodes during log replay. An
+		// Update payload with a zero CreatedAt is a caller bug — it
+		// would clobber the original entry's creation timestamp with
+		// the JSON zero value.
+		return fmt.Errorf("update file: created_at is required")
+	}
 
 	// Stamp the LSN from the current Raft log index so consumers that
 	// watch f.files for "did this entry change" can detect the update.
@@ -777,6 +787,12 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 					Msg("manifest path validation failed during batch pre-check — entire batch refused")
 				return fmt.Errorf("batch file ops: op[%d]: %w", i, err)
 			}
+			// Mirror applyRegisterFileStruct's CreatedAt requirement
+			// in the pre-pass so a batch that would fail mid-apply on
+			// this check is refused atomically up front.
+			if rp.File.CreatedAt.IsZero() {
+				return fmt.Errorf("batch file ops: op[%d]: register file: created_at is required", i)
+			}
 			decoded[i] = rp
 		case CommandUpdateFile:
 			var up UpdateFilePayload
@@ -793,6 +809,10 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 					Int("batch_index", i).
 					Msg("manifest path validation failed during batch pre-check — entire batch refused")
 				return fmt.Errorf("batch file ops: op[%d]: %w", i, err)
+			}
+			// Mirror applyUpdateFileStruct's CreatedAt requirement.
+			if up.File.CreatedAt.IsZero() {
+				return fmt.Errorf("batch file ops: op[%d]: update file: created_at is required", i)
 			}
 			decoded[i] = up
 		case CommandDeleteFile:

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -245,8 +245,7 @@ func NewClusterFSM(logger zerolog.Logger) *ClusterFSM {
 // op is "register" or "update" for log disambiguation. errors.Is(err,
 // ErrPath*) gives the rejection reason. See GHSA-f85q-mvg8-qf37.
 func (f *ClusterFSM) rejectManifestPath(op, path string, logIndex uint64, err error) error {
-	f.rejectedPaths.Add(1)
-	metrics.Get().IncClusterManifestRejectedPaths()
+	f.incRejectedPaths()
 	f.logger.Error().
 		Err(err).
 		Str("op", op).
@@ -254,6 +253,18 @@ func (f *ClusterFSM) rejectManifestPath(op, path string, logIndex uint64, err er
 		Uint64("log_index", logIndex).
 		Msg("manifest path validation failed — entry refused, not added to f.files")
 	return fmt.Errorf("%s file: %w", op, err)
+}
+
+// incRejectedPaths increments both the per-FSM rejectedPaths counter
+// (consumed by Node.Start's end-of-boot summary log + tests) and the
+// process-wide metrics-package counter (exposed via /metrics and
+// /api/v1/metrics as arc_cluster_manifest_rejected_paths_total).
+// Every site that refuses a manifest entry — runtime apply, batch
+// pre-pass, snapshot Restore — calls through here so the two
+// counters stay in sync. See GHSA-f85q-mvg8-qf37.
+func (f *ClusterFSM) incRejectedPaths() {
+	f.rejectedPaths.Add(1)
+	metrics.Get().IncClusterManifestRejectedPaths()
 }
 
 // RejectedPathsCount returns the count of manifest entries refused by
@@ -797,8 +808,7 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 				return fmt.Errorf("batch file ops: op[%d] unmarshal: %w", i, err)
 			}
 			if err := ValidateManifestPath(rp.File.Path); err != nil {
-				f.rejectedPaths.Add(1)
-				metrics.Get().IncClusterManifestRejectedPaths()
+				f.incRejectedPaths()
 				f.logger.Error().
 					Err(err).
 					Str("op", "batch-prevalidate").
@@ -821,8 +831,7 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 				return fmt.Errorf("batch file ops: op[%d] unmarshal: %w", i, err)
 			}
 			if err := ValidateManifestPath(up.File.Path); err != nil {
-				f.rejectedPaths.Add(1)
-				metrics.Get().IncClusterManifestRejectedPaths()
+				f.incRejectedPaths()
 				f.logger.Error().
 					Err(err).
 					Str("op", "batch-prevalidate").
@@ -948,8 +957,7 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 		// panic — bricking the node's boot. Treat as a quarantine.
 		// See Gemini PR #446 r6.
 		if entry == nil {
-			f.rejectedPaths.Add(1)
-			metrics.Get().IncClusterManifestRejectedPaths()
+			f.incRejectedPaths()
 			f.logger.Error().
 				Str("path", path).
 				Str("source", "snapshot").
@@ -957,8 +965,7 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 			continue
 		}
 		if err := ValidateManifestPath(path); err != nil {
-			f.rejectedPaths.Add(1)
-			metrics.Get().IncClusterManifestRejectedPaths()
+			f.incRejectedPaths()
 			f.logger.Error().
 				Err(err).
 				Str("path", path).

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -941,6 +941,21 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 	// subsequent reads.
 	restoredFiles := make(map[string]*FileEntry, len(snapshot.Files))
 	for path, entry := range snapshot.Files {
+		// Defensive nil-check: f.files is map[string]*FileEntry, so a
+		// corrupted or attacker-crafted snapshot with `null` values
+		// would deserialize to nil pointers here. Without this skip,
+		// the secondary-index rebuild below (entry.Database) would
+		// panic — bricking the node's boot. Treat as a quarantine.
+		// See Gemini PR #446 r6.
+		if entry == nil {
+			f.rejectedPaths.Add(1)
+			metrics.Get().IncClusterManifestRejectedPaths()
+			f.logger.Error().
+				Str("path", path).
+				Str("source", "snapshot").
+				Msg("manifest entry is nil during snapshot restore — entry refused, not added to f.files")
+			continue
+		}
 		if err := ValidateManifestPath(path); err != nil {
 			f.rejectedPaths.Add(1)
 			metrics.Get().IncClusterManifestRejectedPaths()

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -524,7 +524,15 @@ func (f *ClusterFSM) applyRegisterFile(payload []byte, logIndex uint64) interfac
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return fmt.Errorf("failed to unmarshal register file payload: %w", err)
 	}
+	return f.applyRegisterFileStruct(p, logIndex)
+}
 
+// applyRegisterFileStruct is the struct-taking variant of applyRegisterFile.
+// applyBatchFileOps calls this directly after unmarshalling the payload
+// once in its pre-validation pass, avoiding a second unmarshal in the
+// apply loop. Non-batch callers go through applyRegisterFile, which
+// unmarshals + dispatches here.
+func (f *ClusterFSM) applyRegisterFileStruct(p RegisterFilePayload, logIndex uint64) interface{} {
 	// Validate the path BEFORE any state mutation. See GHSA-f85q-mvg8-qf37:
 	// historically the only check was empty-string, which let an attacker
 	// register arbitrary paths (/etc/passwd, s3://attacker-bucket/..., etc.)
@@ -633,6 +641,13 @@ func (f *ClusterFSM) applyUpdateFile(payload []byte, logIndex uint64) interface{
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return fmt.Errorf("failed to unmarshal update file payload: %w", err)
 	}
+	return f.applyUpdateFileStruct(p, logIndex)
+}
+
+// applyUpdateFileStruct is the struct-taking variant of applyUpdateFile.
+// applyBatchFileOps calls this directly after unmarshalling once during
+// pre-validation, avoiding a second unmarshal in the apply loop.
+func (f *ClusterFSM) applyUpdateFileStruct(p UpdateFilePayload, logIndex uint64) interface{} {
 	// Same validation as applyRegisterFile — an attacker who can submit
 	// Update commands could otherwise insert a new manifest entry at a
 	// malicious path (Update writes f.files[entry.Path] = &entry, so a
@@ -643,6 +658,14 @@ func (f *ClusterFSM) applyUpdateFile(payload []byte, logIndex uint64) interface{
 	if err := ValidateManifestPath(p.File.Path); err != nil {
 		return f.rejectManifestPath("update", p.File.Path, logIndex, err)
 	}
+
+	// Stamp the LSN from the current Raft log index so consumers that
+	// watch f.files for "did this entry change" can detect the update.
+	// Without this, an Update that mutates an existing entry would
+	// leave the LSN at its registration-time value, and downstream
+	// consumers (e.g. compaction watchers) couldn't distinguish a
+	// fresh state from a stale one.
+	p.File.LSN = logIndex
 
 	f.mu.Lock()
 	entry := p.File
@@ -730,36 +753,53 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 	// uses the path as a map key (delete of a non-existent key is a
 	// no-op); validating delete paths would change existing semantics
 	// for callers that legitimately race delete-then-register.
+	//
+	// We store each decoded Register/Update payload in parallel slots
+	// (decoded[i]) so the apply loop below can call the *Struct apply
+	// variants directly without re-unmarshalling. Each payload is
+	// decoded exactly once; Delete ops keep nil decoded slots.
+	decoded := make([]any, len(p.Ops))
 	for i, op := range p.Ops {
-		var pathToValidate string
 		switch op.Type {
 		case CommandRegisterFile:
 			var rp RegisterFilePayload
 			if err := json.Unmarshal(op.Payload, &rp); err != nil {
 				return fmt.Errorf("batch file ops: op[%d] unmarshal: %w", i, err)
 			}
-			pathToValidate = rp.File.Path
+			if err := ValidateManifestPath(rp.File.Path); err != nil {
+				f.rejectedPaths.Add(1)
+				f.logger.Error().
+					Err(err).
+					Str("op", "batch-prevalidate").
+					Str("path", rp.File.Path).
+					Uint64("log_index", logIndex).
+					Int("batch_index", i).
+					Msg("manifest path validation failed during batch pre-check — entire batch refused")
+				return fmt.Errorf("batch file ops: op[%d]: %w", i, err)
+			}
+			decoded[i] = rp
 		case CommandUpdateFile:
 			var up UpdateFilePayload
 			if err := json.Unmarshal(op.Payload, &up); err != nil {
 				return fmt.Errorf("batch file ops: op[%d] unmarshal: %w", i, err)
 			}
-			pathToValidate = up.File.Path
+			if err := ValidateManifestPath(up.File.Path); err != nil {
+				f.rejectedPaths.Add(1)
+				f.logger.Error().
+					Err(err).
+					Str("op", "batch-prevalidate").
+					Str("path", up.File.Path).
+					Uint64("log_index", logIndex).
+					Int("batch_index", i).
+					Msg("manifest path validation failed during batch pre-check — entire batch refused")
+				return fmt.Errorf("batch file ops: op[%d]: %w", i, err)
+			}
+			decoded[i] = up
 		case CommandDeleteFile:
-			continue
+			// no decode/validate here; applyDeleteFile handles the path
+			// as a map key (no-op for unknown keys).
 		default:
 			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
-		}
-		if err := ValidateManifestPath(pathToValidate); err != nil {
-			f.rejectedPaths.Add(1)
-			f.logger.Error().
-				Err(err).
-				Str("op", "batch-prevalidate").
-				Str("path", pathToValidate).
-				Uint64("log_index", logIndex).
-				Int("batch_index", i).
-				Msg("manifest path validation failed during batch pre-check — entire batch refused")
-			return fmt.Errorf("batch file ops: op[%d]: %w", i, err)
 		}
 	}
 
@@ -767,19 +807,19 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 		var result interface{}
 		switch op.Type {
 		case CommandRegisterFile:
-			result = f.applyRegisterFile(op.Payload, logIndex)
+			result = f.applyRegisterFileStruct(decoded[i].(RegisterFilePayload), logIndex)
 		case CommandDeleteFile:
 			result = f.applyDeleteFile(op.Payload)
 		case CommandUpdateFile:
-			result = f.applyUpdateFile(op.Payload, logIndex)
+			result = f.applyUpdateFileStruct(decoded[i].(UpdateFilePayload), logIndex)
 		default:
 			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
 		}
-		// applyRegisterFile and applyDeleteFile return nil on success or an
-		// error on failure — they never return a non-nil non-error value.
-		// The type-assert is defensive: if either handler is ever refactored
-		// to return something unexpected, we propagate it as an error rather
-		// than silently ignoring it.
+		// apply*FileStruct and applyDeleteFile return nil on success or
+		// an error on failure — they never return a non-nil non-error
+		// value. The type-assert is defensive: if either handler is ever
+		// refactored to return something unexpected, we propagate it as
+		// an error rather than silently ignoring it.
 		if result != nil {
 			if err, ok := result.(error); ok {
 				return fmt.Errorf("batch file ops: op[%d] (type=%d): %w", i, op.Type, err)

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/raft"
@@ -147,17 +148,17 @@ type BatchFileOpsPayload struct {
 
 // FSMSnapshot represents a snapshot of the FSM state.
 type FSMSnapshot struct {
-	Nodes              map[string]*NodeInfo  `json:"nodes"`
-	PrimaryWriterID    string                `json:"primary_writer_id,omitempty"`
-	ActiveCompactorID  string                `json:"active_compactor_id,omitempty"`
-	Files              map[string]*FileEntry `json:"files,omitempty"` // File manifest (peer replication)
+	Nodes             map[string]*NodeInfo  `json:"nodes"`
+	PrimaryWriterID   string                `json:"primary_writer_id,omitempty"`
+	ActiveCompactorID string                `json:"active_compactor_id,omitempty"`
+	Files             map[string]*FileEntry `json:"files,omitempty"` // File manifest (peer replication)
 }
 
 // ClusterFSM implements the raft.FSM interface for cluster state management.
 // It maintains the authoritative state of nodes in the cluster.
 type ClusterFSM struct {
-	mu              sync.RWMutex
-	nodes           map[string]*NodeInfo
+	mu                sync.RWMutex
+	nodes             map[string]*NodeInfo
 	primaryWriterID   string                // ID of the current primary writer node
 	activeCompactorID string                // ID of the node currently holding the compactor lease
 	files             map[string]*FileEntry // File manifest (path → entry) for peer replication
@@ -167,14 +168,25 @@ type ClusterFSM struct {
 	filesByDB map[string]map[string]struct{}
 	logger    zerolog.Logger
 
+	// rejectedPaths counts manifest entries refused by path validation
+	// across every code path that mutates the manifest: applyRegisterFile,
+	// applyUpdateFile (steady-state runtime AND log replay), and Restore
+	// (snapshot boot). A non-zero value — or, more usefully, non-zero
+	// growth — is the load-bearing operator signal that somebody
+	// proposed a path this FSM refused. Scrape and alert on it.
+	//
+	// Atomic because /metrics scrapes read it concurrently with FSM
+	// Apply on the runFSM goroutine. See GHSA-f85q-mvg8-qf37.
+	rejectedPaths atomic.Int64
+
 	// Callbacks for state changes
-	onNodeAdded      func(*NodeInfo)
-	onNodeRemoved    func(string)
-	onNodeUpdated    func(*NodeInfo)
-	onWriterPromoted   func(newPrimaryID, oldPrimaryID string)
+	onNodeAdded         func(*NodeInfo)
+	onNodeRemoved       func(string)
+	onNodeUpdated       func(*NodeInfo)
+	onWriterPromoted    func(newPrimaryID, oldPrimaryID string)
 	onCompactorAssigned func(newCompactorID, oldCompactorID string)
-	onFileRegistered   func(*FileEntry)
-	onFileDeleted      func(path string, reason string)
+	onFileRegistered    func(*FileEntry)
+	onFileDeleted       func(path string, reason string)
 }
 
 // NewClusterFSM creates a new cluster FSM.
@@ -185,6 +197,60 @@ func NewClusterFSM(logger zerolog.Logger) *ClusterFSM {
 		filesByDB: make(map[string]map[string]struct{}),
 		logger:    logger.With().Str("component", "cluster-fsm").Logger(),
 	}
+}
+
+// rejectManifestPath centralizes the FSM-side response to a path that
+// failed ValidateManifestPath. Used by applyRegisterFile and
+// applyUpdateFile.
+//
+// In every case: log at Error, increment the rejectedPaths counter,
+// and return a wrapped validation error. The downstream behaviour
+// then depends on whether Apply is being called by a proposer or by
+// log replay — and crucially, the *security property* (entry does
+// NOT land in f.files) holds in both cases because we return BEFORE
+// any state mutation in the caller.
+//
+//   - Proposer path (Arc's Node.RegisterFile / .UpdateFile etc.):
+//     hashicorp/raft delivers the error via future.Response(), and
+//     Arc's node.go propagates it to the caller. The leader's
+//     Register/Update API call returns the validation error.
+//
+//   - Log replay (hashicorp/raft runFSM goroutine processing committed
+//     entries past the snapshot): the error is silently swallowed by
+//     runFSM (req.future == nil for replayed entries) — boot
+//     continues, the entry doesn't land, the counter is incremented,
+//     and operators see the Error log line.
+//
+// Note: hashicorp/raft commits a proposed entry to the leader's log
+// AND replicates it to followers BEFORE Apply runs. So a malicious
+// path is briefly in every node's Raft log; the security property is
+// that no node's FSM puts it in f.files. The Raft log is bounded by
+// the snapshot rotation interval — eventually the malicious entry is
+// garbage-collected when a snapshot is taken (Snapshot drains
+// f.files, which never contained the malicious entry).
+//
+// op is "register" or "update" for log disambiguation. errors.Is(err,
+// ErrPath*) gives the rejection reason. See GHSA-f85q-mvg8-qf37.
+func (f *ClusterFSM) rejectManifestPath(op, path string, logIndex uint64, err error) error {
+	f.rejectedPaths.Add(1)
+	f.logger.Error().
+		Err(err).
+		Str("op", op).
+		Str("path", path).
+		Uint64("log_index", logIndex).
+		Msg("manifest path validation failed — entry refused, not added to f.files")
+	return fmt.Errorf("%s file: %w", op, err)
+}
+
+// RejectedPathsCount returns the count of manifest entries refused by
+// path validation across every FSM code path (snapshot Restore +
+// runtime Apply + log replay Apply). The counter is monotonic. A
+// non-zero growth rate is the load-bearing operator signal that
+// somebody — a peer, a stored snapshot, or a pre-validation Raft log
+// entry — proposed a path this FSM refused. Scrape and alert on it.
+// See GHSA-f85q-mvg8-qf37.
+func (f *ClusterFSM) RejectedPathsCount() int64 {
+	return f.rejectedPaths.Load()
 }
 
 // SetCallbacks sets the FSM callbacks for state changes.
@@ -263,7 +329,7 @@ func (f *ClusterFSM) Apply(log *raft.Log) interface{} {
 	case CommandBatchFileOps:
 		return f.applyBatchFileOps(cmd.Payload, log.Index)
 	case CommandUpdateFile:
-		return f.applyUpdateFile(cmd.Payload)
+		return f.applyUpdateFile(cmd.Payload, log.Index)
 	default:
 		return fmt.Errorf("unknown command type: %d", cmd.Type)
 	}
@@ -459,8 +525,14 @@ func (f *ClusterFSM) applyRegisterFile(payload []byte, logIndex uint64) interfac
 		return fmt.Errorf("failed to unmarshal register file payload: %w", err)
 	}
 
-	if p.File.Path == "" {
-		return fmt.Errorf("register file: path is required")
+	// Validate the path BEFORE any state mutation. See GHSA-f85q-mvg8-qf37:
+	// historically the only check was empty-string, which let an attacker
+	// register arbitrary paths (/etc/passwd, s3://attacker-bucket/..., etc.)
+	// into the authoritative manifest. ValidateManifestPath rejects every
+	// malicious shape from the audit (scheme, absolute, parent-traversal,
+	// NUL, oversize) plus the historical empty-string case.
+	if err := ValidateManifestPath(p.File.Path); err != nil {
+		return f.rejectManifestPath("register", p.File.Path, logIndex, err)
 	}
 	if p.File.CreatedAt.IsZero() {
 		// The creator is responsible for setting CreatedAt before appending
@@ -556,13 +628,20 @@ func (f *ClusterFSM) applyDeleteFile(payload []byte) interface{} {
 	return nil
 }
 
-func (f *ClusterFSM) applyUpdateFile(payload []byte) interface{} {
+func (f *ClusterFSM) applyUpdateFile(payload []byte, logIndex uint64) interface{} {
 	var p UpdateFilePayload
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return fmt.Errorf("failed to unmarshal update file payload: %w", err)
 	}
-	if p.File.Path == "" {
-		return fmt.Errorf("update file: path is required")
+	// Same validation as applyRegisterFile — an attacker who can submit
+	// Update commands could otherwise insert a new manifest entry at a
+	// malicious path (Update writes f.files[entry.Path] = &entry, so a
+	// payload with Path="/etc/passwd" would create a fresh entry at
+	// that path rather than mutating any pre-existing one). The end
+	// risk to operators is the same as in applyRegisterFile: a hostile
+	// path in f.files. See GHSA-f85q-mvg8-qf37.
+	if err := ValidateManifestPath(p.File.Path); err != nil {
+		return f.rejectManifestPath("update", p.File.Path, logIndex, err)
 	}
 
 	f.mu.Lock()
@@ -639,6 +718,51 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 		return fmt.Errorf("failed to unmarshal batch file ops payload: %w", err)
 	}
 
+	// Pre-validate every Register/Update path BEFORE any state
+	// mutation so the batch is atomic with respect to path validation:
+	// if any op carries a malicious path, the whole batch is refused
+	// and NO ops have side-effects. Without this pass, an attacker
+	// could place a legitimate op first and a malicious op second —
+	// the legitimate op would land before the loop hit the malicious
+	// one. See GHSA-f85q-mvg8-qf37 review notes.
+	//
+	// Delete ops are not validated here because applyDeleteFile only
+	// uses the path as a map key (delete of a non-existent key is a
+	// no-op); validating delete paths would change existing semantics
+	// for callers that legitimately race delete-then-register.
+	for i, op := range p.Ops {
+		var pathToValidate string
+		switch op.Type {
+		case CommandRegisterFile:
+			var rp RegisterFilePayload
+			if err := json.Unmarshal(op.Payload, &rp); err != nil {
+				return fmt.Errorf("batch file ops: op[%d] unmarshal: %w", i, err)
+			}
+			pathToValidate = rp.File.Path
+		case CommandUpdateFile:
+			var up UpdateFilePayload
+			if err := json.Unmarshal(op.Payload, &up); err != nil {
+				return fmt.Errorf("batch file ops: op[%d] unmarshal: %w", i, err)
+			}
+			pathToValidate = up.File.Path
+		case CommandDeleteFile:
+			continue
+		default:
+			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
+		}
+		if err := ValidateManifestPath(pathToValidate); err != nil {
+			f.rejectedPaths.Add(1)
+			f.logger.Error().
+				Err(err).
+				Str("op", "batch-prevalidate").
+				Str("path", pathToValidate).
+				Uint64("log_index", logIndex).
+				Int("batch_index", i).
+				Msg("manifest path validation failed during batch pre-check — entire batch refused")
+			return fmt.Errorf("batch file ops: op[%d]: %w", i, err)
+		}
+	}
+
 	for i, op := range p.Ops {
 		var result interface{}
 		switch op.Type {
@@ -647,7 +771,7 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 		case CommandDeleteFile:
 			result = f.applyDeleteFile(op.Payload)
 		case CommandUpdateFile:
-			result = f.applyUpdateFile(op.Payload)
+			result = f.applyUpdateFile(op.Payload, logIndex)
 		default:
 			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
 		}
@@ -697,15 +821,37 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 		return fmt.Errorf("failed to decode snapshot: %w", err)
 	}
 
+	// Validate every restored manifest path. Entries that fail
+	// validation are LOGGED AT ERROR + SKIPPED (NOT added to f.files)
+	// and counted into rejectedPaths so operators can alert on a
+	// non-zero growth rate. See GHSA-f85q-mvg8-qf37. We deliberately
+	// continue restoring the rest of the snapshot rather than failing
+	// hard — a cluster boot blocked by a single malicious entry in a
+	// historical snapshot would be unrecoverable.
+	//
+	// Rebuild f.files in a fresh map rather than mutating
+	// snapshot.Files in place; this keeps the snapshot struct
+	// untouched and makes the filter step impossible to skip on
+	// subsequent reads.
+	restoredFiles := make(map[string]*FileEntry, len(snapshot.Files))
+	for path, entry := range snapshot.Files {
+		if err := ValidateManifestPath(path); err != nil {
+			f.rejectedPaths.Add(1)
+			f.logger.Error().
+				Err(err).
+				Str("path", path).
+				Str("source", "snapshot").
+				Msg("manifest path validation failed during snapshot restore — entry refused, not added to f.files")
+			continue
+		}
+		restoredFiles[path] = entry
+	}
+
 	f.mu.Lock()
 	f.nodes = snapshot.Nodes
 	f.primaryWriterID = snapshot.PrimaryWriterID
 	f.activeCompactorID = snapshot.ActiveCompactorID
-	if snapshot.Files != nil {
-		f.files = snapshot.Files
-	} else {
-		f.files = make(map[string]*FileEntry)
-	}
+	f.files = restoredFiles
 	// Rebuild the database → files secondary index from the restored files
 	f.filesByDB = make(map[string]map[string]struct{}, len(f.files))
 	for path, entry := range f.files {

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -832,8 +832,24 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 			}
 			decoded[i] = up
 		case CommandDeleteFile:
-			// no decode/validate here; applyDeleteFile handles the path
-			// as a map key (no-op for unknown keys).
+			// Delete paths intentionally bypass ValidateManifestPath
+			// (applyDeleteFile only uses the path as a map key — delete
+			// of a non-existent key is a no-op). BUT we still must
+			// pre-check the basic structural invariants that
+			// applyDeleteFile enforces: unmarshal success and non-empty
+			// path. Without this, a malformed Delete payload would pass
+			// the pre-pass and fail mid-apply, violating the batch
+			// atomicity invariant. (We decode for the structural check
+			// but don't store the result — the apply loop re-decodes
+			// from op.Payload since applyDeleteFile has no *Struct
+			// variant.)
+			var dp DeleteFilePayload
+			if err := json.Unmarshal(op.Payload, &dp); err != nil {
+				return fmt.Errorf("batch file ops: op[%d] unmarshal: %w", i, err)
+			}
+			if dp.Path == "" {
+				return fmt.Errorf("batch file ops: op[%d]: delete file: path is required", i)
+			}
 		default:
 			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
 		}

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/hashicorp/raft"
 	"github.com/rs/zerolog"
 )
@@ -170,13 +171,25 @@ type ClusterFSM struct {
 
 	// rejectedPaths counts manifest entries refused by path validation
 	// across every code path that mutates the manifest: applyRegisterFile,
-	// applyUpdateFile (steady-state runtime AND log replay), and Restore
-	// (snapshot boot). A non-zero value — or, more usefully, non-zero
-	// growth — is the load-bearing operator signal that somebody
-	// proposed a path this FSM refused. Scrape and alert on it.
+	// applyUpdateFile (steady-state runtime AND log replay), batch
+	// pre-validation, and Restore (snapshot boot). A non-zero value —
+	// or, more usefully, non-zero growth — is the load-bearing operator
+	// signal that somebody proposed a path this FSM refused.
 	//
-	// Atomic because /metrics scrapes read it concurrently with FSM
-	// Apply on the runFSM goroutine. See GHSA-f85q-mvg8-qf37.
+	// Surfaced three ways:
+	//   - RejectedPathsCount() Go-level getter (used by Node.Start's
+	//     end-of-boot summary log).
+	//   - The per-entry "manifest path validation failed" Error log lines.
+	//   - The process-wide metrics package counter
+	//     arc_cluster_manifest_rejected_paths_total, exported via
+	//     /metrics (Prometheus) and /api/v1/metrics (JSON). Every
+	//     rejectedPaths.Add(1) site also calls
+	//     metrics.Get().IncClusterManifestRejectedPaths() so the two
+	//     counters stay in sync.
+	//
+	// Atomic because /metrics scrapes read the (process-wide) sibling
+	// counter concurrently with FSM Apply on the runFSM goroutine. See
+	// GHSA-f85q-mvg8-qf37.
 	rejectedPaths atomic.Int64
 
 	// Callbacks for state changes
@@ -233,6 +246,7 @@ func NewClusterFSM(logger zerolog.Logger) *ClusterFSM {
 // ErrPath*) gives the rejection reason. See GHSA-f85q-mvg8-qf37.
 func (f *ClusterFSM) rejectManifestPath(op, path string, logIndex uint64, err error) error {
 	f.rejectedPaths.Add(1)
+	metrics.Get().IncClusterManifestRejectedPaths()
 	f.logger.Error().
 		Err(err).
 		Str("op", op).
@@ -778,6 +792,7 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 			}
 			if err := ValidateManifestPath(rp.File.Path); err != nil {
 				f.rejectedPaths.Add(1)
+				metrics.Get().IncClusterManifestRejectedPaths()
 				f.logger.Error().
 					Err(err).
 					Str("op", "batch-prevalidate").
@@ -801,6 +816,7 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 			}
 			if err := ValidateManifestPath(up.File.Path); err != nil {
 				f.rejectedPaths.Add(1)
+				metrics.Get().IncClusterManifestRejectedPaths()
 				f.logger.Error().
 					Err(err).
 					Str("op", "batch-prevalidate").
@@ -823,6 +839,12 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 		}
 	}
 
+	// Apply loop. Each *Struct call re-validates path + CreatedAt that
+	// the pre-pass above already passed for the same payload — that's
+	// intentional defense-in-depth (two cheap checks vs. one JSON
+	// unmarshal), and it lets the *Struct functions stand on their
+	// own when called outside the batch path (single-op Register /
+	// Update from internal/cluster/raft/node.go).
 	for i, op := range p.Ops {
 		var result interface{}
 		switch op.Type {
@@ -833,6 +855,9 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 		case CommandUpdateFile:
 			result = f.applyUpdateFileStruct(decoded[i].(UpdateFilePayload), logIndex)
 		default:
+			// Unreachable: pre-pass at lines above rejects unsupported
+			// op types. Kept for type-completeness so the switch isn't
+			// missing the default arm.
 			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
 		}
 		// apply*FileStruct and applyDeleteFile return nil on success or
@@ -897,6 +922,7 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 	for path, entry := range snapshot.Files {
 		if err := ValidateManifestPath(path); err != nil {
 			f.rejectedPaths.Add(1)
+			metrics.Get().IncClusterManifestRejectedPaths()
 			f.logger.Error().
 				Err(err).
 				Str("path", path).

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -613,7 +613,13 @@ func (f *ClusterFSM) applyDeleteFile(payload []byte) interface{} {
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return fmt.Errorf("failed to unmarshal delete file payload: %w", err)
 	}
+	return f.applyDeleteFileStruct(p)
+}
 
+// applyDeleteFileStruct is the struct-taking variant of applyDeleteFile.
+// applyBatchFileOps calls this directly after unmarshalling once during
+// pre-validation, avoiding a second unmarshal in the apply loop.
+func (f *ClusterFSM) applyDeleteFileStruct(p DeleteFilePayload) interface{} {
 	if p.Path == "" {
 		return fmt.Errorf("delete file: path is required")
 	}
@@ -834,15 +840,13 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 		case CommandDeleteFile:
 			// Delete paths intentionally bypass ValidateManifestPath
 			// (applyDeleteFile only uses the path as a map key — delete
-			// of a non-existent key is a no-op). BUT we still must
-			// pre-check the basic structural invariants that
-			// applyDeleteFile enforces: unmarshal success and non-empty
-			// path. Without this, a malformed Delete payload would pass
-			// the pre-pass and fail mid-apply, violating the batch
-			// atomicity invariant. (We decode for the structural check
-			// but don't store the result — the apply loop re-decodes
-			// from op.Payload since applyDeleteFile has no *Struct
-			// variant.)
+			// of a non-existent key is a no-op). BUT we still pre-check
+			// the structural invariants that applyDeleteFile enforces:
+			// unmarshal success and non-empty path. Without this, a
+			// malformed Delete payload would pass the pre-pass and fail
+			// mid-apply, violating the batch atomicity invariant. The
+			// decoded payload is stored in decoded[i] so the apply loop
+			// reuses it (one unmarshal per Delete op instead of two).
 			var dp DeleteFilePayload
 			if err := json.Unmarshal(op.Payload, &dp); err != nil {
 				return fmt.Errorf("batch file ops: op[%d] unmarshal: %w", i, err)
@@ -850,6 +854,7 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 			if dp.Path == "" {
 				return fmt.Errorf("batch file ops: op[%d]: delete file: path is required", i)
 			}
+			decoded[i] = dp
 		default:
 			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
 		}
@@ -867,7 +872,7 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 		case CommandRegisterFile:
 			result = f.applyRegisterFileStruct(decoded[i].(RegisterFilePayload), logIndex)
 		case CommandDeleteFile:
-			result = f.applyDeleteFile(op.Payload)
+			result = f.applyDeleteFileStruct(decoded[i].(DeleteFilePayload))
 		case CommandUpdateFile:
 			result = f.applyUpdateFileStruct(decoded[i].(UpdateFilePayload), logIndex)
 		default:
@@ -876,11 +881,11 @@ func (f *ClusterFSM) applyBatchFileOps(payload []byte, logIndex uint64) interfac
 			// missing the default arm.
 			return fmt.Errorf("batch file ops: op[%d] unsupported type: %d", i, op.Type)
 		}
-		// apply*FileStruct and applyDeleteFile return nil on success or
-		// an error on failure — they never return a non-nil non-error
-		// value. The type-assert is defensive: if either handler is ever
-		// refactored to return something unexpected, we propagate it as
-		// an error rather than silently ignoring it.
+		// apply*FileStruct return nil on success or an error on failure
+		// — they never return a non-nil non-error value. The type-assert
+		// is defensive: if any handler is ever refactored to return
+		// something unexpected, we propagate it as an error rather than
+		// silently ignoring it.
 		if result != nil {
 			if err, ok := result.(error); ok {
 				return fmt.Errorf("batch file ops: op[%d] (type=%d): %w", i, op.Type, err)

--- a/internal/cluster/raft/fsm_test.go
+++ b/internal/cluster/raft/fsm_test.go
@@ -977,6 +977,51 @@ func TestApplyUpdateFile_RejectsMaliciousPath(t *testing.T) {
 	}
 }
 
+// TestApplyUpdateFile_BumpsLSN pins that applyUpdateFile stamps the
+// current Raft log index into the entry's LSN, matching the contract
+// applyRegisterFile already satisfies. Without this, an Update that
+// mutates an existing entry would leave the LSN at its
+// registration-time value, and downstream consumers that watch LSN
+// for "did this entry change" (e.g. compaction watchers) couldn't
+// distinguish a fresh state from a stale one. Gemini #446-r1 #1.
+func TestApplyUpdateFile_BumpsLSN(t *testing.T) {
+	t.Parallel()
+	fsm := newTestFSM()
+
+	// Register at log index 10 → LSN should be 10.
+	legit := makeFileEntry("db/cpu/2026/05/20/15/file.parquet", "db", "cpu", 100)
+	regData := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: legit})
+	if result := fsm.Apply(&raft.Log{Index: 10, Data: regData}); result != nil {
+		t.Fatalf("legit register failed: %v", result)
+	}
+	got, exists := fsm.GetFile(legit.Path)
+	if !exists {
+		t.Fatal("entry should exist after register")
+	}
+	if got.LSN != 10 {
+		t.Fatalf("post-register LSN: got %d, want 10", got.LSN)
+	}
+
+	// Update at log index 42 with same path but different size.
+	updated := legit
+	updated.SizeBytes = 999
+	updateData := makeCommand(t, CommandUpdateFile, UpdateFilePayload{File: updated})
+	if result := fsm.Apply(&raft.Log{Index: 42, Data: updateData}); result != nil {
+		t.Fatalf("legit update failed: %v", result)
+	}
+
+	got, exists = fsm.GetFile(legit.Path)
+	if !exists {
+		t.Fatal("entry should still exist after update")
+	}
+	if got.LSN != 42 {
+		t.Errorf("post-update LSN: got %d, want 42 (Update must stamp LSN from log index, not preserve registration-time value)", got.LSN)
+	}
+	if got.SizeBytes != 999 {
+		t.Errorf("post-update SizeBytes: got %d, want 999 (update should land)", got.SizeBytes)
+	}
+}
+
 // TestFSMRestore_QuarantinesMaliciousSnapshotEntries pins the
 // snapshot-restore quarantine path. A snapshot containing 3 legit +
 // 2 malicious entries must round-trip with only the 3 legit entries

--- a/internal/cluster/raft/fsm_test.go
+++ b/internal/cluster/raft/fsm_test.go
@@ -1213,6 +1213,74 @@ func TestApplyBatchFileOps_RejectsZeroCreatedAt_AtomicPrevalidation(t *testing.T
 	})
 }
 
+// TestApplyBatchFileOps_RejectsEmptyDeletePath_AtomicPrevalidation pins
+// that the batch pre-pass also catches structural invariants for
+// Delete ops (unmarshal success + non-empty path). Without this, a
+// batch with [legit, delete-with-empty-path] would have applied the
+// legit op before applyDeleteFile rejected the second — violating
+// batch atomicity. Gemini #446-r4.
+func TestApplyBatchFileOps_RejectsEmptyDeletePath_AtomicPrevalidation(t *testing.T) {
+	t.Parallel()
+	fsm := newTestFSM()
+
+	legitFile := makeFileEntry("db/cpu/2026/05/20/15/legit.parquet", "db", "cpu", 100)
+	legitPayload, _ := json.Marshal(RegisterFilePayload{File: legitFile})
+	emptyDelPayload, _ := json.Marshal(DeleteFilePayload{Path: "", Reason: "test"})
+
+	batchData := makeCommand(t, CommandBatchFileOps, BatchFileOpsPayload{
+		Ops: []BatchFileOp{
+			{Type: CommandRegisterFile, Payload: legitPayload},
+			{Type: CommandDeleteFile, Payload: emptyDelPayload},
+		},
+	})
+	result := fsm.Apply(&raft.Log{Index: 1, Data: batchData})
+	if result == nil {
+		t.Fatal("batch with empty-path Delete should error")
+	}
+	if _, ok := result.(error); !ok {
+		t.Fatalf("expected error result, got %T", result)
+	}
+	// Atomic: legit Register MUST NOT land.
+	if fsm.FileCount() != 0 {
+		t.Errorf("batch atomicity violated: f.files has %d entries (expected 0)", fsm.FileCount())
+	}
+	if _, exists := fsm.GetFile(legitFile.Path); exists {
+		t.Error("legit op preceding empty-path Delete MUST NOT land")
+	}
+	// Delete path is not validated for shape (it's a map-key lookup),
+	// so the rejectedPaths counter is NOT incremented by this case —
+	// only by ValidateManifestPath rejections.
+	if c := fsm.RejectedPathsCount(); c != 0 {
+		t.Errorf("empty-Delete-path rejection should NOT touch rejectedPaths counter (got %d)", c)
+	}
+}
+
+// TestApplyBatchFileOps_RejectsMalformedDeletePayload_AtomicPrevalidation
+// pins the second half of the Delete pre-check: if op.Payload doesn't
+// even unmarshal as a DeleteFilePayload, refuse the whole batch.
+// Gemini #446-r4.
+func TestApplyBatchFileOps_RejectsMalformedDeletePayload_AtomicPrevalidation(t *testing.T) {
+	t.Parallel()
+	fsm := newTestFSM()
+
+	legitFile := makeFileEntry("db/cpu/2026/05/20/15/legit.parquet", "db", "cpu", 100)
+	legitPayload, _ := json.Marshal(RegisterFilePayload{File: legitFile})
+
+	batchData := makeCommand(t, CommandBatchFileOps, BatchFileOpsPayload{
+		Ops: []BatchFileOp{
+			{Type: CommandRegisterFile, Payload: legitPayload},
+			{Type: CommandDeleteFile, Payload: []byte("not-valid-json{")},
+		},
+	})
+	result := fsm.Apply(&raft.Log{Index: 1, Data: batchData})
+	if result == nil {
+		t.Fatal("batch with malformed Delete payload should error")
+	}
+	if fsm.FileCount() != 0 {
+		t.Errorf("batch atomicity violated: legit op landed despite malformed Delete (count=%d)", fsm.FileCount())
+	}
+}
+
 // TestApplyUpdateFile_RejectsZeroCreatedAt pins the standalone (non-batch)
 // path's CreatedAt requirement on Update. Gemini #446-r2.
 func TestApplyUpdateFile_RejectsZeroCreatedAt(t *testing.T) {

--- a/internal/cluster/raft/fsm_test.go
+++ b/internal/cluster/raft/fsm_test.go
@@ -1124,3 +1124,119 @@ func TestApplyBatchFileOps_RejectsMaliciousPath_AtomicPrevalidation(t *testing.T
 		t.Errorf("expected RejectedPathsCount=1 (one malicious op), got %d", c)
 	}
 }
+
+// TestApplyBatchFileOps_RejectsZeroCreatedAt_AtomicPrevalidation pins
+// that the batch pre-validation pass mirrors applyRegisterFileStruct's
+// CreatedAt requirement. Without this, a batch containing a legit op
+// followed by an op with zero CreatedAt would pass path-validation
+// pre-pass → the legit op would land in f.files → the second op
+// would fail mid-apply → batch atomicity violated. Gemini #446-r2.
+func TestApplyBatchFileOps_RejectsZeroCreatedAt_AtomicPrevalidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("register with zero CreatedAt", func(t *testing.T) {
+		t.Parallel()
+		fsm := newTestFSM()
+
+		legitFile := makeFileEntry("db/cpu/2026/05/20/15/legit.parquet", "db", "cpu", 100)
+		// CreatedAt deliberately left zero.
+		badFile := FileEntry{
+			Path:         "db/cpu/2026/05/20/15/bad.parquet",
+			Database:     "db",
+			Measurement:  "cpu",
+			SizeBytes:    100,
+			OriginNodeID: "writer-1",
+			Tier:         "hot",
+		}
+
+		legitPayload, _ := json.Marshal(RegisterFilePayload{File: legitFile})
+		badPayload, _ := json.Marshal(RegisterFilePayload{File: badFile})
+
+		batchData := makeCommand(t, CommandBatchFileOps, BatchFileOpsPayload{
+			Ops: []BatchFileOp{
+				{Type: CommandRegisterFile, Payload: legitPayload},
+				{Type: CommandRegisterFile, Payload: badPayload},
+			},
+		})
+		result := fsm.Apply(&raft.Log{Index: 1, Data: batchData})
+		if result == nil {
+			t.Fatal("batch with zero-CreatedAt op should error")
+		}
+		if _, ok := result.(error); !ok {
+			t.Fatalf("expected error result, got %T", result)
+		}
+		// Atomic: legit op preceding bad op MUST NOT land.
+		if fsm.FileCount() != 0 {
+			t.Errorf("batch atomicity violated: f.files has %d entries (expected 0)", fsm.FileCount())
+		}
+	})
+
+	t.Run("update with zero CreatedAt", func(t *testing.T) {
+		t.Parallel()
+		fsm := newTestFSM()
+
+		// Pre-register an entry so the update has something to mutate.
+		preReg := makeFileEntry("db/cpu/2026/05/20/15/pre.parquet", "db", "cpu", 100)
+		fsm.Apply(&raft.Log{Index: 1, Data: makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: preReg})})
+
+		legitUpd := preReg
+		legitUpd.SizeBytes = 999
+		badUpd := FileEntry{
+			Path:         "db/cpu/2026/05/20/15/other.parquet",
+			Database:     "db",
+			Measurement:  "cpu",
+			SizeBytes:    200,
+			OriginNodeID: "writer-1",
+			Tier:         "hot",
+			// CreatedAt zero.
+		}
+
+		legitPayload, _ := json.Marshal(UpdateFilePayload{File: legitUpd})
+		badPayload, _ := json.Marshal(UpdateFilePayload{File: badUpd})
+
+		batchData := makeCommand(t, CommandBatchFileOps, BatchFileOpsPayload{
+			Ops: []BatchFileOp{
+				{Type: CommandUpdateFile, Payload: legitPayload},
+				{Type: CommandUpdateFile, Payload: badPayload},
+			},
+		})
+		result := fsm.Apply(&raft.Log{Index: 2, Data: batchData})
+		if result == nil {
+			t.Fatal("batch with zero-CreatedAt update should error")
+		}
+		// Pre-existing entry must keep its original SizeBytes — the
+		// legit update preceding the bad one MUST NOT have landed.
+		got, _ := fsm.GetFile(preReg.Path)
+		if got.SizeBytes != 100 {
+			t.Errorf("batch atomicity violated: legit update landed (SizeBytes=%d, want pre-batch value 100)", got.SizeBytes)
+		}
+	})
+}
+
+// TestApplyUpdateFile_RejectsZeroCreatedAt pins the standalone (non-batch)
+// path's CreatedAt requirement on Update. Gemini #446-r2.
+func TestApplyUpdateFile_RejectsZeroCreatedAt(t *testing.T) {
+	t.Parallel()
+	fsm := newTestFSM()
+
+	bad := FileEntry{
+		Path:         "db/cpu/2026/05/20/15/file.parquet",
+		Database:     "db",
+		Measurement:  "cpu",
+		SizeBytes:    100,
+		OriginNodeID: "writer-1",
+		Tier:         "hot",
+		// CreatedAt zero.
+	}
+	data := makeCommand(t, CommandUpdateFile, UpdateFilePayload{File: bad})
+	result := fsm.Apply(&raft.Log{Index: 1, Data: data})
+	if result == nil {
+		t.Fatal("update with zero CreatedAt should error")
+	}
+	if _, ok := result.(error); !ok {
+		t.Fatalf("expected error result, got %T", result)
+	}
+	if fsm.FileCount() != 0 {
+		t.Errorf("zero-CreatedAt update should not land in files (count=%d)", fsm.FileCount())
+	}
+}

--- a/internal/cluster/raft/fsm_test.go
+++ b/internal/cluster/raft/fsm_test.go
@@ -1077,6 +1077,44 @@ func TestFSMRestore_QuarantinesMaliciousSnapshotEntries(t *testing.T) {
 	}
 }
 
+// TestFSMRestore_HandlesNilFileEntry pins the defensive nil-check on
+// snapshot restore: a corrupted/crafted snapshot with `null` map
+// values must NOT panic the boot (would otherwise deref entry.Database
+// in the secondary-index rebuild). Nil entries are quarantined,
+// counter incremented, boot continues. Gemini #446-r6.
+func TestFSMRestore_HandlesNilFileEntry(t *testing.T) {
+	t.Parallel()
+	snapshot := FSMSnapshot{
+		Nodes: map[string]*NodeInfo{},
+		Files: map[string]*FileEntry{
+			"db/cpu/2026/05/20/15/legit.parquet":   {Path: "db/cpu/2026/05/20/15/legit.parquet", Database: "db", Measurement: "cpu", CreatedAt: time.Now()},
+			"db/cpu/2026/05/20/15/corrupt.parquet": nil, // explicit nil entry
+		},
+	}
+	snapshotBytes, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	fsm := newTestFSM()
+	if err := fsm.Restore(io.NopCloser(bytes.NewReader(snapshotBytes))); err != nil {
+		t.Fatalf("Restore should not error on nil entry (got %v)", err)
+	}
+
+	if fsm.FileCount() != 1 {
+		t.Errorf("expected 1 legit entry restored, got %d", fsm.FileCount())
+	}
+	if c := fsm.RejectedPathsCount(); c != 1 {
+		t.Errorf("expected 1 quarantined entry (nil entry), got %d", c)
+	}
+	if _, exists := fsm.GetFile("db/cpu/2026/05/20/15/corrupt.parquet"); exists {
+		t.Error("nil entry should not have been restored")
+	}
+	if _, exists := fsm.GetFile("db/cpu/2026/05/20/15/legit.parquet"); !exists {
+		t.Error("legit entry should still be restored alongside nil entry")
+	}
+}
+
 // TestApplyBatchFileOps_RejectsMaliciousPath_AtomicPrevalidation pins
 // the atomicity invariant: when a batch contains a malicious entry —
 // even mid-batch — NO ops from the batch have side-effects. The

--- a/internal/cluster/raft/fsm_test.go
+++ b/internal/cluster/raft/fsm_test.go
@@ -858,3 +858,224 @@ func TestFSMBatchFileOpsEmpty(t *testing.T) {
 		t.Errorf("FileCount() = %d, want 0", count)
 	}
 }
+
+// TestApplyRegisterFile_RejectsMaliciousPath pins the security
+// property of GHSA-f85q-mvg8-qf37 across every malicious path shape:
+// Apply returns an error, the entry does NOT land in f.files, and
+// the rejectedPaths counter increments. The error is delivered to
+// the proposer via future.Response(); during log replay it's
+// silently swallowed by hashicorp/raft because req.future == nil,
+// but the security property (entry not in f.files) and visibility
+// (counter + Error log line) both hold.
+func TestApplyRegisterFile_RejectsMaliciousPath(t *testing.T) {
+	t.Parallel()
+	maliciousPaths := []string{
+		"/etc/passwd",
+		"s3://attacker-bucket/poisoned.parquet",
+		"../../etc/shadow",
+		"db\x00/etc/passwd",
+		"file:///etc/passwd",
+	}
+	for _, mp := range maliciousPaths {
+		t.Run(mp, func(t *testing.T) {
+			fsm := newTestFSM()
+			file := makeFileEntry(mp, "db", "cpu", 100)
+			data := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: file})
+
+			result := fsm.Apply(&raft.Log{Index: 1, Data: data})
+			if result == nil {
+				t.Fatalf("malicious path %q: Apply should have returned error", mp)
+			}
+			if _, ok := result.(error); !ok {
+				t.Fatalf("malicious path %q: expected error result, got %T", mp, result)
+			}
+			if fsm.FileCount() != 0 {
+				t.Errorf("malicious path %q: should not have landed in files (count=%d)", mp, fsm.FileCount())
+			}
+			if c := fsm.RejectedPathsCount(); c != 1 {
+				t.Errorf("malicious path %q: rejectedPaths should be 1, got %d", mp, c)
+			}
+		})
+	}
+}
+
+// TestApplyRegisterFile_MixedBatchIsolatesMaliciousEntries verifies
+// that when a stream of Apply calls contains both legitimate and
+// malicious entries, only the legitimate ones land in f.files and the
+// counter reflects all rejections. Simulates the "leader applies a
+// flush from a writer that has a malicious peer also proposing to
+// the same FSM" shape (which doesn't happen in practice but pins the
+// per-Apply isolation invariant).
+func TestApplyRegisterFile_MixedBatchIsolatesMaliciousEntries(t *testing.T) {
+	t.Parallel()
+	fsm := newTestFSM()
+
+	entries := []FileEntry{
+		makeFileEntry("/etc/passwd", "db", "cpu", 1),
+		makeFileEntry("db/cpu/2026/05/20/15/legit1.parquet", "db", "cpu", 100),
+		makeFileEntry("s3://attacker/poisoned.parquet", "db", "cpu", 1),
+		makeFileEntry("db/cpu/2026/05/20/15/legit2.parquet", "db", "cpu", 100),
+	}
+	for i, file := range entries {
+		data := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: file})
+		fsm.Apply(&raft.Log{Index: uint64(i + 1), Data: data})
+	}
+
+	if fsm.FileCount() != 2 {
+		t.Errorf("expected 2 legit entries to land, got count=%d", fsm.FileCount())
+	}
+	if c := fsm.RejectedPathsCount(); c != 2 {
+		t.Errorf("expected 2 rejected entries, got %d", c)
+	}
+	for _, malicious := range []string{"/etc/passwd", "s3://attacker/poisoned.parquet"} {
+		if _, exists := fsm.GetFile(malicious); exists {
+			t.Errorf("malicious entry %q must not be in f.files", malicious)
+		}
+	}
+	for _, legit := range []string{
+		"db/cpu/2026/05/20/15/legit1.parquet",
+		"db/cpu/2026/05/20/15/legit2.parquet",
+	} {
+		if _, exists := fsm.GetFile(legit); !exists {
+			t.Errorf("legit entry %q must be in f.files", legit)
+		}
+	}
+}
+
+// TestApplyUpdateFile_RejectsMaliciousPath pins that the same
+// validation guards apply to update commands. Without this, an
+// attacker who can submit Update could rewrite an existing entry's
+// path to a malicious value.
+func TestApplyUpdateFile_RejectsMaliciousPath(t *testing.T) {
+	t.Parallel()
+	fsm := newTestFSM()
+
+	// Register a legit entry first so there's something to update.
+	legit := makeFileEntry("db/cpu/2026/05/20/15/file.parquet", "db", "cpu", 100)
+	regData := makeCommand(t, CommandRegisterFile, RegisterFilePayload{File: legit})
+	if result := fsm.Apply(&raft.Log{Index: 1, Data: regData}); result != nil {
+		t.Fatalf("legit register failed: %v", result)
+	}
+
+	// Attempt to "update" with a malicious path.
+	bad := makeFileEntry("../../etc/shadow", "db", "cpu", 100)
+	updateData := makeCommand(t, CommandUpdateFile, UpdateFilePayload{File: bad})
+	result := fsm.Apply(&raft.Log{Index: 2, Data: updateData})
+	if result == nil {
+		t.Fatal("update with malicious path should error")
+	}
+	if _, ok := result.(error); !ok {
+		t.Fatalf("expected error result, got %T", result)
+	}
+
+	// Original entry still present + unchanged.
+	if _, exists := fsm.GetFile(legit.Path); !exists {
+		t.Error("legitimate entry should be untouched by rejected update")
+	}
+	if _, exists := fsm.GetFile(bad.Path); exists {
+		t.Error("malicious path should not appear in files")
+	}
+}
+
+// TestFSMRestore_QuarantinesMaliciousSnapshotEntries pins the
+// snapshot-restore quarantine path. A snapshot containing 3 legit +
+// 2 malicious entries must round-trip with only the 3 legit entries
+// in f.files, and the quarantine counter must reflect both
+// rejections.
+func TestFSMRestore_QuarantinesMaliciousSnapshotEntries(t *testing.T) {
+	t.Parallel()
+	// Build a snapshot manually (not via Snapshot/Persist) so we can
+	// inject malicious entries that Snapshot() would never produce
+	// from our own state (Snapshot draws from f.files, which is
+	// validation-protected at write time after this PR).
+	snapshot := FSMSnapshot{
+		Nodes:           map[string]*NodeInfo{},
+		PrimaryWriterID: "",
+		Files: map[string]*FileEntry{
+			"db/cpu/2026/05/20/15/legit1.parquet":   {Path: "db/cpu/2026/05/20/15/legit1.parquet", Database: "db", Measurement: "cpu", CreatedAt: time.Now()},
+			"db/cpu/2026/05/20/15/legit2.parquet":   {Path: "db/cpu/2026/05/20/15/legit2.parquet", Database: "db", Measurement: "cpu", CreatedAt: time.Now()},
+			"db/cpu/2026/05/20/15/legit3.parquet":   {Path: "db/cpu/2026/05/20/15/legit3.parquet", Database: "db", Measurement: "cpu", CreatedAt: time.Now()},
+			"/etc/passwd":                           {Path: "/etc/passwd", Database: "db", Measurement: "cpu", CreatedAt: time.Now()},
+			"s3://attacker-bucket/poisoned.parquet": {Path: "s3://attacker-bucket/poisoned.parquet", Database: "db", Measurement: "cpu", CreatedAt: time.Now()},
+		},
+	}
+	snapshotBytes, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	fsm := newTestFSM()
+	if err := fsm.Restore(io.NopCloser(bytes.NewReader(snapshotBytes))); err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+
+	if fsm.FileCount() != 3 {
+		t.Errorf("expected 3 legit entries restored, got %d", fsm.FileCount())
+	}
+	if c := fsm.RejectedPathsCount(); c != 2 {
+		t.Errorf("expected 2 rejected entries, got %d", c)
+	}
+	if _, exists := fsm.GetFile("/etc/passwd"); exists {
+		t.Error("/etc/passwd should not have been restored")
+	}
+	if _, exists := fsm.GetFile("s3://attacker-bucket/poisoned.parquet"); exists {
+		t.Error("s3:// scheme path should not have been restored")
+	}
+	for _, legit := range []string{
+		"db/cpu/2026/05/20/15/legit1.parquet",
+		"db/cpu/2026/05/20/15/legit2.parquet",
+		"db/cpu/2026/05/20/15/legit3.parquet",
+	} {
+		if _, exists := fsm.GetFile(legit); !exists {
+			t.Errorf("legit entry %q should be restored", legit)
+		}
+	}
+}
+
+// TestApplyBatchFileOps_RejectsMaliciousPath_AtomicPrevalidation pins
+// the atomicity invariant: when a batch contains a malicious entry —
+// even mid-batch — NO ops from the batch have side-effects. The
+// pre-validation pass walks every Register/Update path before any
+// applyXxx is called, so the legit op BEFORE the malicious one does
+// NOT land. This closes the High finding from internal review:
+// without pre-validation, the leader's f.files would diverge from
+// "the malicious entry never replicates" claim in the release notes.
+func TestApplyBatchFileOps_RejectsMaliciousPath_AtomicPrevalidation(t *testing.T) {
+	t.Parallel()
+	fsm := newTestFSM()
+
+	// Order matters: legit op FIRST so a non-atomic implementation
+	// would have applied it before reaching the malicious op.
+	legitFile := makeFileEntry("db/cpu/2026/05/20/15/legit.parquet", "db", "cpu", 100)
+	maliciousFile := makeFileEntry("../../etc/shadow", "db", "cpu", 100)
+
+	legitPayload, _ := json.Marshal(RegisterFilePayload{File: legitFile})
+	maliciousPayload, _ := json.Marshal(RegisterFilePayload{File: maliciousFile})
+
+	batchData := makeCommand(t, CommandBatchFileOps, BatchFileOpsPayload{
+		Ops: []BatchFileOp{
+			{Type: CommandRegisterFile, Payload: legitPayload},
+			{Type: CommandRegisterFile, Payload: maliciousPayload},
+		},
+	})
+	result := fsm.Apply(&raft.Log{Index: 1, Data: batchData})
+	if result == nil {
+		t.Fatal("batch with malicious entry should error")
+	}
+	if _, ok := result.(error); !ok {
+		t.Fatalf("expected error result, got %T", result)
+	}
+	// Atomic pre-validation: no ops land in f.files, including the
+	// legit op that came BEFORE the malicious one in the batch.
+	if fsm.FileCount() != 0 {
+		t.Errorf("batch should leave f.files unchanged on validation failure; got %d entries", fsm.FileCount())
+	}
+	if _, exists := fsm.GetFile(legitFile.Path); exists {
+		t.Error("legit op preceding malicious op MUST NOT land — batch must be atomic on validation failure")
+	}
+	// The rejected-paths counter increments once per pre-validation
+	// rejection (one per malicious op in the batch).
+	if c := fsm.RejectedPathsCount(); c != 1 {
+		t.Errorf("expected RejectedPathsCount=1 (one malicious op), got %d", c)
+	}
+}

--- a/internal/cluster/raft/node.go
+++ b/internal/cluster/raft/node.go
@@ -207,10 +207,29 @@ func (n *Node) Start() error {
 	}
 	n.snapStore = snapStore
 
-	// Create Raft instance
+	// Create Raft instance. Inside NewRaft, hashicorp/raft synchronously
+	// calls fsm.Restore (if a snapshot exists) — path validation in
+	// Restore logs+skips malicious entries and increments
+	// rejectedPaths. Post-NewRaft, log replay runs on the runFSM
+	// goroutine; ClusterFSM.Apply rejects malicious entries via the
+	// same path-validation helper (the Apply error is silently
+	// swallowed for replayed entries because req.future == nil, but
+	// the entry doesn't land in f.files and the counter still
+	// increments — see GHSA-f85q-mvg8-qf37 design notes on
+	// rejectManifestPath).
 	ra, err := raft.NewRaft(raftConfig, n.fsm, logStore, stableStore, snapStore, transport)
 	if err != nil {
 		return fmt.Errorf("failed to create raft instance: %w", err)
+	}
+	if count := n.fsm.RejectedPathsCount(); count > 0 {
+		// Only fires for snapshot Restore rejections (synchronous
+		// inside NewRaft). Log-replay rejections happen on runFSM
+		// post-NewRaft and surface via the per-entry Error log lines
+		// emitted by rejectManifestPath. Operators alerting on
+		// rejectedPaths metric scrape will see both.
+		n.logger.Error().
+			Int64("count", count).
+			Msg("manifest path validation refused entries during snapshot restore — see per-entry Error logs tagged 'manifest path validation failed' for the offending paths. Sources: pre-validation Arc version, OR prior compromise. Audit and verify they are not present in active queries.")
 	}
 	n.raft = ra
 

--- a/internal/cluster/raft/path_validation.go
+++ b/internal/cluster/raft/path_validation.go
@@ -73,11 +73,20 @@ func ValidateManifestPath(path string) error {
 	if strings.ContainsRune(path, 0) {
 		return ErrPathNullByte
 	}
-	// Reject URL schemes before checking absolute paths so the
-	// distinguishing rejection reason logged is the more specific one
-	// (`scheme` rather than `absolute`) for paths like `file:///etc/passwd`.
-	if strings.Contains(path, "://") {
-		return ErrPathScheme
+	// Reject any colon in the path EXCEPT the Windows drive-letter
+	// case at exactly index 1 (e.g. `C:\Windows\...`). This catches
+	// not only `s3://...` (which the prior `://` substring check
+	// covered) but also single-slash URIs like `file:/etc/passwd`
+	// and scheme-only URIs like `mailto:foo` or `data:...`. Legit
+	// Arc storage paths never contain `:` — the partition format is
+	// `{db}/{measurement}/{YYYY}/{MM}/{DD}/{HH}/{filename}.parquet`,
+	// none of which can legitimately carry a colon. The Windows-drive
+	// exception falls through to the absolute-path check below, which
+	// rejects with the more specific ErrPathAbsolute reason.
+	if idx := strings.Index(path, ":"); idx != -1 {
+		if idx != 1 || !isAbsolutePath(path) {
+			return ErrPathScheme
+		}
 	}
 	if isAbsolutePath(path) {
 		return ErrPathAbsolute

--- a/internal/cluster/raft/path_validation.go
+++ b/internal/cluster/raft/path_validation.go
@@ -1,0 +1,138 @@
+package raft
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// MaxManifestPathLen bounds a manifest entry's path to a safe length.
+// 4096 matches the typical POSIX PATH_MAX. A malicious sender that bypassed
+// the other checks could otherwise propose a multi-megabyte path string and
+// inflate the FSM's in-memory map.
+const MaxManifestPathLen = 4096
+
+// Sentinel errors returned by ValidateManifestPath. Exported so callers
+// (live-commit handlers, startup quarantine, tests) can branch on the
+// specific rejection reason via errors.Is.
+var (
+	// ErrPathEmpty: the path field is the empty string. This was the
+	// only check pre-PR.
+	ErrPathEmpty = errors.New("manifest path: empty")
+
+	// ErrPathTooLong: path exceeds MaxManifestPathLen bytes.
+	ErrPathTooLong = errors.New("manifest path: exceeds maximum length")
+
+	// ErrPathTraversal: path contains a `..` segment. Legitimate Arc
+	// storage paths are flat and partition-hierarchical; ".." never
+	// appears.
+	ErrPathTraversal = errors.New("manifest path: contains parent-directory traversal")
+
+	// ErrPathAbsolute: path begins with `/` (POSIX absolute) or matches
+	// a Windows drive prefix (C:\, etc). Legitimate Arc paths are
+	// relative to the storage backend root, never absolute.
+	ErrPathAbsolute = errors.New("manifest path: absolute paths not permitted")
+
+	// ErrPathScheme: path contains a URL scheme separator (`://`).
+	// Legitimate Arc paths are storage-backend-relative; the scheme is
+	// added by the backend at read time, not stored in the manifest.
+	// A scheme in the manifest is the canonical worm-primitive shape
+	// (s3://attacker-bucket/...).
+	ErrPathScheme = errors.New("manifest path: contains URL scheme")
+
+	// ErrPathNullByte: path contains a NUL byte. NUL is forbidden in
+	// most filesystem APIs and would smuggle through C-string callers
+	// (everything before the NUL gets evaluated, everything after
+	// silently ignored).
+	ErrPathNullByte = errors.New("manifest path: contains NUL byte")
+)
+
+// ValidateManifestPath rejects paths that cannot legitimately come from
+// Arc's writer (internal/cluster/file_registrar.go) or compactor
+// (internal/cluster/compaction_bridge.go). Legitimate paths follow the
+// shape {database}/{measurement}/{year}/{month}/{day}/{hour}/{filename}
+// or a compaction-output variant — always RELATIVE to the storage
+// backend root, never carrying a scheme, never containing parent
+// traversal.
+//
+// We don't enforce the exact partition format because compaction
+// output, retention rewrites, and future code paths can legitimately
+// differ. The checks below catch every malicious shape enumerated in
+// GHSA-f85q-mvg8-qf37 (Arc Enterprise audit X2, 2026-05-19) without
+// over-constraining what writers may produce.
+//
+// Checks are ordered from cheapest to most expensive so the common
+// "happy path" early-returns at the first emptiness check.
+func ValidateManifestPath(path string) error {
+	if path == "" {
+		return ErrPathEmpty
+	}
+	if len(path) > MaxManifestPathLen {
+		return fmt.Errorf("%w: %d bytes", ErrPathTooLong, len(path))
+	}
+	if strings.ContainsRune(path, 0) {
+		return ErrPathNullByte
+	}
+	// Reject URL schemes before checking absolute paths so the
+	// distinguishing rejection reason logged is the more specific one
+	// (`scheme` rather than `absolute`) for paths like `file:///etc/passwd`.
+	if strings.Contains(path, "://") {
+		return ErrPathScheme
+	}
+	if isAbsolutePath(path) {
+		return ErrPathAbsolute
+	}
+	if hasParentTraversalSegment(path) {
+		return ErrPathTraversal
+	}
+	return nil
+}
+
+// isAbsolutePath returns true for POSIX-absolute paths (leading `/`)
+// and Windows-absolute paths (drive letter, e.g. `C:\` or `C:/`).
+// Legitimate Arc manifest paths are relative to the storage backend
+// root and never lead with either shape.
+func isAbsolutePath(path string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	if path[0] == '/' || path[0] == '\\' {
+		return true
+	}
+	// Windows drive letter (`C:`, `D:`, ...) followed by separator.
+	// Catches `C:\Windows\System32\config\SAM` and `C:/foo/bar`.
+	if len(path) >= 3 && path[1] == ':' &&
+		((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) &&
+		(path[2] == '\\' || path[2] == '/') {
+		return true
+	}
+	return false
+}
+
+// hasParentTraversalSegment returns true if any path segment is
+// exactly `..`. Treats BOTH `/` and `\` as separators in the same pass
+// so mixed-separator paths (e.g. `db/..\etc` or `db\..\etc`) are
+// caught — splitting on one separator at a time misses the case where
+// `..` sits between two different separators.
+//
+// We check segment equality, not substring containment, so legitimate
+// filenames containing `..` as part of a longer token (e.g.
+// `db/m/2026/05/20/15/measurement_20260520_150000..parquet`) aren't
+// false-positives. The Arc writer doesn't produce that shape today,
+// but the segment check is the correct semantics regardless.
+func hasParentTraversalSegment(path string) bool {
+	// Fast path: if the literal `..` substring isn't present at all,
+	// no segment can equal `..`.
+	if !strings.Contains(path, "..") {
+		return false
+	}
+	segments := strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	for _, segment := range segments {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cluster/raft/path_validation_test.go
+++ b/internal/cluster/raft/path_validation_test.go
@@ -37,9 +37,22 @@ func TestValidateManifestPath_RejectionMatrix(t *testing.T) {
 		{"s3 scheme", "s3://attacker-bucket/poisoned.parquet", ErrPathScheme},
 		{"http scheme", "http://evil.example.com/payload", ErrPathScheme},
 		{"https scheme", "https://evil.example.com/payload", ErrPathScheme},
-		{"file scheme", "file:///etc/passwd", ErrPathScheme},
+		{"file scheme triple slash", "file:///etc/passwd", ErrPathScheme},
+		{"file scheme single slash", "file:/etc/passwd", ErrPathScheme},
 		{"azure scheme", "azure://container/blob", ErrPathScheme},
 		{"scheme inside", "db/m/x://y/file.parquet", ErrPathScheme},
+		// Scheme-only URI shapes (no `//` after the colon) — still
+		// rejected as scheme because no legit Arc path contains `:`.
+		{"mailto scheme", "mailto:victim@example.com", ErrPathScheme},
+		{"data scheme", "data:text/plain,exfil", ErrPathScheme},
+		{"colon-only at zero", "x:y", ErrPathScheme},
+		{"colon mid path", "db/m/foo:bar/file.parquet", ErrPathScheme},
+		// Edge case: single-char prefix with colon at index 1 that is
+		// NOT a Windows drive letter (digit, symbol). The Windows
+		// drive-letter exception requires [A-Za-z] AND a path-separator
+		// at index 2; a bare `0:foo` matches neither and is rejected
+		// as scheme.
+		{"digit colon", "0:foo", ErrPathScheme},
 
 		// Absolute paths.
 		{"posix absolute", "/etc/passwd", ErrPathAbsolute},

--- a/internal/cluster/raft/path_validation_test.go
+++ b/internal/cluster/raft/path_validation_test.go
@@ -1,0 +1,137 @@
+package raft
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestValidateManifestPath_RejectionMatrix covers every malicious shape
+// enumerated in GHSA-f85q-mvg8-qf37 (Arc Enterprise audit X2, 2026-05-19)
+// plus close-shape variants. The test is table-driven and each row
+// asserts BOTH that the path is rejected AND that the rejection reason
+// (sentinel error) matches — so a future refactor that swallows the
+// reason classification doesn't silently pass.
+func TestValidateManifestPath_RejectionMatrix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		path string
+		want error
+	}{
+		// Empty (pre-PR's only check; kept for completeness).
+		{"empty", "", ErrPathEmpty},
+
+		// Length cap.
+		{"too long", strings.Repeat("a", MaxManifestPathLen+1), ErrPathTooLong},
+		{"length exactly cap", strings.Repeat("a", MaxManifestPathLen), nil},
+
+		// NUL injection. NUL before `://` ordering matters: NUL is
+		// checked first so the rejection reason is the more
+		// security-relevant one.
+		{"nul byte at end", "db/m/2026/05/20/15/file.parquet\x00", ErrPathNullByte},
+		{"nul byte mid", "db\x00/etc/passwd", ErrPathNullByte},
+		{"nul then scheme", "db\x00://etc/passwd", ErrPathNullByte},
+
+		// URL schemes (the canonical worm-primitive shape).
+		{"s3 scheme", "s3://attacker-bucket/poisoned.parquet", ErrPathScheme},
+		{"http scheme", "http://evil.example.com/payload", ErrPathScheme},
+		{"https scheme", "https://evil.example.com/payload", ErrPathScheme},
+		{"file scheme", "file:///etc/passwd", ErrPathScheme},
+		{"azure scheme", "azure://container/blob", ErrPathScheme},
+		{"scheme inside", "db/m/x://y/file.parquet", ErrPathScheme},
+
+		// Absolute paths.
+		{"posix absolute", "/etc/passwd", ErrPathAbsolute},
+		{"posix absolute slash only", "/", ErrPathAbsolute},
+		{"windows backslash absolute", "\\Windows\\System32", ErrPathAbsolute},
+		{"windows drive letter upper", "C:\\Windows\\System32\\config\\SAM", ErrPathAbsolute},
+		{"windows drive letter lower", "c:/foo/bar", ErrPathAbsolute},
+		{"windows drive d", "D:\\data", ErrPathAbsolute},
+
+		// Parent traversal.
+		{"basic parent traversal", "../etc/passwd", ErrPathTraversal},
+		{"deep parent traversal", "../../../../etc/shadow", ErrPathTraversal},
+		{"traversal mid-path", "db/../../../etc/passwd", ErrPathTraversal},
+		{"traversal windows separator", "db\\..\\..\\etc", ErrPathTraversal},
+		{"traversal mixed separator", "db/..\\etc", ErrPathTraversal},
+
+		// Negative cases that LOOK suspicious but aren't:
+		// - filename containing ".." as substring inside a longer token
+		//   (legitimate by our segment-equality rule)
+		// - leading dot files like ".hidden" (not parent traversal)
+		// - trailing dots like "foo." (not parent traversal)
+		{"dotdot substring in filename", "db/m/2026/05/20/15/measurement_20260520..parquet", nil},
+		{"dot filename", "db/m/2026/05/20/15/.hidden.parquet", nil},
+		{"dotdot trailing on segment", "db/m/2026/05/20/15/foo..parquet", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateManifestPath(c.path)
+			if c.want == nil {
+				if err != nil {
+					t.Errorf("expected accept, got reject: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected reject with %v, got nil", c.want)
+			}
+			if !errors.Is(err, c.want) {
+				t.Errorf("expected errors.Is(%v), got %v", c.want, err)
+			}
+		})
+	}
+}
+
+// TestValidateManifestPath_AcceptsLegitimateShapes covers the path
+// formats Arc's production code (file_registrar.go + compaction_bridge.go)
+// actually produces. If any of these starts failing, this PR has broken
+// a hot ingestion path.
+func TestValidateManifestPath_AcceptsLegitimateShapes(t *testing.T) {
+	t.Parallel()
+	legit := []string{
+		// Writer hot path: ArrowBuffer.generateStoragePath format.
+		"production/metrics/2026/05/20/15/metrics_20260520_153012_123456789.parquet",
+		// Compaction output (hourly): the same shape but with `_compacted` suffix.
+		"production/metrics/2026/05/20/15/metrics_20260520_150000_000000000_compacted.parquet",
+		// Compaction output (daily): hour collapsed.
+		"production/metrics/2026/05/20/metrics_20260520_compacted.parquet",
+		// Database with hyphens, measurement with underscores.
+		"my-app-staging/http_requests/2026/05/20/15/http_requests_20260520_153012_000000000.parquet",
+		// Numeric-only database (legitimate; Arc doesn't restrict the shape).
+		"7/m/2026/05/20/15/m_x.parquet",
+	}
+	for _, p := range legit {
+		if err := ValidateManifestPath(p); err != nil {
+			t.Errorf("legitimate path rejected: %q → %v", p, err)
+		}
+	}
+}
+
+// TestValidateManifestPath_SentinelErrorsViaErrorsIs pins that callers
+// can branch on the rejection reason. A future refactor that returns
+// raw fmt.Errorf strings (which can't be Is-matched) would break this
+// test — by design, because the live-commit handler and the startup
+// quarantine both log the rejection reason as a structured field.
+func TestValidateManifestPath_SentinelErrorsViaErrorsIs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path     string
+		sentinel error
+	}{
+		{"", ErrPathEmpty},
+		{strings.Repeat("a", MaxManifestPathLen+1), ErrPathTooLong},
+		{"foo\x00bar", ErrPathNullByte},
+		{"s3://x/y", ErrPathScheme},
+		{"/etc/passwd", ErrPathAbsolute},
+		{"../etc", ErrPathTraversal},
+	}
+	for _, c := range cases {
+		err := ValidateManifestPath(c.path)
+		if !errors.Is(err, c.sentinel) {
+			t.Errorf("path %q: expected errors.Is(%v), got %v", c.path, c.sentinel, err)
+		}
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -123,6 +123,15 @@ type Metrics struct {
 	replicationEntriesDroppedTotal atomic.Int64 // Total replication entries dropped due to full buffer
 	replicationSequenceGapsTotal   atomic.Int64 // Total number of missing replication entries detected via sequence gaps
 
+	// Cluster FSM security metrics (Enterprise only — only mutated when
+	// the Raft FSM is constructed, which is gated by cluster.enabled +
+	// Enterprise license. See internal/cluster/raft/fsm.go and
+	// GHSA-f85q-mvg8-qf37). A non-zero growth rate is the load-bearing
+	// operator signal that somebody (a peer, a stored snapshot, or a
+	// pre-validation Raft log entry) proposed a path the FSM refused.
+	// Alert on this.
+	clusterManifestRejectedPathsTotal atomic.Int64
+
 	logger zerolog.Logger
 }
 
@@ -301,6 +310,12 @@ func (m *Metrics) SetQueryMgmtHistorySize(n int64)   { m.queryMgmtHistorySize.St
 func (m *Metrics) IncReplicationEntriesDropped()      { m.replicationEntriesDroppedTotal.Add(1) }
 func (m *Metrics) IncReplicationSequenceGaps(n int64) { m.replicationSequenceGapsTotal.Add(n) }
 
+// IncClusterManifestRejectedPaths increments the cluster FSM
+// path-rejection counter. Called from internal/cluster/raft/fsm.go
+// when ValidateManifestPath refuses a Register/Update/Restore path.
+// See GHSA-f85q-mvg8-qf37 for the security context.
+func (m *Metrics) IncClusterManifestRejectedPaths() { m.clusterManifestRejectedPathsTotal.Add(1) }
+
 // Snapshot returns all metrics as a map (for JSON endpoint)
 func (m *Metrics) Snapshot() map[string]interface{} {
 	var memStats runtime.MemStats
@@ -430,6 +445,9 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 		// Replication
 		"replication_entries_dropped_total": m.replicationEntriesDroppedTotal.Load(),
 		"replication_sequence_gaps_total":   m.replicationSequenceGapsTotal.Load(),
+
+		// Cluster FSM security (Enterprise)
+		"cluster_manifest_rejected_paths_total": m.clusterManifestRejectedPathsTotal.Load(),
 	}
 }
 
@@ -723,6 +741,11 @@ func (m *Metrics) PrometheusFormat() string {
 	b = append(b, "# HELP arc_replication_sequence_gaps_total Total sequence gaps detected on replication receivers\n"...)
 	b = append(b, "# TYPE arc_replication_sequence_gaps_total counter\n"...)
 	b = appendMetric(b, "arc_replication_sequence_gaps_total", float64(m.replicationSequenceGapsTotal.Load()))
+
+	// Cluster FSM security metrics (Enterprise — see GHSA-f85q-mvg8-qf37)
+	b = append(b, "# HELP arc_cluster_manifest_rejected_paths_total Total manifest path proposals refused by the cluster FSM. Non-zero growth indicates a peer/snapshot/log entry proposed a path validation refused (URL scheme, absolute, parent-traversal, NUL, oversize).\n"...)
+	b = append(b, "# TYPE arc_cluster_manifest_rejected_paths_total counter\n"...)
+	b = appendMetric(b, "arc_cluster_manifest_rejected_paths_total", float64(m.clusterManifestRejectedPathsTotal.Load()))
 
 	return string(b)
 }


### PR DESCRIPTION
## Summary

Closes [GHSA-f85q-mvg8-qf37](https://github.com/Basekick-Labs/arc/security/advisories/GHSA-f85q-mvg8-qf37) / audit X2 — **Enterprise-only critical**, reported by [@NeuroWinter](https://github.com/NeuroWinter) on 2026-05-19.

The Raft FSM's `applyRegisterFile` and `applyUpdateFile` only checked that proposed file paths were non-empty. An attacker with one valid cluster credential — or one compromised cluster node — could register arbitrary paths (`/etc/passwd`, `s3://attacker-bucket/poisoned.parquet`, `../../etc/shadow`) into the authoritative cluster manifest. Other peers fetched those files to serve queries → host-level file disclosure + attacker-controlled data poisoning. Canonical cluster-worm primitive.

## What's in this PR

- **`internal/cluster/raft/path_validation.go` (NEW)** — `ValidateManifestPath` with shape-based rejection of URL schemes, absolute paths, parent-traversal segments, NUL bytes, oversize paths, empty paths. Sentinel errors for `errors.Is` branching.
- **`internal/cluster/raft/fsm.go`** — validator wired into `applyRegisterFile`, `applyUpdateFile`, snapshot `Restore`. New `applyBatchFileOps` pre-validation pass for batch atomicity. Unified `rejectManifestPath` helper that always logs Error + increments counter + returns wrapped error. New `RejectedPathsCount()` getter for operator metrics.
- **`internal/cluster/raft/node.go`** — end-of-`NewRaft` summary Error log if any snapshot Restore entries were rejected.
- **Tests** — table-driven rejection matrix, sentinel-`errors.Is` matrix, positive matrix for production writer/compaction output, batch atomicity, snapshot quarantine round-trip.
- **Release notes** — operator-facing under `## Security fixes`.

## Design

Shape-based validation, not backend-aware prefix matching. The legitimate path format produced by Arc's writer (`internal/cluster/file_registrar.go`) and compactor (`internal/cluster/compaction_bridge.go`) is always relative, scheme-less, no `..` — so the shape check catches every malicious shape from the audit without plumbing `*config.StorageConfig` into the FSM.

**How rejection interacts with hashicorp/raft.** Honest explanation in the release notes — the malicious entry IS in the Raft log temporarily (the leader writes and ships before Apply runs). The security property is that every node's FSM independently refuses to put it in `f.files`. The malicious entry gets garbage-collected on the next snapshot rotation. Earlier draft incorrectly claimed "Raft refuses the commit" — internal review caught it.

**Boot-replay handling.** `applyRegisterFile` always rejects malicious paths and increments the counter, regardless of whether the call came from a proposer or log replay. During log replay, hashicorp/raft silently swallows the Apply error (`req.future == nil`) — but the in-FSM effects (counter + Error log + non-membership) still happen. Per-entry Error log lines surface log-replay rejections; the `Node.Start` summary surfaces snapshot Restore rejections (which are synchronous inside `NewRaft`).

## Internal review (per CLAUDE.md)

Configuration matrix written first, then single deep reviewer. First pass found **2 Blockers**:

1. Quarantine mode `defer` cleared the flag before log-replay ran (hashicorp/raft's `runFSM` is a goroutine post-`NewRaft`).
2. Release notes falsely claimed "Raft refuses the commit / entry never replicates" — wrong about Raft semantics.

Both fixed via redesign (dropped the dual-mode quarantine flag entirely; unified single-mode rejection that's correct on both code paths). Re-review on the redesigned code says **"all prior findings addressed cleanly, merge it."**

## Test plan

- [x] `go build ./cmd/... ./internal/...` clean
- [x] `go test -race ./internal/cluster/raft/...` green
- [x] `go test ./internal/cluster/... ./internal/api/...` green
- [x] `gofmt -l internal/cluster/raft/` clean
- [x] Binary smoke: arc starts cleanly in single-node cluster mode with enterprise license, Raft bootstraps + elects leader, FSM online, `RejectedPathsCount = 0` on fresh boot, no panic
- [x] Internal review (configuration matrix + single deep reviewer) per CLAUDE.md — 2 Blockers found + fixed + re-reviewed clean

## Out of scope

- **X1** (HMAC on `MsgReplicateSync`, [GHSA-wfgr-8x84-22q7](https://github.com/Basekick-Labs/arc/security/advisories/GHSA-wfgr-8x84-22q7)) — same audit reporter, same severity tier. Separate PR.
- **Backend-aware prefix matching** — tracked as a follow-up tightening. The shape-based check kills the documented worm primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)