### PR TITLE
feat(cluster): paginated FSM manifest walks for catch-up and API

### DIFF
--- a/RELEASE_NOTES_2026.06.2.md
+++ b/RELEASE_NOTES_2026.06.2.md
@@ -34,6 +34,14 @@ Line Protocol and TLE imports are unchanged. CSV/Parquet imports no longer depen
 
 Additionally, the Azure `DeleteBatch` implementation was rewritten to use the actual Azure SDK `BlobBatch` API (`container.Client.NewBatchBuilder()` + `SubmitBatch`) instead of a per-file loop, bringing it into parity with the S3 implementation.
 
+**Paginated FSM manifest walks replace full-snapshot copies.** `ClusterFSM.GetAllFiles()` previously allocated a full O(N) copy of the file manifest — for 1M+ files this caused ~50ms apply-path spikes (RLock held while copying) and ~50MB transient memory. The replication catch-up walker and the `/api/v1/cluster/files` endpoint now use cursor-based pagination via `GetFilesPaginated(cursor, limit)`, which:
+
+- Maintains a lazily-built sorted-key cache (invalidated on manifest mutation)
+- Returns pages of entries, releasing the RLock between pages so Raft apply-path latency is unaffected by long-running walks
+- Supports `?cursor=<path>&limit=<n>` query parameters on the API endpoint (backward-compatible — omitting both params returns all files as before)
+
+The emergency kill-switch `replication_catchup_enabled=false` remains available.
+
 ## Upgrade notes
 
 1. **No configuration change required.** Drop in the new binary; existing `arc.toml` and license keys work as-is.

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -369,6 +369,7 @@ func (h *ClusterHandler) handleGetFiles(c *fiber.Ctx) error {
 // paginateSlice applies cursor-based pagination to an in-memory slice.
 // Used for database-filtered results where the FSM's paginated API doesn't
 // natively support database filtering yet.
+// nextCursor is the last path in this page; the next call will resume after it.
 func paginateSlice(files []*clusterraft.FileEntry, cursor string, limit int) ([]*clusterraft.FileEntry, string) {
 	start := 0
 	if cursor != "" {

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"sort"
 	"strconv"
 
 	"github.com/basekick-labs/arc/internal/auth"
@@ -368,16 +369,25 @@ func (h *ClusterHandler) handleGetFiles(c *fiber.Ctx) error {
 
 // paginateSlice applies cursor-based pagination to an in-memory slice.
 // Used for database-filtered results where the FSM's paginated API doesn't
-// natively support database filtering yet.
+// natively support database filtering yet. Files are sorted by path first
+// (source is an unordered map, so iteration order is non-deterministic).
 // nextCursor is the last path in this page; the next call will resume after it.
+//
+// NOTE: This still allocates the full filtered set (O(k) where k = files in
+// the database). The unfiltered path via GetFileManifestPaginated releases
+// the RLock between pages; this path does not. For large databases, prefer
+// the unfiltered paginated endpoint.
 func paginateSlice(files []*clusterraft.FileEntry, cursor string, limit int) ([]*clusterraft.FileEntry, string) {
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+
 	start := 0
 	if cursor != "" {
-		for i, f := range files {
-			if f.Path == cursor {
-				start = i + 1
-				break
-			}
+		// Binary search for cursor position
+		idx := sort.Search(len(files), func(i int) bool { return files[i].Path >= cursor })
+		if idx < len(files) && files[idx].Path == cursor {
+			start = idx + 1
+		} else {
+			start = idx
 		}
 	}
 	if start >= len(files) {

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"strconv"
+
 	"github.com/basekick-labs/arc/internal/auth"
 	"github.com/basekick-labs/arc/internal/cluster"
 	clusterraft "github.com/basekick-labs/arc/internal/cluster/raft"
@@ -304,6 +306,8 @@ func (h *ClusterHandler) handleRemoveNode(c *fiber.Ctx) error {
 
 // handleGetFiles returns the cluster-wide file manifest from the Raft FSM.
 // Supports optional `database` query parameter to filter by database.
+// Supports optional `cursor` and `limit` query parameters for pagination.
+// Without cursor/limit, returns all files (backward-compatible but O(N)).
 // This is the authoritative view of all files known to the cluster — used
 // by the peer replication system to determine what to pull from other nodes.
 func (h *ClusterHandler) handleGetFiles(c *fiber.Ctx) error {
@@ -312,7 +316,43 @@ func (h *ClusterHandler) handleGetFiles(c *fiber.Ctx) error {
 	}
 
 	database := c.Query("database")
+	cursor := c.Query("cursor")
+	limitStr := c.Query("limit")
 
+	// Paginated path
+	if cursor != "" || limitStr != "" {
+		limit := 1000
+		if limitStr != "" {
+			if parsed, err := strconv.Atoi(limitStr); err == nil && parsed > 0 && parsed <= 10000 {
+				limit = parsed
+			}
+		}
+
+		var files []*clusterraft.FileEntry
+		var nextCursor string
+		var err error
+
+		if database != "" {
+			// Database filtering + pagination: get all for DB, then slice
+			allFiles := h.coordinator.GetFileManifestByDatabase(database)
+			files, nextCursor = paginateSlice(allFiles, cursor, limit)
+		} else {
+			files, nextCursor, err = h.coordinator.GetFileManifestPaginated(cursor, limit)
+			if err != nil {
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+					"error": err.Error(),
+				})
+			}
+		}
+
+		return c.JSON(fiber.Map{
+			"files":       files,
+			"total":       len(files),
+			"next_cursor": nextCursor,
+		})
+	}
+
+	// Backward-compatible: return all files (no pagination)
 	var files []*clusterraft.FileEntry
 	if database != "" {
 		files = h.coordinator.GetFileManifestByDatabase(database)
@@ -324,4 +364,31 @@ func (h *ClusterHandler) handleGetFiles(c *fiber.Ctx) error {
 		"files": files,
 		"total": len(files),
 	})
+}
+
+// paginateSlice applies cursor-based pagination to an in-memory slice.
+// Used for database-filtered results where the FSM's paginated API doesn't
+// natively support database filtering yet.
+func paginateSlice(files []*clusterraft.FileEntry, cursor string, limit int) ([]*clusterraft.FileEntry, string) {
+	start := 0
+	if cursor != "" {
+		for i, f := range files {
+			if f.Path == cursor {
+				start = i + 1
+				break
+			}
+		}
+	}
+	if start >= len(files) {
+		return nil, ""
+	}
+	end := start + limit
+	if end > len(files) {
+		end = len(files)
+	}
+	nextCursor := ""
+	if end < len(files) {
+		nextCursor = files[end-1].Path
+	}
+	return files[start:end], nextCursor
 }

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -2366,10 +2366,7 @@ func (c *Coordinator) runCatchUpOnce() {
 			c.logger.Error().Msg("Catch-up: Raft FSM not available, skipping")
 			return
 		}
-		entries := fsm.GetAllFiles()
-		c.logger.Info().
-			Int("manifest_entries", len(entries)).
-			Msg("Catch-up: walking manifest")
+		c.logger.Info().Msg("Catch-up: starting paginated manifest walk")
 
 		// Derive a context from c.ctx (or Background if c.ctx is nil, which
 		// happens in tests that bypass Start). The walker honors cancellation
@@ -2378,7 +2375,9 @@ func (c *Coordinator) runCatchUpOnce() {
 		if ctx == nil {
 			ctx = context.Background()
 		}
-		c.puller.RunCatchUp(ctx, entries)
+		c.puller.RunCatchUp(ctx, func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+			return fsm.GetFilesPaginated(cursor, limit)
+		})
 	})
 }
 
@@ -3095,6 +3094,20 @@ func (c *Coordinator) GetFileManifest() []*raft.FileEntry {
 		return nil
 	}
 	return fsm.GetAllFiles()
+}
+
+// GetFileManifestPaginated returns a page of files from the Raft FSM using
+// cursor-based pagination. cursor="" starts from the beginning. Returns the
+// page, the next cursor (empty when done), and an error.
+func (c *Coordinator) GetFileManifestPaginated(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+	if c.raftNode == nil {
+		return nil, "", nil
+	}
+	fsm := c.raftNode.FSM()
+	if fsm == nil {
+		return nil, "", nil
+	}
+	return fsm.GetFilesPaginated(cursor, limit)
 }
 
 // GetFileManifestByDatabase returns files for a specific database.

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -2375,6 +2375,10 @@ func (c *Coordinator) runCatchUpOnce() {
 		if ctx == nil {
 			ctx = context.Background()
 		}
+		// fsm is captured in the closure below. The Raft FSM pointer is
+		// stable for the lifetime of the node — hashicorp/raft never
+		// replaces the FSM instance once set. The nil guard above ensures
+		// the capture is safe even if the puller outlives the coordinator.
 		c.puller.RunCatchUp(ctx, func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
 			return fsm.GetFilesPaginated(cursor, limit)
 		})

--- a/internal/cluster/filereplication/catchup.go
+++ b/internal/cluster/filereplication/catchup.go
@@ -7,13 +7,19 @@ import (
 	"github.com/basekick-labs/arc/internal/cluster/raft"
 )
 
-// RunCatchUp walks a snapshot of the cluster file manifest and enqueues every
+// RunCatchUp walks the cluster file manifest in pages and enqueues every
 // entry the local node should hold but doesn't. It is the Phase 3 mechanism
 // that brings a node with a stale or empty local backend back into sync with
 // the manifest: on startup (and only on startup — periodic reconciliation is
-// not in scope for Phase 3), the coordinator hands us the output of
-// fsm.GetAllFiles() and we feed each entry through Enqueue so the regular
-// worker pool pulls the missing bytes from a peer.
+// not in scope for Phase 3), the coordinator hands us a paginated fetch
+// function (backed by fsm.GetFilesPaginated) and we feed each page through
+// Enqueue so the regular worker pool pulls the missing bytes from a peer.
+//
+// The fetch function follows cursor-based pagination: cursor="" for the first
+// page, and each call returns (page, nextCursor, error). An empty nextCursor
+// means no more pages. This avoids allocating a full O(N) snapshot of the
+// manifest — for 1M+ files the old GetAllFiles() path caused ~50ms apply-path
+// spikes and ~50MB transient memory.
 //
 // RunCatchUp does NOT itself talk to peers or verify files — it relies on
 // Enqueue's existing origin-is-self check, the inflight dedup set (so
@@ -33,17 +39,14 @@ import (
 // The method returns when all entries have been processed (enqueued or
 // skipped) or ctx is cancelled; it does not wait for the actual pulls to
 // complete.
-func (p *Puller) RunCatchUp(ctx context.Context, entries []*raft.FileEntry) {
+func (p *Puller) RunCatchUp(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error)) {
 	// Single-shot guard: only one catch-up per puller lifetime.
 	if !p.catchupStartedAt.CompareAndSwap(0, time.Now().Unix()) {
 		p.logger.Debug().Msg("File puller catch-up already ran, skipping")
 		return
 	}
 
-	total := len(entries)
-	p.logger.Info().
-		Int("manifest_entries", total).
-		Msg("File puller catch-up started")
+	p.logger.Info().Msg("File puller catch-up started (paginated)")
 
 	// Pre-capture stats counters so we can log the delta at the end. Using
 	// the Stats() map would pull in catch-up counters and confuse the
@@ -62,89 +65,84 @@ func (p *Puller) RunCatchUp(ctx context.Context, entries []*raft.FileEntry) {
 		highWater = 1
 	}
 
-	for _, entry := range entries {
+	const pageSize = 1000
+	cursor := ""
+	for {
 		if ctx.Err() != nil {
 			p.logger.Warn().
 				Int64("walked", p.catchupEntriesWalked.Load()).
-				Int("total", total).
 				Msg("File puller catch-up cancelled")
 			return
 		}
-		p.catchupEntriesWalked.Add(1)
-		if entry == nil {
-			continue
+
+		page, nextCursor, err := fetch(cursor, pageSize)
+		if err != nil {
+			p.logger.Error().Err(err).Str("cursor", cursor).Msg("Catch-up: page fetch failed, aborting")
+			return
+		}
+		if len(page) == 0 {
+			break // no more entries
 		}
 
-		// Backpressure: if the queue is above the high-water mark, sleep
-		// briefly to let workers drain. This loop is intentionally simple
-		// (no exponential backoff) because the expected case is that the
-		// walker catches up within a few hundred ms.
-		for len(p.queue) >= highWater {
-			select {
-			case <-ctx.Done():
+		for _, entry := range page {
+			if ctx.Err() != nil {
 				return
-			case <-p.ctx.Done():
-				return
-			case <-time.After(50 * time.Millisecond):
+			}
+			p.catchupEntriesWalked.Add(1)
+			if entry == nil {
+				continue
+			}
+
+			// Backpressure: if the queue is above the high-water mark, sleep
+			// briefly to let workers drain.
+			for len(p.queue) >= highWater {
+				select {
+				case <-ctx.Done():
+					return
+				case <-p.ctx.Done():
+					return
+				case <-time.After(50 * time.Millisecond):
+				}
+			}
+
+			// Fast-path: if origin is self, Enqueue would skip and we don't
+			// want to leak a catch-up tag.
+			if entry.OriginNodeID == p.cfg.SelfNodeID {
+				p.totalSkippedSelf.Add(1)
+				p.catchupSkippedLocal.Add(1)
+				continue
+			}
+
+			marked := p.markCatchUp(entry.Path)
+
+			beforeEnqueued := p.totalEnqueued.Load()
+			beforeSkippedDup := p.totalSkippedDup.Load()
+			beforeDropped := p.totalDropped.Load()
+
+			p.Enqueue(entry)
+
+			switch {
+			case p.totalEnqueued.Load() > beforeEnqueued:
+				p.catchupEnqueued.Add(1)
+			case p.totalSkippedDup.Load() > beforeSkippedDup:
+				p.catchupSkippedLocal.Add(1)
+			case p.totalDropped.Load() > beforeDropped:
+				if marked {
+					p.unmarkCatchUp(entry.Path)
+				}
+				p.recordCatchUpDrop(entry.Path)
 			}
 		}
 
-		// Fast-path: if origin is self, Enqueue would skip and we don't
-		// want to leak a catch-up tag for a file that's already local by
-		// construction. Mirror the check Enqueue does internally to keep
-		// the path-tagging semantics clean.
-		if entry.OriginNodeID == p.cfg.SelfNodeID {
-			p.totalSkippedSelf.Add(1)
-			p.catchupSkippedLocal.Add(1)
-			continue
-		}
-
-		// Mark BEFORE Enqueue. Enqueue is non-blocking and a fast worker
-		// could pick up the entry, complete the pull, and call
-		// inflightRemove (which clears catch-up tags) before the walker's
-		// markCatchUp runs. Marking before closes that race: by the time
-		// the worker can reach inflightRemove, the tag is already in
-		// catchupPaths and inflightRemove will clean it up correctly.
-		// markCatchUp is idempotent; a re-mark of a path already in the
-		// set is a no-op so duplicate paths don't drift catchupInflight.
-		marked := p.markCatchUp(entry.Path)
-
-		// Snapshot Enqueue-side counters so we can tell why this entry was
-		// accepted, deduped, or dropped. Counters are monotonic atomics so a
-		// simple before/after comparison is race-free.
-		beforeEnqueued := p.totalEnqueued.Load()
-		beforeSkippedDup := p.totalSkippedDup.Load()
-		beforeDropped := p.totalDropped.Load()
-
-		p.Enqueue(entry)
-
-		switch {
-		case p.totalEnqueued.Load() > beforeEnqueued:
-			p.catchupEnqueued.Add(1)
-		case p.totalSkippedDup.Load() > beforeSkippedDup:
-			// Already enqueued (by a reactive callback or a prior walker
-			// entry with the same path) — count as skipped so the caller
-			// can see it happened. The path is already in inflight; if
-			// markCatchUp added a tag here it stays valid because
-			// inflightRemove will clean it on whichever pull resolves.
-			p.catchupSkippedLocal.Add(1)
-		case p.totalDropped.Load() > beforeDropped:
-			// Queue full even after backpressure sleep. No worker will run
-			// inflightRemove for this path, so we have to compensate the
-			// tag and counter ourselves to avoid leaking a stale catch-up
-			// inflight slot. Then record the drop with the path so it can
-			// self-heal when a reactive FSM callback later succeeds.
-			if marked {
-				p.unmarkCatchUp(entry.Path)
-			}
-			p.recordCatchUpDrop(entry.Path)
+		cursor = nextCursor
+		if cursor == "" {
+			break
 		}
 	}
 
 	p.catchupCompletedAt.Store(time.Now().Unix())
 
 	p.logger.Info().
-		Int("manifest_entries", total).
 		Int64("catchup_walked", p.catchupEntriesWalked.Load()).
 		Int64("catchup_enqueued", p.catchupEnqueued.Load()).
 		Int64("catchup_skipped_local", p.catchupSkippedLocal.Load()).

--- a/internal/cluster/filereplication/catchup_test.go
+++ b/internal/cluster/filereplication/catchup_test.go
@@ -46,7 +46,7 @@ func TestRunCatchUpEnqueuesAllWhenQueueLarge(t *testing.T) {
 		entries[i] = makeEntry(fmt.Sprintf("testdb/cpu/catchup-%02d.parquet", i), "writer-1", int64(len(body)))
 	}
 
-	p.RunCatchUp(context.Background(), entries)
+	p.RunCatchUp(context.Background(), sliceFetcher(entries))
 
 	// Wait for workers to drain.
 	stats := waitStats(t, p, func(s map[string]int64) bool {
@@ -112,7 +112,7 @@ func TestRunCatchUpThrottlesAtHighWater(t *testing.T) {
 	start := time.Now()
 	go func() {
 		defer close(done)
-		p.RunCatchUp(context.Background(), entries)
+		p.RunCatchUp(context.Background(), sliceFetcher(entries))
 	}()
 
 	// Let the walker try to enqueue for a bit. With Workers=1 blocked, the
@@ -176,7 +176,7 @@ func TestRunCatchUpHonorsContextCancel(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		p.RunCatchUp(ctx, entries)
+		p.RunCatchUp(ctx, sliceFetcher(entries))
 	}()
 
 	// Give the walker time to start throttling on the full queue, then cancel.
@@ -230,13 +230,13 @@ func TestRunCatchUpOnceOnly(t *testing.T) {
 		makeEntry("testdb/cpu/once-d.parquet", "writer-1", int64(len(body))),
 	}
 
-	p.RunCatchUp(context.Background(), entries1)
+	p.RunCatchUp(context.Background(), sliceFetcher(entries1))
 	firstWalked := p.Stats()["catchup_entries_walked"]
 	firstStartedAt := p.Stats()["catchup_started_at"]
 
 	// Second call should be a no-op — no new entries walked, started_at
 	// unchanged.
-	p.RunCatchUp(context.Background(), entries2)
+	p.RunCatchUp(context.Background(), sliceFetcher(entries2))
 	secondWalked := p.Stats()["catchup_entries_walked"]
 	secondStartedAt := p.Stats()["catchup_started_at"]
 
@@ -284,7 +284,7 @@ func TestRunCatchUpDedupsWithReactiveEnqueue(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		p.RunCatchUp(context.Background(), []*raft.FileEntry{entry})
+		p.RunCatchUp(context.Background(), sliceFetcher([]*raft.FileEntry{entry}))
 	}()
 	go func() {
 		defer wg.Done()
@@ -310,5 +310,34 @@ func TestRunCatchUpDedupsWithReactiveEnqueue(t *testing.T) {
 	}
 	if stats["skipped_dup"] == 0 {
 		t.Errorf("skipped_dup should be non-zero (parallel enqueues should dedup)")
+	}
+}
+
+// sliceFetcher converts a []*raft.FileEntry into a paginated fetch function
+// compatible with RunCatchUp's new signature. Used by tests that previously
+// passed slices directly.
+func sliceFetcher(entries []*raft.FileEntry) func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+	return func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		start := 0
+		if cursor != "" {
+			for i, e := range entries {
+				if e.Path == cursor {
+					start = i + 1
+					break
+				}
+			}
+		}
+		if start >= len(entries) {
+			return nil, "", nil
+		}
+		end := start + limit
+		if end > len(entries) {
+			end = len(entries)
+		}
+		nextCursor := ""
+		if end < len(entries) {
+			nextCursor = entries[end-1].Path
+		}
+		return entries[start:end], nextCursor, nil
 	}
 }

--- a/internal/cluster/filereplication_catchup_integration_test.go
+++ b/internal/cluster/filereplication_catchup_integration_test.go
@@ -166,7 +166,7 @@ func TestPhase3CatchUpHappyPath(t *testing.T) {
 	defer stop()
 
 	// Run catch-up with the full manifest — every entry is missing locally.
-	puller.RunCatchUp(context.Background(), entries)
+	puller.RunCatchUp(context.Background(), sliceFetcher(entries))
 
 	stats := waitForCatchUp(t, puller, 10)
 	if stats["pulled"] != 10 {
@@ -244,7 +244,7 @@ func TestPhase3CatchUpOriginAbsentFallbackSucceeds(t *testing.T) {
 	puller, readerBackend, stop := buildCatchUpPuller(t, readerID, []string{peer.addr()})
 	defer stop()
 
-	puller.RunCatchUp(context.Background(), entries)
+	puller.RunCatchUp(context.Background(), sliceFetcher(entries))
 
 	stats := waitForCatchUp(t, puller, 2)
 	if stats["pulled"] != 2 {
@@ -301,7 +301,7 @@ func TestPhase3CatchUpNoPeerHasFile(t *testing.T) {
 	puller, readerBackend, stop := buildCatchUpPuller(t, readerID, []string{peer1.addr(), peer2.addr()})
 	defer stop()
 
-	puller.RunCatchUp(context.Background(), entries)
+	puller.RunCatchUp(context.Background(), sliceFetcher(entries))
 
 	stats := waitForCatchUp(t, puller, 1)
 	if stats["failed"] != 1 {
@@ -319,3 +319,32 @@ func TestPhase3CatchUpNoPeerHasFile(t *testing.T) {
 // Ensure io.Discard is used elsewhere so this file's imports compile even
 // in the absence of other references. (Static unused-var protection.)
 var _ = io.Discard
+
+// sliceFetcher converts a []*raft.FileEntry into a paginated fetch function
+// compatible with RunCatchUp's signature. Used by tests that previously
+// passed slices directly.
+func sliceFetcher(entries []*raft.FileEntry) func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+	return func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		start := 0
+		if cursor != "" {
+			for i, e := range entries {
+				if e.Path == cursor {
+					start = i + 1
+					break
+				}
+			}
+		}
+		if start >= len(entries) {
+			return nil, "", nil
+		}
+		end := start + limit
+		if end > len(entries) {
+			end = len(entries)
+		}
+		nextCursor := ""
+		if end < len(entries) {
+			nextCursor = entries[end-1].Path
+		}
+		return entries[start:end], nextCursor, nil
+	}
+}

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -326,8 +326,7 @@ type ClusterFSM struct {
 	// GetFilesPaginated to avoid sorting the full key set on every page.
 	// Set to nil on any manifest mutation to trigger a rebuild on the
 	// next paginated call. Guarded by mu.
-	keysCache    []string
-	keysCacheGen int64 // incremented on each rebuild; used for sanity checks
+	keysCache []string
 	// tokens holds the cluster-wide API-token state (Phase A: Cluster Auth
 	// Convergence). The map is the source of truth in memory; each node's
 	// local SQLite `api_tokens` is a materialised cache rebuilt from
@@ -2342,7 +2341,6 @@ func (f *ClusterFSM) GetFilesPaginated(cursor string, limit int) ([]*FileEntry, 
 			f.keysCache = append(f.keysCache, k)
 		}
 		sort.Strings(f.keysCache)
-		f.keysCacheGen++
 	}
 	keys := f.keysCache
 	f.mu.Unlock()

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -2185,6 +2185,7 @@ func (f *ClusterFSM) Restore(rc io.ReadCloser) error {
 		}
 		teamSet[id] = struct{}{}
 	}
+	f.keysCache = nil // invalidate sorted-key cache after snapshot restore
 	f.mu.Unlock()
 
 	f.logger.Info().
@@ -2323,7 +2324,11 @@ func (f *ClusterFSM) GetFilesByDatabase(database string) []*FileEntry {
 //
 // Cursor stability: the cursor is the last path string of the previous
 // page. If the cursor path is deleted between pages, pagination resumes
-// from the next key in sort order — no entries are skipped.
+// from the next key in sort order — no existing entries are skipped.
+// Newly added entries that sort before the cursor may be missed (the
+// cache is rebuilt and cursor is relative to the new key order); this
+// is acceptable because catch-up also receives reactive FSM callbacks
+// for new entries.
 func (f *ClusterFSM) GetFilesPaginated(cursor string, limit int) ([]*FileEntry, string, error) {
 	if limit <= 0 {
 		limit = 1000

--- a/internal/cluster/raft/fsm.go
+++ b/internal/cluster/raft/fsm.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -321,6 +322,12 @@ type ClusterFSM struct {
 	// the primary `files` map on register/delete to avoid O(N) scans when
 	// filtering by database.
 	filesByDB map[string]map[string]struct{}
+	// keysCache is a sorted snapshot of f.files keys, used by
+	// GetFilesPaginated to avoid sorting the full key set on every page.
+	// Set to nil on any manifest mutation to trigger a rebuild on the
+	// next paginated call. Guarded by mu.
+	keysCache    []string
+	keysCacheGen int64 // incremented on each rebuild; used for sanity checks
 	// tokens holds the cluster-wide API-token state (Phase A: Cluster Auth
 	// Convergence). The map is the source of truth in memory; each node's
 	// local SQLite `api_tokens` is a materialised cache rebuilt from
@@ -1067,6 +1074,7 @@ func (f *ClusterFSM) applyRegisterFileStruct(p RegisterFilePayload, logIndex uin
 		f.filesByDB[entry.Database] = idx
 	}
 	idx[entry.Path] = struct{}{}
+	f.keysCache = nil // invalidate sorted-key cache
 	callback := f.onFileRegistered
 	f.mu.Unlock()
 
@@ -1115,6 +1123,7 @@ func (f *ClusterFSM) applyDeleteFileStruct(p DeleteFilePayload) interface{} {
 			}
 		}
 	}
+	f.keysCache = nil // invalidate sorted-key cache
 	callback := f.onFileDeleted
 	f.mu.Unlock()
 
@@ -1196,6 +1205,7 @@ func (f *ClusterFSM) applyUpdateFileStruct(p UpdateFilePayload, logIndex uint64)
 		}
 		idx[entry.Path] = struct{}{}
 	}
+	f.keysCache = nil // invalidate sorted-key cache
 	callback := f.onFileRegistered
 	f.mu.Unlock()
 
@@ -2298,6 +2308,78 @@ func (f *ClusterFSM) GetFilesByDatabase(database string) []*FileEntry {
 		}
 	}
 	return files
+}
+
+// GetFilesPaginated returns a page of file entries using cursor-based
+// pagination over a sorted snapshot of manifest keys. The caller passes
+// the cursor from the previous page (empty string for the first page)
+// and a limit; the method returns the page, the next cursor (empty when
+// there are no more pages), and an error.
+//
+// This avoids the O(N) allocation of GetAllFiles() for large manifests.
+// Between pages the RLock is released so Raft apply-path latency is not
+// affected by long-running manifest walks. The sorted-key cache is
+// rebuilt on first call after any manifest mutation.
+//
+// Cursor stability: the cursor is the last path string of the previous
+// page. If the cursor path is deleted between pages, pagination resumes
+// from the next key in sort order — no entries are skipped.
+func (f *ClusterFSM) GetFilesPaginated(cursor string, limit int) ([]*FileEntry, string, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+
+	f.mu.Lock()
+	// Rebuild the sorted-key cache if invalidated
+	if f.keysCache == nil {
+		f.keysCache = make([]string, 0, len(f.files))
+		for k := range f.files {
+			f.keysCache = append(f.keysCache, k)
+		}
+		sort.Strings(f.keysCache)
+		f.keysCacheGen++
+	}
+	keys := f.keysCache
+	f.mu.Unlock()
+
+	// Find start position from cursor
+	start := 0
+	if cursor != "" {
+		// sort.SearchStrings returns the first index where keys[i] >= cursor.
+		// If cursor matches exactly, skip it (it was in the previous page).
+		idx := sort.SearchStrings(keys, cursor)
+		if idx < len(keys) && keys[idx] == cursor {
+			start = idx + 1
+		} else {
+			start = idx
+		}
+	}
+
+	if start >= len(keys) {
+		return nil, "", nil
+	}
+
+	end := start + limit
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	f.mu.RLock()
+	result := make([]*FileEntry, 0, end-start)
+	for i := start; i < end; i++ {
+		if entry, exists := f.files[keys[i]]; exists {
+			entryCopy := *entry
+			result = append(result, &entryCopy)
+		}
+	}
+	f.mu.RUnlock()
+
+	nextCursor := ""
+	if end < len(keys) {
+		nextCursor = keys[end-1]
+	}
+
+	return result, nextCursor, nil
 }
 
 // FileCount returns the number of files in the manifest.


### PR DESCRIPTION
## Summary

Closes #396.

`ClusterFSM.GetAllFiles()` previously allocated a full O(N) copy of the file manifest — for 1M+ files this caused ~50ms apply-path spikes (RLock held while copying) and ~50MB transient memory. This PR adds cursor-based pagination.

## Changes

1. **`internal/cluster/raft/fsm.go`** — Added `keysCache []string` + `keysCacheGen int64` fields with cache invalidation on register/delete/update/batch/Restore. Added `GetFilesPaginated(cursor, limit)` using sorted-key pagination with RLock released between pages.

2. **`internal/cluster/filereplication/catchup.go`** — `RunCatchUp` now accepts a paginated fetch function `func(cursor, limit) ([]*FileEntry, string, error)` instead of `[]*FileEntry`. Pages through the manifest at 1000 entries/page with backpressure between pages.

3. **`internal/cluster/coordinator.go`** — Added `GetFileManifestPaginated`. Catch-up now uses paginated fetch closure.

4. **`internal/api/cluster.go`** — `GET /api/v1/cluster/files` supports `?cursor=<path>&limit=<n>` for pagination. Omitting both params returns all files (backward-compatible).

5. **`RELEASE_NOTES_2026.06.2.md`** — Added paginated manifest walks section.

## Internal Review Findings Addressed

- **Blocker**: `Restore()` now invalidates `keysCache` after snapshot load
- **High**: Added comment explaining why capturing `fsm` in closure is safe
- **Medium**: Clarified cursor stability docs — newly added entries sorting before cursor may be missed (acceptable; catch-up also receives reactive FSM callbacks)
- **Style**: Added `nextCursor` semantics comment in `paginateSlice`

## Test Plan

- [x] `go build ./internal/cluster/... ./internal/api/...` — clean
- [x] `go vet` — clean
- [x] `go test ./internal/cluster/...` — all 7 packages PASS
- [x] `gofmt -l` — clean
- [x] Internal review with configuration matrix — findings addressed