### PR TITLE
feat(release): build macOS binaries for Homebrew tap

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -340,6 +340,24 @@ jobs:
             artifact: arc-fips-linux-arm64
             build_tags: duckdb_arrow,fips
             gofips: "v1.0.0"
+          # macOS (darwin) binaries for the Homebrew tap (basekick-labs/homebrew-tap).
+          # Standard variant only: the FIPS story is Linux/CMVP-focused, and brew
+          # users want the standard build. DuckDB links statically via CGO, so the
+          # resulting Mach-O depends only on macOS system libs (verified with
+          # otool -L) — no runtime deps for the formula. macos-14 = arm64 (Apple
+          # Silicon), macos-13 = amd64 (Intel).
+          - runner: macos-14
+            suffix: darwin-arm64
+            variant: standard
+            artifact: arc-darwin-arm64
+            build_tags: duckdb_arrow
+            gofips: ""
+          - runner: macos-13
+            suffix: darwin-amd64
+            variant: standard
+            artifact: arc-darwin-amd64
+            build_tags: duckdb_arrow
+            gofips: ""
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
@@ -461,6 +479,7 @@ jobs:
           sha256sum \
             arc-linux-amd64 arc-linux-arm64 \
             arc-fips-linux-amd64 arc-fips-linux-arm64 \
+            arc-darwin-amd64 arc-darwin-arm64 \
             > sha256sums.txt
           cat sha256sums.txt
           # SLSA generator expects base64-encoded "HASH  filename\n..." lines (sha256sum format)
@@ -1459,6 +1478,8 @@ jobs:
             release-artifacts/**/*.intoto.jsonl
             release-artifacts/**/*-linux-amd64
             release-artifacts/**/*-linux-arm64
+            release-artifacts/**/*-darwin-amd64
+            release-artifacts/**/*-darwin-arm64
           fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE_NOTES_2026.06.3.md
+++ b/RELEASE_NOTES_2026.06.3.md
@@ -2,7 +2,7 @@
 
 > **Status:** In progress.
 
-> **This is a patch release.** A single reliability fix — no new features, no breaking API changes, no schema migrations. Drop-in upgrade from v2026.06.2.
+> **This is a patch release.** A reliability fix plus macOS/Homebrew packaging — no breaking API changes and no schema migrations. Drop-in upgrade from v2026.06.2.
 
 ## Reliability fix
 
@@ -13,3 +13,41 @@ The cause was a subtle string-lifetime detail at the request boundary. Arc's wri
 The behavior only showed up under concurrency with buffer reuse, so a steady or moderate write stream was very unlikely to see it, while a rapid burst of large payloads alongside other concurrent writers could hit it more often. It touched the MessagePack, line-protocol (native and InfluxDB-compatible), TLE, and bulk-import (CSV / Parquet / line-protocol / TLE) write paths. Reads and queries were never affected. There are no configuration, API, or on-disk format changes, and the fix is a drop-in upgrade.
 
 If you happen to find rows under an unexpected database or measurement directory after running heavy concurrent ingest on an earlier version, those files are ordinary, intact Parquet and can simply be re-ingested once you're on 26.06.3.
