### PR TITLE
content(scripts): PI/AF demo data generators for partner handoff

### DIFF
--- a/scripts/pi-demo-data/README.md
+++ b/scripts/pi-demo-data/README.md
@@ -1,0 +1,155 @@
+# Arc PI / AF Data Reference demo data
+
+Self-contained scripts to generate synthetic sensor data and load it into an Arc
+instance, for building and benchmarking a PI-style integration (PlotValues,
+RecordedValues, Summaries) and for the anomaly-detection demo.
+
+Two datasets:
+
+| Script | Dataset | Use for |
+|---|---|---|
+| `generate_trend_data.py` | 3 tags x 365 days, irregular timestamps, ~31.5M rows (`historian.sensors`) | **PlotValues / trend** queries — the AF Data Reference case |
+| `generate_anomaly_data.py` | 3 machines x 60 days @ 5s, 2 injected faults, ~3.1M rows (`factory.vibration`) | Anomaly detection (z-score, MAD, seasonal residual) |
+
+Both shape the data exactly like Arc stores it natively (columnar Parquet,
+`time`-partitioned), so query performance is representative.
+
+## Prerequisites
+
+```bash
+pip install duckdb msgpack
+```
+
+A running Arc instance. Default target is `http://localhost:8000`. To run Arc
+locally with auth disabled (simplest for a demo):
+
+```bash
+docker run -d -p 8000:8000 -e ARC_AUTH_ENABLED=false \
+  ghcr.io/basekick-labs/arc:latest
+```
+
+If auth is enabled, pass your write/admin token with `--token`.
+
+## Generate + load
+
+```bash
+# PI-style trend dataset (~31.5M rows; a few minutes over HTTP)
+python generate_trend_data.py
+
+# Anomaly-detection dataset (~3.1M rows; under a minute)
+python generate_anomaly_data.py
+
+# Against a remote Arc with auth:
+python generate_trend_data.py --arc-url https://arc.example.com --token "$ARC_TOKEN"
+
+# Just produce a local .parquet without loading (fast, for inspection):
+python generate_trend_data.py --parquet-only
+```
+
+Each script prints a sample query when it finishes.
+
+> **Tip for the trend dataset:** Arc partitions by `year/month/day/hour`. A
+> freshly-loaded year is thousands of small hourly files, and a wide-range query
+> opens all of them. Let Arc's **compaction** run (enabled by default) so the
+> files coalesce — a year-trend query drops from ~1.5 s to ~120 ms once the data
+> is compacted. This is the single biggest performance lever for wide trends.
+
+## PlotValues query (the trend case)
+
+This is the PI plot algorithm: bucket the time range into `intervals` pixel-bins
+and return min / max / first / last per bin, so a year-long trend renders from
+~`intervals` rows instead of millions. `arg_min`/`arg_max` pick the first/last
+*value at timestamp* per bin (faster and more correct than `FIRST_VALUE`/
+`LAST_VALUE` window functions under Arc's multi-threaded execution).
+
+```sql
+SELECT
+  bucket_id,
+  min(value)            AS mn,         -- min in bin
+  max(value)            AS mx,         -- max in bin
+  arg_min(value, time)  AS first_val,  -- first reading (value at earliest ts)
+  arg_max(value, time)  AS last_val,   -- last reading  (value at latest ts)
+  min(time)             AS first_ts,
+  max(time)             AS last_ts
+FROM (
+  SELECT value, time,
+    (epoch_ms(time) - epoch_ms(TIMESTAMP '<start>')) // <bucket_ms> AS bucket_id
+  FROM historian.sensors
+  WHERE tag = '<tag>'
+    AND time >= TIMESTAMP '<start>'
+    AND time <  TIMESTAMP '<end>'
+)
+GROUP BY bucket_id
+ORDER BY bucket_id;
+```
+
+Map AF's `PlotValues(timeRange, intervals, ...)`:
+
+- `<bucket_ms> = (end_ms - start_ms) / intervals` — `intervals` is your pixel count.
+- Keep the time range tight (`WHERE time >= ... AND time < ...`): Arc physically
+  skips Parquet files outside the range. This is the biggest perf lever after
+  compaction.
+- Select only the columns you need (`time`, `value`, `tag`) — Arc is columnar, so
+  unread columns never touch disk.
+
+POST it to `/api/v1/query` (JSON is fine for the small decimated result). For
+**raw** bulk pulls (`RecordedValues` over a big range), use `/api/v1/query/arrow`
+— Arrow IPC is ~5x faster and ~3x smaller than JSON for large row counts.
+
+## Anomaly-detection queries (the factory dataset)
+
+Three pure-SQL detectors against `factory.vibration`. The injected faults:
+compressor-01 spike on 2025-05-31 02:00–08:00, pump-01 bearing ramp 2025-06-10..15.
+
+**Rolling z-score** (sudden events / step changes):
+
+```sql
+WITH series AS (
+  SELECT machine, time_bucket(INTERVAL '10 minutes', time) AS ts, avg(value) AS v
+  FROM vibration GROUP BY machine, ts
+),
+z AS (
+  SELECT machine, ts, v,
+         avg(v) OVER w AS mean, stddev(v) OVER w AS sd
+  FROM series
+  WINDOW w AS (PARTITION BY machine ORDER BY ts
+              ROWS BETWEEN 144 PRECEDING AND 1 PRECEDING)
+)
+SELECT machine, ts, v, (v - mean) / NULLIF(sd, 0) AS zscore
+FROM z
+WHERE abs((v - mean) / NULLIF(sd, 0)) > 4
+ORDER BY abs((v - mean) / NULLIF(sd, 0)) DESC;
+```
+
+**Seasonal residual** (gradual drift, fleet-wide; the production-friendly one):
+
+```sql
+WITH baseline AS (
+  SELECT machine, extract('hour' FROM time_bucket(INTERVAL '1 hour', time)) AS hod,
+         avg(value) AS expected, stddev(value) AS expected_sd
+  FROM vibration
+  WHERE time < TIMESTAMP '2025-05-31'        -- known-good training window
+  GROUP BY machine, hod
+),
+recent AS (
+  SELECT machine, time_bucket(INTERVAL '1 hour', time) AS ts, avg(value) AS v
+  FROM vibration
+  WHERE time >= TIMESTAMP '2025-06-05'
+  GROUP BY machine, ts
+)
+SELECT r.machine, r.ts, r.v, b.expected,
+       (r.v - b.expected) / NULLIF(b.expected_sd, 0) AS residual_z
+FROM recent r
+JOIN baseline b ON r.machine = b.machine AND extract('hour' FROM r.ts) = b.hod
+WHERE abs((r.v - b.expected) / NULLIF(b.expected_sd, 0)) > 3
+ORDER BY r.machine, r.ts;
+```
+
+Full write-up: https://basekick.net/blog/anomaly-detection-with-arc
+
+## Notes
+
+- The synthetic data is dated 2025 (the demo's reference year); adjust the
+  `TIMESTAMP` literals in the generators if you want a different epoch.
+- `time` is sent as epoch milliseconds; Arc stores it as `Timestamp(us)`.
+- Questions: ignacio@basekick.net

--- a/scripts/pi-demo-data/arc_ingest.py
+++ b/scripts/pi-demo-data/arc_ingest.py
@@ -1,0 +1,86 @@
+"""
+Shared helper: stream a DuckDB table into Arc over the MessagePack columnar
+write endpoint (POST /api/v1/write/msgpack).
+
+Used by generate_anomaly_data.py and generate_trend_data.py. Pure stdlib +
+msgpack + duckdb; no Arc client library required.
+
+The columnar payload Arc expects is a top-level array of records, each:
+    {"m": "<measurement>", "columns": {"<col>": [values...], ...}}
+with the target database passed in the `x-arc-database` header. The `time`
+column must be epoch milliseconds (int64); Arc stores it as Timestamp(us).
+"""
+
+import time
+import urllib.request
+
+import msgpack
+
+
+def ingest_table(
+    con,
+    *,
+    source_sql,
+    measurement,
+    database,
+    columns,
+    arc_url="http://localhost:8000",
+    token=None,
+    chunk_rows=400_000,
+):
+    """
+    Stream rows from a DuckDB query into Arc.
+
+    con          : an open duckdb connection
+    source_sql   : SELECT that yields the columns named in `columns`, ordered by time.
+                   It must NOT include LIMIT/OFFSET — this helper paginates for you.
+    measurement  : Arc measurement name (e.g. "vibration")
+    database     : Arc database name (e.g. "factory") -> x-arc-database header
+    columns      : list of column names to send, in order. The first MUST be the
+                   epoch-millisecond int64 time column (named "time" in Arc).
+    arc_url      : base URL of the Arc instance
+    token        : optional admin/write API token (Bearer). Omit if auth disabled.
+    chunk_rows   : rows per HTTP POST.
+    """
+    write_url = arc_url.rstrip("/") + "/api/v1/write/msgpack"
+    headers = {
+        "Content-Type": "application/msgpack",
+        "x-arc-database": database,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    total = con.execute(f"SELECT count(*) FROM ({source_sql})").fetchone()[0]
+    print(f"  ingesting {total:,} rows into {database}.{measurement} "
+          f"in chunks of {chunk_rows:,} ...")
+
+    sent, offset, t0 = 0, 0, time.time()
+    while offset < total:
+        rows = con.execute(
+            f"SELECT {', '.join(columns)} FROM ({source_sql}) "
+            f"LIMIT {chunk_rows} OFFSET {offset}"
+        ).fetchall()
+        if not rows:
+            break
+
+        # Transpose row tuples into per-column arrays (columnar payload).
+        cols = {name: [] for name in columns}
+        for r in rows:
+            for i, name in enumerate(columns):
+                cols[name].append(r[i])
+
+        payload = msgpack.packb(
+            [{"m": measurement, "columns": cols}], use_bin_type=True
+        )
+        req = urllib.request.Request(write_url, data=payload, headers=headers)
+        resp = urllib.request.urlopen(req, timeout=120)
+        if resp.status not in (200, 204):
+            raise RuntimeError(f"write failed: HTTP {resp.status} {resp.read()[:200]!r}")
+
+        sent += len(rows)
+        offset += chunk_rows
+
+    elapsed = time.time() - t0
+    rate = sent / elapsed / 1e6 if elapsed else 0
+    print(f"  done: {sent:,} rows in {elapsed:.1f}s ({rate:.2f}M rows/sec)")
+    return sent

--- a/scripts/pi-demo-data/arc_ingest.py
+++ b/scripts/pi-demo-data/arc_ingest.py
@@ -12,6 +12,7 @@ column must be epoch milliseconds (int64); Arc stores it as Timestamp(us).
 """
 
 import time
+import urllib.error
 import urllib.request
 
 import msgpack
@@ -54,31 +55,36 @@ def ingest_table(
     print(f"  ingesting {total:,} rows into {database}.{measurement} "
           f"in chunks of {chunk_rows:,} ...")
 
-    sent, offset, t0 = 0, 0, time.time()
-    while offset < total:
-        rows = con.execute(
-            f"SELECT {', '.join(columns)} FROM ({source_sql}) "
-            f"LIMIT {chunk_rows} OFFSET {offset}"
-        ).fetchall()
+    # Execute the SELECT once and stream it with fetchmany(). Looping with
+    # LIMIT/OFFSET would re-scan all preceding rows on every chunk (O(N^2));
+    # streaming a single cursor is O(N).
+    sent, t0 = 0, time.time()
+    result = con.execute(f"SELECT {', '.join(columns)} FROM ({source_sql})")
+    while True:
+        rows = result.fetchmany(chunk_rows)
         if not rows:
             break
 
         # Transpose row tuples into per-column arrays (columnar payload).
-        cols = {name: [] for name in columns}
-        for r in rows:
-            for i, name in enumerate(columns):
-                cols[name].append(r[i])
+        cols = {name: list(values) for name, values in zip(columns, zip(*rows))}
 
         payload = msgpack.packb(
             [{"m": measurement, "columns": cols}], use_bin_type=True
         )
         req = urllib.request.Request(write_url, data=payload, headers=headers)
-        resp = urllib.request.urlopen(req, timeout=120)
-        if resp.status not in (200, 204):
-            raise RuntimeError(f"write failed: HTTP {resp.status} {resp.read()[:200]!r}")
+        try:
+            # `with` closes the response socket promptly after each request.
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                if resp.status not in (200, 204):
+                    raise RuntimeError(
+                        f"write failed: HTTP {resp.status} {resp.read()[:200]!r}"
+                    )
+        except urllib.error.HTTPError as e:
+            # urlopen raises on non-2xx; surface Arc's error body, which is
+            # otherwise lost.
+            raise RuntimeError(f"write failed: HTTP {e.code} {e.read()[:200]!r}") from e
 
         sent += len(rows)
-        offset += chunk_rows
 
     elapsed = time.time() - t0
     rate = sent / elapsed / 1e6 if elapsed else 0

--- a/scripts/pi-demo-data/generate_anomaly_data.py
+++ b/scripts/pi-demo-data/generate_anomaly_data.py
@@ -95,7 +95,7 @@ def main():
 
     # Order by time so Arc's hour-partitioning lands cleanly.
     source_sql = """
-        SELECT epoch_ms(time)::BIGINT AS time, machine, value
+        SELECT (epoch(time) * 1000)::BIGINT AS time, machine, value
         FROM vibration ORDER BY time
     """
 

--- a/scripts/pi-demo-data/generate_anomaly_data.py
+++ b/scripts/pi-demo-data/generate_anomaly_data.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Generate the anomaly-detection demo dataset and load it into Arc.
+
+3 machines x 60 days of vibration readings (mm/s), one every 5 seconds, with a
+clean baseline (daily thermal cycle + 8-hour shift cycle + sensor noise) plus
+TWO deliberately injected faults:
+
+  * compressor-01 : a sudden 6-hour excursion to ~11 mm/s on 2025-05-31
+                    (think: a valve event).
+  * pump-01       : a gradual bearing degradation over 2025-06-10..15, ramping
+                    from 4.5 up to ~7.5 mm/s, then snapping back after a repair.
+
+Result: db=`factory`, measurement=`vibration`, columns (time, machine, value).
+~3.1M rows. This is the exact dataset behind the anomaly-detection tutorial,
+so the z-score / MAD / seasonal-residual queries reproduce as written.
+
+Usage:
+    pip install duckdb msgpack
+    # start Arc (default http://localhost:8000), then:
+    python generate_anomaly_data.py
+    python generate_anomaly_data.py --arc-url http://host:8000 --token $ARC_TOKEN
+
+Pass --parquet-only to just write a local parquet and skip the Arc load.
+"""
+
+import argparse
+
+import duckdb
+
+from arc_ingest import ingest_table
+
+DATABASE = "factory"
+MEASUREMENT = "vibration"
+
+
+def build(con):
+    print("generating anomaly dataset (3 machines x 60 days @ 5s) ...")
+    # Base grid: one row per machine per 5 seconds across 60 days.
+    con.execute("""
+        CREATE TABLE base AS
+        SELECT
+          TIMESTAMP '2025-05-01 00:00:00' + INTERVAL (s) SECOND
+            + INTERVAL (CAST(random() * 2000 AS BIGINT)) MILLISECOND AS time,
+          m.machine,
+          s AS sec
+        FROM range(0, 60 * 24 * 3600, 5) t(s)
+        CROSS JOIN (VALUES ('pump-01'), ('pump-02'), ('compressor-01')) m(machine);
+    """)
+
+    # Vibration signal in mm/s: baseline 4.5 + daily + shift cycles + noise,
+    # plus the two injected faults and rare transient sensor glitches.
+    con.execute("""
+        CREATE TABLE vibration AS
+        SELECT time, machine,
+          GREATEST(0.1,
+            4.5
+            + 0.8 * sin(sec / 86400.0 * 2 * pi())          -- daily thermal cycle
+            + 0.4 * sin(sec / 28800.0 * 2 * pi())          -- 8-hour shift cycle
+            + (random() - 0.5) * 0.6                       -- sensor noise
+
+            -- FAULT 1: pump-01 bearing degradation, ramps up over 5 days
+            + CASE WHEN machine = 'pump-01'
+                   AND time BETWEEN TIMESTAMP '2025-06-10' AND TIMESTAMP '2025-06-15'
+                THEN 3.0 * (epoch(time) - epoch(TIMESTAMP '2025-06-10'))
+                          / (5 * 86400.0)
+                ELSE 0 END
+
+            -- FAULT 2: compressor-01 sudden 6-hour spike event
+            + CASE WHEN machine = 'compressor-01'
+                   AND time BETWEEN TIMESTAMP '2025-05-31 02:00:00'
+                                AND TIMESTAMP '2025-05-31 08:00:00'
+                THEN 6.5 ELSE 0 END
+
+            -- transient point glitches (rare)
+            + CASE WHEN random() < 0.0002 THEN random() * 8 ELSE 0 END
+          )::DOUBLE AS value
+        FROM base;
+    """)
+
+    n = con.execute("SELECT count(*) FROM vibration").fetchone()[0]
+    print(f"  generated {n:,} rows")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arc-url", default="http://localhost:8000")
+    ap.add_argument("--token", default=None, help="Arc write/admin token (omit if auth disabled)")
+    ap.add_argument("--parquet-only", action="store_true",
+                    help="write vibration.parquet locally and skip the Arc load")
+    args = ap.parse_args()
+
+    con = duckdb.connect()
+    build(con)
+
+    # Order by time so Arc's hour-partitioning lands cleanly.
+    source_sql = """
+        SELECT epoch_ms(time)::BIGINT AS time, machine, value
+        FROM vibration ORDER BY time
+    """
+
+    if args.parquet_only:
+        con.execute(f"COPY ({source_sql}) TO 'vibration.parquet' (FORMAT parquet)")
+        print("  wrote vibration.parquet (skipped Arc load)")
+        return
+
+    ingest_table(
+        con,
+        source_sql=source_sql,
+        measurement=MEASUREMENT,
+        database=DATABASE,
+        columns=["time", "machine", "value"],
+        arc_url=args.arc_url,
+        token=args.token,
+    )
+    print(f"\nLoaded. Try a query:\n"
+          f'  curl -X POST {args.arc_url}/api/v1/query \\\n'
+          f'    -H "content-type: application/json" -H "x-arc-database: {DATABASE}" \\\n'
+          f"""    -d '{{"sql":"SELECT machine, count(*), round(avg(value),2) FROM {MEASUREMENT} GROUP BY machine"}}'""")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pi-demo-data/generate_trend_data.py
+++ b/scripts/pi-demo-data/generate_trend_data.py
@@ -75,7 +75,7 @@ def main():
     build(con)
 
     source_sql = """
-        SELECT epoch_ms(time)::BIGINT AS time, tag, value, status
+        SELECT (epoch(time) * 1000)::BIGINT AS time, tag, value, status
         FROM sensors ORDER BY time
     """
 

--- a/scripts/pi-demo-data/generate_trend_data.py
+++ b/scripts/pi-demo-data/generate_trend_data.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Generate the PI-style trend demo dataset and load it into Arc.
+
+A high-rate historian-shaped dataset for exercising PlotValues / trend queries
+(the AF Data Reference use case): irregularly-spaced sensor readings over a full
+year, like real PI exception/compression archive data.
+
+3 tags x 365 days, one base reading every ~3 seconds with random sub-second
+jitter on the timestamps. Signal is a slow daily sine + hourly sine + noise +
+occasional spikes. ~31.5M rows.
+
+Result: db=`historian`, measurement=`sensors`, columns (time, tag, value, status).
+
+This is the dataset for the PlotValues benchmark: bucket a wide time range into
+N pixel-bins and return min/max/first/last per bin so a year-long trend renders
+from ~1000 rows instead of millions. See README.md for the PlotValues query.
+
+Usage:
+    pip install duckdb msgpack
+    # start Arc (default http://localhost:8000), then:
+    python generate_trend_data.py
+    python generate_trend_data.py --arc-url http://host:8000 --token $ARC_TOKEN
+
+Pass --parquet-only to just write a local parquet and skip the Arc load.
+Note: 31.5M rows over HTTP takes a few minutes; --parquet-only is much faster
+if you want to inspect the data locally first.
+"""
+
+import argparse
+
+import duckdb
+
+from arc_ingest import ingest_table
+
+DATABASE = "historian"
+MEASUREMENT = "sensors"
+
+
+def build(con):
+    print("generating PI-style trend dataset (3 tags x 365 days, irregular) ...")
+    # range() gives a base point every 3s; the MILLISECOND jitter makes the
+    # timestamps irregular, the way exception/compression archives are.
+    con.execute("""
+        CREATE TABLE sensors AS
+        SELECT
+          TIMESTAMP '2025-01-01 00:00:00'
+            + INTERVAL (s) SECOND
+            + INTERVAL (CAST(random() * 900 AS BIGINT)) MILLISECOND AS time,
+          tag,
+          (50
+            + 30 * sin(s / 86400.0 * 2 * pi())             -- daily cycle
+            + 5  * sin(s / 3600.0  * 2 * pi())             -- hourly cycle
+            + (random() - 0.5) * 8                         -- noise
+            + CASE WHEN random() < 0.001 THEN (random() - 0.5) * 60
+                   ELSE 0 END                              -- occasional spikes
+          )::DOUBLE AS value,
+          CASE WHEN random() < 0.0005 THEN 1 ELSE 0 END AS status  -- mostly good
+        FROM range(0, 365 * 24 * 3600, 3) t(s)
+        CROSS JOIN (VALUES ('vibration'), ('temp'), ('pressure')) tags(tag);
+    """)
+    n = con.execute("SELECT count(*) FROM sensors").fetchone()[0]
+    print(f"  generated {n:,} rows")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arc-url", default="http://localhost:8000")
+    ap.add_argument("--token", default=None, help="Arc write/admin token (omit if auth disabled)")
+    ap.add_argument("--parquet-only", action="store_true",
+                    help="write sensors.parquet locally and skip the Arc load")
+    args = ap.parse_args()
+
+    con = duckdb.connect()
+    build(con)
+
+    source_sql = """
+        SELECT epoch_ms(time)::BIGINT AS time, tag, value, status
+        FROM sensors ORDER BY time
+    """
+
+    if args.parquet_only:
+        con.execute(f"COPY ({source_sql}) TO 'sensors.parquet' (FORMAT parquet)")
+        print("  wrote sensors.parquet (skipped Arc load)")
+        return
+
+    ingest_table(
+        con,
+        source_sql=source_sql,
+        measurement=MEASUREMENT,
+        database=DATABASE,
+        columns=["time", "tag", "value", "status"],
+        arc_url=args.arc_url,
+        token=args.token,
+    )
+    print(f"\nLoaded. See README.md for the PlotValues query against "
+          f"{DATABASE}.{MEASUREMENT}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Self-contained scripts to generate synthetic sensor data and load it into Arc, for handing to a partner building a PI-style integration (a custom AF Data Reference) and for reproducing the anomaly-detection blog demo.

Lives in `scripts/pi-demo-data/`:

- **`generate_trend_data.py`** — 3 tags × 365 days, irregular timestamps, ~31.5M rows (`historian.sensors`). The PI-style historian shape for **PlotValues / trend** queries (the AF Data Reference case).
- **`generate_anomaly_data.py`** — 3 machines × 60 days @ 5s with 2 injected faults, ~3.1M rows (`factory.vibration`). The anomaly-detection dataset.
- **`arc_ingest.py`** — shared MessagePack columnar ingest helper (stdlib + `msgpack` + `duckdb`; no Arc client library needed).
- **`README.md`** — prerequisites, generate+load commands, the verified PlotValues query (with AF `PlotValues(...)` mapping), the anomaly queries, and the compaction perf tip.

Both datasets are shaped exactly as Arc stores data natively (columnar Parquet, `time`-partitioned), so query performance is representative.

## Test plan

- [x] `--parquet-only` path runs for both generators (3.1M / 31.5M rows produced)
- [x] Full load verified end-to-end against a live Arc instance (`ARC_AUTH_ENABLED=false`): anomaly dataset loaded 3.1M rows in ~2s via `/api/v1/write/msgpack`
- [x] Loaded data is queryable; per-machine stats show the injected pump-01 fault (avg 4.63 / max 14.37 vs healthy 4.50 / 13.31)
- [x] README's seasonal-residual detector flags exactly the faulty machine over the fault window (96 hours on pump-01, 0 on healthy machines)
- [x] PlotValues query verified separately against the trend dataset earlier (year trend → 1000 bins, ~118ms compacted)
- [x] Confirmed `ARC_AUTH_ENABLED` is the correct env var (viper `ARC` prefix + `.`→`_`)

## Notes

- Not product code — demo/reproduction tooling under `scripts/`. No changes to Arc itself.
- Synthetic data is dated 2025 (the demo reference year); generators have `TIMESTAMP` literals that can be adjusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)