### PR TITLE
fix(import): parse CSV/Parquet in-process via ArrowBuffer (#472)

### DIFF
--- a/RELEASE_NOTES_2026.06.2.md
+++ b/RELEASE_NOTES_2026.06.2.md
@@ -12,12 +12,26 @@ This release strengthens internal verification routines on the Arc Enterprise ac
 
 Operators on 26.06.1 should plan to upgrade.
 
+## Bug fixes
+
+**CSV and Parquet bulk imports now work against the shipped DuckDB version.** `POST /api/v1/import/csv` and `/api/v1/import/parquet` previously introspected the uploaded file by running DuckDB queries against it (`read_csv` / `read_parquet` + `DESCRIBE`); the `DESCRIBE`-as-subquery form was rejected by the DuckDB version Arc ships, so CSV imports failed with an HTTP 422 parser error before any data landed. Both formats now parse rows in-process and ingest through the same streaming pipeline as Line Protocol and TLE imports — no DuckDB queries against the uploaded file.
+
+User-visible behavior changes:
+
+- A 0-byte or header-only upload now returns `400 "file is empty"` / `"file contains no rows"` (previously a confusing parser error).
+- Imports validate up front and reject, with a clear `400`, a file whose `time_column` rename would collide with an existing `time` column, or a file with duplicate column names — cases that could previously have silently dropped a column.
+- CSV uploads are now subject to the same 500 MB size cap already enforced for the other import formats.
+- Parquet `DECIMAL` columns are imported as `DOUBLE` (Arc's ingest path does not carry per-column decimal precision for imports). Use Line Protocol with a configured decimal column if exact decimal precision is required.
+
+Line Protocol and TLE imports are unchanged. CSV/Parquet imports no longer depend on the DuckDB sandbox's allowed-directories list.
+
 ## Upgrade notes
 
 1. **No configuration change required.** Drop in the new binary; existing `arc.toml` and license keys work as-is.
 2. **Active licenses keep working.** Arc binaries running against `enterprise.basekick.net` continue to operate normally; no re-activation or license-key reissuance is required.
 3. **OSS-only deployments** (no `[license]` block in `arc.toml`) are unaffected by the license-verification change. The database-API authorization change applies only when authentication is enabled in `arc.toml`.
 4. **Token review for operators using non-admin tokens for database management**: if any automation provisions databases via `POST /api/v1/databases`, ensure the token it uses has the `admin` permission. Auto-create-on-write (databases that come into existence as a side-effect of line-protocol or msgpack writes) is unaffected — write tokens continue to work for ingestion.
+5. **CSV/Parquet import callers**: imports that relied on a Parquet `DECIMAL` column round-tripping as a decimal will now receive a `DOUBLE`. Imports of malformed files (empty, duplicate headers, or a `time_column` rename that collides with an existing `time` column) now fail fast with a `400` instead of partially succeeding — review any automation that ignored import error responses.
 
 ## Dependencies
 

--- a/RELEASE_NOTES_2026.06.2.md
+++ b/RELEASE_NOTES_2026.06.2.md
@@ -19,7 +19,8 @@ Operators on 26.06.1 should plan to upgrade.
 User-visible behavior changes:
 
 - A 0-byte or header-only upload now returns `400 "file is empty"` / `"file contains no rows"` (previously a confusing parser error).
-- Imports validate up front and reject, with a clear `400`, a file whose `time_column` rename would collide with an existing `time` column, or a file with duplicate column names — cases that could previously have silently dropped a column.
+- Imports validate up front and reject, with a clear `400`: empty, blank, or duplicate column names; a `time_column` rename that would collide with an existing `time` column; or (for Parquet) a `NaN`/`Inf` value in a floating-point time column — cases that could previously have silently dropped a column, crashed the import, or written corrupt partition boundaries.
+- Time columns now accept **fractional (floating-point) epochs** (e.g. `1609459200.123`), preserving sub-second precision; the old DuckDB path tolerated these and the in-process rewrite restores parity. Integer epochs keep full precision (no float round-trip). For Parquet, the time column may be a `TIMESTAMP`, an integer or floating-point epoch, or a timestamp string.
 - CSV uploads are now subject to the same 500 MB size cap already enforced for the other import formats.
 - Parquet `DECIMAL` columns are imported as `DOUBLE` (Arc's ingest path does not carry per-column decimal precision for imports). Use Line Protocol with a configured decimal column if exact decimal precision is required.
 
@@ -31,7 +32,7 @@ Line Protocol and TLE imports are unchanged. CSV/Parquet imports no longer depen
 2. **Active licenses keep working.** Arc binaries running against `enterprise.basekick.net` continue to operate normally; no re-activation or license-key reissuance is required.
 3. **OSS-only deployments** (no `[license]` block in `arc.toml`) are unaffected by the license-verification change. The database-API authorization change applies only when authentication is enabled in `arc.toml`.
 4. **Token review for operators using non-admin tokens for database management**: if any automation provisions databases via `POST /api/v1/databases`, ensure the token it uses has the `admin` permission. Auto-create-on-write (databases that come into existence as a side-effect of line-protocol or msgpack writes) is unaffected — write tokens continue to work for ingestion.
-5. **CSV/Parquet import callers**: imports that relied on a Parquet `DECIMAL` column round-tripping as a decimal will now receive a `DOUBLE`. Imports of malformed files (empty, duplicate headers, or a `time_column` rename that collides with an existing `time` column) now fail fast with a `400` instead of partially succeeding — review any automation that ignored import error responses.
+5. **CSV/Parquet import callers**: imports that relied on a Parquet `DECIMAL` column round-tripping as a decimal will now receive a `DOUBLE`. Malformed files now fail fast with a `400` instead of partially succeeding (empty file, empty/blank/duplicate column names, a `time_column` rename that collides with an existing `time` column, or a `NaN`/`Inf` float time value) — review any automation that ignored import error responses.
 
 ## Dependencies
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1850,9 +1850,12 @@ func main() {
 	tleHandler.RegisterRoutes(server.GetApp())
 
 	// Register Import handler (CSV, Parquet, Line Protocol, TLE bulk import).
-	// uploadDir is the same path that database.New added to the DuckDB
-	// sandbox's allowed_directories — staying in sync keeps imports working.
-	importHandler := api.NewImportHandler(db, storageBackend, dbConfig.UploadDir, logger.Get("import"))
+	// All formats parse in-process and ingest through the ArrowBuffer pipeline;
+	// no import path issues DuckDB queries against the uploaded file, so the
+	// handler no longer needs the sandbox-allowlisted upload directory.
+	// (dbConfig.UploadDir is still allowlisted for delete.go's S3 COPY ... TO
+	// staging — see NewDeleteHandler below.)
+	importHandler := api.NewImportHandler(logger.Get("import"))
 	importHandler.SetArrowBuffer(arrowBuffer)
 	if authManager != nil && rbacManager != nil {
 		importHandler.SetAuthAndRBAC(authManager, rbacManager)

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -1,19 +1,13 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/basekick-labs/arc/internal/auth"
-	"github.com/basekick-labs/arc/internal/database"
 	"github.com/basekick-labs/arc/internal/ingest"
-	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/basekick-labs/arc/pkg/models"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
@@ -50,13 +44,17 @@ type TLEImportResult struct {
 	DurationMs     int64    `json:"duration_ms"`
 }
 
-// ImportHandler handles bulk CSV, Parquet, and Line Protocol file imports
+// ImportHandler handles bulk CSV, Parquet, Line Protocol, and TLE file imports.
+//
+// All formats parse rows in-process and ingest through the ArrowBuffer pipeline
+// (the same path as streaming writes). No import path issues DuckDB queries
+// against the uploaded file, so imports do not require the upload directory to
+// be in the DuckDB sandbox allowlist. (The allowlist entry that still exists is
+// retained solely for delete.go's S3 COPY ... TO staging — see cmd/arc/main.go.)
 type ImportHandler struct {
-	db      *database.DuckDB
-	storage storage.Backend
-	logger  zerolog.Logger
+	logger zerolog.Logger
 
-	// ArrowBuffer for LP import (uses the streaming ingest pipeline)
+	// arrowBuffer is the streaming ingest pipeline used by every import format.
 	arrowBuffer *ingest.ArrowBuffer
 
 	// authManager holds the concrete *auth.AuthManager. See
@@ -65,37 +63,17 @@ type ImportHandler struct {
 	authManager *auth.AuthManager
 	rbacManager RBACChecker
 
-	// uploadDir is the directory under which multipart uploads land. Must
-	// be one of the prefixes in the DuckDB sandbox's allowed_directories
-	// list, otherwise read_csv/read_parquet on the uploaded file fails.
-	// Empty means use the OS default (only safe before the sandbox lockdown
-	// was introduced — kept for legacy/test paths that don't go through
-	// main.go).
-	uploadDir string
-
 	// Stats
 	totalRequests atomic.Int64
 	totalRecords  atomic.Int64
 	totalErrors   atomic.Int64
 }
 
-// NewImportHandler creates a new ImportHandler. uploadDir must be the same
-// path cmd/arc/main.go added to the DuckDB sandbox's allowed_directories,
-// otherwise read_csv/read_parquet on the uploaded file fails post-lockdown.
-// Logs a Warn on empty uploadDir; the request handler also fails-closed at
-// every POST so misconfiguration surfaces both at startup and at the first
-// import attempt. Tests that exercise the handler should pass a non-empty
-// path (typically a t.TempDir() inside LocalStorageRoot).
-func NewImportHandler(db *database.DuckDB, storage storage.Backend, uploadDir string, logger zerolog.Logger) *ImportHandler {
-	componentLogger := logger.With().Str("component", "import-handler").Logger()
-	if uploadDir == "" {
-		componentLogger.Warn().Msg("NewImportHandler called with empty uploadDir — imports will fail under the DuckDB sandbox; cmd/arc/main.go should pass the sandbox-allowlisted upload directory")
-	}
+// NewImportHandler creates a new ImportHandler. The ArrowBuffer must be set via
+// SetArrowBuffer before any import is served.
+func NewImportHandler(logger zerolog.Logger) *ImportHandler {
 	return &ImportHandler{
-		db:        db,
-		storage:   storage,
-		uploadDir: uploadDir,
-		logger:    componentLogger,
+		logger: logger.With().Str("component", "import-handler").Logger(),
 	}
 }
 
@@ -125,153 +103,6 @@ func (h *ImportHandler) RegisterRoutes(app *fiber.App) {
 	app.Get("/api/v1/import/stats", h.Stats)
 
 	h.logger.Info().Msg("Import routes registered")
-}
-
-// handleCSVImport handles CSV file upload and import
-func (h *ImportHandler) handleCSVImport(c *fiber.Ctx) error {
-	return h.handleFileImport(c, "csv", func(c *fiber.Ctx) importOptions {
-		return importOptions{
-			format:     "csv",
-			timeColumn: c.Query("time_column", "time"),
-			timeFormat: c.Query("time_format", ""),
-			delimiter:  c.Query("delimiter", ","),
-			skipRows:   c.QueryInt("skip_rows", 0),
-		}
-	})
-}
-
-// handleParquetImport handles Parquet file upload and import
-func (h *ImportHandler) handleParquetImport(c *fiber.Ctx) error {
-	return h.handleFileImport(c, "parquet", func(c *fiber.Ctx) importOptions {
-		return importOptions{
-			format:     "parquet",
-			timeColumn: c.Query("time_column", "time"),
-		}
-	})
-}
-
-// handleFileImport is the shared implementation for CSV and Parquet imports.
-// It validates inputs, handles file upload, calls importFile, and returns the result.
-func (h *ImportHandler) handleFileImport(c *fiber.Ctx, format string, buildOpts func(*fiber.Ctx) importOptions) error {
-	h.totalRequests.Add(1)
-	start := time.Now()
-
-	database := c.Get("x-arc-database")
-	if database == "" {
-		database = c.Query("db")
-	}
-	if database == "" {
-		h.totalErrors.Add(1)
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "database is required (set x-arc-database header or db query param)",
-		})
-	}
-
-	if !isValidDatabaseName(database) {
-		h.totalErrors.Add(1)
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "invalid database name: must start with a letter and contain only alphanumeric characters, underscores, or hyphens (max 64 characters)",
-		})
-	}
-
-	measurement := c.Query("measurement")
-	if measurement == "" {
-		h.totalErrors.Add(1)
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "measurement query parameter is required",
-		})
-	}
-
-	if !isValidMeasurementName(measurement) {
-		h.totalErrors.Add(1)
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": fmt.Sprintf("invalid measurement name %q: must start with a letter and contain only alphanumeric characters, underscores, or hyphens", measurement),
-		})
-	}
-
-	// Check RBAC permissions
-	if h.rbacManager != nil && h.rbacManager.IsRBACEnabled() {
-		if err := CheckWritePermissions(c, h.rbacManager, h.logger, database, []string{measurement}); err != nil {
-			h.totalErrors.Add(1)
-			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
-				"error": err.Error(),
-			})
-		}
-	}
-
-	// Get uploaded file
-	fileHeader, err := c.FormFile("file")
-	if err != nil {
-		h.totalErrors.Add(1)
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "no file uploaded: use multipart/form-data with field name 'file'",
-		})
-	}
-
-	// Fail-closed when the handler was constructed without a sandbox-
-	// allowlisted uploadDir. Without this guard, os.MkdirTemp("", ...) would
-	// fall back to os.TempDir() — outside the DuckDB sandbox — and the
-	// post-upload read_csv/read_parquet would fail with a confusing
-	// permission error. The constructor Warn surfaces the misconfiguration
-	// at startup; this fail-fast at request time provides a clearer signal.
-	if h.uploadDir == "" {
-		h.totalErrors.Add(1)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "import handler is misconfigured: uploadDir is empty; the upload directory must be allowlisted in the DuckDB sandbox (see cmd/arc/main.go uploadDir wiring)",
-		})
-	}
-	// Save to temp file inside the sandbox-allowlisted upload directory.
-	tempDir, err := os.MkdirTemp(h.uploadDir, "arc-import-*")
-	if err != nil {
-		h.totalErrors.Add(1)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "failed to create temp directory: " + err.Error(),
-		})
-	}
-	// ToSlash so Windows backslashes from os.MkdirTemp match the
-	// forward-slash sandbox allowlist entry (h.uploadDir is already
-	// normalized by main.go). Without this, reads of the uploaded file
-	// via read_csv/read_parquet would fail with a permission error on
-	// Windows even though the upload landed inside the allowlisted prefix.
-	tempDir = filepath.ToSlash(tempDir)
-	defer os.RemoveAll(tempDir)
-
-	tempFile := filepath.Join(tempDir, "import."+format)
-	if err := c.SaveFile(fileHeader, tempFile); err != nil {
-		h.totalErrors.Add(1)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "failed to save uploaded file: " + err.Error(),
-		})
-	}
-
-	opts := buildOpts(c)
-
-	result, err := h.importFile(c.Context(), database, measurement, tempFile, tempDir, opts)
-	if err != nil {
-		h.totalErrors.Add(1)
-		h.logger.Error().Err(err).
-			Str("database", database).
-			Str("measurement", measurement).
-			Str("format", format).
-			Msg("Import failed")
-		return h.importErrorResponse(c, err)
-	}
-
-	result.DurationMs = time.Since(start).Milliseconds()
-	h.totalRecords.Add(result.RowsImported)
-
-	h.logger.Info().
-		Str("database", database).
-		Str("measurement", measurement).
-		Int64("rows", result.RowsImported).
-		Int("partitions", result.PartitionsCreated).
-		Int64("duration_ms", result.DurationMs).
-		Msg(strings.ToUpper(format) + " import completed")
-
-	return c.JSON(fiber.Map{
-		"status": "ok",
-		"result": result,
-	})
 }
 
 // handleLineProtocolImport handles Line Protocol file upload and import.
@@ -513,290 +344,6 @@ func (e *importError) Error() string {
 	return e.Message
 }
 
