### PR TITLE
feat(metrics): arc_query_client_disconnects_total counter (closes #426)

### DIFF
--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1558,7 +1558,7 @@ localProcessing:
 				}
 				// Per-handler client-disconnect counter (#426).
 				if isClientError(streamErr) {
-					m.IncQueryClientDisconnect("sql_json")
+					m.IncQueryClientDisconnect(metrics.DisconnectPathSQLJSON)
 				}
 				// Warn for client-disconnect / context expiry (headers already
 				// committed, partial result was delivered). Error for genuine
@@ -1784,7 +1784,7 @@ localProcessing:
 				}
 				// Per-handler client-disconnect counter (#426).
 				if isClientError(streamErr) {
-					m.IncQueryClientDisconnect("sql_json")
+					m.IncQueryClientDisconnect(metrics.DisconnectPathSQLJSON)
 				}
 				// Warn for client-disconnect / context expiry (headers already
 				// committed, partial result was delivered). Error for genuine
@@ -3510,7 +3510,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 			// uses the pure database/sql streaming JSON path same as the
 			// other sites above, so it shares the sql_json label.
 			if isClientError(streamErr) {
-				m.IncQueryClientDisconnect("sql_json")
+				m.IncQueryClientDisconnect(metrics.DisconnectPathSQLJSON)
 			}
 			// Warn for client-disconnect / context expiry (headers already
 			// committed, partial result was delivered). Error for genuine

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1556,6 +1556,10 @@ localProcessing:
 						h.queryRegistry.Fail(queryID, streamErr.Error())
 					}
 				}
+				// Per-handler client-disconnect counter (#426).
+				if isClientError(streamErr) {
+					m.IncQueryClientDisconnect("sql_json")
+				}
 				// Warn for client-disconnect / context expiry (headers already
 				// committed, partial result was delivered). Error for genuine
 				// server-side failures (scanner, db iteration).
@@ -1777,6 +1781,10 @@ localProcessing:
 					} else {
 						h.queryRegistry.Fail(queryID, streamErr.Error())
 					}
+				}
+				// Per-handler client-disconnect counter (#426).
+				if isClientError(streamErr) {
+					m.IncQueryClientDisconnect("sql_json")
 				}
 				// Warn for client-disconnect / context expiry (headers already
 				// committed, partial result was delivered). Error for genuine
