### PR TITLE
fix(release): auto-generate Homebrew formula with real arm64 sha256 (#528)

### DIFF
--- a/.github/homebrew/arc.rb.tmpl
+++ b/.github/homebrew/arc.rb.tmpl
@@ -10,24 +10,26 @@
 #
 # Binary formula: downloads the prebuilt, cosign-signed macOS binary from the
 # GitHub release (built on macOS runners; DuckDB is statically linked, so the
-# binary depends only on macOS system libraries — no `depends_on`).
+# Mach-O depends only on macOS system libraries).
 #
-# Apple Silicon only: Homebrew on macOS is Apple-Silicon-only and the release
-# workflow does not build an Intel (darwin-amd64) asset.
+# Apple Silicon macOS only. The platform is declared with top-level
+# `depends_on :macos` / `depends_on arch: :arm64` (not nested on_macos/on_arm
+# blocks) so `brew install`/`brew info` on Linux or Intel macOS fails with a
+# clean "requires arm64 / macOS" message instead of the cryptic
+# `Error: arc: url is missing` you get when the only url is inside a skipped
+# platform block. The release workflow builds no Intel (darwin-amd64) asset.
 #
 # Install:  brew install basekick-labs/tap/arc
 class Arc < Formula
   desc "High-performance columnar analytical database (DuckDB/Parquet/Arrow)"
   homepage "https://github.com/basekick-labs/arc"
+  url "https://github.com/basekick-labs/arc/releases/download/v__VERSION__/arc-darwin-arm64"
   version "__VERSION__"
+  sha256 "__DARWIN_ARM64_SHA256__"
   license "AGPL-3.0-or-later"
 
-  on_macos do
-    on_arm do
-      url "https://github.com/basekick-labs/arc/releases/download/v#{version}/arc-darwin-arm64"
-      sha256 "__DARWIN_ARM64_SHA256__"
-    end
-  end
+  depends_on arch: :arm64
+  depends_on :macos
 
   def install
     # The release asset is the bare arm64 binary; install it as `arc`. Explicit

--- a/.github/homebrew/arc.rb.tmpl
+++ b/.github/homebrew/arc.rb.tmpl
@@ -30,8 +30,10 @@ class Arc < Formula
   end
 
   def install
-    # The release asset is the bare binary named per-arch; install it as `arc`.
-    bin.install Dir["arc-darwin-*"].first => "arc"
+    # The release asset is the bare arm64 binary; install it as `arc`. Explicit
+    # name (not a glob) so a missing/renamed asset fails loud naming the file,
+    # rather than Dir[...].first => nil raising a cryptic TypeError.
+    bin.install "arc-darwin-arm64" => "arc"
   end
 
   def caveats

--- a/.github/homebrew/arc.rb.tmpl
+++ b/.github/homebrew/arc.rb.tmpl
@@ -1,0 +1,54 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for Arc — high-performance columnar analytical database.
+#
+# GENERATED FILE — do not edit by hand. The release workflow
+# (.github/workflows/release-build.yml, job `homebrew-formula`) renders this
+# template with the real version and arc-darwin-arm64 sha256, then pushes it to
+# basekick-labs/homebrew-tap. Edit this template, not the tap copy.
+#
+# Binary formula: downloads the prebuilt, cosign-signed macOS binary from the
+# GitHub release (built on macOS runners; DuckDB is statically linked, so the
+# binary depends only on macOS system libraries — no `depends_on`).
+#
+# Apple Silicon only: Homebrew on macOS is Apple-Silicon-only and the release
+# workflow does not build an Intel (darwin-amd64) asset.
+#
+# Install:  brew install basekick-labs/tap/arc
+class Arc < Formula
+  desc "High-performance columnar analytical database (DuckDB/Parquet/Arrow)"
+  homepage "https://github.com/basekick-labs/arc"
+  version "__VERSION__"
+  license "AGPL-3.0-or-later"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/basekick-labs/arc/releases/download/v#{version}/arc-darwin-arm64"
+      sha256 "__DARWIN_ARM64_SHA256__"
+    end
+  end
+
+  def install
+    # The release asset is the bare binary named per-arch; install it as `arc`.
+    bin.install Dir["arc-darwin-*"].first => "arc"
+  end
+
+  def caveats
+    <<~EOS
+      Arc stores data locally by default under ./data/arc (relative to CWD).
+      Start the server:  arc
+      Then it listens on http://localhost:8000 (see `arc --help`).
+
+      Docs: https://docs.basekick.net/arc
+    EOS
+  end
+
+  test do
+    # `arc` boots a server rather than offering a --version-only flag, so the
+    # smoke test asserts the binary is present and Mach-O executable. A fuller
+    # test (boot + /health) would require backgrounding the server.
+    assert_predicate bin/"arc", :executable?
+    assert_match "Mach-O", shell_output("file #{bin}/arc")
+  end
+end

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1511,3 +1511,109 @@ jobs:
           echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
           echo "1. Review release notes" >> $GITHUB_STEP_SUMMARY
           echo "2. Publish when ready" >> $GITHUB_STEP_SUMMARY
+
+  # Render the Homebrew formula from .github/homebrew/arc.rb.tmpl with the real
+  # version + arc-darwin-arm64 sha256, then push it to basekick-labs/homebrew-tap.
+  #
+  # WHY THIS EXISTS: 26.06.3 shipped a formula with a REPLACE_WITH_DARWIN_ARM64_SHA256
+  # placeholder (the tap was hand-edited, nothing filled the checksum), so
+  # `brew install arc` failed with a checksum mismatch (#528). Templating the
+  # formula from the built artifact's real hash makes that class of bug impossible.
+  #
+  # The darwin arm64 binary's sha256 is fixed at build time and does not change
+  # when the draft release is later published, so computing it here (before manual
+  # publish) is correct — the asset URL the formula points at resolves once the
+  # release is published.
+  #
+  # REQUIRES the repo secret HOMEBREW_TAP_TOKEN: a fine-grained PAT (or GitHub App
+  # token) with contents:write on basekick-labs/homebrew-tap. GITHUB_TOKEN is
+  # scoped to this repo only and cannot push to the tap. The job no-ops (does not
+  # fail the release) if the secret is absent, so forks and misconfigured runs
+  # don't break the pipeline.
+  homebrew-formula:
+    name: Update Homebrew Tap Formula
+    runs-on: ubuntu-latest
+    needs: [prepare, build-binaries, create-draft-release]
+    # Never push to the production tap from a workflow_dispatch test_mode run:
+    # the formula's url points at v{version}, which for a test run is a draft
+    # (unpublished) asset — brew would 404. Mirrors the `latest` Docker-tag guard.
+    if: needs.prepare.outputs.test_mode != 'true'
+    steps:
+      - name: Check for tap token
+        id: gate
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN not set — skipping Homebrew formula update. Add a fine-grained PAT with contents:write on basekick-labs/homebrew-tap to enable."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout arc (for template)
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v5
+
+      - name: Download darwin arm64 binary
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          name: arc-binary-standard-darwin-arm64
+          path: ./darwin
+
+      - name: Render formula
+        if: steps.gate.outputs.enabled == 'true'
+        id: render
+        run: |
+          VERSION=${{ needs.prepare.outputs.version }}
+          SHA=$(sha256sum ./darwin/arc-darwin-arm64 | awk '{print $1}')
+          echo "Computed arc-darwin-arm64 sha256: ${SHA}"
+          if [ -z "${SHA}" ] || [ ${#SHA} -ne 64 ]; then
+            echo "::error::Failed to compute a valid sha256 for arc-darwin-arm64"
+            exit 1
+          fi
+          mkdir -p out
+          sed -e "s/__VERSION__/${VERSION}/g" \
+              -e "s/__DARWIN_ARM64_SHA256__/${SHA}/g" \
+              .github/homebrew/arc.rb.tmpl > out/arc.rb
+          # Fail loudly if any placeholder survived templating.
+          if grep -qE '__VERSION__|__DARWIN_ARM64_SHA256__|REPLACE_WITH' out/arc.rb; then
+            echo "::error::Rendered formula still contains a placeholder"
+            cat out/arc.rb
+            exit 1
+          fi
+          echo "----- rendered formula -----"
+          cat out/arc.rb
+
+      - name: Checkout tap
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: basekick-labs/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Commit and push formula
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: tap
+        run: |
+          VERSION=${{ needs.prepare.outputs.version }}
+          mkdir -p Formula
+          cp ../out/arc.rb Formula/arc.rb
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Stage first, then gate on the staged diff: `git diff --quiet` ignores
+          # untracked files, so a brand-new Formula/arc.rb (fresh tap, renamed
+          # path) would be seen as "no change" and silently skipped. --cached
+          # detects both new and modified files.
+          git add Formula/arc.rb
+          if git diff --cached --quiet -- Formula/arc.rb; then
+            echo "Formula already up to date for ${VERSION}; nothing to commit."
+            exit 0
+          fi
+          git commit \
+            -m "chore(arc): update formula to ${VERSION}" \
+            -m "Rendered by the arc release workflow from the built arc-darwin-arm64 artifact's sha256. Do not edit by hand — edit .github/homebrew/arc.rb.tmpl in Basekick-Labs/arc instead."
+          git push
+          echo "✅ Pushed Homebrew formula for ${VERSION} to basekick-labs/homebrew-tap" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Fixes #528 — `brew install arc` failed with a checksum mismatch because the 26.06.3 tap formula shipped with a literal `REPLACE_WITH_DARWIN_ARM64_SHA256` placeholder. The tap was hand-edited and **nothing in CI ever filled the real checksum**.
- The formula also carried a dead `on_intel` block for `arc-darwin-amd64` — a build dropped in 1c5cc2b (that asset doesn't exist).
- Adds a committed, arm64-only formula template (`.github/homebrew/arc.rb.tmpl`) and a `homebrew-formula` release-workflow job that **renders it from the built `arc-darwin-arm64` artifact's real sha256** and pushes to `basekick-labs/homebrew-tap`. Fail-loud if any placeholder survives templating → this bug class can't reship.

### Job safety properties
- **No-ops without the secret** — gates on `HOMEBREW_TAP_TOKEN`; forks / misconfigured runs don't break the release.
- **Skips `test_mode` dispatch runs** — a test run's formula url points at an unpublished draft asset (brew would 404). Mirrors the existing `latest` Docker-tag guard.
- **Stages before the no-op guard** — `git add` then `git diff --cached --quiet`, so a brand-new formula file (fresh tap / renamed path) still commits (`git diff --quiet` alone ignores untracked files).

## ⚠️ Required manual step before this works
Add a repo secret **`HOMEBREW_TAP_TOKEN`**: a fine-grained PAT (or GitHub App token) with **`contents:write` on `basekick-labs/homebrew-tap`**. `GITHUB_TOKEN` is scoped to this repo and can't push to the tap. Until it's added, the job safely no-ops.

## Note on the live tap
The tap was **already hotfixed out-of-band** (real arm64 sha + Intel block removed) to unblock 26.06.3 users immediately — verified with `brew tap basekick-labs/tap && brew install --formula arc`. This PR prevents recurrence for all future releases.

## Test plan
- [x] Workflow YAML parses (`yaml.safe_load`)
- [x] Template renders with no surviving placeholders; output byte-identical to the verified live formula
- [x] No-op guard verified empirically: new file → commits; unchanged file → skips
- [x] Live-tap hotfix `brew install arc` succeeds (Apple Silicon)
- [x] Config matrix + deep reviewer (H-1, H-2, S-1 all fixed)
- [ ] Requires `HOMEBREW_TAP_TOKEN` secret to exercise the push in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)