-// importFile uses DuckDB to read the uploaded file, partition by hour, and write to storage
-func (h *ImportHandler) importFile(ctx context.Context, dbName, measurement, filePath, tempDir string, opts importOptions) (*ImportResult, error) {
-	// Build the DuckDB read expression for the source file
-	readExpr := h.buildReadExpression(filePath, opts)
-
-	// 1. Validate schema — check that time column exists and get column list
-	columns, err := h.getColumns(readExpr)
-	if err != nil {
-		return nil, &importError{
-			StatusCode: fiber.StatusUnprocessableEntity,
-			Message:    "failed to read file",
-			Err:        err,
-		}
-	}
-
-	hasTimeCol := false
-	for _, col := range columns {
-		if col == opts.timeColumn {
-			hasTimeCol = true
-			break
-		}
-	}
-	if !hasTimeCol {
-		return nil, &importError{
-			StatusCode: fiber.StatusBadRequest,
-			Message:    fmt.Sprintf("time column %q not found in file; available columns: %s", opts.timeColumn, strings.Join(columns, ", ")),
-		}
-	}
-
-	// 2. Build time cast expression for normalization to TIMESTAMP
-	timeCast := h.buildTimeCast(opts.timeColumn, opts.timeFormat)
-
-	// 3. Get row count and time range
-	statsQuery := fmt.Sprintf(
-		"SELECT COUNT(*), MIN(%s)::VARCHAR, MAX(%s)::VARCHAR FROM %s",
-		timeCast, timeCast, readExpr,
-	)
-	rows, err := h.db.Query(statsQuery)
-	if err != nil {
-		return nil, &importError{
-			StatusCode: fiber.StatusUnprocessableEntity,
-			Message:    "failed to analyze file",
-			Err:        err,
-		}
-	}
-
-	var totalRows int64
-	var minTime, maxTime string
-	if rows.Next() {
-		if err := rows.Scan(&totalRows, &minTime, &maxTime); err != nil {
-			rows.Close()
-			return nil, &importError{
-				StatusCode: fiber.StatusUnprocessableEntity,
-				Message:    "failed to read file statistics",
-				Err:        err,
-			}
-		}
-	}
-	rows.Close()
-
-	if totalRows == 0 {
-		return nil, &importError{
-			StatusCode: fiber.StatusBadRequest,
-			Message:    "file contains no rows",
-		}
-	}
-
-	// 4. Get distinct hour partitions
-	partitionQuery := fmt.Sprintf(
-		"SELECT DISTINCT date_trunc('hour', %s)::VARCHAR AS partition_hour FROM %s ORDER BY partition_hour",
-		timeCast, readExpr,
-	)
-	partRows, err := h.db.Query(partitionQuery)
-	if err != nil {
-		return nil, &importError{
-			StatusCode: fiber.StatusInternalServerError,
-			Message:    "failed to determine partitions",
-			Err:        err,
-		}
-	}
-
-	var partitionHours []string
-	for partRows.Next() {
-		var hour string
-		if err := partRows.Scan(&hour); err != nil {
-			partRows.Close()
-			return nil, &importError{
-				StatusCode: fiber.StatusInternalServerError,
-				Message:    "failed to read partition hours",
-				Err:        err,
-			}
-		}
-		partitionHours = append(partitionHours, hour)
-	}
-	partRows.Close()
-
-	// 5. For each partition hour, COPY to a temp Parquet file, then upload to storage
-	outputDir := filepath.Join(tempDir, "output")
-	if err := os.MkdirAll(outputDir, 0o700); err != nil {
-		return nil, &importError{
-			StatusCode: fiber.StatusInternalServerError,
-			Message:    "failed to create output directory",
-			Err:        err,
-		}
-	}
-
-	// Rename the time column to "time" if it has a different name, so Arc's
-	// standard schema always has a "time" column
-	selectExpr := "*"
-	if opts.timeColumn != "time" {
-		// Build column list, renaming the time column
-		var selectCols []string
-		for _, col := range columns {
-			if col == opts.timeColumn {
-				selectCols = append(selectCols, fmt.Sprintf("%s AS time", timeCast))
-			} else {
-				selectCols = append(selectCols, fmt.Sprintf("\"%s\"", col))
-			}
-		}
-		selectExpr = strings.Join(selectCols, ", ")
-	} else {
-		// Still need to cast time column for normalization
-		var selectCols []string
-		for _, col := range columns {
-			if col == "time" {
-				selectCols = append(selectCols, fmt.Sprintf("%s AS time", timeCast))
-			} else {
-				selectCols = append(selectCols, fmt.Sprintf("\"%s\"", col))
-			}
-		}
-		selectExpr = strings.Join(selectCols, ", ")
-	}
-
-	partitionsCreated := 0
-	for _, hourStr := range partitionHours {
-		// Parse the partition hour to construct Arc's storage path
-		partTime, err := time.Parse("2006-01-02 15:04:05", hourStr)
-		if err != nil {
-			// Try with timezone suffix
-			partTime, err = time.Parse("2006-01-02 15:04:05-07", hourStr)
-			if err != nil {
-				partTime, err = time.Parse("2006-01-02T15:04:05Z", hourStr)
-				if err != nil {
-					h.logger.Warn().Str("hour", hourStr).Msg("Failed to parse partition hour, skipping")
-					continue
-				}
-			}
-		}
-		partTime = partTime.UTC()
-
-		// Generate output Parquet file
-		outFile := filepath.Join(outputDir, fmt.Sprintf("part_%s.parquet", partTime.Format("20060102_150405")))
-
-		copyQuery := fmt.Sprintf(
-			"COPY (SELECT %s FROM %s WHERE date_trunc('hour', %s) = '%s' ORDER BY %s) TO '%s' (FORMAT PARQUET, COMPRESSION SNAPPY)",
-			selectExpr, readExpr, timeCast, hourStr, timeCast, escapeSQLString(outFile),
-		)
-
-		if _, err := h.db.Exec(copyQuery); err != nil {
-			return nil, &importError{
-				StatusCode: fiber.StatusInternalServerError,
-				Message:    fmt.Sprintf("failed to write partition %s", hourStr),
-				Err:        err,
-			}
-		}
-
-		// Read the generated Parquet file
-		parquetData, err := os.ReadFile(outFile)
-		if err != nil {
-			return nil, &importError{
-				StatusCode: fiber.StatusInternalServerError,
-				Message:    "failed to read generated parquet file",
-				Err:        err,
-			}
-		}
-
-		// Generate Arc-standard storage path
-		storagePath := generateStoragePath(dbName, measurement, partTime)
-
-		// Upload to storage backend
-		if err := h.storage.Write(ctx, storagePath, parquetData); err != nil {
-			return nil, &importError{
-				StatusCode: fiber.StatusInternalServerError,
-				Message:    fmt.Sprintf("failed to upload partition %s to storage", hourStr),
-				Err:        err,
-			}
-		}
-
-		h.logger.Debug().
-			Str("partition", hourStr).
-			Str("path", storagePath).
-			Int("size_bytes", len(parquetData)).
-			Msg("Partition uploaded")
-
-		partitionsCreated++
-	}
-
-	return &ImportResult{
-		Database:          dbName,
-		Measurement:       measurement,
-		RowsImported:      totalRows,
-		PartitionsCreated: partitionsCreated,
-		TimeRangeMin:      minTime,
-		TimeRangeMax:      maxTime,
-		Columns:           columns,
-	}, nil
-}
-
-// buildReadExpression builds the DuckDB read expression for the source file
-func (h *ImportHandler) buildReadExpression(filePath string, opts importOptions) string {
-	escaped := escapeSQLString(filePath)
-	switch opts.format {
-	case "csv":
-		parts := []string{fmt.Sprintf("'%s'", escaped)}
-		parts = append(parts, "auto_detect=true")
-		parts = append(parts, "header=true")
-		if opts.delimiter != "," {
-			parts = append(parts, fmt.Sprintf("delim='%s'", escapeSQLString(opts.delimiter)))
-		}
-		if opts.skipRows > 0 {
-			parts = append(parts, fmt.Sprintf("skip=%d", opts.skipRows))
-		}
-		return fmt.Sprintf("read_csv(%s)", strings.Join(parts, ", "))
-	case "parquet":
-		return fmt.Sprintf("read_parquet('%s')", escaped)
-	default:
-		return fmt.Sprintf("read_csv('%s', auto_detect=true)", escaped)
-	}
-}
-
-// buildTimeCast builds the SQL expression to cast the time column to TIMESTAMP
-func (h *ImportHandler) buildTimeCast(timeColumn, timeFormat string) string {
-	col := fmt.Sprintf("\"%s\"", timeColumn)
-	switch timeFormat {
-	case "epoch_s":
-		return fmt.Sprintf("to_timestamp(%s::BIGINT)", col)
-	case "epoch_ms":
-		return fmt.Sprintf("to_timestamp(%s::BIGINT / 1000.0)", col)
-	case "epoch_us":
-		return fmt.Sprintf("to_timestamp(%s::BIGINT / 1000000.0)", col)
-	case "epoch_ns":
-		return fmt.Sprintf("to_timestamp(%s::BIGINT / 1000000000.0)", col)
-	default:
-		// Auto-detect: DuckDB handles most timestamp formats natively
-		return fmt.Sprintf("%s::TIMESTAMP", col)
-	}
-}
-
-// getColumns returns the column names from the source file
-func (h *ImportHandler) getColumns(readExpr string) ([]string, error) {
-	query := fmt.Sprintf("SELECT column_name FROM (DESCRIBE %s)", readExpr)
-	rows, err := h.db.Query(query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var columns []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
-		}
-		columns = append(columns, name)
-	}
-	return columns, nil
-}
-
-// generateStoragePath creates an Arc-standard storage path for a partition
-// Format: {database}/{measurement}/{YYYY}/{MM}/{DD}/{HH}/{measurement}_{YYYYMMDD}_{HHMMSS}_{nanos}.parquet
-func generateStoragePath(dbName, measurement string, partitionTime time.Time) string {
-	year := partitionTime.Format("2006")
-	month := partitionTime.Format("01")
-	day := partitionTime.Format("02")
-	hour := partitionTime.Format("15")
-
-	now := time.Now().UTC()
-	timestamp := now.Format("20060102_150405")
-	nanos := now.UnixNano() % 1_000_000_000
-
-	return fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s_%s_%09d.parquet",
-		dbName, measurement, year, month, day, hour, measurement, timestamp, nanos)
-}
-
 // importErrorResponse returns the appropriate HTTP error response for an import error
 func (h *ImportHandler) importErrorResponse(c *fiber.Ctx, err error) error {
 	if ie, ok := err.(*importError); ok {
@@ -807,11 +354,6 @@ func (h *ImportHandler) importErrorResponse(c *fiber.Ctx, err error) error {
 	return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 		"error": err.Error(),
 	})
-}
-
-// escapeSQLString escapes single quotes for safe use in DuckDB SQL strings
-func escapeSQLString(s string) string {
-	return strings.ReplaceAll(s, "'", "''")
 }
 
 // handleTLEImport handles TLE file upload and import.

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -172,16 +172,25 @@ func (h *ImportHandler) handleLineProtocolImport(c *fiber.Ctx) error {
 	}
 	defer file.Close()
 
-	data, err := io.ReadAll(file)
+	// Size limit for bulk LP import (applies to both compressed and uncompressed)
+	const maxImportSize = 500 * 1024 * 1024 // 500MB
+
+	// Bound the read at the limit (+1 to detect overflow) so an oversized upload
+	// is rejected without buffering the whole body — the global BodyLimit (1GB)
+	// is a coarser backstop; this matches the CSV/Parquet handlers.
+	data, err := io.ReadAll(io.LimitReader(file, maxImportSize+1))
 	if err != nil {
 		h.totalErrors.Add(1)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to read uploaded file: " + err.Error(),
 		})
 	}
-
-	// Size limit for bulk LP import (applies to both compressed and uncompressed)
-	const maxImportSize = 500 * 1024 * 1024 // 500MB
+	if int64(len(data)) > maxImportSize {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+			"error": "file exceeds 500MB limit",
+		})
+	}
 
 	// Detect and decompress gzip (magic bytes: 0x1f 0x8b)
 	if len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b {
@@ -195,7 +204,7 @@ func (h *ImportHandler) handleLineProtocolImport(c *fiber.Ctx) error {
 		data = decompressed
 	}
 
-	// Enforce size limit on uncompressed data
+	// Enforce size limit on uncompressed data (decompressed gzip may exceed it)
 	if len(data) > maxImportSize {
 		h.totalErrors.Add(1)
 		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
@@ -406,15 +415,23 @@ func (h *ImportHandler) handleTLEImport(c *fiber.Ctx) error {
 	}
 	defer file.Close()
 
-	data, err := io.ReadAll(file)
+	const maxImportSize = 500 * 1024 * 1024 // 500MB
+
+	// Bound the read at the limit (+1 to detect overflow) so an oversized upload
+	// is rejected without buffering the whole body — matches CSV/Parquet/LP.
+	data, err := io.ReadAll(io.LimitReader(file, maxImportSize+1))
 	if err != nil {
 		h.totalErrors.Add(1)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "failed to read uploaded file: " + err.Error(),
 		})
 	}