@@ -3498,6 +3506,12 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 
 		if streamErr != nil {
 			m.IncQueryErrors()
+			// Per-handler client-disconnect counter (#426). queryMeasurement
+			// uses the pure database/sql streaming JSON path same as the
+			// other sites above, so it shares the sql_json label.
+			if isClientError(streamErr) {
+				m.IncQueryClientDisconnect("sql_json")
+			}
 			// Warn for client-disconnect / context expiry (headers already
 			// committed, partial result was delivered). Error for genuine
 			// server-side failures.

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -265,6 +265,13 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 
 		if streamErr != nil {
 			m.IncQueryErrors()
+			// Per-handler client-disconnect counter (#426). Lets operators
+			// dashboard the rate without log-scraping. Only fires on
+			// client-side events (disconnect / deadline / context-cancel)
+			// — server-side stream failures stay in IncQueryErrors only.
+			if isClientError(streamErr) {
+				m.IncQueryClientDisconnect("arrow_ipc")
+			}
 			// Warn for client-disconnect / timeout (expected ops noise);
 			// Error for everything else (real server-side problem worth
 			// alerting on).

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -270,7 +270,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			// client-side events (disconnect / deadline / context-cancel)
 			// — server-side stream failures stay in IncQueryErrors only.
 			if isClientError(streamErr) {
-				m.IncQueryClientDisconnect("arrow_ipc")
+				m.IncQueryClientDisconnect(metrics.DisconnectPathArrowIPC)
 			}
 			// Warn for client-disconnect / timeout (expected ops noise);
 			// Error for everything else (real server-side problem worth

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -159,7 +159,7 @@ func executeArrowJSONQuery(
 			// for the rationale; arrow_json is the duckdb_arrow build path
 			// that /api/v1/query takes by default.
 			if isClientError(streamErr) {
-				m.IncQueryClientDisconnect("arrow_json")
+				m.IncQueryClientDisconnect(metrics.DisconnectPathArrowJSON)
 			}
 			// Warn for client-disconnect / context expiry (expected ops noise
 			// — headers were already committed, the client got partial bytes).

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -155,6 +155,12 @@ func executeArrowJSONQuery(
 			} else if onFail != nil {
 				onFail(streamErr.Error())
 			}
+			// Per-handler client-disconnect counter (#426). See query_arrow.go
+			// for the rationale; arrow_json is the duckdb_arrow build path
+			// that /api/v1/query takes by default.
+			if isClientError(streamErr) {
+				m.IncQueryClientDisconnect("arrow_json")
+			}
 			// Warn for client-disconnect / context expiry (expected ops noise
 			// — headers were already committed, the client got partial bytes).
 			// Error for everything else: scanner/reader failures are real

--- a/internal/metrics/disconnect_test.go
+++ b/internal/metrics/disconnect_test.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIncQueryClientDisconnect covers the three valid paths plus the
+// silent-drop branch for an unknown label. The "silent drop" semantics
+// matter for #426: if a typo at a call site (e.g. "arrow-json" instead
+// of "arrow_json") were ever to land, we'd rather emit no count than
+// pollute the labelled time series with a malformed value.
+func TestIncQueryClientDisconnect(t *testing.T) {
+	m := &Metrics{}
+
+	m.IncQueryClientDisconnect("arrow_ipc")
+	m.IncQueryClientDisconnect("arrow_ipc")
+	m.IncQueryClientDisconnect("arrow_json")
+	m.IncQueryClientDisconnect("sql_json")
+	m.IncQueryClientDisconnect("sql_json")
+	m.IncQueryClientDisconnect("sql_json")
+
+	// Invalid label: must NOT increment any counter.
+	m.IncQueryClientDisconnect("arrow-json")
+	m.IncQueryClientDisconnect("")
+
+	if got, want := m.queryDisconnectsArrowIPC.Load(), int64(2); got != want {
+		t.Errorf("arrow_ipc counter = %d, want %d", got, want)
+	}
+	if got, want := m.queryDisconnectsArrowJSON.Load(), int64(1); got != want {
+		t.Errorf("arrow_json counter = %d, want %d", got, want)
+	}
+	if got, want := m.queryDisconnectsSQLJSON.Load(), int64(3); got != want {
+		t.Errorf("sql_json counter = %d, want %d", got, want)
+	}
+}
+
+// TestPrometheusFormat_DisconnectMetric verifies the three labelled
+// time series are emitted in the Prometheus text exposition format
+// even when the counters are zero (Prometheus convention: counters
+// must be present so rate() over a fresh process doesn't produce
+// gaps). Also locks in the metric name + label shape against
+// accidental rename.
+func TestPrometheusFormat_DisconnectMetric(t *testing.T) {
+	m := &Metrics{}
+	m.IncQueryClientDisconnect("arrow_ipc")
+	m.IncQueryClientDisconnect("sql_json")
+	m.IncQueryClientDisconnect("sql_json")
+
+	out := m.PrometheusFormat()
+
+	for _, want := range []string{
+		`# TYPE arc_query_client_disconnects_total counter`,
+		`arc_query_client_disconnects_total{path="arrow_ipc"} 1`,
+		`arc_query_client_disconnects_total{path="arrow_json"} 0`,
+		`arc_query_client_disconnects_total{path="sql_json"} 2`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("PrometheusFormat missing %q\n--- full output ---\n%s", want, out)
+		}
+	}
+}

--- a/internal/metrics/disconnect_test.go
+++ b/internal/metrics/disconnect_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestIncQueryClientDisconnect covers the three valid paths plus the
@@ -10,17 +11,24 @@ import (
 // matter for #426: if a typo at a call site (e.g. "arrow-json" instead
 // of "arrow_json") were ever to land, we'd rather emit no count than
 // pollute the labelled time series with a malformed value.
+//
+// Note on string-literal usage: the VALID-label calls use the typed
+// constants (matching production call-site discipline); the INVALID
+// calls use raw literals on purpose — typed constants would defeat
+// the test (you can't typo a constant, so you can't test the silent-
+// drop guard with one).
 func TestIncQueryClientDisconnect(t *testing.T) {
-	m := &Metrics{}
+	m := &Metrics{startTime: time.Now().UTC()}
 
-	m.IncQueryClientDisconnect("arrow_ipc")
-	m.IncQueryClientDisconnect("arrow_ipc")
-	m.IncQueryClientDisconnect("arrow_json")
-	m.IncQueryClientDisconnect("sql_json")
-	m.IncQueryClientDisconnect("sql_json")
-	m.IncQueryClientDisconnect("sql_json")
+	m.IncQueryClientDisconnect(DisconnectPathArrowIPC)
+	m.IncQueryClientDisconnect(DisconnectPathArrowIPC)
+	m.IncQueryClientDisconnect(DisconnectPathArrowJSON)
+	m.IncQueryClientDisconnect(DisconnectPathSQLJSON)
+	m.IncQueryClientDisconnect(DisconnectPathSQLJSON)
+	m.IncQueryClientDisconnect(DisconnectPathSQLJSON)
 
-	// Invalid label: must NOT increment any counter.
+	// Invalid labels: must NOT increment any counter. Raw literals
+	// here on purpose — see comment above.
 	m.IncQueryClientDisconnect("arrow-json")
 	m.IncQueryClientDisconnect("")
 
@@ -41,11 +49,17 @@ func TestIncQueryClientDisconnect(t *testing.T) {
 // must be present so rate() over a fresh process doesn't produce
 // gaps). Also locks in the metric name + label shape against
 // accidental rename.
+//
+// startTime: time.Now().UTC() is required because PrometheusFormat
+// emits arc_uptime_seconds derived from time.Since(m.startTime). A
+// zero startTime yields ~9.2e9 seconds (~292 years) which is
+// observationally harmless but misleading if a test ever asserts on
+// uptime shape.
 func TestPrometheusFormat_DisconnectMetric(t *testing.T) {
-	m := &Metrics{}
-	m.IncQueryClientDisconnect("arrow_ipc")
-	m.IncQueryClientDisconnect("sql_json")
-	m.IncQueryClientDisconnect("sql_json")
+	m := &Metrics{startTime: time.Now().UTC()}
+	m.IncQueryClientDisconnect(DisconnectPathArrowIPC)
+	m.IncQueryClientDisconnect(DisconnectPathSQLJSON)
+	m.IncQueryClientDisconnect(DisconnectPathSQLJSON)
 
 	out := m.PrometheusFormat()
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -281,17 +281,28 @@ func (m *Metrics) RecordQueryLatency(durationMicros int64) {
 	m.queryLatencyCount.Add(1)
 }
 
+// Label values for the arc_query_client_disconnects_total Prometheus
+// counter. Exported so callers in internal/api can reference them via
+// these constants instead of repeating the string literal at every
+// call site — typos become compile-time errors and the label set
+// stays single-source-of-truth here.
+const (
+	DisconnectPathArrowIPC  = "arrow_ipc"
+	DisconnectPathArrowJSON = "arrow_json"
+	DisconnectPathSQLJSON   = "sql_json"
+)
+
 // IncQueryClientDisconnect increments the per-handler client-disconnect
-// counter. `path` MUST be one of "arrow_ipc", "arrow_json", "sql_json";
+// counter. `path` MUST be one of the DisconnectPath* constants above;
 // any other value is silently dropped so a typo at the call site can't
 // emit a malformed labelled time series.
 func (m *Metrics) IncQueryClientDisconnect(path string) {
 	switch path {
-	case "arrow_ipc":
+	case DisconnectPathArrowIPC:
 		m.queryDisconnectsArrowIPC.Add(1)
-	case "arrow_json":
+	case DisconnectPathArrowJSON:
 		m.queryDisconnectsArrowJSON.Add(1)
-	case "sql_json":
+	case DisconnectPathSQLJSON:
 		m.queryDisconnectsSQLJSON.Add(1)
 	}
 }
@@ -717,9 +728,9 @@ func (m *Metrics) PrometheusFormat() string {
 	// behaviour (#426).
 	b = append(b, "# HELP arc_query_client_disconnects_total Streaming queries the client closed mid-response, by handler path\n"...)
 	b = append(b, "# TYPE arc_query_client_disconnects_total counter\n"...)
-	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", "arrow_ipc", float64(m.queryDisconnectsArrowIPC.Load()))
-	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", "arrow_json", float64(m.queryDisconnectsArrowJSON.Load()))
-	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", "sql_json", float64(m.queryDisconnectsSQLJSON.Load()))
+	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", DisconnectPathArrowIPC, float64(m.queryDisconnectsArrowIPC.Load()))
+	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", DisconnectPathArrowJSON, float64(m.queryDisconnectsArrowJSON.Load()))
+	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", DisconnectPathSQLJSON, float64(m.queryDisconnectsSQLJSON.Load()))
 
 	// Buffer metrics
 	b = append(b, "# HELP arc_buffer_records_buffered Records currently buffered\n"...)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -50,6 +50,17 @@ type Metrics struct {
 	queryLatencySum    atomic.Int64 // microseconds
 	queryLatencyCount  atomic.Int64
 
+	// Client-disconnect mid-stream counters, broken out by streaming
+	// handler so operators can disambiguate "Grafana panels giving up"
+	// (arrow_json — the duckdb_arrow code path /api/v1/query takes) from
+	// "scripts piping into curl that get killed" (sql_json) from
+	// "downstream Arrow consumers like grafana-arrow-datasource that
+	// disconnect on tab close" (arrow_ipc). Incremented at every site
+	// that today only logs a Warn with rows_sent (see #426).
+	queryDisconnectsArrowIPC  atomic.Int64
+	queryDisconnectsArrowJSON atomic.Int64
+	queryDisconnectsSQLJSON   atomic.Int64
+
 	// Arrow buffer metrics
 	bufferRecordsBuffered atomic.Int64
 	bufferRecordsWritten  atomic.Int64
@@ -270,6 +281,21 @@ func (m *Metrics) RecordQueryLatency(durationMicros int64) {
 	m.queryLatencyCount.Add(1)
 }
 
+// IncQueryClientDisconnect increments the per-handler client-disconnect
+// counter. `path` MUST be one of "arrow_ipc", "arrow_json", "sql_json";
+// any other value is silently dropped so a typo at the call site can't
+// emit a malformed labelled time series.
+func (m *Metrics) IncQueryClientDisconnect(path string) {
+	switch path {
+	case "arrow_ipc":
+		m.queryDisconnectsArrowIPC.Add(1)
+	case "arrow_json":
+		m.queryDisconnectsArrowJSON.Add(1)
+	case "sql_json":
+		m.queryDisconnectsSQLJSON.Add(1)
+	}
+}
+
 // Buffer Metrics
 func (m *Metrics) SetBufferRecordsBuffered(count int64) { m.bufferRecordsBuffered.Store(count) }
 func (m *Metrics) SetBufferRecordsWritten(count int64)  { m.bufferRecordsWritten.Store(count) }
@@ -456,6 +482,10 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 		"query_rows_total":     m.queryRowsTotal.Load(),
 		"query_latency_sum_us": m.queryLatencySum.Load(),
 		"query_latency_count":  m.queryLatencyCount.Load(),
+
+		"query_client_disconnects_arrow_ipc_total":  m.queryDisconnectsArrowIPC.Load(),
+		"query_client_disconnects_arrow_json_total": m.queryDisconnectsArrowJSON.Load(),
+		"query_client_disconnects_sql_json_total":   m.queryDisconnectsSQLJSON.Load(),
 
 		// Buffer
 		"buffer_records_buffered":     m.bufferRecordsBuffered.Load(),
@@ -678,6 +708,18 @@ func (m *Metrics) PrometheusFormat() string {
 	b = append(b, "# HELP arc_query_rows_total Total rows returned by queries\n"...)
 	b = append(b, "# TYPE arc_query_rows_total counter\n"...)
 	b = appendMetric(b, "arc_query_rows_total", float64(m.queryRowsTotal.Load()))
+
+	// Per-handler client-disconnect counters. The `path` label
+	// distinguishes Arrow IPC (grafana-arrow-datasource style),
+	// Arrow-to-JSON (duckdb_arrow build serving /api/v1/query), and
+	// pure database/sql JSON (default build). Operators alert on a
+	// rising rate per path to correlate with RSS profiles + dashboard
+	// behaviour (#426).
+	b = append(b, "# HELP arc_query_client_disconnects_total Streaming queries the client closed mid-response, by handler path\n"...)
+	b = append(b, "# TYPE arc_query_client_disconnects_total counter\n"...)
+	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", "arrow_ipc", float64(m.queryDisconnectsArrowIPC.Load()))
+	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", "arrow_json", float64(m.queryDisconnectsArrowJSON.Load()))
+	b = appendMetricWithLabel(b, "arc_query_client_disconnects_total", "path", "sql_json", float64(m.queryDisconnectsSQLJSON.Load()))
 
 	// Buffer metrics
 	b = append(b, "# HELP arc_buffer_records_buffered Records currently buffered\n"...)


### PR DESCRIPTION
Closes #426.

## Summary

- Expose `arc_query_client_disconnects_total{path="arrow_ipc|arrow_json|sql_json"}` Prometheus counter — operators can now alert/dashboard on mid-stream client disconnects (Grafana panel close, browser tab kill) without grepping logs.
- Wired at all 4 existing disconnect Warn-log sites: 1× `arrow_ipc` (query_arrow.go), 1× `arrow_json` (query_arrow_json.go, duckdb_arrow build path), 3× `sql_json` (query.go — `executeQuery` JSON path × 2, `queryMeasurement`).
- Guarded by the existing `isClientError()` predicate so server-side stream failures stay in `IncQueryErrors` only.
- Label switch silently drops unknown values; tests cover both valid and invalid label paths plus the Prometheus output shape (including zero counter present per Prometheus convention).

Internal review: configuration matrix + deep reviewer agent — clean (no Blockers/High/Medium).

## Test plan

- [x] `go test -race ./internal/metrics/ -run 'TestIncQueryClientDisconnect|TestPrometheusFormat_DisconnectMetric' -count=2` — both tests pass 2×
- [x] `go build ./internal/... ./cmd/...` clean (standard + `-tags duckdb_arrow`)
- [x] `go vet` + gofmt clean on touched files
- [ ] Gemini Code Assist review

🤖 Generated with [Claude Code](https://claude.com/claude-code)