### PR TITLE
fix(test): Release buildArrowBatch builders + columns (closes #427)

### DIFF
--- a/internal/api/query_arrow_json_test.go
+++ b/internal/api/query_arrow_json_test.go
@@ -77,17 +77,23 @@ func buildArrowBatch(
 	for i, b := range builders {
 		cols[i] = b.NewArray()
 	}
-
-	rec := array.NewRecord(schema, cols, int64(len(rows)))
+	// Defer the cols Release so it fires even if array.NewRecord panics
+	// (length-mismatch + schema-mismatch are documented panic paths —
+	// verified empirically). Without defer, a NewRecord panic in a
+	// future schema-evolution test would leak every cols entry.
 	// array.NewRecord retains each column (increments refcount); the
 	// builder-returned arrays in `cols` are the test's own references and
 	// must be released so the final refcount on each buffer drops to
 	// (Record's count). When the record is released, refcount hits zero
 	// and CheckedAllocator sees a clean shutdown.
-	for _, c := range cols {
-		c.Release()
-	}
-	return rec
+	defer func() {
+		for _, c := range cols {
+			if c != nil {
+				c.Release()
+			}
+		}
+	}()
+	return array.NewRecord(schema, cols, int64(len(rows)))
 }
 
 // simpleRecordReader wraps a single record batch as an array.RecordReader.

--- a/internal/api/query_arrow_json_test.go
+++ b/internal/api/query_arrow_json_test.go
@@ -35,21 +35,23 @@ func buildArrowBatch(
 ) arrow.Record {
 	numCols := len(schema.Fields())
 	builders := make([]array.Builder, numCols)
-	for i, f := range schema.Fields() {
-		builders[i] = array.NewBuilder(alloc, f.Type)
-	}
+	// Register the cleanup defer BEFORE the init loop so it covers a
+	// panic mid-loop. If we registered it AFTER the loop and
+	// array.NewBuilder panicked at iteration N, the defer would
+	// never register and builders[0..N-1] would leak. nil-check
+	// inside the loop guards against the trailing nil entries.
+	// Verified by counter-example: defer-after-loop never fires
+	// when the loop panics.
 	defer func() {
-		// nil-check: if array.NewBuilder panicked partway through the
-		// init loop above, `builders` is partially populated and the
-		// trailing entries are nil. Calling Release() on a nil
-		// array.Builder panics with a secondary nil-deref, which
-		// masks the original panic and makes test failures opaque.
 		for _, b := range builders {
 			if b != nil {
 				b.Release()
 			}
 		}
 	}()
+	for i, f := range schema.Fields() {
+		builders[i] = array.NewBuilder(alloc, f.Type)
+	}
 
 	for _, row := range rows {
 		for col, val := range row {
@@ -74,18 +76,15 @@ func buildArrowBatch(
 	}
 
 	cols := make([]arrow.Array, numCols)
-	for i, b := range builders {
-		cols[i] = b.NewArray()
-	}
-	// Defer the cols Release so it fires even if array.NewRecord panics
-	// (length-mismatch + schema-mismatch are documented panic paths —
-	// verified empirically). Without defer, a NewRecord panic in a
-	// future schema-evolution test would leak every cols entry.
-	// array.NewRecord retains each column (increments refcount); the
-	// builder-returned arrays in `cols` are the test's own references and
-	// must be released so the final refcount on each buffer drops to
-	// (Record's count). When the record is released, refcount hits zero
-	// and CheckedAllocator sees a clean shutdown.
+	// Register the cols Release defer BEFORE the NewArray loop AND
+	// before array.NewRecord — same lesson as the builders defer above.
+	// b.NewArray could panic on allocator failure, and NewRecord panics
+	// on length / schema mismatch (verified empirically). nil-check
+	// inside guards against partial population from a mid-loop panic.
+	// array.NewRecord retains each column (refcount++); this defer drops
+	// the test's own reference so the final refcount on each buffer is
+	// held only by the returned Record. CheckedAllocator sees a clean
+	// shutdown after Record.Release fires.
 	defer func() {
 		for _, c := range cols {
 			if c != nil {
@@ -93,6 +92,9 @@ func buildArrowBatch(
 			}
 		}
 	}()
+	for i, b := range builders {
+		cols[i] = b.NewArray()
+	}
 	return array.NewRecord(schema, cols, int64(len(rows)))
 }
 

--- a/internal/api/query_arrow_json_test.go
+++ b/internal/api/query_arrow_json_test.go
@@ -19,6 +19,15 @@ import (
 )
 
 // buildArrowBatch creates an Arrow record batch from Go slices for testing.
+//
+// Each builder is released after its array is extracted: b.NewArray()
+// transfers buffer ownership to the returned array, but the builder
+// retains its own reference to those buffers until Release() is called.
+// Without this, every call to buildArrowBatch leaks builder-side
+// allocations — invisible under memory.NewGoAllocator (Go GC eats it),
+// but fatal under memory.NewCheckedAllocator (AssertSize(t, 0) panics).
+// Releasing the builders here lets tests use CheckedAllocator and catch
+// real Arrow leaks in production code paths.
 func buildArrowBatch(
 	alloc memory.Allocator,
 	schema *arrow.Schema,
@@ -29,6 +38,11 @@ func buildArrowBatch(
 	for i, f := range schema.Fields() {
 		builders[i] = array.NewBuilder(alloc, f.Type)
 	}
+	defer func() {
+		for _, b := range builders {
+			b.Release()
+		}
+	}()
 
 	for _, row := range rows {
 		for col, val := range row {
@@ -57,7 +71,16 @@ func buildArrowBatch(
 		cols[i] = b.NewArray()
 	}
 
-	return array.NewRecord(schema, cols, int64(len(rows)))
+	rec := array.NewRecord(schema, cols, int64(len(rows)))
+	// array.NewRecord retains each column (increments refcount); the
+	// builder-returned arrays in `cols` are the test's own references and
+	// must be released so the final refcount on each buffer drops to
+	// (Record's count). When the record is released, refcount hits zero
+	// and CheckedAllocator sees a clean shutdown.
+	for _, c := range cols {
+		c.Release()
+	}
+	return rec
 }
 
 // simpleRecordReader wraps a single record batch as an array.RecordReader.
@@ -357,14 +380,14 @@ func (e *errAfterNBytes) Write(p []byte) (int, error) {
 // limitation: that channel only fires on server shutdown, so Flush errors are
 // our only signal that the client has gone away.
 func TestStreamArrowJSON_FlushErrorBreaksLoop(t *testing.T) {
-	// Note: this test uses NewGoAllocator (not CheckedAllocator) to match
-	// the rest of the test file. The buildArrowBatch helper creates Arrow
-	// builders that aren't explicitly Released — CheckedAllocator would
-	// flag those as leaks, but they're pre-existing and out of scope for
-	// the disconnect-handling fix this test verifies. The actual code path
-	// being tested (streamArrowJSON's break-on-Flush-error) does not itself
-	// retain any Arrow memory beyond what simpleRecordReader.Release frees.
-	alloc := memory.NewGoAllocator()
+	// CheckedAllocator + AssertSize(t, 0) at the end of the test verifies
+	// that streamArrowJSON's break-on-Flush-error path doesn't leak Arrow
+	// memory. The buildArrowBatch helper now releases its builders (#427)
+	// so the only allocations live in the records themselves, which
+	// simpleRecordReader.Release frees. If a future edit forgets to
+	// release a record after the break, AssertSize will catch it.
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer alloc.AssertSize(t, 0)
 
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64},

--- a/internal/api/query_arrow_json_test.go
+++ b/internal/api/query_arrow_json_test.go
@@ -39,8 +39,15 @@ func buildArrowBatch(
 		builders[i] = array.NewBuilder(alloc, f.Type)
 	}
 	defer func() {
+		// nil-check: if array.NewBuilder panicked partway through the
+		// init loop above, `builders` is partially populated and the
+		// trailing entries are nil. Calling Release() on a nil
+		// array.Builder panics with a secondary nil-deref, which
+		// masks the original panic and makes test failures opaque.
 		for _, b := range builders {
-			b.Release()
+			if b != nil {
+				b.Release()
+			}
 		}
 	}()
 


### PR DESCRIPTION
Closes #427.

## Summary

- buildArrowBatch was leaking Arrow allocator buffers — invisible under \`NewGoAllocator\` (Go GC) but blocked CheckedAllocator usage everywhere it was called.
- Two fixes in the helper: \`defer\` Release on builders, plus Release each \`cols[i]\` after \`array.NewRecord\` (which retains rather than transfers ownership).
- Switched \`TestStreamArrowJSON_FlushErrorBreaksLoop\` from \`NewGoAllocator\` → \`NewCheckedAllocator\` + \`defer alloc.AssertSize(t, 0)\`. Future regressions where the disconnect-break path forgets to release a record will now fail this test.

## Test plan

- [x] \`go test -tags duckdb_arrow -race ./internal/api/ -run 'TestStreamArrowJSON' -count=3\` — all 7 streamArrowJSON tests pass 3× (21 runs)
- [x] \`go build -tags duckdb_arrow ./...\` + \`go vet\` clean
- [x] gofmt clean
- [ ] Gemini Code Assist review

🤖 Generated with [Claude Code](https://claude.com/claude-code)