### PR TITLE
test(api): endpoint-level regression tests for SHOW-command RBAC gate

### DIFF
--- a/internal/api/query_rbac_test.go
+++ b/internal/api/query_rbac_test.go
@@ -802,8 +802,9 @@ func TestExecuteQuery_ShowDatabases_CommentBypassDenied(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%q: %v", sql, err)
 		}
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		if resp.StatusCode != fiber.StatusForbidden {
-			bodyBytes, _ := io.ReadAll(resp.Body)
 			t.Errorf("%q: expected 403 (SHOW gate must deny), got %d: %s",
 				sql, resp.StatusCode, string(bodyBytes))
 		}
@@ -834,6 +835,7 @@ func TestExecuteQuery_ShowTables_HeaderDBScoped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusForbidden {
 		bodyBytes, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 403 (SHOW TABLES must check the header db, not default), got %d: %s",

--- a/internal/api/query_rbac_test.go
+++ b/internal/api/query_rbac_test.go
@@ -765,3 +765,104 @@ GROUP BY a.host, b.region`
 		_ = extractTableReferences(sql)
 	}
 }
+
+// =============================================================================
+// SHOW-command RBAC gate — endpoint-level tests (POST /api/v1/query)
+//
+// These exercise the full handler path (not just the regex), confirming the
+// SHOW gate denies before any storage access. Each is revert-verified: with
+// its fix removed, the request escapes the gate and the test fails.
+// =============================================================================
+
+// TestExecuteQuery_ShowDatabases_CommentBypassDenied verifies a SHOW command
+// hidden behind a comment cannot bypass the RBAC gate. The gate matches against
+// comment-stripped SQL (normalizeSQLForShow); without that, the raw match fails,
+// checkQueryPermissions finds zero table refs and allows it, and DuckDB strips
+// the comment and executes the SHOW — leaking the database list. The token here
+// lacks *.*:read, so every form must be denied (403).
+func TestExecuteQuery_ShowDatabases_CommentBypassDenied(t *testing.T) {
+	rbac := &mockRBACChecker{
+		enabled:      true,
+		allowAll:     false, // *.* check is denied
+		deniedReason: "no read permission to list databases",
+	}
+	app := setupQueryRBACTest(t, rbac, tokenMiddleware(1, "no-wildcard"))
+
+	for _, sql := range []string{
+		"SHOW DATABASES",
+		"/* sneaky */ SHOW DATABASES",
+		"-- sneaky\nSHOW DATABASES",
+		"SHOW DATABASES -- trailing",
+	} {
+		body := strings.NewReader(`{"sql": ` + jsonQuote(sql) + `}`)
+		req := httptest.NewRequest("POST", "/api/v1/query", body)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("%q: %v", sql, err)
+		}
+		if resp.StatusCode != fiber.StatusForbidden {
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			t.Errorf("%q: expected 403 (SHOW gate must deny), got %d: %s",
+				sql, resp.StatusCode, string(bodyBytes))
+		}
+	}
+}
+
+// TestExecuteQuery_ShowTables_HeaderDBScoped verifies that SHOW TABLES with no
+// explicit `FROM db` checks permission against the x-arc-database header (the
+// database the command actually targets via handleShowTables), not literal
+// "default". The token has read on "default" but not "secretdb"; with
+// x-arc-database: secretdb the request must be denied (403), proving the check
+// follows the header.
+func TestExecuteQuery_ShowTables_HeaderDBScoped(t *testing.T) {
+	rbac := &mockRBACChecker{
+		enabled:      true,
+		allowAll:     false,
+		allowedDBs:   map[string]bool{"default": true},
+		deniedReason: "no read permission",
+	}
+	app := setupQueryRBACTest(t, rbac, tokenMiddleware(1, "default-only"))
+
+	body := strings.NewReader(`{"sql": "SHOW TABLES"}`)
+	req := httptest.NewRequest("POST", "/api/v1/query", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-arc-database", "secretdb")
+
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != fiber.StatusForbidden {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403 (SHOW TABLES must check the header db, not default), got %d: %s",
+			resp.StatusCode, string(bodyBytes))
+	}
+}
+
+// jsonQuote returns a JSON-quoted string for embedding a SQL string (with
+// newlines/quotes) into a request body without pulling in encoding/json at the
+// call sites.
+func jsonQuote(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\r':
+			b.WriteString(`\r`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/api/query_rbac_test.go
+++ b/internal/api/query_rbac_test.go
@@ -788,25 +788,27 @@ func TestExecuteQuery_ShowDatabases_CommentBypassDenied(t *testing.T) {
 	}
 	app := setupQueryRBACTest(t, rbac, tokenMiddleware(1, "no-wildcard"))
 
-	for _, sql := range []string{
-		"SHOW DATABASES",
-		"/* sneaky */ SHOW DATABASES",
-		"-- sneaky\nSHOW DATABASES",
-		"SHOW DATABASES -- trailing",
+	for _, tc := range []struct {
+		name string
+		json string // pre-escaped JSON request body
+	}{
+		{name: "plain SHOW DATABASES", json: `{"sql": "SHOW DATABASES"}`},
+		{name: "block comment before SHOW", json: `{"sql": "/* sneaky */ SHOW DATABASES"}`},
+		{name: "dash comment before SHOW", json: "{\"sql\": \"-- sneaky\\nSHOW DATABASES\"}"},
+		{name: "trailing dash comment", json: `{"sql": "SHOW DATABASES -- trailing"}`},
 	} {
-		body := strings.NewReader(`{"sql": ` + jsonQuote(sql) + `}`)
-		req := httptest.NewRequest("POST", "/api/v1/query", body)
+		req := httptest.NewRequest("POST", "/api/v1/query", strings.NewReader(tc.json))
 		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := app.Test(req, -1)
 		if err != nil {
-			t.Fatalf("%q: %v", sql, err)
+			t.Fatalf("%s: %v", tc.name, err)
 		}
 		bodyBytes, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if resp.StatusCode != fiber.StatusForbidden {
-			t.Errorf("%q: expected 403 (SHOW gate must deny), got %d: %s",
-				sql, resp.StatusCode, string(bodyBytes))
+			t.Errorf("%s: expected 403 (SHOW gate must deny), got %d: %s",
+				tc.name, resp.StatusCode, string(bodyBytes))
 		}
 	}
 }
@@ -841,30 +843,4 @@ func TestExecuteQuery_ShowTables_HeaderDBScoped(t *testing.T) {
 		t.Fatalf("expected 403 (SHOW TABLES must check the header db, not default), got %d: %s",
 			resp.StatusCode, string(bodyBytes))
 	}
-}
-
-// jsonQuote returns a JSON-quoted string for embedding a SQL string (with
-// newlines/quotes) into a request body without pulling in encoding/json at the
-// call sites.
-func jsonQuote(s string) string {
-	var b strings.Builder
-	b.WriteByte('"')
-	for _, r := range s {
-		switch r {
-		case '"':
-			b.WriteString(`\"`)
-		case '\\':
-			b.WriteString(`\\`)
-		case '\n':
-			b.WriteString(`\n`)
-		case '\t':
-			b.WriteString(`\t`)
-		case '\r':
-			b.WriteString(`\r`)
-		default:
-			b.WriteRune(r)
-		}
-	}
-	b.WriteByte('"')
-	return b.String()
 }