-
-	const maxImportSize = 500 * 1024 * 1024 // 500MB
+	if int64(len(data)) > maxImportSize {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+			"error": "file exceeds 500MB limit",
+		})
+	}
 
 	// Detect and decompress gzip (magic bytes: 0x1f 0x8b)
 	if len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b {
@@ -428,6 +445,7 @@ func (h *ImportHandler) handleTLEImport(c *fiber.Ctx) error {
 		data = decompressed
 	}
 
+	// Enforce size limit on uncompressed data (decompressed gzip may exceed it)
 	if len(data) > maxImportSize {
 		h.totalErrors.Add(1)
 		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -328,10 +328,8 @@ func (h *ImportHandler) importParquet(ctx fiberContext, database, measurement st
 	columns := make(map[string][]interface{}, len(header))
 	var timeMicros []int64
 	for i, name := range header {
-		vals, conv := arrowColumnToInterfaces(tbl.Column(i))
-		if conv != nil {
-			return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: fmt.Sprintf("unsupported parquet column %q", name), Err: conv}
-		}
+		// Time column: normalize to micros via the dedicated path; don't run it
+		// through arrowColumnToInterfaces (its result would just be discarded).
 		if i == timeFieldIdx {
 			tm, terr := parquetColumnToTimeMicros(tbl.Column(i), opts.timeFormat)
 			if terr != nil {
@@ -339,6 +337,10 @@ func (h *ImportHandler) importParquet(ctx fiberContext, database, measurement st
 			}
 			timeMicros = tm
 			continue
+		}
+		vals, conv := arrowColumnToInterfaces(tbl.Column(i))
+		if conv != nil {
+			return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: fmt.Sprintf("unsupported parquet column %q", name), Err: conv}
 		}
 		columns[name] = vals
 	}
@@ -629,6 +631,10 @@ func stringsToTimeMicros(raw []string, timeFormat string) ([]int64, error) {
 // or auto-detection. Used for the (rare) Parquet string time column; the CSV path
 // uses stringsToTimeMicros directly with layout caching.
 func oneTimeValueToMicros(s, timeFormat string) (int64, error) {
+	// Trim so Parquet string/binary time columns behave like the CSV path
+	// (stringsToTimeMicros trims before parsing); a value like " 1609459200 "
+	// should parse identically regardless of source.
+	s = strings.TrimSpace(s)
 	switch timeFormat {
 	case "epoch_s", "epoch_ms", "epoch_us", "epoch_ns":
 		// Integer epoch -> int64 math (no float precision loss for large ns).

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -142,6 +142,10 @@ func (h *ImportHandler) importCSV(ctx fiberContext, database, measurement string
 	if len(header) == 0 {
 		return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "file is empty"}
 	}
+	// Strip a UTF-8 BOM from the first header field (Excel-on-Windows exports
+	// prepend one); otherwise the first column name carries the BOM and a
+	// time_column like "time" won't match.
+	header[0] = strings.TrimPrefix(header[0], "\xef\xbb\xbf")
 
 	timeIdx, herr := validateImportHeader(header, opts.timeColumn)
 	if herr != nil {

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -1,0 +1,777 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/basekick-labs/arc/pkg/models"
+	"github.com/gofiber/fiber/v2"
+)
+
+// maxImportSize bounds in-memory buffering of an uploaded import file.
+// Mirrors the limit already enforced by the LP/TLE import handlers.
+const maxImportSize = 500 * 1024 * 1024 // 500MB
+
+// microPerHour matches ingest.groupByHour's bucketing (t / 3_600_000_000).
+// Used to compute partitions_created in-process, identical to what the
+// ArrowBuffer will write for a single-flush import.
+const microPerHour = int64(3_600_000_000)
+
+// =============================================================================
+// CSV import — in-process parsing, no DuckDB on the temp file.
+// =============================================================================
+
+// handleCSVImport parses an uploaded CSV in-process and ingests it through the
+// ArrowBuffer pipeline (same path as LP/TLE imports). It never issues DuckDB
+// queries against the uploaded file, so the upload does not need to be in the
+// DuckDB sandbox allowlist.
+func (h *ImportHandler) handleCSVImport(c *fiber.Ctx) error {
+	h.totalRequests.Add(1)
+	start := time.Now()
+
+	database, measurement, errResp := h.importPreamble(c)
+	if errResp != nil {
+		return errResp
+	}
+
+	if h.arrowBuffer == nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "import handler is misconfigured: ArrowBuffer is not set",
+		})
+	}
+
+	opts := importOptions{
+		format:     "csv",
+		timeColumn: c.Query("time_column", "time"),
+		timeFormat: c.Query("time_format", ""),
+		delimiter:  c.Query("delimiter", ","),
+		skipRows:   c.QueryInt("skip_rows", 0),
+	}
+
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "no file uploaded: use multipart/form-data with field name 'file'",
+		})
+	}
+	if fileHeader.Size > maxImportSize {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+			"error": fmt.Sprintf("file exceeds maximum import size of %d bytes", maxImportSize),
+		})
+	}
+
+	f, err := fileHeader.Open()
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to open uploaded file: " + err.Error(),
+		})
+	}
+	defer f.Close()
+
+	// Defense in depth: bound how much we read even if Size under-reports
+	// (e.g. chunked uploads). The CSV reader streams from this limited reader so
+	// the whole file is never required to fit a single buffer, but we still cap
+	// total bytes to avoid unbounded heap growth from rawCols/columns.
+	result, ierr := h.importCSV(c.Context(), database, measurement, io.LimitReader(f, maxImportSize+1), opts)
+	if ierr != nil {
+		h.totalErrors.Add(1)
+		h.logger.Error().Err(ierr).Str("database", database).Str("measurement", measurement).Msg("CSV import failed")
+		return h.importErrorResponse(c, ierr)
+	}
+
+	result.DurationMs = time.Since(start).Milliseconds()
+	h.totalRecords.Add(result.RowsImported)
+	h.logger.Info().
+		Str("database", database).Str("measurement", measurement).
+		Int64("rows", result.RowsImported).Int("partitions", result.PartitionsCreated).
+		Int64("duration_ms", result.DurationMs).Msg("CSV import completed")
+
+	return c.JSON(fiber.Map{"status": "ok", "result": result})
+}
+
+// importCSV reads the CSV stream, infers per-column types, normalizes the time
+// column to int64 microseconds, and ingests via WriteColumnarRecord.
+func (h *ImportHandler) importCSV(ctx fiberContext, database, measurement string, r io.Reader, opts importOptions) (*ImportResult, *importError) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1 // tolerate ragged rows; we validate against the header
+	if opts.delimiter != "" {
+		runes := []rune(opts.delimiter)
+		if len(runes) != 1 {
+			return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: fmt.Sprintf("delimiter must be a single character, got %q", opts.delimiter)}
+		}
+		reader.Comma = runes[0]
+	}
+
+	// skip_rows: discard N leading rows before the header.
+	for i := 0; i < opts.skipRows; i++ {
+		if _, err := reader.Read(); err != nil {
+			if err == io.EOF {
+				return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "file is empty"}
+			}
+			return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "failed to skip rows", Err: err}
+		}
+	}
+
+	header, err := reader.Read()
+	if err != nil {
+		if err == io.EOF {
+			return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "file is empty"}
+		}
+		return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "failed to read CSV header", Err: err}
+	}
+	if len(header) == 0 {
+		return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "file is empty"}
+	}
+
+	timeIdx, herr := validateImportHeader(header, opts.timeColumn)
+	if herr != nil {
+		return nil, herr
+	}
+
+	// Read all rows as raw strings, one slice per column.
+	rawCols := make([][]string, len(header))
+	for i := range rawCols {
+		rawCols[i] = make([]string, 0, 1024)
+	}
+	rowCount := 0
+	for {
+		rec, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: fmt.Sprintf("failed to parse CSV at row %d", rowCount+1), Err: err}
+		}
+		for i := range header {
+			if i < len(rec) {
+				rawCols[i] = append(rawCols[i], rec[i])
+			} else {
+				rawCols[i] = append(rawCols[i], "") // ragged row: missing trailing fields -> empty
+			}
+		}
+		rowCount++
+	}
+
+	if rowCount == 0 {
+		return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "file contains no rows"}
+	}
+
+	// Normalize the time column to int64 micros.
+	timeMicros, terr := stringsToTimeMicros(rawCols[timeIdx], opts.timeFormat)
+	if terr != nil {
+		return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: fmt.Sprintf("failed to parse time column %q", opts.timeColumn), Err: terr}
+	}
+
+	// Build columnar data with native typed values; rename time column to "time".
+	columns := make(map[string][]interface{}, len(header))
+	for i, name := range header {
+		if i == timeIdx {
+			continue // handled separately
+		}
+		columns[name] = inferAndConvertColumn(rawCols[i])
+	}
+	timeCol := make([]interface{}, len(timeMicros))
+	for i, v := range timeMicros {
+		timeCol[i] = v
+	}
+	columns["time"] = timeCol
+
+	record := &models.ColumnarRecord{
+		Measurement: measurement,
+		Columnar:    true,
+		Columns:     columns,
+	}
+	if err := h.arrowBuffer.WriteColumnarRecord(ctx, database, record); err != nil {
+		return nil, &importError{StatusCode: fiber.StatusInternalServerError, Message: "failed to ingest CSV data", Err: err}
+	}
+	if err := h.arrowBuffer.FlushAll(ctx); err != nil {
+		return nil, &importError{StatusCode: fiber.StatusInternalServerError, Message: "failed to flush imported data", Err: err}
+	}
+
+	return buildImportResult(database, measurement, header, opts.timeColumn, timeMicros), nil
+}
+
+// =============================================================================
+// Parquet import — in-process arrow-go read, no DuckDB on the temp file.
+// =============================================================================
+
+// handleParquetImport reads an uploaded Parquet file in-process via arrow-go and
+// ingests it through the ArrowBuffer pipeline. No DuckDB queries against the file.
+func (h *ImportHandler) handleParquetImport(c *fiber.Ctx) error {
+	h.totalRequests.Add(1)
+	start := time.Now()
+
+	database, measurement, errResp := h.importPreamble(c)
+	if errResp != nil {
+		return errResp
+	}
+
+	if h.arrowBuffer == nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "import handler is misconfigured: ArrowBuffer is not set",
+		})
+	}
+
+	opts := importOptions{
+		format:     "parquet",
+		timeColumn: c.Query("time_column", "time"),
+		timeFormat: c.Query("time_format", ""),
+	}
+
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "no file uploaded: use multipart/form-data with field name 'file'",
+		})
+	}
+
+	f, err := fileHeader.Open()
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to open uploaded file: " + err.Error(),
+		})
+	}
+	defer f.Close()
+
+	// Parquet readers need random access; buffer the upload in memory (bounded).
+	data, err := io.ReadAll(io.LimitReader(f, maxImportSize+1))
+	if err != nil {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to read uploaded file: " + err.Error()})
+	}
+	if int64(len(data)) > maxImportSize {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{"error": fmt.Sprintf("file exceeds maximum import size of %d bytes", maxImportSize)})
+	}
+	if len(data) == 0 {
+		h.totalErrors.Add(1)
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "file is empty"})
+	}
+
+	result, ierr := h.importParquet(c.Context(), database, measurement, data, opts)
+	if ierr != nil {
+		h.totalErrors.Add(1)
+		h.logger.Error().Err(ierr).Str("database", database).Str("measurement", measurement).Msg("Parquet import failed")
+		return h.importErrorResponse(c, ierr)
+	}
+
+	result.DurationMs = time.Since(start).Milliseconds()
+	h.totalRecords.Add(result.RowsImported)
+	h.logger.Info().
+		Str("database", database).Str("measurement", measurement).
+		Int64("rows", result.RowsImported).Int("partitions", result.PartitionsCreated).
+		Int64("duration_ms", result.DurationMs).Msg("Parquet import completed")
+
+	return c.JSON(fiber.Map{"status": "ok", "result": result})
+}
+
+// importParquet reads the in-memory Parquet bytes into Arrow arrays, normalizes
+// the time column to int64 micros, and ingests via WriteColumnarRecord.
+func (h *ImportHandler) importParquet(ctx fiberContext, database, measurement string, data []byte, opts importOptions) (*ImportResult, *importError) {
+	pf, err := file.NewParquetReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: "failed to read parquet file", Err: err}
+	}
+	defer pf.Close()
+
+	arrowReader, err := pqarrow.NewFileReader(pf, pqarrow.ArrowReadProperties{}, nil)
+	if err != nil {
+		return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: "failed to open parquet reader", Err: err}
+	}
+
+	tbl, err := arrowReader.ReadTable(ctx)
+	if err != nil {
+		return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: "failed to read parquet table", Err: err}
+	}
+	defer tbl.Release()
+
+	schema := tbl.Schema()
+	header := make([]string, schema.NumFields())
+	for i := 0; i < schema.NumFields(); i++ {
+		header[i] = schema.Field(i).Name
+	}
+
+	timeFieldIdx, herr := validateImportHeader(header, opts.timeColumn)
+	if herr != nil {
+		return nil, herr
+	}
+
+	numRows := int(tbl.NumRows())
+	if numRows == 0 {
+		return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "file contains no rows"}
+	}
+
+	columns := make(map[string][]interface{}, len(header))
+	var timeMicros []int64
+	for i, name := range header {
+		vals, conv := arrowColumnToInterfaces(tbl.Column(i))
+		if conv != nil {
+			return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: fmt.Sprintf("unsupported parquet column %q", name), Err: conv}
+		}
+		if i == timeFieldIdx {
+			tm, terr := parquetColumnToTimeMicros(tbl.Column(i), opts.timeFormat)
+			if terr != nil {
+				return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: fmt.Sprintf("failed to parse time column %q", opts.timeColumn), Err: terr}
+			}
+			timeMicros = tm
+			continue
+		}
+		columns[name] = vals
+	}
+
+	timeCol := make([]interface{}, len(timeMicros))
+	for i, v := range timeMicros {
+		timeCol[i] = v
+	}
+	columns["time"] = timeCol
+
+	record := &models.ColumnarRecord{
+		Measurement: measurement,
+		Columnar:    true,
+		Columns:     columns,
+	}
+	if err := h.arrowBuffer.WriteColumnarRecord(ctx, database, record); err != nil {
+		return nil, &importError{StatusCode: fiber.StatusInternalServerError, Message: "failed to ingest parquet data", Err: err}
+	}
+	if err := h.arrowBuffer.FlushAll(ctx); err != nil {
+		return nil, &importError{StatusCode: fiber.StatusInternalServerError, Message: "failed to flush imported data", Err: err}
+	}
+
+	return buildImportResult(database, measurement, header, opts.timeColumn, timeMicros), nil
+}
+
+// =============================================================================
+// Shared helpers
+// =============================================================================
+
+// fiberContext is the context type accepted by ArrowBuffer write methods.
+// c.Context() returns context.Context; aliased for readability.
+type fiberContext = context.Context
+
+// importPreamble validates the database/measurement and RBAC, returning a ready
+// error response if validation fails. Shared by CSV and Parquet handlers.
+func (h *ImportHandler) importPreamble(c *fiber.Ctx) (string, string, error) {
+	database := c.Get("x-arc-database")
+	if database == "" {
+		database = c.Query("db")
+	}
+	if database == "" {
+		h.totalErrors.Add(1)
+		return "", "", c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "database is required (set x-arc-database header or db query param)"})
+	}
+	if !isValidDatabaseName(database) {
+		h.totalErrors.Add(1)
+		return "", "", c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid database name: must start with a letter and contain only alphanumeric characters, underscores, or hyphens (max 64 characters)"})
+	}
+
+	measurement := c.Query("measurement")
+	if measurement == "" {
+		h.totalErrors.Add(1)
+		return "", "", c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "measurement query parameter is required"})
+	}
+	if !isValidMeasurementName(measurement) {
+		h.totalErrors.Add(1)
+		return "", "", c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": fmt.Sprintf("invalid measurement name %q: must start with a letter and contain only alphanumeric characters, underscores, or hyphens", measurement)})
+	}
+
+	if h.rbacManager != nil && h.rbacManager.IsRBACEnabled() {
+		if err := CheckWritePermissions(c, h.rbacManager, h.logger, database, []string{measurement}); err != nil {
+			h.totalErrors.Add(1)
+			return "", "", c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": err.Error()})
+		}
+	}
+
+	return database, measurement, nil
+}
+
+// validateImportHeader rejects header shapes that would cause silent data loss
+// when columns are keyed by name into a map[string][]interface{}:
+//   - duplicate column names (one would overwrite the other), and
+//   - a literal "time" column colliding with a renamed non-"time" time_column.
+//
+// Returns the index of timeColumn in the header on success.
+func validateImportHeader(header []string, timeColumn string) (int, *importError) {
+	timeIdx := -1
+	seen := make(map[string]struct{}, len(header))
+	for i, name := range header {
+		if _, dup := seen[name]; dup {
+			return -1, &importError{
+				StatusCode: fiber.StatusBadRequest,
+				Message:    fmt.Sprintf("duplicate column name %q in file; column names must be unique", name),
+			}
+		}
+		seen[name] = struct{}{}
+		if name == timeColumn {
+			timeIdx = i
+		}
+	}
+	if timeIdx == -1 {
+		return -1, &importError{
+			StatusCode: fiber.StatusBadRequest,
+			Message:    fmt.Sprintf("time column %q not found in file; available columns: %s", timeColumn, strings.Join(header, ", ")),
+		}
+	}
+	// The time column is renamed to "time" before ingest. If the file already has
+	// a different column literally named "time", renaming would overwrite it.
+	if timeColumn != "time" {
+		if _, hasTime := seen["time"]; hasTime {
+			return -1, &importError{
+				StatusCode: fiber.StatusBadRequest,
+				Message:    fmt.Sprintf("cannot rename time column %q to \"time\": a column named \"time\" already exists in the file", timeColumn),
+			}
+		}
+	}
+	return timeIdx, nil
+}
+
+// buildImportResult computes the ImportResult fields in-process from the parsed
+// time column, with no follow-up DuckDB query. partitions_created counts distinct
+// hour buckets exactly as ingest.groupByHour will (t / microPerHour).
+func buildImportResult(database, measurement string, header []string, timeColumn string, timeMicros []int64) *ImportResult {
+	// Output columns: header with the time column renamed to "time".
+	cols := make([]string, len(header))
+	for i, c := range header {
+		if c == timeColumn {
+			cols[i] = "time"
+		} else {
+			cols[i] = c
+		}
+	}
+
+	var minT, maxT int64
+	hourBuckets := make(map[int64]struct{})
+	for i, t := range timeMicros {
+		if i == 0 || t < minT {
+			minT = t
+		}
+		if i == 0 || t > maxT {
+			maxT = t
+		}
+		hourBuckets[t/microPerHour] = struct{}{}
+	}
+
+	return &ImportResult{
+		Database:          database,
+		Measurement:       measurement,
+		RowsImported:      int64(len(timeMicros)),
+		PartitionsCreated: len(hourBuckets),
+		TimeRangeMin:      time.UnixMicro(minT).UTC().Format(time.RFC3339Nano),
+		TimeRangeMax:      time.UnixMicro(maxT).UTC().Format(time.RFC3339Nano),
+		Columns:           cols,
+	}
+}
+
+// inferAndConvertColumn scans all cells of a string column and converts to the
+// narrowest native type that fits the whole column: int64, then float64, then
+// bool, else string. Empty cells become nil (null) for numeric/bool columns.
+// This mirrors the auto-typing the old DuckDB read_csv path provided, so numeric
+// columns stay numeric instead of degrading to STRING in the ArrowBuffer.
+func inferAndConvertColumn(raw []string) []interface{} {
+	isInt, isFloat, isBool := true, true, true
+	for _, s := range raw {
+		if s == "" {
+			continue // empty cells don't constrain the type
+		}
+		if isInt {
+			if _, err := strconv.ParseInt(s, 10, 64); err != nil {
+				isInt = false
+			}
+		}
+		if isFloat {
+			if _, err := strconv.ParseFloat(s, 64); err != nil {
+				isFloat = false
+			}
+		}
+		if isBool {
+			if !isBoolLiteral(s) {
+				isBool = false
+			}
+		}
+		if !isInt && !isFloat && !isBool {
+			break
+		}
+	}
+
+	out := make([]interface{}, len(raw))
+	switch {
+	case isInt:
+		for i, s := range raw {
+			if s == "" {
+				out[i] = nil
+				continue
+			}
+			v, _ := strconv.ParseInt(s, 10, 64)
+			out[i] = v
+		}
+	case isFloat:
+		for i, s := range raw {
+			if s == "" {
+				out[i] = nil
+				continue
+			}
+			v, _ := strconv.ParseFloat(s, 64)
+			out[i] = v
+		}
+	case isBool:
+		for i, s := range raw {
+			if s == "" {
+				out[i] = nil
+				continue
+			}
+			out[i] = strings.EqualFold(s, "true") || s == "1"
+		}
+	default:
+		for i, s := range raw {
+			out[i] = s
+		}
+	}
+	return out
+}
+
+func isBoolLiteral(s string) bool {
+	switch strings.ToLower(s) {
+	case "true", "false":
+		return true
+	default:
+		return false
+	}
+}
+
+// stringsToTimeMicros converts a string time column to []int64 microseconds.
+// Explicit epoch_* formats are deterministic; "" (auto) magnitude-detects numeric
+// values and falls back to parsing common timestamp string layouts.
+func stringsToTimeMicros(raw []string, timeFormat string) ([]int64, error) {
+	out := make([]int64, len(raw))
+	for i, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return nil, fmt.Errorf("empty value in time column at row %d", i+1)
+		}
+		micros, err := oneTimeValueToMicros(s, timeFormat)
+		if err != nil {
+			return nil, fmt.Errorf("row %d: %w", i+1, err)
+		}
+		out[i] = micros
+	}
+	return out, nil
+}
+
+func oneTimeValueToMicros(s, timeFormat string) (int64, error) {
+	switch timeFormat {
+	case "epoch_s", "epoch_ms", "epoch_us", "epoch_ns":
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid epoch value %q: %w", s, err)
+		}
+		return epochToMicros(n, timeFormat), nil
+	case "":
+		// Auto: numeric -> magnitude detection; else parse as timestamp string.
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return autoEpochToMicros(n), nil
+		}
+		return parseTimestampString(s)
+	default:
+		return 0, fmt.Errorf("unsupported time_format %q (want epoch_s|epoch_ms|epoch_us|epoch_ns or empty for auto)", timeFormat)
+	}
+}
+
+func epochToMicros(n int64, format string) int64 {
+	switch format {
+	case "epoch_s":
+		return n * 1_000_000
+	case "epoch_ms":
+		return n * 1_000
+	case "epoch_us":
+		return n
+	case "epoch_ns":
+		return n / 1_000
+	default:
+		return n
+	}
+}
+
+// autoEpochToMicros detects the unit by magnitude, matching the heuristic in
+// ingest.MessagePackDecoder.normalizeTimestamps.
+func autoEpochToMicros(n int64) int64 {
+	switch {
+	case n < 1e10: // seconds
+		return n * 1_000_000
+	case n < 1e13: // milliseconds
+		return n * 1_000
+	case n < 1e16: // microseconds
+		return n
+	default: // nanoseconds
+		return n / 1_000
+	}
+}
+
+// parseTimestampString parses common timestamp string layouts (UTC if no zone).
+func parseTimestampString(s string) (int64, error) {
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC().UnixMicro(), nil
+		}
+	}
+	return 0, fmt.Errorf("unrecognized timestamp %q (supported: RFC3339, 'YYYY-MM-DD[ T]HH:MM:SS[.fff]', 'YYYY-MM-DD', or set time_format)", s)
+}
+
+// =============================================================================
+// Arrow column conversion
+// =============================================================================
+
+// arrowColumnToInterfaces converts a (possibly chunked) Arrow column to a flat
+// []interface{} of native Go values, preserving nulls as nil.
+func arrowColumnToInterfaces(col *arrow.Column) ([]interface{}, error) {
+	out := make([]interface{}, 0, col.Len())
+	for _, chunk := range col.Data().Chunks() {
+		switch a := chunk.(type) {
+		case *array.Int64:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), a.Value(i))
+			}
+		case *array.Int32:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
+			}
+		case *array.Float64:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), a.Value(i))
+			}
+		case *array.Float32:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), float64(a.Value(i)))
+			}
+		case *array.String:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), a.Value(i))
+			}
+		case *array.Boolean:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), a.Value(i))
+			}
+		case *array.Decimal128:
+			// Arc's ingest pipeline only carries decimals when a measurement has
+			// an explicit DecimalSpec configured; imports don't. Convert to
+			// float64 (DECIMAL -> DOUBLE), the same type CSV infers for decimal
+			// values. This is lossy for very large/high-precision decimals but
+			// matches how imported analytical data is queried.
+			dt := a.DataType().(*arrow.Decimal128Type)
+			scale := dt.Scale
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					out = append(out, nil)
+					continue
+				}
+				out = append(out, a.Value(i).ToFloat64(scale))
+			}
+		case *array.Timestamp:
+			unit := a.DataType().(*arrow.TimestampType).Unit
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), arrowTimestampToMicros(int64(a.Value(i)), unit))
+			}
+		default:
+			return nil, fmt.Errorf("unsupported arrow type %s", chunk.DataType())
+		}
+	}
+	return out, nil
+}
+
+func appendOrNil(out []interface{}, isNull bool, v interface{}) []interface{} {
+	if isNull {
+		return append(out, nil)
+	}
+	return append(out, v)
+}
+
+// parquetColumnToTimeMicros converts the time column to []int64 micros. Arrow
+// TIMESTAMP columns convert by unit; integer columns use the epoch/auto logic.
+func parquetColumnToTimeMicros(col *arrow.Column, timeFormat string) ([]int64, error) {
+	out := make([]int64, 0, col.Len())
+	for _, chunk := range col.Data().Chunks() {
+		switch a := chunk.(type) {
+		case *array.Timestamp:
+			unit := a.DataType().(*arrow.TimestampType).Unit
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				out = append(out, arrowTimestampToMicros(int64(a.Value(i)), unit))
+			}
+		case *array.Int64:
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				out = append(out, intTimeToMicros(a.Value(i), timeFormat))
+			}
+		case *array.Int32:
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				out = append(out, intTimeToMicros(int64(a.Value(i)), timeFormat))
+			}
+		case *array.String:
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				micros, err := oneTimeValueToMicros(a.Value(i), timeFormat)
+				if err != nil {
+					return nil, fmt.Errorf("row %d: %w", len(out)+1, err)
+				}
+				out = append(out, micros)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported time column arrow type %s", chunk.DataType())
+		}
+	}
+	return out, nil
+}
+
+func intTimeToMicros(n int64, timeFormat string) int64 {
+	if timeFormat == "" {
+		return autoEpochToMicros(n)
+	}
+	return epochToMicros(n, timeFormat)
+}
+
+func arrowTimestampToMicros(v int64, unit arrow.TimeUnit) int64 {
+	switch unit {
+	case arrow.Second:
+		return v * 1_000_000
+	case arrow.Millisecond:
+		return v * 1_000
+	case arrow.Microsecond:
+		return v
+	case arrow.Nanosecond:
+		return v / 1_000
+	default:
+		return v
+	}
+}

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -536,6 +536,13 @@ func inferAndConvertColumn(raw []string) (interface{}, []bool) {
 				isBool = false
 			}
 		}
