### PR TITLE
fix(pruning): wire periodic janitor for partition pruner caches

### DIFF
--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -250,6 +250,27 @@ Subdirectories are deliberately ignored — DuckDB 1.5.1 uses a flat layout. If 
 
 The previous draft also added a post-`db.Close()` sweep; review caught that it was effectively dead code (DuckDB had already unlinked, and the 60 s mtime guard would skip anything still in flight) and risked stalling shutdown past `systemd`'s `TimeoutStopSec`. It was dropped before merge.
 
+### Partition pruner caches no longer grow unboundedly over process lifetime
+
+`internal/pruning/partition_pruner.go` has two TTL caches — `globCache` (30 s TTL) and `partitionCache` (60 s TTL) — populated on every query. Their `get()` returns "expired" as a cache miss but does **not** evict the stale entry; neither cache has a max-size cap. The public `CleanupGlobCache()` and `CleanupPartitionCache()` methods existed since the 2024-12 and 2026-01 cache PRs respectively but had **zero production callers** anywhere in the binary. Under workloads with high-cardinality glob patterns or distinct `(path, sql)` keys (typical for satellite-telemetry dashboards), both maps accumulate Go-heap entries monotonically until either `InvalidateAllCaches()` runs post-compaction or the process exits — one component of a 24-hour RSS climb observed on a demo container that required daily restarts.
+
+26.06.1 wires a janitor goroutine that sweeps both caches at a 30-second interval (matching the shorter TTL → worst-case entry retention is bounded at ~2× TTL):
+
+- **`PartitionPruner.StartCleanup(ctx, interval)`** — public method that spawns the sweeper. Exits cleanly when `ctx` is cancelled. Idempotent via a `cleanupStarted` atomic flag, so a hot-reload path or test refactor can't silently multiply goroutines.
+- **`QueryHandler.StartBackgroundWorkers(ctx)`** — the seam from `main.go`. Today this just delegates to the pruner; the wrapper exists so future per-handler background workers land in one obvious place.
+- **`cmd/arc/main.go`** wires the lifecycle: ad-hoc `context.WithCancel`, hook registered at `shutdown.PriorityHTTPServer` (the earliest tier — the janitor owns nothing but a ticker and reads in-memory maps, so it's safe to stop first). Mirrors the WAL maintenance pattern already in `main.go`.
+- **Concurrent sweep**: glob and partition cache cleanups run on independent goroutines per tick. The two cache mutexes are unrelated, so parallelising them prevents a future hot-glob-cache from delaying the partition sweep behind it (or vice versa).
+
+Operator-visible: one new info line at startup —
+
+```
+Partition pruner cache janitor started interval=30000
+```
+
+and the symmetric "stopped" line on graceful shutdown. No new configuration knob; the 30 s interval is hard-coded today and operators do not need to tune it. The fix has no effect on the cache **hit rate** — entries are only swept after they're already expired by TTL, which the existing `get()` already treats as a miss.
+
+Out of scope for this release: a max-size LRU layer on top of both caches. The sweep-cost analysis showed this is unlikely to bite at realistic key cardinality between 30-second sweeps; will revisit when telemetry shows sweep latency above 10 ms.
+
 ### Startup banner now invites OSS operators to Arc Enterprise
 
 When Arc starts without a working Enterprise license — either because no `license.key` was configured, or because activation/verification failed and `licenseClient` was reset to nil — startup logs now include a single `Info` line:

--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -259,7 +259,6 @@ The previous draft also added a post-`db.Close()` sweep; review caught that it w
 - **`PartitionPruner.StartCleanup(ctx, interval)`** — public method that spawns the sweeper. Exits cleanly when `ctx` is cancelled. Idempotent via a `cleanupStarted` atomic flag, so a hot-reload path or test refactor can't silently multiply goroutines.
 - **`QueryHandler.StartBackgroundWorkers(ctx)`** — the seam from `main.go`. Today this just delegates to the pruner; the wrapper exists so future per-handler background workers land in one obvious place.
 - **`cmd/arc/main.go`** wires the lifecycle: ad-hoc `context.WithCancel`, hook registered at `shutdown.PriorityHTTPServer` (the earliest tier — the janitor owns nothing but a ticker and reads in-memory maps, so it's safe to stop first). Mirrors the WAL maintenance pattern already in `main.go`.
-- **Concurrent sweep**: glob and partition cache cleanups run on independent goroutines per tick. The two cache mutexes are unrelated, so parallelising them prevents a future hot-glob-cache from delaying the partition sweep behind it (or vice versa).
 
 Operator-visible: one new info line at startup —
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1534,6 +1534,21 @@ func main() {
 		queryHandler.SetAuthAndRBAC(authManager, rbacManager)
 	}
 	queryHandler.RegisterRoutes(server.GetApp())
+	// Start the handler's background workers (currently the partition
+	// pruner cache janitor — sweeps expired globCache / partitionCache
+	// entries so they don't accumulate over the process lifetime).
+	// Matches the WAL maintenance pattern at line 730: ad-hoc cancel
+	// context registered with the shutdown coordinator. Runs in the
+	// HTTPServer priority band (the earliest tier) because the janitor
+	// has nothing to flush — it just owns a ticker and an in-memory
+	// map. Stopping it early frees the goroutine without blocking any
+	// downstream shutdown hook.
+	queryWorkersCtx, queryWorkersCancel := context.WithCancel(context.Background())
+	shutdownCoordinator.RegisterHook("query-handler-workers", func(_ context.Context) error {
+		queryWorkersCancel()
+		return nil
+	}, shutdown.PriorityHTTPServer)
+	queryHandler.StartBackgroundWorkers(queryWorkersCtx)
 
 	// Wire up cluster router to handlers for request forwarding
 	// This enables reader nodes to forward writes to writers, and

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -938,6 +938,23 @@ func (h *QueryHandler) InvalidateCaches() {
 	h.logger.Info().Msg("Query caches invalidated after compaction")
 }
 
+// StartBackgroundWorkers spawns the long-lived goroutines the handler
+// needs: today this is the partition pruner cache janitor, which
+// sweeps expired entries from globCache + partitionCache so they don't
+// accumulate over the process lifetime. (Both caches are TTL-only with
+// no max-size cap and no read-side eviction — get() returns "expired"
+// as a miss but leaves the stale entry in the map.)
+//
+// The workers stop when ctx is cancelled. The handler itself remains
+// usable after that, and InvalidateCaches() (called post-compaction)
+// continues to reset both maps, but expired entries are no longer
+// swept on a schedule — they accumulate until the next compaction
+// flushes everything or the process exits. Production callers should
+// pass a context tied to process lifetime via the shutdown coordinator.
+func (h *QueryHandler) StartBackgroundWorkers(ctx context.Context) {
+	h.pruner.StartCleanup(ctx, 0) // 0 → DefaultCleanupInterval
+}
+
 // extractTableReferences extracts all database.measurement references from SQL
 // Returns a slice of TableReference structs for permission checking
 func extractTableReferences(sql string) []TableReference {

--- a/internal/pruning/partition_pruner.go
+++ b/internal/pruning/partition_pruner.go
@@ -948,6 +948,15 @@ func (p *PartitionPruner) CleanupPartitionCache() int {
 // before it's removed, bounding worst-case retention at ~2× TTL.
 const DefaultCleanupInterval = 30 * time.Second
 
+// minCleanupInterval is the smallest interval StartCleanup will honor.
+// Anything below this is clamped up to prevent a misconfigured caller
+// (or a fuzz input that passes a sub-millisecond duration) from
+// pinning a CPU core in a tight ticker loop. 1ms is a generous floor
+// — orders of magnitude below any plausible production interval and
+// any fast-iteration test (tests in this package use 5–10ms).
+// (Gemini round 3 / PR #450.)
+const minCleanupInterval = 1 * time.Millisecond
+
 // StartCleanup spawns a background goroutine that periodically removes
 // expired entries from both caches. The goroutine exits when ctx is
 // cancelled (or its Done channel closes). Caller controls lifetime via
@@ -977,6 +986,13 @@ func (p *PartitionPruner) StartCleanup(ctx context.Context, interval time.Durati
 	}
 	if interval <= 0 {
 		interval = DefaultCleanupInterval
+	}
+	if interval < minCleanupInterval {
+		p.logger.Warn().
+			Dur("requested", interval).
+			Dur("clamped", minCleanupInterval).
+			Msg("Cleanup interval below floor; clamping to prevent tight-loop sweep")
+		interval = minCleanupInterval
 	}
 	go p.cleanupLoop(ctx, interval)
 	p.logger.Info().

--- a/internal/pruning/partition_pruner.go
+++ b/internal/pruning/partition_pruner.go
@@ -986,12 +986,14 @@ func (p *PartitionPruner) StartCleanup(ctx context.Context, interval time.Durati
 
 // cleanupLoop is the body of the janitor goroutine. Runs until ctx is
 // cancelled. One sweep per tick; sweeps are cheap (single mu.Lock +
-// map iteration, no allocations) so we don't bother debouncing.
-//
-// The two cleanups run on independent goroutines per tick because they
-// take unrelated mutexes (globCache.mu vs partitionCache.mu). A future
-// hot-glob-cache that grows entries between sweeps shouldn't delay the
-// partition sweep behind it, or vice versa. (Gemini round 1 / PR #450.)
+// map iteration, no allocations) — at realistic key cardinality the
+// sweep cost is on the order of microseconds, well below the
+// goroutine-spawn + WaitGroup-sync overhead that parallelising the
+// two sweeps would add. Run sequentially; if a future profile ever
+// shows the sweep itself blocking concurrent get() calls under a
+// hot-cache workload, that's the trigger to revisit. (Gemini round 2
+// / PR #450 reversed a round-1 suggestion to parallelise after
+// pointing out the overhead inversion.)
 func (p *PartitionPruner) cleanupLoop(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -1001,17 +1003,8 @@ func (p *PartitionPruner) cleanupLoop(ctx context.Context, interval time.Duratio
 			p.logger.Info().Msg("Partition pruner cache janitor stopped")
 			return
 		case <-ticker.C:
-			var wg sync.WaitGroup
-			wg.Add(2)
-			go func() {
-				defer wg.Done()
-				p.CleanupGlobCache()
-			}()
-			go func() {
-				defer wg.Done()
-				p.CleanupPartitionCache()
-			}()
-			wg.Wait()
+			p.CleanupGlobCache()
+			p.CleanupPartitionCache()
 		}
 	}
 }

--- a/internal/pruning/partition_pruner.go
+++ b/internal/pruning/partition_pruner.go
@@ -272,7 +272,7 @@ type PartitionPruner struct {
 	// goroutine per pruner. Idempotent on repeat calls — second and
 	// later invocations log a warn and return without spawning. Guards
 	// against a future hot-reload or test refactor accidentally
-	// multiplying goroutines silently. Internal-review M1 on PR #450.
+	// multiplying goroutines silently.
 	cleanupStarted atomic.Bool
 }
 
@@ -954,7 +954,6 @@ const DefaultCleanupInterval = 30 * time.Second
 // pinning a CPU core in a tight ticker loop. 1ms is a generous floor
 // — orders of magnitude below any plausible production interval and
 // any fast-iteration test (tests in this package use 5–10ms).
-// (Gemini round 3 / PR #450.)
 const minCleanupInterval = 1 * time.Millisecond
 
 // StartCleanup spawns a background goroutine that periodically removes
@@ -972,10 +971,8 @@ const minCleanupInterval = 1 * time.Millisecond
 // Combined with no max-size cap on either cache, a workload with
 // high-cardinality glob patterns or distinct (path, sql) keys will
 // grow the maps monotonically over the lifetime of the process. The
-// public Cleanup{Glob,Partition}Cache methods existed since the
-// 2024-12 and 2026-01 cache PRs but had no production caller — this
-// fills that gap. See https://github.com/Basekick-Labs/arc/pull/450
-// (Q2 finding from the 2026-05-22 memory-retention triage).
+// public Cleanup{Glob,Partition}Cache methods exist but had no
+// production caller — this fills that gap.
 //
 // interval=0 uses DefaultCleanupInterval. Negative values are
 // rejected by clamping to the default.
@@ -1004,12 +1001,10 @@ func (p *PartitionPruner) StartCleanup(ctx context.Context, interval time.Durati
 // cancelled. One sweep per tick; sweeps are cheap (single mu.Lock +
 // map iteration, no allocations) — at realistic key cardinality the
 // sweep cost is on the order of microseconds, well below the
-// goroutine-spawn + WaitGroup-sync overhead that parallelising the
+// goroutine-spawn + WaitGroup-sync overhead that parallelizing the
 // two sweeps would add. Run sequentially; if a future profile ever
 // shows the sweep itself blocking concurrent get() calls under a
-// hot-cache workload, that's the trigger to revisit. (Gemini round 2
-// / PR #450 reversed a round-1 suggestion to parallelise after
-// pointing out the overhead inversion.)
+// hot-cache workload, that's the trigger to revisit.
 func (p *PartitionPruner) cleanupLoop(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/internal/pruning/partition_pruner.go
+++ b/internal/pruning/partition_pruner.go
@@ -267,6 +267,13 @@ type PartitionPruner struct {
 	globCache      *globCache
 	partitionCache *partitionCache
 	storage        storage.Backend // Optional storage backend for S3/Azure path validation
+
+	// cleanupStarted ensures StartCleanup spawns at most one janitor
+	// goroutine per pruner. Idempotent on repeat calls — second and
+	// later invocations log a warn and return without spawning. Guards
+	// against a future hot-reload or test refactor accidentally
+	// multiplying goroutines silently. Internal-review M1 on PR #450.
+	cleanupStarted atomic.Bool
 }
 
 // PrunerStats tracks partition pruning statistics using atomic counters for thread-safety
@@ -932,6 +939,68 @@ func (p *PartitionPruner) CleanupPartitionCache() int {
 		p.logger.Debug().Int("removed", removed).Msg("Cleaned up expired partition cache entries")
 	}
 	return removed
+}
+
+// DefaultCleanupInterval is how often the background janitor sweeps
+// expired entries from both caches. 30 seconds matches the shorter of
+// the two TTLs (GlobCacheTTL = 30s, PartitionCacheTTL = 60s) — after
+// expiry an entry can sit in the map for at most one sweep interval
+// before it's removed, bounding worst-case retention at ~2× TTL.
+const DefaultCleanupInterval = 30 * time.Second
+
+// StartCleanup spawns a background goroutine that periodically removes
+// expired entries from both caches. The goroutine exits when ctx is
+// cancelled (or its Done channel closes). Caller controls lifetime via
+// the context.
+//
+// Idempotent: only the first call per *PartitionPruner spawns the
+// janitor. Subsequent calls log a warn and return without spawning,
+// so a hot-reload path or a test refactor can't silently multiply
+// goroutines.
+//
+// Why this exists: get() returns "expired" as a cache miss but does
+// NOT remove the stale entry — there's no eviction path on read.
+// Combined with no max-size cap on either cache, a workload with
+// high-cardinality glob patterns or distinct (path, sql) keys will
+// grow the maps monotonically over the lifetime of the process. The
+// public Cleanup{Glob,Partition}Cache methods existed since the
+// 2024-12 and 2026-01 cache PRs but had no production caller — this
+// fills that gap. See https://github.com/Basekick-Labs/arc/pull/450
+// (Q2 finding from the 2026-05-22 memory-retention triage).
+//
+// interval=0 uses DefaultCleanupInterval. Negative values are
+// rejected by clamping to the default.
+func (p *PartitionPruner) StartCleanup(ctx context.Context, interval time.Duration) {
+	if !p.cleanupStarted.CompareAndSwap(false, true) {
+		p.logger.Warn().Msg("Partition pruner cache janitor already started; ignoring duplicate StartCleanup call")
+		return
+	}
+	if interval <= 0 {
+		interval = DefaultCleanupInterval
+	}
+	go p.cleanupLoop(ctx, interval)
+	p.logger.Info().
+		Dur("interval", interval).
+		Msg("Partition pruner cache janitor started")
+}
+
+// cleanupLoop is the body of the janitor goroutine. Runs until ctx is
+// cancelled. One sweep per tick; sweeps are cheap (single mu.Lock +
+// map iteration, no allocations) so we don't bother debouncing or
+// running them in a worker pool.
+func (p *PartitionPruner) cleanupLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info().Msg("Partition pruner cache janitor stopped")
+			return
+		case <-ticker.C:
+			p.CleanupGlobCache()
+			p.CleanupPartitionCache()
+		}
+	}
 }
 
 // GetGlobCacheStats returns glob cache statistics

--- a/internal/pruning/partition_pruner.go
+++ b/internal/pruning/partition_pruner.go
@@ -986,8 +986,12 @@ func (p *PartitionPruner) StartCleanup(ctx context.Context, interval time.Durati
 
 // cleanupLoop is the body of the janitor goroutine. Runs until ctx is
 // cancelled. One sweep per tick; sweeps are cheap (single mu.Lock +
-// map iteration, no allocations) so we don't bother debouncing or
-// running them in a worker pool.
+// map iteration, no allocations) so we don't bother debouncing.
+//
+// The two cleanups run on independent goroutines per tick because they
+// take unrelated mutexes (globCache.mu vs partitionCache.mu). A future
+// hot-glob-cache that grows entries between sweeps shouldn't delay the
+// partition sweep behind it, or vice versa. (Gemini round 1 / PR #450.)
 func (p *PartitionPruner) cleanupLoop(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -997,8 +1001,17 @@ func (p *PartitionPruner) cleanupLoop(ctx context.Context, interval time.Duratio
 			p.logger.Info().Msg("Partition pruner cache janitor stopped")
 			return
 		case <-ticker.C:
-			p.CleanupGlobCache()
-			p.CleanupPartitionCache()
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				p.CleanupGlobCache()
+			}()
+			go func() {
+				defer wg.Done()
+				p.CleanupPartitionCache()
+			}()
+			wg.Wait()
 		}
 	}
 }

--- a/internal/pruning/partition_pruner_test.go
+++ b/internal/pruning/partition_pruner_test.go
@@ -1288,3 +1288,147 @@ func TestExtractStoragePrefix(t *testing.T) {
 		})
 	}
 }