### PR DESCRIPTION
## Summary

Adds two handler-level (not just regex) regression tests for the SHOW-command RBAC gate merged in #489. They were prepared during #489 but deferred, because that branch carried a stale copy of `query_rbac_test.go`; they now land alongside the authoritative file on `main`.

- **`TestExecuteQuery_ShowDatabases_CommentBypassDenied`** — a commented SHOW (`/* x */ SHOW DATABASES`, `-- x\nSHOW DATABASES`, trailing comment) must be denied with 403, not slip past the gate to DuckDB.
- **`TestExecuteQuery_ShowTables_HeaderDBScoped`** — `SHOW TABLES` with no `FROM db` must check permission against the `x-arc-database` header (the db `handleShowTables` actually lists), not literal `"default"`.

Both are **revert-verified**: with the corresponding fix removed from `query.go`, the request escapes the gate (nil-deref 500 instead of 403), proving the tests guard the behavior rather than passing trivially.

## Test plan

- [x] `go test ./internal/api/... -count=1` — passes
- [x] `go test -tags duckdb_arrow ./internal/api/... -count=1` — passes
- [x] `gofmt -l` / `go vet ./internal/api/...` — clean
- [x] Revert-verified both tests fail when their fix is removed

Test-only change; no production code touched. Part of the coverage tracked by #491.