+
+## Deployment
+
+**Install Arc on macOS with Homebrew.** Arc is now available through a Homebrew tap, so macOS users can install and update the `arc` binary with one command:
+
+```bash
+brew install basekick-labs/tap/arc
+```
+
+or, equivalently:
+
+```bash
+brew tap basekick-labs/tap
+brew install arc
+```
+
+Then start the server:
+
+```bash
+arc            # listens on http://localhost:8000
+arc --help
+```
+
+The release now builds native **macOS binaries** for both Apple Silicon (`arc-darwin-arm64`) and Intel (`arc-darwin-amd64`), alongside the existing Linux binaries, `.deb`/`.rpm` packages, container images, and Helm chart. Like every other release binary, the macOS binaries are built on GitHub-hosted runners and **cosign-signed** with keyless OIDC (a `.bundle` signature sidecar is attached to the release for offline verification). DuckDB is statically linked into the binary, so the Homebrew install has **no runtime dependencies** — it drops a single self-contained `arc` executable into your Homebrew prefix.
+
+The formula installs the standard (non-FIPS) build, which is the right choice for local development and evaluation on macOS. The FIPS variant remains a Linux/CMVP-focused build distributed as a container image and Linux packages; see the FIPS deployment guide. Linux users should continue to use the `.deb`/`.rpm`, container, or Helm artifacts from the [release page](https://github.com/basekick-labs/arc/releases).
+
+The tap lives at [github.com/basekick-labs/homebrew-tap](https://github.com/basekick-labs/homebrew-tap); the formula is updated automatically on each Arc release.
+
+## Upgrade notes
+
+1. **No configuration change required.** Drop in the new binary; existing `arc.toml` and license keys work as-is.
+2. **macOS Homebrew users:** if you previously installed Arc by downloading a binary manually, you can switch to the tap with `brew install basekick-labs/tap/arc`. Homebrew will manage the binary and future updates from then on.
+3. **Active licenses keep working.** No re-activation or license-key reissuance is required.
+
+## Dependencies
+
+No product dependency changes in this release. The macOS build uses the same Go toolchain, build tags (`duckdb_arrow`), and static-DuckDB linkage as the existing Linux builds.

--- a/RELEASE_NOTES_2026.06.3.md
+++ b/RELEASE_NOTES_2026.06.3.md
@@ -26,8 +26,10 @@ or, equivalently:
 
 ```bash
 brew tap basekick-labs/tap
-brew install arc
+brew install --formula arc
 ```
+
+(The `--formula` flag is needed because `arc` is also the name of a Homebrew *cask* — the Arc browser — so a bare `brew install arc` after tapping would be ambiguous. The fully-qualified `brew install basekick-labs/tap/arc` above has no such ambiguity.)
 
 Then start the server:
 

--- a/RELEASE_NOTES_2026.06.3.md
+++ b/RELEASE_NOTES_2026.06.3.md
@@ -38,7 +38,7 @@ arc --help
 
 The release now builds native **macOS binaries** for both Apple Silicon (`arc-darwin-arm64`) and Intel (`arc-darwin-amd64`), alongside the existing Linux binaries, `.deb`/`.rpm` packages, container images, and Helm chart. Like every other release binary, the macOS binaries are built on GitHub-hosted runners and **cosign-signed** with keyless OIDC (a `.bundle` signature sidecar is attached to the release for offline verification). DuckDB is statically linked into the binary, so the Homebrew install has **no runtime dependencies** — it drops a single self-contained `arc` executable into your Homebrew prefix.
 
-The formula installs the standard (non-FIPS) build, which is the right choice for local development and evaluation on macOS. The FIPS variant remains a Linux/CMVP-focused build distributed as a container image and Linux packages; see the FIPS deployment guide. Linux users should continue to use the `.deb`/`.rpm`, container, or Helm artifacts from the [release page](https://github.com/basekick-labs/arc/releases).
+The formula installs the standard (non-FIPS) build, which is the right choice for local development and evaluation on macOS. The FIPS variant remains a Linux/CMVP-focused build distributed as a container image and Linux packages; see the [FIPS 140-3 mode guide](https://docs.basekick.net/docs/configuration/fips). Linux users should continue to use the `.deb`/`.rpm`, container, or Helm artifacts from the [release page](https://github.com/basekick-labs/arc/releases).
 
 The tap lives at [github.com/basekick-labs/homebrew-tap](https://github.com/basekick-labs/homebrew-tap); the formula is updated automatically on each Arc release.
 


### PR DESCRIPTION
## Summary

- Adds native **macOS binary builds** to the release workflow so `brew install` can work: `darwin-arm64` (macos-14 / Apple Silicon) and `darwin-amd64` (macos-13 / Intel), standard variant only.
- DuckDB links **statically** via CGO — the resulting Mach-O depends only on macOS system libraries (verified with `otool -L`), so the Homebrew formula needs no runtime deps.
- Wires the darwin binaries into the **SLSA sha256 subjects** and the release **`files:` block** (which previously listed only the Linux artifacts, so darwin would build but not attach).
- Drafts `RELEASE_NOTES_2026.06.3.md` with the `brew install basekick-labs/tap/arc` instructions.

This is the prerequisite for the `basekick-labs/homebrew-tap` (published separately). The tap formula points at the `arc-darwin-*` release assets this PR produces.

## Why standard-only (no FIPS darwin)

The FIPS build is Linux/CMVP-focused and distributed as a container image + Linux packages. Homebrew users on macOS want the standard build for local dev/eval. Adding a darwin-FIPS leg would be scope creep with no CMVP relevance.

## Test plan

- [x] `go build -tags=duckdb_arrow` builds + runs natively on macOS arm64 (verified locally; `otool -L` confirms static DuckDB, only system libs)
- [x] Workflow YAML validates; FIPS-only steps (`if: matrix.variant == 'fips'`) correctly skip for the standard darwin legs
- [x] No Linux-only commands in the shared build/sign/upload steps
- [ ] CI green on this PR (macOS runners build + sign the darwin binaries)
- [ ] Next release publishes `arc-darwin-arm64` / `arc-darwin-amd64` assets, then the tap formula checksums are filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)