+		// Once every candidate type is ruled out the column is a string; stop
+		// scanning. (hasValue is already true here, and string columns ignore
+		// hasEmpty — empty cells are valid "" values, not nulls — so an early
+		// break can't change the result.)
+		if !isInt && !isFloat && !isBool {
+			break
+		}
 	}
 
 	// An all-empty column has no values to constrain the type; default to string

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/basekick-labs/arc/internal/ingest"
 	"github.com/basekick-labs/arc/pkg/models"
 	"github.com/gofiber/fiber/v2"
 )
@@ -325,11 +326,13 @@ func (h *ImportHandler) importParquet(ctx fiberContext, database, measurement st
 		return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: "file contains no rows"}
 	}
 
-	columns := make(map[string][]interface{}, len(header))
+	// Extract typed slices directly from the Arrow chunks (no []interface{}
+	// boxing) and ingest via WriteTypedColumnarDirect.
+	cols := make(map[string]interface{}, len(header))
+	validity := make(map[string][]bool, len(header))
 	var timeMicros []int64
 	for i, name := range header {
-		// Time column: normalize to micros via the dedicated path; don't run it
-		// through arrowColumnToInterfaces (its result would just be discarded).
+		// Time column: normalize to micros via the dedicated path.
 		if i == timeFieldIdx {
 			tm, terr := parquetColumnToTimeMicros(tbl.Column(i), opts.timeFormat)
 			if terr != nil {
@@ -338,25 +341,22 @@ func (h *ImportHandler) importParquet(ctx fiberContext, database, measurement st
 			timeMicros = tm
 			continue
 		}
-		vals, conv := arrowColumnToInterfaces(tbl.Column(i))
+		vals, valid, conv := arrowColumnToTyped(tbl.Column(i))
 		if conv != nil {
 			return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: fmt.Sprintf("unsupported parquet column %q", name), Err: conv}
 		}
-		columns[name] = vals
+		cols[name] = vals
+		if valid != nil {
+			validity[name] = valid
+		}
 	}
+	cols["time"] = timeMicros
 
-	timeCol := make([]interface{}, len(timeMicros))
-	for i, v := range timeMicros {
-		timeCol[i] = v
+	batch := &ingest.TypedColumnBatch{
+		Data:     cols,
+		Validity: validity,
 	}
-	columns["time"] = timeCol
-
-	record := &models.ColumnarRecord{
-		Measurement: measurement,
-		Columnar:    true,
-		Columns:     columns,
-	}
-	if err := h.arrowBuffer.WriteColumnarRecord(ctx, database, record); err != nil {
+	if err := h.arrowBuffer.WriteTypedColumnarDirect(ctx, database, measurement, batch, numRows); err != nil {
 		return nil, &importError{StatusCode: fiber.StatusInternalServerError, Message: "failed to ingest parquet data", Err: err}
 	}
 	if err := h.arrowBuffer.FlushAll(ctx); err != nil {
@@ -736,115 +736,195 @@ func parseTimestampString(s string) (int64, string, error) {
 // Arrow column conversion
 // =============================================================================
 
-// arrowColumnToInterfaces converts a (possibly chunked) Arrow column to a flat
-// []interface{} of native Go values, preserving nulls as nil.
-func arrowColumnToInterfaces(col *arrow.Column) ([]interface{}, error) {
+// arrowColumnToTyped converts a (possibly chunked) Arrow column to a flat typed
+// Go slice ([]int64 / []float64 / []string / []bool) plus a null-validity bitmap
+// (nil when the column has no nulls; validity[i]=false marks a null).
+//
+// This feeds ArrowBuffer.WriteTypedColumnarDirect, avoiding the per-value boxing
+// of a []interface{} intermediate. Measured on 1M rows × 4 cols, the typed path
+// is ~13x faster and allocates ~8 slices vs ~4M boxed values.
+func arrowColumnToTyped(col *arrow.Column) (interface{}, []bool, error) {
 	if col == nil || col.Data() == nil {
-		return nil, fmt.Errorf("column or column data is nil")
+		return nil, nil, fmt.Errorf("column or column data is nil")
 	}
-	out := make([]interface{}, 0, col.Len())
-	for _, chunk := range col.Data().Chunks() {
-		switch a := chunk.(type) {
-		case *array.Int64:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), a.Value(i))
+	length := col.Len()
+	chunks := col.Data().Chunks()
+	if len(chunks) == 0 {
+		return nil, nil, fmt.Errorf("column has no data chunks")
+	}
+
+	// Validity bitmap only when the column actually contains nulls.
+	var validity []bool
+	if col.Data().NullN() > 0 {
+		validity = make([]bool, length)
+		idx := 0
+		for _, chunk := range chunks {
+			for i := 0; i < chunk.Len(); i++ {
+				validity[idx] = !chunk.IsNull(i)
+				idx++
 			}
-		case *array.Int32:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
-			}
-		case *array.Int16:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
-			}
-		case *array.Int8:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
-			}
-		case *array.Uint64:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
-			}
-		case *array.Uint32:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
-			}
-		case *array.Uint16:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
-			}
-		case *array.Uint8:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
-			}
-		case *array.Float64:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), a.Value(i))
-			}
-		case *array.Float32:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), float64(a.Value(i)))
-			}
-		case *array.String:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), a.Value(i))
-			}
-		case *array.Binary:
-			// BYTE_ARRAY without a UTF8 logical annotation reads as Binary, not
-			// String (common from Spark and some writers). Treat as string.
-			// Explicit branch (not appendOrNil) so string(a.Value(i)) isn't
-			// evaluated for null rows.
-			for i := 0; i < a.Len(); i++ {
-				if a.IsNull(i) {
-					out = append(out, nil)
-				} else {
-					out = append(out, string(a.Value(i)))
-				}
-			}
-		case *array.FixedSizeBinary:
-			for i := 0; i < a.Len(); i++ {
-				if a.IsNull(i) {
-					out = append(out, nil)
-				} else {
-					out = append(out, string(a.Value(i)))
-				}
-			}
-		case *array.Boolean:
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), a.Value(i))
-			}
-		case *array.Decimal128:
-			// Arc's ingest pipeline only carries decimals when a measurement has
-			// an explicit DecimalSpec configured; imports don't. Convert to
-			// float64 (DECIMAL -> DOUBLE), the same type CSV infers for decimal
-			// values. This is lossy for very large/high-precision decimals but
-			// matches how imported analytical data is queried.
-			dt := a.DataType().(*arrow.Decimal128Type)
-			scale := dt.Scale
-			for i := 0; i < a.Len(); i++ {
-				if a.IsNull(i) {
-					out = append(out, nil)
-					continue
-				}
-				out = append(out, a.Value(i).ToFloat64(scale))
-			}
-		case *array.Timestamp:
-			unit := a.DataType().(*arrow.TimestampType).Unit
-			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), arrowTimestampToMicros(int64(a.Value(i)), unit))
-			}
-		default:
-			return nil, fmt.Errorf("unsupported arrow type %s", chunk.DataType())
 		}
 	}
-	return out, nil
-}
 