+
+// TestStartCleanup_RemovesExpiredEntries verifies the janitor goroutine
+// sweeps expired entries from both caches at the configured interval.
+// Pre-PR the public Cleanup{Glob,Partition}Cache methods existed but
+// had no production caller; entries that expired by TTL stayed in the
+// map until invalidate() ran (post-compaction). This test pins that
+// the janitor actually evicts past-TTL entries on its own.
+func TestStartCleanup_RemovesExpiredEntries(t *testing.T) {
+	pruner := NewPartitionPruner(zerolog.Nop())
+
+	// Use tiny TTLs so the test runs in ~100ms instead of 30s.
+	pruner.globCache.ttl = 20 * time.Millisecond
+	pruner.partitionCache.ttl = 20 * time.Millisecond
+
+	// Seed both caches.
+	pruner.globCache.set("/seed/*.parquet", []string{"a.parquet", "b.parquet"})
+	pruner.partitionCache.set("seed-key", "/seed/optimized", true)
+
+	if _, _, size := pruner.globCache.stats(); size != 1 {
+		t.Fatalf("expected glob cache size 1 after seed, got %d", size)
+	}
+	if _, _, size := pruner.partitionCache.stats(); size != 1 {
+		t.Fatalf("expected partition cache size 1 after seed, got %d", size)
+	}
+
+	// Start the janitor with a sub-TTL sweep interval so an entry
+	// seeded at t=0 has time to expire (>20ms) AND be swept before
+	// the test deadline.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pruner.StartCleanup(ctx, 10*time.Millisecond)
+
+	// Both entries should be gone within ~3 sweep intervals.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		_, _, globSize := pruner.globCache.stats()
+		_, _, partSize := pruner.partitionCache.stats()
+		if globSize == 0 && partSize == 0 {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_, _, globSize := pruner.globCache.stats()
+	_, _, partSize := pruner.partitionCache.stats()
+	t.Fatalf("janitor did not evict expired entries within 500ms: glob=%d, partition=%d", globSize, partSize)
+}
+
+// TestStartCleanup_StopsOnContextCancel verifies the janitor goroutine
+// exits when the parent context is cancelled. Without this, every
+// process-lifetime call to StartCleanup would leak a goroutine on
+// shutdown.
+func TestStartCleanup_StopsOnContextCancel(t *testing.T) {
+	pruner := NewPartitionPruner(zerolog.Nop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pruner.StartCleanup(ctx, 5*time.Millisecond)
+
+	// Let the loop tick at least once so we know it's running.
+	time.Sleep(20 * time.Millisecond)
+
+	// Cancel; the goroutine should observe ctx.Done() on its next
+	// tick (or sooner if the select picks Done() first).
+	cancel()
+
+	// Seed an entry that would expire, then verify the janitor is
+	// no longer sweeping: if it's running, the entry disappears
+	// within a sweep; if stopped, it stays.
+	pruner.globCache.ttl = 5 * time.Millisecond
+	pruner.globCache.set("/post-stop/*.parquet", []string{"x.parquet"})
+
+	// Wait well past TTL + several sweep intervals — if the janitor
+	// were still running, the entry would be gone by now.
+	time.Sleep(50 * time.Millisecond)
+
+	if _, _, size := pruner.globCache.stats(); size != 1 {
+		t.Fatalf("janitor still sweeping after ctx cancel: glob cache size = %d (want 1)", size)
+	}
+}
+
+// TestStartCleanup_DefaultInterval verifies that passing 0 falls back
+// to DefaultCleanupInterval — the intended "use the sensible default"
+// shape for production callers.
+func TestStartCleanup_DefaultInterval(t *testing.T) {
+	if DefaultCleanupInterval <= 0 {
+		t.Fatalf("DefaultCleanupInterval must be positive, got %v", DefaultCleanupInterval)
+	}
+
+	pruner := NewPartitionPruner(zerolog.Nop())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// We don't wait DefaultCleanupInterval (30s) — the goroutine
+	// behaviour at the default interval is exercised by production.
+	// Just confirm the zero/negative path doesn't panic and the
+	// first call succeeds.
+	pruner.StartCleanup(ctx, 0)
+	if !pruner.cleanupStarted.Load() {
+		t.Fatal("StartCleanup(ctx, 0) did not flip cleanupStarted")
+	}
+}
+
+// TestStartCleanup_Idempotent verifies the second StartCleanup call on
+// the same pruner is a no-op. Without this, a future hot-reload path
+// or test refactor could silently multiply janitor goroutines.
+func TestStartCleanup_Idempotent(t *testing.T) {
+	pruner := NewPartitionPruner(zerolog.Nop())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pruner.StartCleanup(ctx, 5*time.Millisecond)
+	if !pruner.cleanupStarted.Load() {
+		t.Fatal("first StartCleanup did not flip cleanupStarted")
+	}
+
+	// Second call must NOT spawn another goroutine. Easiest way to
+	// pin the invariant is to observe that cleanupStarted remains
+	// true (no panic, no state-change) and that no second log line
+	// for "started" fires. Since we can't easily capture logger
+	// calls here without a custom sink, we rely on the
+	// CompareAndSwap guard returning false on the second call —
+	// the test's value is "the second call doesn't panic AND
+	// cleanupStarted stays true."
+	pruner.StartCleanup(ctx, 5*time.Millisecond)
+	pruner.StartCleanup(ctx, -1*time.Second)
+	pruner.StartCleanup(ctx, 0)
+	if !pruner.cleanupStarted.Load() {
+		t.Fatal("cleanupStarted unexpectedly reset after repeat calls")
+	}
+
+	// Sanity: the underlying goroutine is still alive and still
+	// sweeping. Seed an entry with a TTL shorter than the sweep
+	// interval and verify it gets evicted.
+	pruner.globCache.ttl = 2 * time.Millisecond
+	pruner.globCache.set("/idempotent/*.parquet", []string{"x.parquet"})
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, _, size := pruner.globCache.stats(); size == 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_, _, size := pruner.globCache.stats()
+	t.Fatalf("janitor goroutine appears dead after repeat StartCleanup calls: glob size = %d", size)
+}

--- a/internal/pruning/partition_pruner_test.go
+++ b/internal/pruning/partition_pruner_test.go
@@ -1389,6 +1389,43 @@ func TestStartCleanup_DefaultInterval(t *testing.T) {
 	}
 }
 
+// TestStartCleanup_ClampsTinyInterval verifies that intervals below
+// minCleanupInterval are clamped up to prevent a tight-loop sweep.
+// Gemini round 3 finding (PR #450).
+func TestStartCleanup_ClampsTinyInterval(t *testing.T) {
+	if minCleanupInterval <= 0 {
+		t.Fatalf("minCleanupInterval must be positive, got %v", minCleanupInterval)
+	}
+
+	pruner := NewPartitionPruner(zerolog.Nop())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// 1 nanosecond would spin a CPU core if not clamped.
+	pruner.StartCleanup(ctx, 1*time.Nanosecond)
+	if !pruner.cleanupStarted.Load() {
+		t.Fatal("StartCleanup with sub-floor interval did not flip cleanupStarted")
+	}
+
+	// Give it a moment — if the clamp failed, we'd be in a tight
+	// loop. We can't easily observe the ticker interval from
+	// outside, but the lack of test timeout under -race is itself a
+	// signal. Seed an entry with a tiny TTL and confirm a sweep
+	// happens within a reasonable window (the clamp keeps sweeps
+	// at >= 1ms; over 50ms we should see at least a few sweeps).
+	pruner.globCache.ttl = 1 * time.Millisecond
+	pruner.globCache.set("/clamp/*.parquet", []string{"x.parquet"})
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, _, size := pruner.globCache.stats(); size == 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_, _, size := pruner.globCache.stats()
+	t.Fatalf("janitor did not sweep within 200ms after clamp: glob size = %d", size)
+}
+
 // TestStartCleanup_Idempotent verifies the second StartCleanup call on
 // the same pruner is a no-op. Without this, a future hot-reload path
 // or test refactor could silently multiply janitor goroutines.


### PR DESCRIPTION
## Summary

- Wires a background janitor goroutine to call `pruner.CleanupGlobCache()` + `pruner.CleanupPartitionCache()` every 30s. Pre-PR both methods existed and were ready to use but had **zero production callers** — both maps grew monotonically over the process lifetime.
- One component of the 24h RSS climb on the satellite-data demo container (identified by the 2026-05-22 memory-retention triage).
- Goroutine is owned by `*PartitionPruner`; started via `QueryHandler.StartBackgroundWorkers(ctx)` from `cmd/arc/main.go` with a shutdown hook at `PriorityHTTPServer`. Idempotent via `cleanupStarted` atomic — repeat calls are no-ops.

## Why this is a real bug, not a perf knob

```
$ grep -rn "CleanupGlobCache\|CleanupPartitionCache" \
    --include='*.go' --exclude='*_test.go' \
    --exclude='*/partition_pruner.go'
# zero matches
```

`get()` on both caches returns "expired" as a cache miss but **does not remove the stale entry** (verified at `partition_pruner.go:45-65` and `:188-206`). Neither cache has a max-size cap. Under satellite-shape workloads with high-cardinality glob patterns or distinct `(path, sql)` keys, both maps accumulate forever — capped only by post-compaction `InvalidateAllCaches()` (which itself is rare and not a designed eviction strategy). The 2026-01-25 progress doc explicitly says *"prevents unbounded cache growth"* about `CleanupPartitionCache()` and then nobody wired the cleanup.

## Test plan

- [x] `go test -race ./internal/pruning/... ./internal/api/...` — all green, including 4 new tests
- [x] `go vet ./internal/pruning/... ./internal/api/... ./cmd/arc/...` clean
- [x] `gofmt -l` clean on all 4 touched files
- [x] Binary smoke (CLAUDE.md mandates this when touching `cmd/arc/main.go`):
  - `Partition pruner cache janitor started interval=30000` at boot
  - `Partition pruner cache janitor stopped` on SIGINT
  - Process exits cleanly without SIGKILL
- [x] Internal review (configuration matrix + deep reviewer): 0 blockers / 0 high / 2 medium — both addressed (M1 idempotent guard via `cleanupStarted.CompareAndSwap`, M2 doc accuracy on `StartBackgroundWorkers`)
- [ ] Gemini Code Assist review (requested below)

## Tests added

- `TestStartCleanup_RemovesExpiredEntries` — seeds both caches, starts janitor with sub-TTL interval, asserts entries gone within 500ms.
- `TestStartCleanup_StopsOnContextCancel` — verifies the goroutine exits on ctx cancel by seeding a post-cancel entry and confirming it does NOT get swept.
- `TestStartCleanup_DefaultInterval` — `interval=0` → `DefaultCleanupInterval`, no panic.
- `TestStartCleanup_Idempotent` — repeat `StartCleanup` calls don't spawn additional goroutines; the first janitor remains alive and sweeping.

## Out of scope

- Adding a max-size LRU cap on either cache. The sweep-cost analysis (S2 in the internal review) said this is unlikely to bite at realistic key cardinality; revisit when telemetry shows sweep latency > 10ms.
- The other findings from the 2026-05-22 triage (Q1 client-disconnect leak, Q3 + C3 glibc-arena retention via DuckDB pool). Q1 and Q3 are already addressed on `main` by PRs #424 and #420 respectively — the satellite demo (v26.05.1) needs an upgrade to pick those up; this PR is the only finding that's still broken on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)