### PR TITLE
feat(license): offline (air-gapped) license activation from a signed file

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -105,9 +105,68 @@ func main() {
 	}
 
 	// Validate Enterprise License early (before component initialization)
-	// This allows us to apply core limits to DuckDB and ingestion workers
+	// This allows us to apply core limits to DuckDB and ingestion workers.
 	var licenseClient *license.Client
-	if cfg.License.Key != "" {
+
+	// applyLicense logs the verified license and enforces its core limit on the
+	// Go runtime / DuckDB / ingest workers. Shared by the online and offline
+	// paths so both enforce identically.
+	applyLicense := func(lic *license.License) {
+		log.Info().
+			Str("tier", string(lic.Tier)).
+			Str("status", lic.Status).
+			Int("days_remaining", lic.DaysRemaining).
+			Int("max_cores", lic.MaxCores).
+			Time("expires_at", lic.ExpiresAt).
+			Strs("features", lic.Features).
+			Msg("Enterprise license verified successfully")
+
+		if lic.MaxCores > 0 {
+			machineCores := runtime.NumCPU()
+			if machineCores > lic.MaxCores {
+				previousGOMAXPROCS := runtime.GOMAXPROCS(lic.MaxCores)
+				log.Info().
+					Int("machine_cores", machineCores).
+					Int("licensed_cores", lic.MaxCores).
+					Int("gomaxprocs_before", previousGOMAXPROCS).
+					Int("gomaxprocs_after", lic.MaxCores).
+					Msg("License core limit applied via GOMAXPROCS")
+
+				cfg.Database.ThreadCount = lic.MaxCores
+				log.Info().Int("duckdb_threads", lic.MaxCores).Msg("License core limit applied to DuckDB threads")
+
+				if cfg.Ingest.FlushWorkers > lic.MaxCores {
+					cfg.Ingest.FlushWorkers = lic.MaxCores
+					log.Info().Int("flush_workers", lic.MaxCores).Msg("License core limit applied to ingestion flush workers")
+				}
+			}
+		}
+	}
+
+	switch {
+	case cfg.License.FilePath != "":
+		// Offline (air-gapped / GovCloud) activation: verify a signed license
+		// file on disk with NO network. Takes precedence over license.key —
+		// the file path is the explicit air-gapped intent.
+		if cfg.License.Key != "" {
+			log.Warn().Msg("Both license.file_path and license.key are set; using the offline file and ignoring the key")
+		}
+		log.Info().
+			Str("file_path", cfg.License.FilePath).
+			Msg("Validating enterprise license from offline file")
+
+		lc, err := license.LoadOfflineLicense(cfg.License.FilePath, logger.Get("license"))
+		if err != nil {
+			// Fail closed: any verification/read error disables enterprise
+			// features (same posture as a failed online activation), non-fatal.
+			log.Warn().Err(err).Msg("Offline license validation failed - enterprise features disabled")
+		} else {
+			licenseClient = lc
+			lic, _ := licenseClient.ActivateOrVerify(context.Background()) // offline: returns the loaded license, no network
+			applyLicense(lic)
+		}
+
+	case cfg.License.Key != "":
 		log.Info().
 			Str("license_key", cfg.License.Key[:min(12, len(cfg.License.Key))]+"...").
 			Str("server_url", license.LicenseServerURL).
@@ -120,8 +179,8 @@ func main() {
 		})
 		if err != nil {
 			log.Warn().Err(err).Msg("Failed to initialize license client - enterprise features disabled")
+			licenseClient = nil
 		} else {
-			// Activate or verify license at startup
 			lic, err := licenseClient.ActivateOrVerify(context.Background())
 			if err != nil {
 				log.Warn().
@@ -130,48 +189,11 @@ func main() {
 					Msg("License activation/verification failed - enterprise features disabled")
 				licenseClient = nil
 			} else {
-				log.Info().
-					Str("tier", string(lic.Tier)).
-					Str("status", lic.Status).
-					Int("days_remaining", lic.DaysRemaining).
-					Int("max_cores", lic.MaxCores).
-					Time("expires_at", lic.ExpiresAt).
-					Strs("features", lic.Features).
-					Msg("Enterprise license verified successfully")
-
-				// Apply core limits from license to config
-				// This ensures DuckDB and ingestion workers respect the license
-				if lic.MaxCores > 0 {
-					machineCores := runtime.NumCPU()
-
-					if machineCores > lic.MaxCores {
-						// Limit Go runtime to licensed cores - this is the real enforcement
-						previousGOMAXPROCS := runtime.GOMAXPROCS(lic.MaxCores)
-						log.Info().
-							Int("machine_cores", machineCores).
-							Int("licensed_cores", lic.MaxCores).
-							Int("gomaxprocs_before", previousGOMAXPROCS).
-							Int("gomaxprocs_after", lic.MaxCores).
-							Msg("License core limit applied via GOMAXPROCS")
-
-						// Also set DuckDB thread count to match
-						cfg.Database.ThreadCount = lic.MaxCores
-						log.Info().
-							Int("duckdb_threads", lic.MaxCores).
-							Msg("License core limit applied to DuckDB threads")
-
-						// Limit ingestion flush workers to licensed cores
-						if cfg.Ingest.FlushWorkers > lic.MaxCores {
-							cfg.Ingest.FlushWorkers = lic.MaxCores
-							log.Info().
-								Int("flush_workers", lic.MaxCores).
-								Msg("License core limit applied to ingestion flush workers")
-						}
-					}
-				}
+				applyLicense(lic)
 			}
 		}
-	} else {
+
+	default:
 		log.Warn().Msg("Enterprise license not configured - enterprise features disabled")
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,7 +212,12 @@ type QueryConfig struct {
 // LicenseConfig holds configuration for enterprise license validation
 type LicenseConfig struct {
 	Enabled bool   // Enable license validation (default: false)
-	Key     string // License key (ARC-ENT-XXXX-XXXX-XXXX-XXXX)
+	Key     string // License key (ARC-ENT-XXXX-XXXX-XXXX-XXXX) — online activation
+	// FilePath points at a signed offline license file ({license_file,
+	// license_signature} JSON) for air-gapped / GovCloud deployments that
+	// cannot reach the license server. When set, Arc verifies it locally with
+	// no network and it takes precedence over Key.
+	FilePath string
 }
 
 // SchedulerConfig holds configuration for automatic schedulers (Enterprise features)
@@ -641,6 +646,10 @@ func Load() (*Config, error) {
 		License: LicenseConfig{
 			Enabled: v.GetBool("license.enabled"),
 			Key:     v.GetString("license.key"),
+			// Trimmed so a stray-whitespace path does not take the offline
+			// branch and silently shadow a valid license.key (it would fail to
+			// open and disable enterprise features). Empty/blank => online path.
+			FilePath: strings.TrimSpace(v.GetString("license.file_path")),
 		},
 		Scheduler: SchedulerConfig{
 			RetentionSchedule: v.GetString("scheduler.retention_schedule"),
@@ -1006,6 +1015,7 @@ func setDefaults(v *viper.Viper) {
 	// Note: Server URL and validation interval are hardcoded in internal/license/client.go
 	v.SetDefault("license.enabled", false) // Disabled by default
 	v.SetDefault("license.key", "")        // Must be provided
+	v.SetDefault("license.file_path", "")  // Offline (air-gapped) signed license file; takes precedence over key
 
 	// Scheduler defaults (Enterprise features)
 	// Note: CQ and retention schedulers are auto-enabled when their features are enabled AND license allows

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -937,3 +937,41 @@ func TestLoad_StorageValuesTrimmed(t *testing.T) {
 		t.Errorf("Cold.S3Bucket = %q, want trimmed %q (pointer mutation must persist)", cfg.TieredStorage.Cold.S3Bucket, "cold-bucket")
 	}
 }
+
+// TestLoad_LicenseFilePathTrimmed: a whitespace-padded license.file_path is
+// trimmed at load so it doesn't take the offline branch and silently shadow a
+// valid license.key. Empty after trim => online path (FilePath == "").
+func TestLoad_LicenseFilePathTrimmed(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"real path preserved", "/etc/arc/license.json", "/etc/arc/license.json"},
+		{"surrounding whitespace trimmed", "  /etc/arc/license.json  ", "/etc/arc/license.json"},
+		{"whitespace-only becomes empty", "   ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "arc-lic-cfg")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+			oldWd, _ := os.Getwd()
+			os.Chdir(tmpDir)
+			defer os.Chdir(oldWd)
+
+			os.Setenv("ARC_LICENSE_FILE_PATH", tc.env)
+			defer os.Unsetenv("ARC_LICENSE_FILE_PATH")
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.License.FilePath != tc.want {
+				t.Errorf("License.FilePath = %q, want %q", cfg.License.FilePath, tc.want)
+			}
+		})
+	}
+}

--- a/internal/license/client.go
+++ b/internal/license/client.go
@@ -47,6 +47,11 @@ type Client struct {
 	mu          sync.RWMutex
 	stopCh      chan struct{}
 	logger      zerolog.Logger
+	// offline is true for a client built from an on-disk signed license
+	// file (air-gapped activation). Offline clients perform NO network
+	// calls — Activate/Verify/StartPeriodicValidation are no-ops — and the
+	// license is the verified contents of the file, valid until its expiry.
+	offline bool
 }
 
 // VerifyRequest represents a license verification request
@@ -141,6 +146,9 @@ type ActivateResponse struct {
 
 // Activate registers this machine with the license server
 func (c *Client) Activate(ctx context.Context) (*License, error) {
+	if c.offline {
+		return nil, fmt.Errorf("offline license client cannot activate over the network")
+	}
 	url := fmt.Sprintf("%s/api/v1/activate", c.serverURL)
 
 	hostname, _ := os.Hostname()
@@ -231,6 +239,9 @@ func (c *Client) Activate(ctx context.Context) (*License, error) {
 
 // Verify validates the license with the enterprise server
 func (c *Client) Verify(ctx context.Context) (*License, error) {
+	if c.offline {
+		return nil, fmt.Errorf("offline license client cannot verify over the network")
+	}
 	url := fmt.Sprintf("%s/api/v1/verify", c.serverURL)
 
 	c.logger.Debug().
@@ -303,6 +314,19 @@ func (c *Client) Verify(ctx context.Context) (*License, error) {
 
 // ActivateOrVerify tries to verify first, and if the machine is not activated, activates it
 func (c *Client) ActivateOrVerify(ctx context.Context) (*License, error) {
+	// Offline (air-gapped) clients are already activated from the on-disk
+	// signed file and must never touch the network. Return the verified
+	// license directly.
+	if c.offline {
+		c.mu.RLock()
+		lic := c.license
+		c.mu.RUnlock()
+		if lic == nil {
+			return nil, fmt.Errorf("offline license client has no loaded license")
+		}
+		return lic, nil
+	}
+
 	// Try to verify first
 	license, err := c.Verify(ctx)
 	if err == nil {
@@ -321,6 +345,15 @@ func (c *Client) ActivateOrVerify(ctx context.Context) (*License, error) {
 
 // StartPeriodicValidation starts background license validation
 func (c *Client) StartPeriodicValidation(interval time.Duration) {
+	// Offline licenses have nothing to re-validate against (no server). Their
+	// validity is the file's expiry, enforced locally via the license status.
+	// Skip the background loop entirely so an air-gapped node makes no network
+	// calls.
+	if c.offline {
+		c.logger.Debug().Msg("Offline license: periodic validation disabled (no network)")
+		return
+	}
+
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()

--- a/internal/license/offline.go
+++ b/internal/license/offline.go
@@ -1,0 +1,96 @@
+package license
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// maxOfflineLicenseBytes caps the on-disk license file we'll read. A signed
+// RSA-2048 license_file is ~800 bytes after base64; 1 MiB is generous headroom
+// while still refusing to slurp a hostile multi-GB file into memory.
+const maxOfflineLicenseBytes = 1 << 20
+
+// OfflineLicenseFile is the on-disk format for air-gapped activation. It is the
+// same detached-signature pair the enterprise server returns over HTTP — the
+// base64 canonical SignedLicense JSON plus its base64 RSA-PKCS1v15 SHA-256
+// signature — so an operator can pre-mint it with the signing key and hand it
+// to an air-gapped customer out-of-band (USB, secure portal). No network is
+// involved on the customer side.
+type OfflineLicenseFile struct {
+	LicenseFile      string `json:"license_file"`      // base64 canonical SignedLicense JSON (the signed bytes)
+	LicenseSignature string `json:"license_signature"` // base64 RSA-PKCS1v15 SHA-256 over the decoded LicenseFile bytes
+}
+
+// LoadOfflineLicense builds a license Client from a signed license file on disk,
+// performing NO network calls. It verifies the detached signature against the
+// pinned enterprise public key (the same VerifyLicenseFile path the online
+// activation uses) and, on success, returns a Client whose license is the
+// verified file contents.
+//
+// Air-gapped / site-license semantics: the machine fingerprint in the signed
+// license is NOT enforced here — offline files are issued unbound (one signed
+// file activates any node for the customer until expiry). Expiry IS enforced via
+// the runtime status the same way as online licenses (deriveStatus): an expired
+// offline file yields an "expired" status and the feature gates fall closed.
+func LoadOfflineLicense(path string, logger zerolog.Logger) (*Client, error) {
+	componentLogger := logger.With().Str("component", "license-offline").Logger()
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open offline license file %q: %w", path, err)
+	}
+	defer f.Close()
+
+	// Bound the read so a malformed/hostile file can't OOM startup. Read
+	// limit+1 to detect overflow, matching the import handlers' pattern.
+	data, err := io.ReadAll(io.LimitReader(f, maxOfflineLicenseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read offline license file %q: %w", path, err)
+	}
+	if int64(len(data)) > maxOfflineLicenseBytes {
+		return nil, fmt.Errorf("offline license file %q exceeds %d bytes", path, maxOfflineLicenseBytes)
+	}
+
+	var lf OfflineLicenseFile
+	if err := json.Unmarshal(data, &lf); err != nil {
+		return nil, fmt.Errorf("parse offline license file %q: %w", path, err)
+	}
+	if lf.LicenseFile == "" || lf.LicenseSignature == "" {
+		return nil, fmt.Errorf("offline license file %q is missing license_file or license_signature", path)
+	}
+
+	// Reuse the exact verification path used for online activation: the
+	// signature is checked against the raw decoded license_file bytes using the
+	// pinned RSA-2048 public key. No struct round-trip, no network.
+	signed, err := VerifyLicenseFile(lf.LicenseFile, lf.LicenseSignature)
+	if err != nil {
+		return nil, fmt.Errorf("offline license signature verification failed: %w", err)
+	}
+
+	license := signed.ToRuntimeLicense(time.Now().UTC())
+
+	c := &Client{
+		// No serverURL / httpClient: an offline client never reaches the network.
+		licenseKey: signed.LicenseKey, // sourced from the signed file, not config
+		license:    license,
+		stopCh:     make(chan struct{}),
+		logger:     componentLogger,
+		offline:    true,
+	}
+
+	componentLogger.Info().
+		Str("tier", string(license.Tier)).
+		Str("status", license.Status).
+		Int("days_remaining", license.DaysRemaining).
+		Int("max_cores", license.MaxCores).
+		Time("expires_at", license.ExpiresAt).
+		Str("path", path).
+		Msg("Offline license loaded and verified")
+
+	return c, nil
+}

--- a/internal/license/offline_test.go
+++ b/internal/license/offline_test.go
@@ -1,0 +1,174 @@
+package license
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// writeOfflineFile marshals an OfflineLicenseFile to a temp path and returns it.
+func writeOfflineFile(t *testing.T, lf OfflineLicenseFile) string {
+	t.Helper()
+	data, err := json.Marshal(lf)
+	if err != nil {
+		t.Fatalf("marshal offline file: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "license.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write offline file: %v", err)
+	}
+	return path
+}
+
+// TestLoadOfflineLicense_GoldenPath: a file signed by the trusted key, with the
+// trusted key pinned, loads and yields an active enterprise license — no network.
+func TestLoadOfflineLicense_GoldenPath(t *testing.T) {
+	withTestPublicKey(t, &rsaKey1.PublicKey)
+
+	lic := sampleLicense()
+	// Make sure it's unexpired relative to now so status is active.
+	lic.IssuedAt = time.Now().UTC().Add(-24 * time.Hour)
+	lic.ExpiresAt = time.Now().UTC().Add(365 * 24 * time.Hour)
+	fileB64, sigB64 := signDetached(t, rsaKey1, lic)
+
+	path := writeOfflineFile(t, OfflineLicenseFile{LicenseFile: fileB64, LicenseSignature: sigB64})
+
+	c, err := LoadOfflineLicense(path, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("LoadOfflineLicense: unexpected error: %v", err)
+	}
+	if !c.offline {
+		t.Error("expected offline=true")
+	}
+	got := c.GetLicense()
+	if got == nil {
+		t.Fatal("expected a loaded license")
+	}
+	if got.Tier != "enterprise" {
+		t.Errorf("tier = %q, want enterprise", got.Tier)
+	}
+	if got.Status != "active" {
+		t.Errorf("status = %q, want active", got.Status)
+	}
+	// Offline client must never reach the network: ActivateOrVerify returns the
+	// loaded license, and Activate/Verify are rejected.
+	if _, err := c.ActivateOrVerify(t.Context()); err != nil {
+		t.Errorf("ActivateOrVerify (offline) should succeed locally, got: %v", err)
+	}
+	if _, err := c.Verify(t.Context()); err == nil {
+		t.Error("Verify on an offline client should error (no network)")
+	}
+	if _, err := c.Activate(t.Context()); err == nil {
+		t.Error("Activate on an offline client should error (no network)")
+	}
+}
+
+// TestLoadOfflineLicense_Rejects covers the fail-closed cases: any verification
+// problem must return an error (caller disables enterprise features).
+func TestLoadOfflineLicense_Rejects(t *testing.T) {
+	withTestPublicKey(t, &rsaKey1.PublicKey)
+
+	validFile, validSig := signDetached(t, rsaKey1, sampleLicense())
+
+	t.Run("tampered payload", func(t *testing.T) {
+		// Re-sign-free tamper: flip a byte of the payload after signing.
+		tampered := []byte(validFile)
+		tampered[len(tampered)/2] ^= 0xFF
+		path := writeOfflineFile(t, OfflineLicenseFile{LicenseFile: string(tampered), LicenseSignature: validSig})
+		if _, err := LoadOfflineLicense(path, zerolog.Nop()); err == nil {
+			t.Error("expected error on tampered payload")
+		}
+	})
+
+	t.Run("wrong signing key", func(t *testing.T) {
+		// Signed by rsaKey2 but rsaKey1 is pinned.
+		f, s := signDetached(t, rsaKey2, sampleLicense())
+		path := writeOfflineFile(t, OfflineLicenseFile{LicenseFile: f, LicenseSignature: s})
+		if _, err := LoadOfflineLicense(path, zerolog.Nop()); err == nil {
+			t.Error("expected error when signed by an untrusted key")
+		}
+	})
+
+	t.Run("missing signature field", func(t *testing.T) {
+		path := writeOfflineFile(t, OfflineLicenseFile{LicenseFile: validFile})
+		if _, err := LoadOfflineLicense(path, zerolog.Nop()); err == nil {
+			t.Error("expected error when license_signature is empty")
+		}
+	})
+
+	t.Run("missing license_file field", func(t *testing.T) {
+		path := writeOfflineFile(t, OfflineLicenseFile{LicenseSignature: validSig})
+		if _, err := LoadOfflineLicense(path, zerolog.Nop()); err == nil {
+			t.Error("expected error when license_file is empty")
+		}
+	})
+
+	t.Run("not valid json", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "garbage.json")
+		if err := os.WriteFile(path, []byte("not json at all"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadOfflineLicense(path, zerolog.Nop()); err == nil {
+			t.Error("expected error on non-JSON file")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "does-not-exist.json")
+		if _, err := LoadOfflineLicense(path, zerolog.Nop()); err == nil {
+			t.Error("expected error on missing file")
+		}
+	})
+
+	t.Run("oversized file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "big.json")
+		big := make([]byte, maxOfflineLicenseBytes+10)
+		for i := range big {
+			big[i] = 'a'
+		}
+		if err := os.WriteFile(path, big, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadOfflineLicense(path, zerolog.Nop()); err == nil {
+			t.Error("expected error on oversized file")
+		}
+	})
+}
+
+// TestLoadOfflineLicense_Expired: a correctly-signed but expired license loads
+// (signature is valid) but its status is "expired" so feature gates fall closed.
+func TestLoadOfflineLicense_Expired(t *testing.T) {
+	withTestPublicKey(t, &rsaKey1.PublicKey)
+
+	lic := sampleLicense()
+	lic.IssuedAt = time.Now().UTC().Add(-400 * 24 * time.Hour)
+	lic.ExpiresAt = time.Now().UTC().Add(-24 * time.Hour) // expired yesterday
+	f, s := signDetached(t, rsaKey1, lic)
+	path := writeOfflineFile(t, OfflineLicenseFile{LicenseFile: f, LicenseSignature: s})
+
+	c, err := LoadOfflineLicense(path, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("expected expired license to load (valid signature), got error: %v", err)
+	}
+	got := c.GetLicense()
+	if got.Status == "active" {
+		t.Errorf("expired license should not have active status, got %q", got.Status)
+	}
+	// Feature gates must be closed for an expired license.
+	if c.CanUseClustering() {
+		t.Error("expired license must not grant clustering")
+	}
+}
+
+func TestLoadOfflineLicense_PathMessageMentionsFile(t *testing.T) {
+	withTestPublicKey(t, &rsaKey1.PublicKey)
+	_, err := LoadOfflineLicense(filepath.Join(t.TempDir(), "nope.json"), zerolog.Nop())
+	if err == nil || !strings.Contains(err.Error(), "nope.json") {
+		t.Errorf("error should name the path, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Arc Enterprise targets aerospace/defense — production often runs in **GovCloud or fully air-gapped** networks that can't reach `enterprise.basekick.net`. Arc previously only activated **online** (HTTP at startup + every 4h), leaving those deployments unable to enable enterprise features.

This adds an **offline activation path**: point `license.file_path` (`ARC_LICENSE_FILE_PATH`) at a signed license file — the same `{license_file, license_signature}` detached pair the server already returns over HTTP, written to disk — and Arc verifies it **locally with no network** and activates.

The crypto already existed (RSA-2048 pinned public key + `VerifyLicenseFile`); this is file-I/O + startup wiring, reusing the exact verification path as online.

## Changes
- **`internal/license/offline.go`** (new): `OfflineLicenseFile` + `LoadOfflineLicense()` — bounded read (1 MiB cap), verify detached signature via `VerifyLicenseFile`, convert via `ToRuntimeLicense`, return an `offline` Client.
- **`internal/license/client.go`**: offline clients are network-free — `StartPeriodicValidation` no-ops; `Activate`/`Verify` hard-error; `ActivateOrVerify` returns the already-verified license.
- **`internal/config/config.go`**: `license.file_path` key, trimmed (a stray-whitespace path can't silently shadow a valid `license.key`).
- **`cmd/arc/main.go`**: startup switch — `file_path` precedence over `key` (warns when both set); shared `applyLicense()` enforces the core limit on both paths; offline errors **fail closed** (warn + OSS, non-fatal).

## Design decisions
- Offline files are **unbound site licenses** — machine fingerprint not enforced (verified safe: nothing downstream relies on it).
- **Expiry IS enforced** via `deriveStatus` (expired → status≠active → all gates closed).
- **Fail-closed** on every error path (missing / garbage / tampered / wrong-key / expired).

## Test plan
- [x] `offline_test.go`: golden path + reject (tampered, wrong key, missing field, non-JSON, missing file, oversized) + expired-gates-closed — reuses the existing `withTestPublicKey`/`signDetached` seam (real production crypto).
- [x] config test pins the `file_path` trim.
- [x] build + vet + tests **with and without `-tags=duckdb_arrow`**.
- [x] **binary run**: missing file → OSS fallback (non-fatal); both `file_path`+`key` set → "ignoring the key", **no online attempt**.
- [x] config matrix (all 7 cells) + **deep security review** — no bypass / fail-open path found.

## Out of scope (fast-follow)
- Server-side operator tool to **mint** the signed file (`enterprise_activation_server`) — being built next.
- Fingerprint-bound offline licenses.
- Air-gapped docs page (follows the server tool so the documented flow is complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)