-func appendOrNil(out []interface{}, isNull bool, v interface{}) []interface{} {
-	if isNull {
-		return append(out, nil)
+	switch chunks[0].(type) {
+	case *array.Int64, *array.Int32, *array.Int16, *array.Int8,
+		*array.Uint64, *array.Uint32, *array.Uint16, *array.Uint8:
+		res := make([]int64, length)
+		idx := 0
+		for _, chunk := range chunks {
+			switch a := chunk.(type) {
+			case *array.Int64:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = a.Value(i)
+					idx++
+				}
+			case *array.Int32:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = int64(a.Value(i))
+					idx++
+				}
+			case *array.Int16:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = int64(a.Value(i))
+					idx++
+				}
+			case *array.Int8:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = int64(a.Value(i))
+					idx++
+				}
+			case *array.Uint64:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = int64(a.Value(i))
+					idx++
+				}
+			case *array.Uint32:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = int64(a.Value(i))
+					idx++
+				}
+			case *array.Uint16:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = int64(a.Value(i))
+					idx++
+				}
+			case *array.Uint8:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = int64(a.Value(i))
+					idx++
+				}
+			default:
+				return nil, nil, fmt.Errorf("mixed chunk types in integer column: %s", chunk.DataType())
+			}
+		}
+		return res, validity, nil
+	case *array.Float64, *array.Float32:
+		res := make([]float64, length)
+		idx := 0
+		for _, chunk := range chunks {
+			switch a := chunk.(type) {
+			case *array.Float64:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = a.Value(i)
+					idx++
+				}
+			case *array.Float32:
+				for i := 0; i < a.Len(); i++ {
+					res[idx] = float64(a.Value(i))
+					idx++
+				}
+			default:
+				return nil, nil, fmt.Errorf("mixed chunk types in float column: %s", chunk.DataType())
+			}
+		}
+		return res, validity, nil
+	case *array.String:
+		res := make([]string, length)
+		idx := 0
+		for _, chunk := range chunks {
+			a := chunk.(*array.String)
+			for i := 0; i < a.Len(); i++ {
+				if !a.IsNull(i) {
+					res[idx] = a.Value(i)
+				}
+				idx++
+			}
+		}
+		return res, validity, nil
+	case *array.Binary:
+		// BYTE_ARRAY without a UTF8 logical annotation reads as Binary, not
+		// String (common from Spark and some writers). Treat as string.
+		res := make([]string, length)
+		idx := 0
+		for _, chunk := range chunks {
+			a := chunk.(*array.Binary)
+			for i := 0; i < a.Len(); i++ {
+				if !a.IsNull(i) {
+					res[idx] = string(a.Value(i))
+				}
+				idx++
+			}
+		}
+		return res, validity, nil
+	case *array.FixedSizeBinary:
+		res := make([]string, length)
+		idx := 0
+		for _, chunk := range chunks {
+			a := chunk.(*array.FixedSizeBinary)
+			for i := 0; i < a.Len(); i++ {
+				if !a.IsNull(i) {
+					res[idx] = string(a.Value(i))
+				}
+				idx++
+			}
+		}
+		return res, validity, nil
+	case *array.Boolean:
+		res := make([]bool, length)
+		idx := 0
+		for _, chunk := range chunks {
+			a := chunk.(*array.Boolean)
+			for i := 0; i < a.Len(); i++ {
+				if !a.IsNull(i) {
+					res[idx] = a.Value(i)
+				}
+				idx++
+			}
+		}
+		return res, validity, nil
+	case *array.Decimal128:
+		// Arc's ingest pipeline only carries decimals when a measurement has an
+		// explicit DecimalSpec configured; imports don't. Convert to float64
+		// (DECIMAL -> DOUBLE), the same type CSV infers for decimal values. Lossy
+		// for very high-precision decimals but matches how imports are queried.
+		res := make([]float64, length)
+		idx := 0
+		for _, chunk := range chunks {
+			a := chunk.(*array.Decimal128)
+			scale := a.DataType().(*arrow.Decimal128Type).Scale
+			for i := 0; i < a.Len(); i++ {
+				if !a.IsNull(i) {
+					res[idx] = a.Value(i).ToFloat64(scale)
+				}
+				idx++
+			}
+		}
+		return res, validity, nil
+	case *array.Timestamp:
+		res := make([]int64, length)
+		idx := 0
+		for _, chunk := range chunks {
+			a := chunk.(*array.Timestamp)
+			unit := a.DataType().(*arrow.TimestampType).Unit
+			for i := 0; i < a.Len(); i++ {
+				res[idx] = arrowTimestampToMicros(int64(a.Value(i)), unit)
+				idx++
+			}
+		}
+		return res, validity, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported arrow type %s", chunks[0].DataType())
 	}
-	return append(out, v)
 }
 
 // parquetColumnToTimeMicros converts the time column to []int64 micros. Arrow

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -110,6 +110,10 @@ func (h *ImportHandler) handleCSVImport(c *fiber.Ctx) error {
 func (h *ImportHandler) importCSV(ctx fiberContext, database, measurement string, r io.Reader, opts importOptions) (*ImportResult, *importError) {
 	reader := csv.NewReader(r)
 	reader.FieldsPerRecord = -1 // tolerate ragged rows; we validate against the header
+	reader.LazyQuotes = true    // tolerate unescaped quotes in user-uploaded CSVs
+	// NOTE: deliberately NOT setting ReuseRecord. We retain the `header` slice
+	// across all subsequent Read() calls (for validation, column naming, and the
+	// result), and ReuseRecord would overwrite its backing array with later rows.
 	if opts.delimiter != "" {
 		runes := []rune(opts.delimiter)
 		if len(runes) != 1 {
@@ -520,7 +524,9 @@ func inferAndConvertColumn(raw []string) (interface{}, []bool) {
 				isInt = false
 			}
 		}
-		if isFloat {
+		// Any valid base-10 integer is also a valid float, so only parse as
+		// float once a value has disqualified the integer type.
+		if isFloat && !isInt {
 			if _, err := strconv.ParseFloat(s, 64); err != nil {
 				isFloat = false
 			}
@@ -578,13 +584,10 @@ func inferAndConvertColumn(raw []string) (interface{}, []bool) {
 	}
 }
 
+// isBoolLiteral reports whether s is a recognized boolean literal. Uses
+// EqualFold / direct comparison to avoid the per-call allocation of ToLower.
 func isBoolLiteral(s string) bool {
-	switch strings.ToLower(s) {
-	case "true", "false", "1", "0":
-		return true
-	default:
-		return false
-	}
+	return s == "1" || s == "0" || strings.EqualFold(s, "true") || strings.EqualFold(s, "false")
 }
 
 // stringsToTimeMicros converts a string time column to []int64 microseconds.

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -547,7 +547,7 @@ func inferAndConvertColumn(raw []string) []interface{} {
 
 func isBoolLiteral(s string) bool {
 	switch strings.ToLower(s) {
-	case "true", "false":
+	case "true", "false", "1", "0":
 		return true
 	default:
 		return false
@@ -556,23 +556,54 @@ func isBoolLiteral(s string) bool {
 
 // stringsToTimeMicros converts a string time column to []int64 microseconds.
 // Explicit epoch_* formats are deterministic; "" (auto) magnitude-detects numeric
-// values and falls back to parsing common timestamp string layouts.
+// values and falls back to parsing common timestamp string layouts. In the auto
+// string case the matched layout is cached and tried first on subsequent rows —
+// CSV time columns are homogeneous, so this avoids re-scanning all layouts per row.
 func stringsToTimeMicros(raw []string, timeFormat string) ([]int64, error) {
 	out := make([]int64, len(raw))
+	cachedLayout := ""
 	for i, s := range raw {
 		s = strings.TrimSpace(s)
 		if s == "" {
 			return nil, fmt.Errorf("empty value in time column at row %d", i+1)
 		}
-		micros, err := oneTimeValueToMicros(s, timeFormat)
+
+		// Explicit epoch format.
+		if timeFormat != "" {
+			micros, err := oneTimeValueToMicros(s, timeFormat)
+			if err != nil {
+				return nil, fmt.Errorf("row %d: %w", i+1, err)
+			}
+			out[i] = micros
+			continue
+		}
+
+		// Auto: numeric -> magnitude detection.
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			out[i] = autoEpochToMicros(n)
+			continue
+		}
+
+		// Auto: timestamp string. Try the cached layout first.
+		if cachedLayout != "" {
+			if t, err := time.Parse(cachedLayout, s); err == nil {
+				out[i] = t.UTC().UnixMicro()
+				continue
+			}
+		}
+		micros, layout, err := parseTimestampString(s)
 		if err != nil {
 			return nil, fmt.Errorf("row %d: %w", i+1, err)
 		}
+		cachedLayout = layout
 		out[i] = micros
 	}
 	return out, nil
 }
 
+// oneTimeValueToMicros converts a single time value with an explicit time_format
+// or auto-detection. Used for the (rare) Parquet string time column; the CSV path
+// uses stringsToTimeMicros directly with layout caching.
 func oneTimeValueToMicros(s, timeFormat string) (int64, error) {
 	switch timeFormat {
 	case "epoch_s", "epoch_ms", "epoch_us", "epoch_ns":
@@ -586,7 +617,8 @@ func oneTimeValueToMicros(s, timeFormat string) (int64, error) {
 		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
 			return autoEpochToMicros(n), nil
 		}
-		return parseTimestampString(s)
+		micros, _, err := parseTimestampString(s)
+		return micros, err
 	default:
 		return 0, fmt.Errorf("unsupported time_format %q (want epoch_s|epoch_ms|epoch_us|epoch_ns or empty for auto)", timeFormat)
 	}
@@ -622,8 +654,9 @@ func autoEpochToMicros(n int64) int64 {
 	}
 }
 
-// parseTimestampString parses common timestamp string layouts (UTC if no zone).
-func parseTimestampString(s string) (int64, error) {
+// parseTimestampString parses common timestamp string layouts (UTC if no zone),
+// returning the micros and the layout that matched (so callers can cache it).
+func parseTimestampString(s string) (int64, string, error) {
 	layouts := []string{
 		time.RFC3339Nano,
 		time.RFC3339,
@@ -634,10 +667,10 @@ func parseTimestampString(s string) (int64, error) {
 	}
 	for _, layout := range layouts {
 		if t, err := time.Parse(layout, s); err == nil {
-			return t.UTC().UnixMicro(), nil
+			return t.UTC().UnixMicro(), layout, nil
 		}
 	}
-	return 0, fmt.Errorf("unrecognized timestamp %q (supported: RFC3339, 'YYYY-MM-DD[ T]HH:MM:SS[.fff]', 'YYYY-MM-DD', or set time_format)", s)
+	return 0, "", fmt.Errorf("unrecognized timestamp %q (supported: RFC3339, 'YYYY-MM-DD[ T]HH:MM:SS[.fff]', 'YYYY-MM-DD', or set time_format)", s)
 }
 
 // =============================================================================
@@ -655,6 +688,30 @@ func arrowColumnToInterfaces(col *arrow.Column) ([]interface{}, error) {
 				out = appendOrNil(out, a.IsNull(i), a.Value(i))
 			}
 		case *array.Int32:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
+			}
+		case *array.Int16:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
+			}
+		case *array.Int8:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
+			}
+		case *array.Uint64:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
+			}
+		case *array.Uint32:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
+			}
+		case *array.Uint16:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
+			}
+		case *array.Uint8:
 			for i := 0; i < a.Len(); i++ {
 				out = appendOrNil(out, a.IsNull(i), int64(a.Value(i)))
 			}
@@ -730,6 +787,27 @@ func parquetColumnToTimeMicros(col *arrow.Column, timeFormat string) ([]int64, e
 				out = append(out, intTimeToMicros(a.Value(i), timeFormat))
 			}
 		case *array.Int32:
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				out = append(out, intTimeToMicros(int64(a.Value(i)), timeFormat))
+			}
+		case *array.Int16:
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				out = append(out, intTimeToMicros(int64(a.Value(i)), timeFormat))
+			}
+		case *array.Uint64:
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				out = append(out, intTimeToMicros(int64(a.Value(i)), timeFormat))
+			}
+		case *array.Uint32:
 			for i := 0; i < a.Len(); i++ {
 				if a.IsNull(i) {
 					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -83,10 +85,10 @@ func (h *ImportHandler) handleCSVImport(c *fiber.Ctx) error {
 	defer f.Close()
 
 	// Defense in depth: bound how much we read even if Size under-reports
-	// (e.g. chunked uploads). The CSV reader streams from this limited reader so
-	// the whole file is never required to fit a single buffer, but we still cap
-	// total bytes to avoid unbounded heap growth from rawCols/columns.
-	result, ierr := h.importCSV(c.Context(), database, measurement, io.LimitReader(f, maxImportSize+1), opts)
+	// (e.g. chunked uploads). Use an erroring limit reader (NOT io.LimitReader,
+	// which returns EOF at the cap — the CSV parser would treat that as a clean
+	// end-of-file and silently import a truncated file with a 200 response).
+	result, ierr := h.importCSV(c.Context(), database, measurement, &limitedReader{r: f, limit: maxImportSize}, opts)
 	if ierr != nil {
 		h.totalErrors.Add(1)
 		h.logger.Error().Err(ierr).Str("database", database).Str("measurement", measurement).Msg("CSV import failed")
@@ -154,6 +156,11 @@ func (h *ImportHandler) importCSV(ctx fiberContext, database, measurement string
 			break
 		}
 		if err != nil {
+			// csv.Reader wraps the underlying reader's error; surface the size
+			// cap as 413 rather than a generic 422 parse error.
+			if errors.Is(err, errImportTooLarge) {
+				return nil, &importError{StatusCode: fiber.StatusRequestEntityTooLarge, Message: fmt.Sprintf("file exceeds maximum import size of %d bytes", maxImportSize)}
+			}
 			return nil, &importError{StatusCode: fiber.StatusUnprocessableEntity, Message: fmt.Sprintf("failed to parse CSV at row %d", rowCount+1), Err: err}
 		}
 		for i := range header {
@@ -646,7 +653,11 @@ func epochToMicros(n int64, format string) int64 {
 func autoEpochToMicros(n int64) int64 {
 	absN := n
 	if absN < 0 {
-		absN = -absN
+		if absN == math.MinInt64 {
+			absN = math.MaxInt64 // -MinInt64 overflows; clamp magnitude
+		} else {
+			absN = -absN
+		}
 	}
 	switch {
 	case absN < 1e10: // seconds
@@ -686,6 +697,9 @@ func parseTimestampString(s string) (int64, string, error) {
 // arrowColumnToInterfaces converts a (possibly chunked) Arrow column to a flat
 // []interface{} of native Go values, preserving nulls as nil.
 func arrowColumnToInterfaces(col *arrow.Column) ([]interface{}, error) {
+	if col == nil || col.Data() == nil {
+		return nil, fmt.Errorf("column or column data is nil")
+	}
 	out := make([]interface{}, 0, col.Len())
 	for _, chunk := range col.Data().Chunks() {
 		switch a := chunk.(type) {
@@ -774,6 +788,9 @@ func appendOrNil(out []interface{}, isNull bool, v interface{}) []interface{} {
 // parquetColumnToTimeMicros converts the time column to []int64 micros. Arrow
 // TIMESTAMP columns convert by unit; integer columns use the epoch/auto logic.
 func parquetColumnToTimeMicros(col *arrow.Column, timeFormat string) ([]int64, error) {
+	if col == nil || col.Data() == nil {
+		return nil, fmt.Errorf("column or column data is nil")
+	}
 	out := make([]int64, 0, col.Len())
 	for _, chunk := range col.Data().Chunks() {
 		switch a := chunk.(type) {
@@ -858,4 +875,27 @@ func arrowTimestampToMicros(v int64, unit arrow.TimeUnit) int64 {
 	default:
 		return v
 	}
+}
+
+// errImportTooLarge is returned by limitedReader when the byte cap is exceeded.
+// Distinct from a parse error so callers map it to 413 rather than 422.
+var errImportTooLarge = errors.New("file exceeds maximum import size")
+
+// limitedReader caps total bytes read and returns errImportTooLarge once the
+// limit is passed. Unlike io.LimitReader (which returns io.EOF at the cap and
+// would make csv.Reader silently truncate the file), this surfaces an explicit
+// error so an oversized upload fails instead of importing partial data.
+type limitedReader struct {
+	r     io.Reader
+	limit int64
+	read  int64
+}
+
+func (lr *limitedReader) Read(p []byte) (int, error) {
+	n, err := lr.r.Read(p)
+	lr.read += int64(n)
+	if lr.read > lr.limit {
+		return n, errImportTooLarge
+	}
+	return n, err
 }

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -492,10 +492,12 @@ func buildImportResult(database, measurement string, header []string, timeColumn
 // columns stay numeric instead of degrading to STRING in the ArrowBuffer.
 func inferAndConvertColumn(raw []string) []interface{} {
 	isInt, isFloat, isBool := true, true, true
+	hasValue := false
 	for _, s := range raw {
 		if s == "" {
 			continue // empty cells don't constrain the type
 		}
+		hasValue = true
 		if isInt {
 			if _, err := strconv.ParseInt(s, 10, 64); err != nil {
 				isInt = false
@@ -517,6 +519,14 @@ func inferAndConvertColumn(raw []string) []interface{} {
 	}
 
 	out := make([]interface{}, len(raw))
+	// An all-empty column has no values to constrain the type; default to string
+	// (keep the empty strings) rather than letting it fall through to int64.
+	if !hasValue {
+		for i, s := range raw {
+			out[i] = s
+		}
+		return out
+	}
 	switch {
 	case isInt:
 		for i, s := range raw {
@@ -585,7 +595,14 @@ func stringsToTimeMicros(raw []string, timeFormat string) ([]int64, error) {
 			continue
 		}
 
-		// Auto: numeric (incl. fractional epochs) -> magnitude detection.
+		// Auto: integer epoch -> int64 math (full precision for large ns epochs).
+		if !strings.Contains(s, ".") {
+			if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+				out[i] = autoIntEpochToMicros(n)
+				continue
+			}
+		}
+		// Auto: fractional epoch -> float magnitude detection.
 		if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
 			out[i] = autoEpochToMicros(f)
 			continue
@@ -614,6 +631,12 @@ func stringsToTimeMicros(raw []string, timeFormat string) ([]int64, error) {
 func oneTimeValueToMicros(s, timeFormat string) (int64, error) {
 	switch timeFormat {
 	case "epoch_s", "epoch_ms", "epoch_us", "epoch_ns":
+		// Integer epoch -> int64 math (no float precision loss for large ns).
+		if !strings.Contains(s, ".") {
+			if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+				return intTimeToMicros(n, timeFormat), nil
+			}
+		}
 		f, err := strconv.ParseFloat(s, 64)
 		if err != nil {
 			return 0, fmt.Errorf("invalid epoch value %q: %w", s, err)
@@ -623,7 +646,12 @@ func oneTimeValueToMicros(s, timeFormat string) (int64, error) {
 		}
 		return epochToMicros(f, timeFormat), nil
 	case "":
-		// Auto: numeric (incl. fractional epochs) -> magnitude detection; else parse as timestamp string.
+		// Auto: integer epoch -> int64 math; fractional -> float; else timestamp string.
+		if !strings.Contains(s, ".") {
+			if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+				return autoIntEpochToMicros(n), nil
+			}
+		}
 		if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
 			return autoEpochToMicros(f), nil
 		}
@@ -846,6 +874,21 @@ func parquetColumnToTimeMicros(col *arrow.Column, timeFormat string) ([]int64, e
 				}
 				out = append(out, intTimeToMicros(int64(a.Value(i)), timeFormat))
 			}
+		case *array.Float64:
+			// Fractional epoch stored as a floating-point column.
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				out = append(out, floatTimeToMicros(a.Value(i), timeFormat))
+			}
+		case *array.Float32:
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				out = append(out, floatTimeToMicros(float64(a.Value(i)), timeFormat))
+			}
 		case *array.String:
 			for i := 0; i < a.Len(); i++ {
 				if a.IsNull(i) {
@@ -887,11 +930,53 @@ func parquetColumnToTimeMicros(col *arrow.Column, timeFormat string) ([]int64, e
 	return out, nil
 }
 
+// intTimeToMicros converts an integer epoch to micros using int64 math (no
+// float64 round-trip), so large nanosecond epochs (>2^53) keep full precision.
 func intTimeToMicros(n int64, timeFormat string) int64 {
-	if timeFormat == "" {
-		return autoEpochToMicros(float64(n))
+	switch timeFormat {
+	case "epoch_s":
+		return n * 1_000_000
+	case "epoch_ms":
+		return n * 1_000
+	case "epoch_us":
+		return n
+	case "epoch_ns":
+		return n / 1_000
+	default:
+		return autoIntEpochToMicros(n)
 	}
-	return epochToMicros(float64(n), timeFormat)
+}
+
+// autoIntEpochToMicros is the int64 counterpart of autoEpochToMicros: magnitude
+// detection on an integer epoch without a lossy float64 conversion.
+func autoIntEpochToMicros(n int64) int64 {
+	absN := n
+	if absN < 0 {
+		if absN == math.MinInt64 {
+			absN = math.MaxInt64
+		} else {
+			absN = -absN
+		}
+	}
+	switch {
+	case absN < 1e10: // seconds
+		return n * 1_000_000
+	case absN < 1e13: // milliseconds
+		return n * 1_000
+	case absN < 1e16: // microseconds
+		return n
+	default: // nanoseconds
+		return n / 1_000
+	}
+}
+
+// floatTimeToMicros converts a fractional epoch (Parquet Float/Double time
+// column) to micros honoring the unit (or auto-detecting it).
+func floatTimeToMicros(f float64, timeFormat string) int64 {
+	if timeFormat == "" {
+		return autoEpochToMicros(f)
+	}
+	return epochToMicros(f, timeFormat)
 }
 
 func arrowTimestampToMicros(v int64, unit arrow.TimeUnit) int64 {

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -585,9 +585,9 @@ func stringsToTimeMicros(raw []string, timeFormat string) ([]int64, error) {
 			continue
 		}
 
-		// Auto: numeric -> magnitude detection.
-		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
-			out[i] = autoEpochToMicros(n)
+		// Auto: numeric (incl. fractional epochs) -> magnitude detection.
+		if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
+			out[i] = autoEpochToMicros(f)
 			continue
 		}
 
@@ -614,15 +614,18 @@ func stringsToTimeMicros(raw []string, timeFormat string) ([]int64, error) {
 func oneTimeValueToMicros(s, timeFormat string) (int64, error) {
 	switch timeFormat {
 	case "epoch_s", "epoch_ms", "epoch_us", "epoch_ns":
-		n, err := strconv.ParseInt(s, 10, 64)
+		f, err := strconv.ParseFloat(s, 64)
 		if err != nil {
 			return 0, fmt.Errorf("invalid epoch value %q: %w", s, err)
 		}
-		return epochToMicros(n, timeFormat), nil
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, fmt.Errorf("invalid epoch value %q: NaN or Inf", s)
+		}
+		return epochToMicros(f, timeFormat), nil
 	case "":
-		// Auto: numeric -> magnitude detection; else parse as timestamp string.
-		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
-			return autoEpochToMicros(n), nil
+		// Auto: numeric (incl. fractional epochs) -> magnitude detection; else parse as timestamp string.
+		if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
+			return autoEpochToMicros(f), nil
 		}
 		micros, _, err := parseTimestampString(s)
 		return micros, err
@@ -631,18 +634,20 @@ func oneTimeValueToMicros(s, timeFormat string) (int64, error) {
 	}
 }
 
-func epochToMicros(n int64, format string) int64 {
+// epochToMicros converts an epoch value (float, to allow fractional seconds like
+// 1609459200.123) in the given unit to int64 microseconds.
+func epochToMicros(f float64, format string) int64 {
 	switch format {
 	case "epoch_s":
-		return n * 1_000_000
+		return int64(f * 1_000_000)
 	case "epoch_ms":
-		return n * 1_000
+		return int64(f * 1_000)
 	case "epoch_us":
-		return n
+		return int64(f)
 	case "epoch_ns":
-		return n / 1_000
+		return int64(f / 1_000)
 	default:
-		return n
+		return int64(f)
 	}
 }
 
@@ -650,24 +655,18 @@ func epochToMicros(n int64, format string) int64 {
 // ingest.MessagePackDecoder.normalizeTimestamps. Magnitude is taken on the
 // absolute value so negative epochs (historical data before 1970) classify by
 // the same thresholds rather than always falling into the "seconds" branch.
-func autoEpochToMicros(n int64) int64 {
-	absN := n
-	if absN < 0 {
-		if absN == math.MinInt64 {
-			absN = math.MaxInt64 // -MinInt64 overflows; clamp magnitude
-		} else {
-			absN = -absN
-		}
-	}
+// Takes float64 to support fractional epochs (sub-second precision preserved).
+func autoEpochToMicros(f float64) int64 {
+	absF := math.Abs(f)
 	switch {
-	case absN < 1e10: // seconds
-		return n * 1_000_000
-	case absN < 1e13: // milliseconds
-		return n * 1_000
-	case absN < 1e16: // microseconds
-		return n
+	case absF < 1e10: // seconds
+		return int64(f * 1_000_000)
+	case absF < 1e13: // milliseconds
+		return int64(f * 1_000)
+	case absF < 1e16: // microseconds
+		return int64(f)
 	default: // nanoseconds
-		return n / 1_000
+		return int64(f / 1_000)
 	}
 }
 
@@ -857,9 +856,9 @@ func parquetColumnToTimeMicros(col *arrow.Column, timeFormat string) ([]int64, e
 
 func intTimeToMicros(n int64, timeFormat string) int64 {
 	if timeFormat == "" {
-		return autoEpochToMicros(n)
+		return autoEpochToMicros(float64(n))
 	}
-	return epochToMicros(n, timeFormat)
+	return epochToMicros(float64(n), timeFormat)
 }
 
 func arrowTimestampToMicros(v int64, unit arrow.TimeUnit) int64 {

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -640,14 +640,20 @@ func epochToMicros(n int64, format string) int64 {
 }
 
 // autoEpochToMicros detects the unit by magnitude, matching the heuristic in
-// ingest.MessagePackDecoder.normalizeTimestamps.
+// ingest.MessagePackDecoder.normalizeTimestamps. Magnitude is taken on the
+// absolute value so negative epochs (historical data before 1970) classify by
+// the same thresholds rather than always falling into the "seconds" branch.
 func autoEpochToMicros(n int64) int64 {
+	absN := n
+	if absN < 0 {
+		absN = -absN
+	}
 	switch {
-	case n < 1e10: // seconds
+	case absN < 1e10: // seconds
 		return n * 1_000_000
-	case n < 1e13: // milliseconds
+	case absN < 1e13: // milliseconds
 		return n * 1_000
-	case n < 1e16: // microseconds
+	case absN < 1e16: // microseconds
 		return n
 	default: // nanoseconds
 		return n / 1_000

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -17,7 +17,6 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/basekick-labs/arc/internal/ingest"
-	"github.com/basekick-labs/arc/pkg/models"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -184,26 +183,27 @@ func (h *ImportHandler) importCSV(ctx fiberContext, database, measurement string
 		return nil, &importError{StatusCode: fiber.StatusBadRequest, Message: fmt.Sprintf("failed to parse time column %q", opts.timeColumn), Err: terr}
 	}
 
-	// Build columnar data with native typed values; rename time column to "time".
-	columns := make(map[string][]interface{}, len(header))
+	// Build typed columnar data (rename time column to "time") and ingest via
+	// WriteTypedColumnarDirect, avoiding per-value []interface{} boxing.
+	cols := make(map[string]interface{}, len(header))
+	validity := make(map[string][]bool, len(header))
 	for i, name := range header {
 		if i == timeIdx {
 			continue // handled separately
 		}
-		columns[name] = inferAndConvertColumn(rawCols[i])
+		vals, valid := inferAndConvertColumn(rawCols[i])
+		cols[name] = vals
+		if valid != nil {
+			validity[name] = valid
+		}
 	}
-	timeCol := make([]interface{}, len(timeMicros))
-	for i, v := range timeMicros {
-		timeCol[i] = v
-	}
-	columns["time"] = timeCol
+	cols["time"] = timeMicros
 
-	record := &models.ColumnarRecord{
-		Measurement: measurement,
-		Columnar:    true,
-		Columns:     columns,
+	batch := &ingest.TypedColumnBatch{
+		Data:     cols,
+		Validity: validity,
 	}
-	if err := h.arrowBuffer.WriteColumnarRecord(ctx, database, record); err != nil {
+	if err := h.arrowBuffer.WriteTypedColumnarDirect(ctx, database, measurement, batch, rowCount); err != nil {
 		return nil, &importError{StatusCode: fiber.StatusInternalServerError, Message: "failed to ingest CSV data", Err: err}
 	}
 	if err := h.arrowBuffer.FlushAll(ctx); err != nil {
@@ -498,14 +498,20 @@ func buildImportResult(database, measurement string, header []string, timeColumn
 
 // inferAndConvertColumn scans all cells of a string column and converts to the
 // narrowest native type that fits the whole column: int64, then float64, then
-// bool, else string. Empty cells become nil (null) for numeric/bool columns.
-// This mirrors the auto-typing the old DuckDB read_csv path provided, so numeric
-// columns stay numeric instead of degrading to STRING in the ArrowBuffer.
-func inferAndConvertColumn(raw []string) []interface{} {
+// bool, else string. It returns a flat typed slice ([]int64/[]float64/[]bool/
+// []string) and a null-validity bitmap (nil when the column has no empty cells;
+// validity[i]=false marks an empty numeric/bool cell as null). String columns
+// keep empty cells as "" and have no nulls.
+//
+// Returning typed slices directly (rather than a boxed []interface{}) lets the
+// caller use WriteTypedColumnarDirect, avoiding per-value boxing — same reason
+// the Parquet path uses arrowColumnToTyped.
+func inferAndConvertColumn(raw []string) (interface{}, []bool) {
 	isInt, isFloat, isBool := true, true, true
-	hasValue := false
+	hasValue, hasEmpty := false, false
 	for _, s := range raw {
 		if s == "" {
+			hasEmpty = true
 			continue // empty cells don't constrain the type
 		}
 		hasValue = true
@@ -524,53 +530,52 @@ func inferAndConvertColumn(raw []string) []interface{} {
 				isBool = false
 			}
 		}
-		if !isInt && !isFloat && !isBool {
-			break
+	}
+
+	// An all-empty column has no values to constrain the type; default to string
+	// (keep the empty strings) rather than letting it fall through to int64.
+	// String columns carry no nulls (empty string is a valid value).
+	if !hasValue || (!isInt && !isFloat && !isBool) {
+		out := make([]string, len(raw))
+		copy(out, raw)
+		return out, nil
+	}
+
+	// Numeric/bool columns: build a validity bitmap only if empty cells exist.
+	var validity []bool
+	if hasEmpty {
+		validity = make([]bool, len(raw))
+		for i, s := range raw {
+			validity[i] = s != ""
 		}
 	}
 
-	out := make([]interface{}, len(raw))
-	// An all-empty column has no values to constrain the type; default to string
-	// (keep the empty strings) rather than letting it fall through to int64.
-	if !hasValue {
-		for i, s := range raw {
-			out[i] = s
-		}
-		return out
-	}
 	switch {
 	case isInt:
+		out := make([]int64, len(raw))
 		for i, s := range raw {
-			if s == "" {
-				out[i] = nil
-				continue
+			if s != "" {
+				out[i], _ = strconv.ParseInt(s, 10, 64)
 			}
-			v, _ := strconv.ParseInt(s, 10, 64)
-			out[i] = v
 		}
+		return out, validity
 	case isFloat:
+		out := make([]float64, len(raw))
 		for i, s := range raw {
-			if s == "" {
-				out[i] = nil
-				continue
+			if s != "" {
+				out[i], _ = strconv.ParseFloat(s, 64)
 			}
-			v, _ := strconv.ParseFloat(s, 64)
-			out[i] = v
 		}
-	case isBool:
+		return out, validity
+	default: // isBool
+		out := make([]bool, len(raw))
 		for i, s := range raw {
-			if s == "" {
-				out[i] = nil
-				continue
+			if s != "" {
+				out[i] = strings.EqualFold(s, "true") || s == "1"
 			}
-			out[i] = strings.EqualFold(s, "true") || s == "1"
 		}
-	default:
-		for i, s := range raw {
-			out[i] = s
-		}
+		return out, validity
 	}
-	return out
 }
 
 func isBoolLiteral(s string) bool {

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -746,6 +746,16 @@ func arrowColumnToInterfaces(col *arrow.Column) ([]interface{}, error) {
 			for i := 0; i < a.Len(); i++ {
 				out = appendOrNil(out, a.IsNull(i), a.Value(i))
 			}
+		case *array.Binary:
+			// BYTE_ARRAY without a UTF8 logical annotation reads as Binary, not
+			// String (common from Spark and some writers). Treat as string.
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), string(a.Value(i)))
+			}
+		case *array.FixedSizeBinary:
+			for i := 0; i < a.Len(); i++ {
+				out = appendOrNil(out, a.IsNull(i), string(a.Value(i)))
+			}
 		case *array.Boolean:
 			for i := 0; i < a.Len(); i++ {
 				out = appendOrNil(out, a.IsNull(i), a.Value(i))
@@ -842,6 +852,29 @@ func parquetColumnToTimeMicros(col *arrow.Column, timeFormat string) ([]int64, e
 					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
 				}
 				micros, err := oneTimeValueToMicros(a.Value(i), timeFormat)
+				if err != nil {
+					return nil, fmt.Errorf("row %d: %w", len(out)+1, err)
+				}
+				out = append(out, micros)
+			}
+		case *array.Binary:
+			// BYTE_ARRAY without a UTF8 logical annotation reads as Binary.
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				micros, err := oneTimeValueToMicros(string(a.Value(i)), timeFormat)
+				if err != nil {
+					return nil, fmt.Errorf("row %d: %w", len(out)+1, err)
+				}
+				out = append(out, micros)
+			}
+		case *array.FixedSizeBinary:
+			for i := 0; i < a.Len(); i++ {
+				if a.IsNull(i) {
+					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
+				}
+				micros, err := oneTimeValueToMicros(string(a.Value(i)), timeFormat)
 				if err != nil {
 					return nil, fmt.Errorf("row %d: %w", len(out)+1, err)
 				}

--- a/internal/api/import_inprocess.go
+++ b/internal/api/import_inprocess.go
@@ -412,6 +412,9 @@ func (h *ImportHandler) importPreamble(c *fiber.Ctx) (string, string, error) {
 
 // validateImportHeader rejects header shapes that would cause silent data loss
 // when columns are keyed by name into a map[string][]interface{}:
+//   - empty column names (e.g. a trailing comma in a CSV header) — these would
+//     pass through to the Arrow schema builder, which indexes name[0] without a
+//     length check and panics on the empty string (a DoS vector),
 //   - duplicate column names (one would overwrite the other), and
 //   - a literal "time" column colliding with a renamed non-"time" time_column.
 //
@@ -420,6 +423,12 @@ func validateImportHeader(header []string, timeColumn string) (int, *importError
 	timeIdx := -1
 	seen := make(map[string]struct{}, len(header))
 	for i, name := range header {
+		if name == "" {
+			return -1, &importError{
+				StatusCode: fiber.StatusBadRequest,
+				Message:    "column name cannot be empty (check for trailing/empty delimiters in the header)",
+			}
+		}
 		if _, dup := seen[name]; dup {
 			return -1, &importError{
 				StatusCode: fiber.StatusBadRequest,
@@ -783,12 +792,22 @@ func arrowColumnToInterfaces(col *arrow.Column) ([]interface{}, error) {
 		case *array.Binary:
 			// BYTE_ARRAY without a UTF8 logical annotation reads as Binary, not
 			// String (common from Spark and some writers). Treat as string.
+			// Explicit branch (not appendOrNil) so string(a.Value(i)) isn't
+			// evaluated for null rows.
 			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), string(a.Value(i)))
+				if a.IsNull(i) {
+					out = append(out, nil)
+				} else {
+					out = append(out, string(a.Value(i)))
+				}
 			}
 		case *array.FixedSizeBinary:
 			for i := 0; i < a.Len(); i++ {
-				out = appendOrNil(out, a.IsNull(i), string(a.Value(i)))
+				if a.IsNull(i) {
+					out = append(out, nil)
+				} else {
+					out = append(out, string(a.Value(i)))
+				}
 			}
 		case *array.Boolean:
 			for i := 0; i < a.Len(); i++ {
@@ -886,14 +905,22 @@ func parquetColumnToTimeMicros(col *arrow.Column, timeFormat string) ([]int64, e
 				if a.IsNull(i) {
 					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
 				}
-				out = append(out, floatTimeToMicros(a.Value(i), timeFormat))
+				v := a.Value(i)
+				if math.IsNaN(v) || math.IsInf(v, 0) {
+					return nil, fmt.Errorf("invalid time value at row %d: NaN or Inf", len(out)+1)
+				}
+				out = append(out, floatTimeToMicros(v, timeFormat))
 			}
 		case *array.Float32:
 			for i := 0; i < a.Len(); i++ {
 				if a.IsNull(i) {
 					return nil, fmt.Errorf("null value in time column at row %d", len(out)+1)
 				}
-				out = append(out, floatTimeToMicros(float64(a.Value(i)), timeFormat))
+				v := float64(a.Value(i))
+				if math.IsNaN(v) || math.IsInf(v, 0) {
+					return nil, fmt.Errorf("invalid time value at row %d: NaN or Inf", len(out)+1)
+				}
+				out = append(out, floatTimeToMicros(v, timeFormat))
 			}
 		case *array.String:
 			for i := 0; i < a.Len(); i++ {

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -25,6 +25,7 @@ func TestInferAndConvertColumn(t *testing.T) {
 		{"mixed -> strings", []string{"1", "abc", "2"}, []interface{}{"1", "abc", "2"}},
 		{"empty int cell -> nil", []string{"1", "", "3"}, []interface{}{int64(1), nil, int64(3)}},
 		{"empty float cell -> nil", []string{"1.5", "", "3.5"}, []interface{}{1.5, nil, 3.5}},
+		{"all-empty column -> string", []string{"", "", ""}, []interface{}{"", "", ""}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -57,6 +58,8 @@ func TestOneTimeValueToMicros(t *testing.T) {
 		{"auto millis", "1609459200000", "", 1609459200000000, false},
 		{"auto micros", "1609459200000000", "", 1609459200000000, false},
 		{"auto nanos", "1609459200000000000", "", 1609459200000000, false},
+		{"auto nanos precise (int64, not float)", "1609459200000001900", "", 1609459200000001, false},
+		{"epoch_ns precise (int64, not float)", "1609459200000001900", "epoch_ns", 1609459200000001, false},
 		{"auto negative seconds (pre-1970)", "-1000000000", "", -1000000000000000, false},
 		{"auto negative millis (pre-1970)", "-1000000000000", "", -1000000000000, false},
 		{"auto RFC3339", "2021-01-01T00:00:00Z", "", 1609459200000000, false},

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -137,6 +137,7 @@ func TestValidateImportHeader(t *testing.T) {
 		{"renamed time column", []string{"ts", "host", "v"}, "ts", 0, false},
 		{"missing time column", []string{"a", "b"}, "ts", -1, true},
 		{"duplicate column names", []string{"a", "a", "b"}, "a", -1, true},
+		{"empty column name (DoS guard)", []string{"time", "v", ""}, "time", -1, true},
 		{"rename collides with existing time", []string{"ts", "time", "v"}, "ts", -1, true},
 		{"time_column==time, no collision", []string{"time", "host"}, "time", 0, false},
 	}

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -49,6 +49,8 @@ func TestOneTimeValueToMicros(t *testing.T) {
 		{"auto millis", "1609459200000", "", 1609459200000000, false},
 		{"auto micros", "1609459200000000", "", 1609459200000000, false},
 		{"auto nanos", "1609459200000000000", "", 1609459200000000, false},
+		{"auto negative seconds (pre-1970)", "-1000000000", "", -1000000000000000, false},
+		{"auto negative millis (pre-1970)", "-1000000000000", "", -1000000000000, false},
 		{"auto RFC3339", "2021-01-01T00:00:00Z", "", 1609459200000000, false},
 		{"auto date-only", "2021-01-01", "", 1609459200000000, false},
 		{"auto space-separated", "2021-01-01 00:00:00", "", 1609459200000000, false},

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"errors"
+	"io"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/basekick-labs/arc/internal/ingest"
@@ -145,6 +148,26 @@ func TestValidateImportHeader(t *testing.T) {
 				t.Errorf("timeIdx = %d, want %d", idx, tt.wantIdx)
 			}
 		})
+	}
+}
+
+func TestLimitedReader(t *testing.T) {
+	// Reading within the limit succeeds and passes through EOF.
+	r := &limitedReader{r: strings.NewReader("hello"), limit: 10}
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error under limit: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("got %q, want hello", got)
+	}
+
+	// Exceeding the limit returns errImportTooLarge (NOT a silent EOF — that's
+	// the bug: io.LimitReader would let csv.Reader truncate quietly).
+	r2 := &limitedReader{r: strings.NewReader("0123456789ABCDEF"), limit: 8}
+	_, err = io.ReadAll(r2)
+	if !errors.Is(err, errImportTooLarge) {
+		t.Errorf("expected errImportTooLarge, got %v", err)
 	}
 }
 

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -60,8 +60,8 @@ func TestOneTimeValueToMicros(t *testing.T) {
 		{"auto nanos", "1609459200000000000", "", 1609459200000000, false},
 		{"auto nanos precise (int64, not float)", "1609459200000001900", "", 1609459200000001, false},
 		{"epoch_ns precise (int64, not float)", "1609459200000001900", "epoch_ns", 1609459200000001, false},
-		{"auto negative seconds (pre-1970)", "-1000000000", "", -1000000000000000, false},
-		{"auto negative millis (pre-1970)", "-1000000000000", "", -1000000000000, false},
+		{"auto negative seconds (pre-1970)", "-1000000000", "", -1000000000000000, false},   // 1e9 -> seconds -> *1e6
+		{"auto negative millis (pre-1970)", "-1000000000000", "", -1000000000000000, false}, // 1e12 -> millis -> *1e3
 		{"auto RFC3339", "2021-01-01T00:00:00Z", "", 1609459200000000, false},
 		{"auto date-only", "2021-01-01", "", 1609459200000000, false},
 		{"auto space-separated", "2021-01-01 00:00:00", "", 1609459200000000, false},

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -45,10 +45,15 @@ func TestOneTimeValueToMicros(t *testing.T) {
 		wantErr    bool
 	}{
 		{"epoch_s", "1609459200", "epoch_s", 1609459200000000, false},
+		{"epoch_s float", "1609459200.123", "epoch_s", 1609459200123000, false},
 		{"epoch_ms", "1609459200000", "epoch_ms", 1609459200000000, false},
+		{"epoch_ms float", "1609459200000.123", "epoch_ms", 1609459200000123, false},
 		{"epoch_us", "1609459200000000", "epoch_us", 1609459200000000, false},
 		{"epoch_ns", "1609459200000000000", "epoch_ns", 1609459200000000, false},
+		{"epoch NaN -> err", "NaN", "epoch_s", 0, true},
+		{"epoch Inf -> err", "Inf", "epoch_s", 0, true},
 		{"auto seconds", "1609459200", "", 1609459200000000, false},
+		{"auto seconds float", "1609459200.123", "", 1609459200123000, false},
 		{"auto millis", "1609459200000", "", 1609459200000000, false},
 		{"auto micros", "1609459200000000", "", 1609459200000000, false},
 		{"auto nanos", "1609459200000000000", "", 1609459200000000, false},

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -81,6 +81,37 @@ func TestStringsToTimeMicros_EmptyValueErrors(t *testing.T) {
 	}
 }
 
+func TestStringsToTimeMicros_CachedLayoutMultiRow(t *testing.T) {
+	// Homogeneous RFC3339 column: layout cached after row 0, applied to all.
+	got, err := stringsToTimeMicros([]string{
+		"2021-01-01T00:00:00Z",
+		"2021-01-01T01:00:00Z",
+		"2021-01-01T02:00:00Z",
+	}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []int64{1609459200000000, 1609462800000000, 1609466400000000}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestInferAndConvertColumn_MixedBoolReps(t *testing.T) {
+	// "true"/"1" mixed -> not all-int (true isn't int), all bool-literal -> bool.
+	got := inferAndConvertColumn([]string{"true", "1", "false", "0"})
+	want := []interface{}{true, true, false, false}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	// Pure 0/1 stays integer (isInt wins over isBool in the switch).
+	gotInt := inferAndConvertColumn([]string{"0", "1", "1", "0"})
+	wantInt := []interface{}{int64(0), int64(1), int64(1), int64(0)}
+	if !reflect.DeepEqual(gotInt, wantInt) {
+		t.Errorf("pure 0/1: got %v, want %v", gotInt, wantInt)
+	}
+}
+
 func TestValidateImportHeader(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -13,25 +13,29 @@ import (
 
 func TestInferAndConvertColumn(t *testing.T) {
 	tests := []struct {
-		name string
-		raw  []string
-		want []interface{}
+		name         string
+		raw          []string
+		wantData     interface{}
+		wantValidity []bool
 	}{
-		{"all ints", []string{"1", "2", "3"}, []interface{}{int64(1), int64(2), int64(3)}},
-		{"all floats", []string{"1.5", "2.0", "3.25"}, []interface{}{1.5, 2.0, 3.25}},
-		{"int then float -> float", []string{"1", "2", "3.5"}, []interface{}{1.0, 2.0, 3.5}},
-		{"bools", []string{"true", "false", "TRUE"}, []interface{}{true, false, true}},
-		{"strings", []string{"a", "b", "c"}, []interface{}{"a", "b", "c"}},
-		{"mixed -> strings", []string{"1", "abc", "2"}, []interface{}{"1", "abc", "2"}},
-		{"empty int cell -> nil", []string{"1", "", "3"}, []interface{}{int64(1), nil, int64(3)}},
-		{"empty float cell -> nil", []string{"1.5", "", "3.5"}, []interface{}{1.5, nil, 3.5}},
-		{"all-empty column -> string", []string{"", "", ""}, []interface{}{"", "", ""}},
+		{"all ints", []string{"1", "2", "3"}, []int64{1, 2, 3}, nil},
+		{"all floats", []string{"1.5", "2.0", "3.25"}, []float64{1.5, 2.0, 3.25}, nil},
+		{"int then float -> float", []string{"1", "2", "3.5"}, []float64{1.0, 2.0, 3.5}, nil},
+		{"bools", []string{"true", "false", "TRUE"}, []bool{true, false, true}, nil},
+		{"strings", []string{"a", "b", "c"}, []string{"a", "b", "c"}, nil},
+		{"mixed -> strings", []string{"1", "abc", "2"}, []string{"1", "abc", "2"}, nil},
+		{"empty int cell -> null", []string{"1", "", "3"}, []int64{1, 0, 3}, []bool{true, false, true}},
+		{"empty float cell -> null", []string{"1.5", "", "3.5"}, []float64{1.5, 0, 3.5}, []bool{true, false, true}},
+		{"all-empty column -> string", []string{"", "", ""}, []string{"", "", ""}, nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := inferAndConvertColumn(tt.raw)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("inferAndConvertColumn(%v) = %v, want %v", tt.raw, got, tt.want)
+			gotData, gotValidity := inferAndConvertColumn(tt.raw)
+			if !reflect.DeepEqual(gotData, tt.wantData) {
+				t.Errorf("inferAndConvertColumn(%v) data = %v (%T), want %v (%T)", tt.raw, gotData, gotData, tt.wantData, tt.wantData)
+			}
+			if !reflect.DeepEqual(gotValidity, tt.wantValidity) {
+				t.Errorf("inferAndConvertColumn(%v) validity = %v, want %v", tt.raw, gotValidity, tt.wantValidity)
 			}
 		})
 	}
@@ -112,14 +116,17 @@ func TestStringsToTimeMicros_CachedLayoutMultiRow(t *testing.T) {
 
 func TestInferAndConvertColumn_MixedBoolReps(t *testing.T) {
 	// "true"/"1" mixed -> not all-int (true isn't int), all bool-literal -> bool.
-	got := inferAndConvertColumn([]string{"true", "1", "false", "0"})
-	want := []interface{}{true, true, false, false}
+	got, validity := inferAndConvertColumn([]string{"true", "1", "false", "0"})
+	want := []bool{true, true, false, false}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
+	if validity != nil {
+		t.Errorf("expected nil validity (no empty cells), got %v", validity)
+	}
 	// Pure 0/1 stays integer (isInt wins over isBool in the switch).
-	gotInt := inferAndConvertColumn([]string{"0", "1", "1", "0"})
-	wantInt := []interface{}{int64(0), int64(1), int64(1), int64(0)}
+	gotInt, _ := inferAndConvertColumn([]string{"0", "1", "1", "0"})
+	wantInt := []int64{0, 1, 1, 0}
 	if !reflect.DeepEqual(gotInt, wantInt) {
 		t.Errorf("pure 0/1: got %v, want %v", gotInt, wantInt)
 	}

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -1,135 +1,148 @@
 package api
 
 import (
+	"reflect"
 	"testing"
-	"time"
 
 	"github.com/basekick-labs/arc/internal/ingest"
 	"github.com/basekick-labs/arc/pkg/models"
 )
 
-func TestBuildReadExpression_CSV(t *testing.T) {
-	h := &ImportHandler{}
-
+func TestInferAndConvertColumn(t *testing.T) {
 	tests := []struct {
-		name     string
-		opts     importOptions
-		expected string
+		name string
+		raw  []string
+		want []interface{}
 	}{
-		{
-			name:     "default CSV",
-			opts:     importOptions{format: "csv", delimiter: ","},
-			expected: "read_csv('/tmp/test.csv', auto_detect=true, header=true)",
-		},
-		{
-			name:     "tab delimiter",
-			opts:     importOptions{format: "csv", delimiter: "\t"},
-			expected: "read_csv('/tmp/test.csv', auto_detect=true, header=true, delim='\t')",
-		},
-		{
-			name:     "skip rows",
-			opts:     importOptions{format: "csv", delimiter: ",", skipRows: 2},
-			expected: "read_csv('/tmp/test.csv', auto_detect=true, header=true, skip=2)",
-		},
-		{
-			name:     "semicolon with skip",
-			opts:     importOptions{format: "csv", delimiter: ";", skipRows: 1},
-			expected: "read_csv('/tmp/test.csv', auto_detect=true, header=true, delim=';', skip=1)",
-		},
+		{"all ints", []string{"1", "2", "3"}, []interface{}{int64(1), int64(2), int64(3)}},
+		{"all floats", []string{"1.5", "2.0", "3.25"}, []interface{}{1.5, 2.0, 3.25}},
+		{"int then float -> float", []string{"1", "2", "3.5"}, []interface{}{1.0, 2.0, 3.5}},
+		{"bools", []string{"true", "false", "TRUE"}, []interface{}{true, false, true}},
+		{"strings", []string{"a", "b", "c"}, []interface{}{"a", "b", "c"}},
+		{"mixed -> strings", []string{"1", "abc", "2"}, []interface{}{"1", "abc", "2"}},
+		{"empty int cell -> nil", []string{"1", "", "3"}, []interface{}{int64(1), nil, int64(3)}},
+		{"empty float cell -> nil", []string{"1.5", "", "3.5"}, []interface{}{1.5, nil, 3.5}},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := h.buildReadExpression("/tmp/test.csv", tt.opts)
-			if result != tt.expected {
-				t.Errorf("got %q, want %q", result, tt.expected)
+			got := inferAndConvertColumn(tt.raw)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("inferAndConvertColumn(%v) = %v, want %v", tt.raw, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestBuildReadExpression_Parquet(t *testing.T) {
-	h := &ImportHandler{}
-
-	result := h.buildReadExpression("/tmp/test.parquet", importOptions{format: "parquet"})
-	expected := "read_parquet('/tmp/test.parquet')"
-	if result != expected {
-		t.Errorf("got %q, want %q", result, expected)
-	}
-}
-
-func TestBuildTimeCast(t *testing.T) {
-	h := &ImportHandler{}
-
+func TestOneTimeValueToMicros(t *testing.T) {
 	tests := []struct {
 		name       string
-		timeCol    string
+		value      string
 		timeFormat string
-		expected   string
+		want       int64
+		wantErr    bool
 	}{
-		{"auto detect", "time", "", `"time"::TIMESTAMP`},
-		{"epoch seconds", "ts", "epoch_s", `to_timestamp("ts"::BIGINT)`},
-		{"epoch milliseconds", "timestamp", "epoch_ms", `to_timestamp("timestamp"::BIGINT / 1000.0)`},
-		{"epoch microseconds", "time", "epoch_us", `to_timestamp("time"::BIGINT / 1000000.0)`},
-		{"epoch nanoseconds", "time", "epoch_ns", `to_timestamp("time"::BIGINT / 1000000000.0)`},
+		{"epoch_s", "1609459200", "epoch_s", 1609459200000000, false},
+		{"epoch_ms", "1609459200000", "epoch_ms", 1609459200000000, false},
+		{"epoch_us", "1609459200000000", "epoch_us", 1609459200000000, false},
+		{"epoch_ns", "1609459200000000000", "epoch_ns", 1609459200000000, false},
+		{"auto seconds", "1609459200", "", 1609459200000000, false},
+		{"auto millis", "1609459200000", "", 1609459200000000, false},
+		{"auto micros", "1609459200000000", "", 1609459200000000, false},
+		{"auto nanos", "1609459200000000000", "", 1609459200000000, false},
+		{"auto RFC3339", "2021-01-01T00:00:00Z", "", 1609459200000000, false},
+		{"auto date-only", "2021-01-01", "", 1609459200000000, false},
+		{"auto space-separated", "2021-01-01 00:00:00", "", 1609459200000000, false},
+		{"epoch with non-numeric -> err", "notanumber", "epoch_s", 0, true},
+		{"auto unparseable -> err", "not a date", "", 0, true},
+		{"bad format -> err", "1609459200", "epoch_weeks", 0, true},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := h.buildTimeCast(tt.timeCol, tt.timeFormat)
-			if result != tt.expected {
-				t.Errorf("got %q, want %q", result, tt.expected)
+			got, err := oneTimeValueToMicros(tt.value, tt.timeFormat)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q (%s), got nil", tt.value, tt.timeFormat)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("oneTimeValueToMicros(%q, %q) = %d, want %d", tt.value, tt.timeFormat, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestGenerateStoragePath(t *testing.T) {
-	partTime := time.Date(2025, 3, 15, 14, 0, 0, 0, time.UTC)
-	path := generateStoragePath("mydb", "cpu", partTime)
-
-	// Check prefix structure
-	prefix := "mydb/cpu/2025/03/15/14/cpu_"
-	if len(path) < len(prefix) || path[:len(prefix)] != prefix {
-		t.Errorf("path %q does not start with expected prefix %q", path, prefix)
-	}
-
-	// Check it ends with .parquet
-	if path[len(path)-8:] != ".parquet" {
-		t.Errorf("path %q does not end with .parquet", path)
+func TestStringsToTimeMicros_EmptyValueErrors(t *testing.T) {
+	if _, err := stringsToTimeMicros([]string{"1609459200", "", "1609459300"}, "epoch_s"); err == nil {
+		t.Error("expected error for empty time value, got nil")
 	}
 }
 
-func TestGenerateStoragePath_DifferentHours(t *testing.T) {
+func TestValidateImportHeader(t *testing.T) {
 	tests := []struct {
-		name           string
-		partTime       time.Time
-		expectedPrefix string
+		name       string
+		header     []string
+		timeColumn string
+		wantIdx    int
+		wantErr    bool
 	}{
-		{
-			"midnight",
-			time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-			"db/metric/2025/01/01/00/metric_",
-		},
-		{
-			"noon",
-			time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC),
-			"db/metric/2025/06/15/12/metric_",
-		},
-		{
-			"end of day",
-			time.Date(2025, 12, 31, 23, 0, 0, 0, time.UTC),
-			"db/metric/2025/12/31/23/metric_",
-		},
+		{"time column present", []string{"time", "host", "v"}, "time", 0, false},
+		{"renamed time column", []string{"ts", "host", "v"}, "ts", 0, false},
+		{"missing time column", []string{"a", "b"}, "ts", -1, true},
+		{"duplicate column names", []string{"a", "a", "b"}, "a", -1, true},
+		{"rename collides with existing time", []string{"ts", "time", "v"}, "ts", -1, true},
+		{"time_column==time, no collision", []string{"time", "host"}, "time", 0, false},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path := generateStoragePath("db", "metric", tt.partTime)
-			if path[:len(tt.expectedPrefix)] != tt.expectedPrefix {
-				t.Errorf("got prefix %q, want %q", path[:len(tt.expectedPrefix)], tt.expectedPrefix)
+			idx, err := validateImportHeader(tt.header, tt.timeColumn)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for header %v (time=%q), got nil", tt.header, tt.timeColumn)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if idx != tt.wantIdx {
+				t.Errorf("timeIdx = %d, want %d", idx, tt.wantIdx)
 			}
 		})
+	}
+}
+
+func TestBuildImportResult(t *testing.T) {
+	// Two distinct hours -> partitions_created = 2. time column renamed to "time".
+	header := []string{"ts", "host", "value"}
+	timeMicros := []int64{
+		1609459200000000, // 2021-01-01T00:00:00Z (hour bucket A)
+		1609459260000000, // 2021-01-01T00:01:00Z (hour bucket A)
+		1609462800000000, // 2021-01-01T01:00:00Z (hour bucket B)
+	}
+	res := buildImportResult("mydb", "cpu", header, "ts", timeMicros)
+
+	if res.Database != "mydb" || res.Measurement != "cpu" {
+		t.Errorf("db/measurement mismatch: %+v", res)
+	}
+	if res.RowsImported != 3 {
+		t.Errorf("RowsImported = %d, want 3", res.RowsImported)
+	}
+	if res.PartitionsCreated != 2 {
+		t.Errorf("PartitionsCreated = %d, want 2 (distinct hour buckets)", res.PartitionsCreated)
+	}
+	wantCols := []string{"time", "host", "value"} // "ts" renamed to "time"
+	if !reflect.DeepEqual(res.Columns, wantCols) {
+		t.Errorf("Columns = %v, want %v", res.Columns, wantCols)
+	}
+	if res.TimeRangeMin != "2021-01-01T00:00:00Z" {
+		t.Errorf("TimeRangeMin = %q, want 2021-01-01T00:00:00Z", res.TimeRangeMin)
+	}
+	if res.TimeRangeMax != "2021-01-01T01:00:00Z" {
+		t.Errorf("TimeRangeMax = %q, want 2021-01-01T01:00:00Z", res.TimeRangeMax)
 	}
 }
 
@@ -245,25 +258,6 @@ func TestMeasurementFilter(t *testing.T) {
 	for _, r := range filtered {
 		if r.Measurement != "cpu" {
 			t.Errorf("expected measurement 'cpu', got %q", r.Measurement)
-		}
-	}
-}
-
-func TestEscapeSQLString(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"normal", "normal"},
-		{"it's", "it''s"},
-		{"a'b'c", "a''b''c"},
-		{"", ""},
-	}
-
-	for _, tt := range tests {
-		result := escapeSQLString(tt.input)
-		if result != tt.expected {
-			t.Errorf("escapeSQLString(%q) = %q, want %q", tt.input, result, tt.expected)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #472. Replaces the CSV/Parquet import handlers' DuckDB-on-temp-file introspection (`read_csv`/`read_parquet` + `DESCRIBE` + `COPY TO`) with **in-process row parsing pushed through `ArrowBuffer`**, mirroring the existing Line Protocol and TLE import handlers.

The immediate bug: the `SELECT column_name FROM (DESCRIBE read_csv(...))` SQL is rejected by the DuckDB version Arc ships (v1.5.1), so CSV imports failed with an HTTP 422 parser error before any data landed. The 0-byte case also errored during introspection, before the empty-file check.

## What changed

- **`internal/api/import_inprocess.go`** (new) — `handleCSVImport` / `handleParquetImport` now parse in-process:
  - CSV via `encoding/csv`, with per-column type inference (`int64` → `float64` → `bool` → `string`) so numeric columns stay numeric instead of degrading to strings.
  - Parquet via the arrow-go `pqarrow` reader (already a dependency); schema from metadata, no `DESCRIBE`.
  - Time column normalized to `int64` microseconds (`epoch_s|ms|us|ns`, or auto: magnitude detection for numerics / RFC3339-family parsing for strings).
  - Ingest via `WriteColumnarRecord` → `FlushAll`, same path as LP/TLE.
  - `ImportResult` computed in-process (rows, partitions = distinct hour buckets `t / 3_600_000_000`, time range, columns) — no follow-up DuckDB query.
- **`internal/api/import.go`** — removed the old path (`importFile`, `buildReadExpression`, `buildTimeCast`, `getColumns`, `generateStoragePath`, `escapeSQLString`); trimmed the handler struct (`db`/`storage`/`uploadDir` fields removed); `NewImportHandler(logger)`.
- **`cmd/arc/main.go`** — updated the `NewImportHandler` call. **`delete.go` wiring and the `UploadDir` sandbox allowlisting are intentionally left intact** (see below).
- **`internal/api/import_test.go`** — removed tests for deleted functions; added unit tests for the new pure helpers (`inferAndConvertColumn`, `oneTimeValueToMicros`, `buildImportResult`, `validateImportHeader`).
- **`RELEASE_NOTES_2026.06.2.md`** — Bug fixes section + upgrade note.

## Behavior changes (user-visible)

- 0-byte / header-only upload → `400 "file is empty"` / `"file contains no rows"` (was a 422 parser error).
- Up-front rejection (`400`) of: `time_column` rename colliding with an existing `time` column, and duplicate header column names — both previously could silently drop a column.
- CSV uploads now subject to the same 500 MB cap as the other formats.
- Parquet `DECIMAL` → `DOUBLE` on import (Arc's import path carries no per-column decimal precision).

## Scope note — sandbox allowlist (issue checkbox 4 NOT done, by design)

The issue asked to drop the upload dir from the DuckDB sandbox `allowed_directories`. That is **blocked by `delete.go`**: `cmd/arc/main.go` passes the same `dbConfig.UploadDir` to both `NewImportHandler` and `NewDeleteHandler`, and `delete.go rewriteS3File` does `COPY ... TO <uploadDir>/...` for S3 deletes, which requires the dir to be allowlisted. Import no longer *depends* on the allowlist (no DuckDB queries against the temp file — verified: zero `read_csv`/`read_parquet`/`DESCRIBE` in logs during import), but the entry stays for delete. Full removal is a follow-up that reworks the S3 delete rewrite.

## Test plan

- [x] `go build ./... && go vet ./internal/api/... && gofmt -l` (clean)
- [x] `go test ./internal/api/...` (green)
- [x] Integration (built binary, auth off, telemetry off):
  - [x] CSV import (3 rows) → 200, correct rows/partitions/time-range; queried back; types preserved (`value`→DOUBLE, `flag`→BOOLEAN, `host`→VARCHAR, `time`→TIMESTAMP)
  - [x] 0-byte CSV → `400 "file is empty"`
  - [x] `delimiter=';'` + `skip_rows=1` → correct ingest
  - [x] `time_format=epoch_s` → correct micros
  - [x] missing time column → `400` with available-columns list
  - [x] Parquet import (DECIMAL column) → 200, decimal → DOUBLE, queried back
  - [x] time-column rename collision → `400`
  - [x] duplicate header → `400`
  - [x] zero `read_csv`/`read_parquet`/`DESCRIBE` in server logs during import
- [x] LP/TLE imports unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)