### PR TITLE
fix(cluster): strip client forwarding headers + harden loop guard (CVE-2026-45045 class)

### DIFF
--- a/RELEASE_NOTES_2026.06.4.md
+++ b/RELEASE_NOTES_2026.06.4.md
@@ -1,0 +1,53 @@
+# Arc v2026.06.4 Release Notes
+
+> **Status:** In development.
+
+> **This is a security-hardening patch release.** Defense-in-depth on the cluster request-forwarding path, plus a routing-integrity fix for clustered deployments. No breaking API changes, no schema migrations, no configuration changes. Drop-in upgrade from v2026.06.3. **Single-node (non-clustered) deployments are unaffected by every change here** — the forwarding path they harden never executes without a cluster router.
+
+## Security hardening
+
+### Strip client-controlled forwarding headers at the inter-node boundary (CVE-2026-45045 class)
+
+Dependabot flagged [CVE-2026-45045 / GHSA-gcfq-8gqf-4876](https://github.com/advisories/GHSA-gcfq-8gqf-4876) in GoFiber: the `BalancerForward` proxy helper injects `X-Real-IP` with `Header.Add()` instead of `Header.Set()`, appending the real client IP as a *second* header value so upstreams that read the first value trust an attacker-supplied IP.
+
+**Arc is not affected by the CVE itself.** Arc does not import or use GoFiber's `middleware/proxy` package — `BalancerForward` is not compiled into the binary (verified against the full build graph). Arc's own reverse-proxy path (the cluster request router) already uses `Header.Set()` for `X-Forwarded-For`, and — critically — **no Arc code on the receiving side trusts `X-Real-IP`, `X-Forwarded-For`, `Forwarded`, or `X-Arc-Original-Host` for anything.** Client IP for audit logs, query attribution, and every other decision is derived exclusively from the TCP socket via Fiber's `c.IP()`, and Fiber is not configured to trust proxy headers (`EnableTrustedProxyCheck` / `ProxyHeader` are unset). So the spoofing primitive the CVE describes has no consumer in Arc.
+
+Because there is **no patched GoFiber v2 release** to bump to (the fix landed only in v3), and because migrating the entire HTTP layer to Fiber v3 would be disproportionate for a vulnerability that does not affect us, we have instead **closed the vulnerability class directly in Arc's own code** as defense-in-depth:
+
+- When a clustered node forwards a write or query to a peer, it now **strips all client-supplied forwarding/identity headers** before the request leaves the node: `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-Port`, `Forwarded` (RFC 7239), `X-Arc-Forwarded-By`, `X-Arc-Original-Host`, `X-Arc-Shard-Routed`, and the CDN client-IP headers `True-Client-IP`, `CF-Connecting-IP`, and `X-Client-IP`. The forwarding node re-establishes the trustworthy values itself from the socket peer and its own node identity.
+- This guarantees a peer can never receive an attacker-injected forwarding header, keeping the "nothing downstream trusts these" property true regardless of what future code on a receiving node might choose to read.
+
+Legitimate end-to-end headers (`Authorization`, `Content-Type`, `x-arc-database`, custom application headers, and non-identity multi-value headers such as `Via`) are unchanged and still forwarded verbatim.
+
+### Routing-integrity fix: `X-Arc-Forwarded-By` loop guard is no longer client-influenceable
+
+While hardening the forwarding path we found a related, lower-severity issue reachable in **clustered** deployments. Arc uses the `X-Arc-Forwarded-By` header as a loop guard: a request that already carries it is treated as "already forwarded, handle locally." That header is client-settable, and the check ran *before* the node's capability check. An **authenticated** caller could therefore set `X-Arc-Forwarded-By` on a direct request to a node that cannot serve it locally (e.g. a write to a reader node, or a query to a compactor node) and suppress the forward — forcing the node onto a local path that is structurally guaranteed to fail.
+
+This was never a privilege escalation, data-exposure, or cross-tenant issue — the peer re-authenticates the forwarded `Authorization` token, and identity is always socket-derived. It was a self-inflicted routing break available only to already-authenticated callers (CWE-290, authentication-bypass-by-spoofing class, but bounded to routing behavior).
+
+The fix reorders the decision so the header can no longer force a doomed local path:
+
+- If the node **can** serve the request type locally, it does — the `X-Arc-Forwarded-By` header is not consulted at all (the common case).
+- If the node **cannot** serve locally and the request carries the marker, this is a genuine routing loop *or* a spoofed header; the node now returns a deterministic **`508 Loop Detected`** (`request already forwarded and cannot be served by this node`) instead of silently attempting local processing.
+- If the node cannot serve locally and there is no marker, it forwards to a capable peer as before.
+
+Genuine peer-to-peer loops (which should never happen in a healthy cluster) now terminate cleanly with the same clear error instead of a confusing local failure.
+
+## Impact by deployment mode
+
+| Deployment | Affected by these changes? |
+|---|---|
+| Single-node / OSS standalone (no cluster router) | **No.** The forwarding path never executes; behavior is byte-for-byte identical to 26.06.3. |
+| Clustered, homogeneous nodes (every node can serve every request) | Header-stripping applies to forwarded requests; loop-guard reorder is a no-op because nodes serve locally. |
+| Clustered with role separation (reader / writer / compactor) | Header-stripping applies; a spoofed or looped `X-Arc-Forwarded-By` on a non-capable node now returns `508` instead of a failed local attempt. |
+
+## Upgrade notes
+
+1. **No configuration change required.** Drop in the new binary; existing `arc.toml` and license keys work as-is.
+2. **No API or on-disk format changes.** Reads, queries, and storage layout are untouched.
+3. **Clustered operators:** if any external tooling deliberately sets `X-Arc-Forwarded-By`, `X-Real-IP`, or `X-Forwarded-*` headers on requests to Arc and expects them to survive an inter-node forward, note that these are now stripped on the forwarding hop and re-established by Arc. Client IP has never been derived from these headers, so log/audit attribution is unchanged.
+4. **Active licenses keep working.** No re-activation required.
+
+## Dependencies
+
+No product dependency changes in this release. GoFiber remains at `v2.52.13`; Dependabot alert #12 (CVE-2026-45045) is addressed by the in-code hardening above rather than a dependency bump, because no patched v2 release exists and the vulnerable code path (`middleware/proxy.BalancerForward`) is not present in Arc's build graph.

--- a/internal/api/lineprotocol.go
+++ b/internal/api/lineprotocol.go
@@ -187,7 +187,14 @@ func (h *LineProtocolHandler) handleWrite(c *fiber.Ctx, database string, precisi
 
 	// Check if this request should be forwarded to a writer node
 	// Reader nodes cannot process writes locally, so they forward to writers
-	if h.router != nil && ShouldForwardWrite(h.router, c) {
+	switch WriteForwardDecision(h.router, c) {
+	case ForwardAlreadyForwarded:
+		// Already-forwarded marker on a node that cannot ingest locally:
+		// a routing loop or a spoofed X-Arc-Forwarded-By header. Return a
+		// deterministic error instead of a doomed local write attempt.
+		h.totalErrors.Add(1)
+		return RespondAlreadyForwarded(c)
+	case ForwardToPeer:
 		h.logger.Debug().Msg("Forwarding Line Protocol write request to writer node")
 
 		httpReq, err := BuildHTTPRequest(c)

--- a/internal/api/msgpack.go
+++ b/internal/api/msgpack.go
@@ -171,7 +171,13 @@ func (h *MsgPackHandler) RegisterRoutes(app *fiber.App) {
 func (h *MsgPackHandler) writeMsgPack(c *fiber.Ctx) error {
 	// Check if this request should be forwarded to a writer node
 	// Reader nodes cannot process writes locally, so they forward to writers
-	if h.router != nil && ShouldForwardWrite(h.router, c) {
+	switch WriteForwardDecision(h.router, c) {
+	case ForwardAlreadyForwarded:
+		// Already-forwarded marker on a node that cannot ingest locally:
+		// a routing loop or a spoofed X-Arc-Forwarded-By header. Return a
+		// deterministic error instead of a doomed local write attempt.
+		return RespondAlreadyForwarded(c)
+	case ForwardToPeer:
 		h.logger.Debug().Msg("Forwarding write request to writer node")
 
 		httpReq, err := BuildHTTPRequest(c)

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1374,7 +1374,14 @@ func (h *QueryHandler) executeQuery(c *fiber.Ctx) error {
 
 	// Check if this request should be forwarded to a reader/writer node
 	// Compactor nodes cannot process queries locally, so they forward to readers/writers
-	if ShouldForwardQuery(h.router, c) {
+	switch QueryForwardDecision(h.router, c) {
+	case ForwardAlreadyForwarded:
+		// Already-forwarded marker on a node that cannot serve queries
+		// locally: a routing loop or a spoofed X-Arc-Forwarded-By header.
+		// Return a deterministic error instead of a doomed local attempt.
+		m.IncQueryErrors()
+		return RespondAlreadyForwarded(c)
+	case ForwardToPeer:
 		h.logger.Debug().Msg("Forwarding query request to reader/writer node")
 
 		httpReq, err := BuildHTTPRequest(c)

--- a/internal/api/routing.go
+++ b/internal/api/routing.go
@@ -32,6 +32,48 @@ func isHopByHop(header string) bool {
 	return hopByHopHeaders[header]
 }
 
+// clientForwardingHeaders are client-controlled forwarding / identity
+// headers that MUST NOT be propagated verbatim from an inbound client
+// request onto an inter-node forward. The forwarding node re-establishes
+// the trustworthy values itself (internal/cluster/router.go Sets
+// X-Forwarded-For, X-Arc-Forwarded-By, X-Arc-Original-Host from the socket
+// peer and local node identity), so passing the client's copies through
+// would let a caller inject spoofed values a peer might log or, in future
+// code, trust — the same failure class as CVE-2026-45045 (X-Real-IP
+// spoofing). Arc trusts none of these on the receive side today (identity
+// is derived only from the socket via fiber c.IP()); stripping them here
+// is defense-in-depth that keeps that property true regardless of what a
+// downstream node later chooses to read.
+//
+// Keys are in http.CanonicalHeaderKey form (the VisitAll callback
+// canonicalises before lookup).
+// If future receive-side code ever derives client identity from a header
+// (a custom Fiber ProxyHeader, or a CDN client-IP header), that header MUST
+// be added here so a client cannot pre-seed it across a forward hop.
+var clientForwardingHeaders = map[string]bool{
+	"X-Real-Ip":           true, // canonical form of X-Real-IP
+	"X-Forwarded-For":     true,
+	"X-Forwarded-Host":    true,
+	"X-Forwarded-Proto":   true,
+	"X-Forwarded-Port":    true,
+	"Forwarded":           true, // RFC 7239
+	"X-Arc-Forwarded-By":  true, // internal loop marker; only the peer may set it
+	"X-Arc-Original-Host": true,
+	"X-Arc-Shard-Routed":  true, // internal shard-loop marker
+	// CDN / proxy client-IP headers. Not read by Arc today (identity is
+	// socket-only), stripped defensively so they cannot be trusted later.
+	"True-Client-Ip":   true, // canonical form of True-Client-IP (Akamai/Cloudflare)
+	"Cf-Connecting-Ip": true, // canonical form of CF-Connecting-IP (Cloudflare)
+	"X-Client-Ip":      true, // canonical form of X-Client-IP
+}
+
+// isClientForwardingHeader reports whether a canonicalised header key is a
+// client-controlled forwarding/identity header stripped at the forward
+// boundary. See clientForwardingHeaders.
+func isClientForwardingHeader(canonicalKey string) bool {
+	return clientForwardingHeaders[canonicalKey]
+}
+
 // BuildHTTPRequest converts a Fiber context to a net/http Request for
 // forwarding via the router.
 //
@@ -94,7 +136,9 @@ func BuildHTTPRequest(c *fiber.Ctx) (*http.Request, error) {
 	// Add (not Set) preserves multi-value headers: fasthttp emits a
 	// separate VisitAll callback per value, so Set would overwrite
 	// earlier values and only the last would forward. Affects Via,
-	// X-Forwarded-For, Accept (multiple content types), and similar.
+	// Accept (multiple content types), and similar. (Client forwarding
+	// headers like X-Forwarded-For are stripped below, so they are not
+	// among the multi-value headers preserved here.)
 	//
 	// http.CanonicalHeaderKey before isHopByHop lookup: fasthttp
 	// normalises header keys to canonical form by default, but a
@@ -117,6 +161,14 @@ func BuildHTTPRequest(c *fiber.Ctx) (*http.Request, error) {
 	c.Request().Header.VisitAll(func(key, value []byte) {
 		k := http.CanonicalHeaderKey(string(key))
 		if isHopByHop(k) || k == "Content-Length" || k == "Host" {
+			return
+		}
+		// Strip client-controlled forwarding/identity headers. The
+		// forwarding node re-establishes the trustworthy values itself
+		// (router.go), so a client cannot inject spoofed X-Real-IP /
+		// X-Forwarded-* / X-Arc-* onto the inter-node hop. Same class as
+		// CVE-2026-45045. See clientForwardingHeaders.
+		if isClientForwardingHeader(k) {
 			return
 		}
 		req.Header[k] = append(req.Header[k], string(value))
@@ -154,46 +206,96 @@ func CopyResponse(c *fiber.Ctx, resp *http.Response) error {
 	return c.Send(body)
 }
 
-// ShouldForwardWrite checks if a write request should be forwarded to another node.
-// Returns true if the request should be forwarded (local node cannot handle writes).
-// Returns false if:
-//   - Router is nil (no clustering)
-//   - Request is already forwarded (loop prevention)
-//   - Local node can handle writes
-func ShouldForwardWrite(router *cluster.Router, c *fiber.Ctx) bool {
-	// No router means no clustering - process locally
+// ForwardDecision is the outcome of the pre-handler routing check. It
+// separates the two reasons a request is not forwarded — "handle it here"
+// versus "it was already forwarded and this node still cannot serve it" —
+// so the second case produces a deterministic error instead of silently
+// falling through to a local path that is structurally guaranteed to fail.
+//
+// Splitting these two cases is also what makes the X-Arc-Forwarded-By loop
+// guard non-abusable. The header is client-settable (it survives at the
+// HTTP boundary and is only overwritten on the *outbound* forward in
+// internal/cluster/router.go), so an authenticated caller can set it on a
+// direct request. Previously that collapsed into "do not forward" and the
+// node then attempted local processing it could not complete — a
+// client-triggered routing bypass / self-inflicted failure. Now a present
+// header on a node that cannot route locally yields ForwardAlreadyForwarded,
+// which the handler answers with a clear 508-style error. A genuine
+// peer->peer loop terminates the same way. On a node that *can* serve
+// locally the header is irrelevant and ignored entirely (the common case).
+type ForwardDecision int
+
+const (
+	// ForwardLocal: handle the request on this node.
+	ForwardLocal ForwardDecision = iota
+	// ForwardToPeer: forward the request to another node.
+	ForwardToPeer
+	// ForwardAlreadyForwarded: the request carries the forwarded-by marker
+	// but this node cannot serve it locally — a loop or a spoofed header.
+	// The handler must return an error, never fall through to local.
+	ForwardAlreadyForwarded
+)
+
+// decideForward centralizes the routing decision for both writes and
+// queries. isWrite selects the capability checked on the local node.
+func decideForward(router *cluster.Router, c *fiber.Ctx, isWrite bool) ForwardDecision {
+	// No router means no clustering - process locally.
 	if router == nil {
-		return false
+		return ForwardLocal
 	}
 
-	// Check for forwarding loop - if X-Arc-Forwarded-By is set, this request was already forwarded
+	// A node that can serve this request type locally always does so.
+	// The X-Arc-Forwarded-By header is irrelevant here and is NOT
+	// consulted — this keeps a client-supplied value from having any
+	// effect on the common (capable-node) path.
+	if router.CanRouteLocally(isWrite) {
+		return ForwardLocal
+	}
+
+	// This node cannot serve locally. If the request is already marked as
+	// forwarded, forwarding it again would loop; and because the marker is
+	// client-settable, honoring it as "handle locally" would let a caller
+	// force a doomed local path. Surface a deterministic error instead.
 	if c.Get(ForwardedByHeader) != "" {
-		return false
+		return ForwardAlreadyForwarded
 	}
 
-	// Check if local node can handle writes
-	return !router.CanRouteLocally(true) // isWrite=true
+	return ForwardToPeer
 }
 
-// ShouldForwardQuery checks if a query request should be forwarded to another node.
-// Returns true if the request should be forwarded (local node cannot handle queries).
-// Returns false if:
-//   - Router is nil (no clustering)
-//   - Request is already forwarded (loop prevention)
-//   - Local node can handle queries
+// ShouldForwardWrite reports whether a write request should be forwarded to
+// another node. It returns true only for ForwardToPeer; ForwardLocal and
+// ForwardAlreadyForwarded both return false. Callers that need to
+// distinguish the already-forwarded case (to emit an error rather than fall
+// through to local processing) should use WriteForwardDecision instead.
+func ShouldForwardWrite(router *cluster.Router, c *fiber.Ctx) bool {
+	return decideForward(router, c, true) == ForwardToPeer
+}
+
+// ShouldForwardQuery reports whether a query request should be forwarded to
+// another node. See ShouldForwardWrite for the return-value semantics.
 func ShouldForwardQuery(router *cluster.Router, c *fiber.Ctx) bool {
-	// No router means no clustering - process locally
-	if router == nil {
-		return false
-	}
+	return decideForward(router, c, false) == ForwardToPeer
+}
 
-	// Check for forwarding loop - if X-Arc-Forwarded-By is set, this request was already forwarded
-	if c.Get(ForwardedByHeader) != "" {
-		return false
-	}
+// WriteForwardDecision returns the full routing decision for a write.
+func WriteForwardDecision(router *cluster.Router, c *fiber.Ctx) ForwardDecision {
+	return decideForward(router, c, true)
+}
 
-	// Check if local node can handle queries
-	return !router.CanRouteLocally(false) // isWrite=false
+// QueryForwardDecision returns the full routing decision for a query.
+func QueryForwardDecision(router *cluster.Router, c *fiber.Ctx) ForwardDecision {
+	return decideForward(router, c, false)
+}
+
+// RespondAlreadyForwarded writes the error returned when a node receives a
+// request marked as already-forwarded that it cannot serve locally (a
+// routing loop or a spoofed X-Arc-Forwarded-By header). Uses 508 Loop
+// Detected so the condition is distinguishable from a transient 503.
+func RespondAlreadyForwarded(c *fiber.Ctx) error {
+	return c.Status(fiber.StatusLoopDetected).JSON(fiber.Map{
+		"error": "request already forwarded and cannot be served by this node",
+	})
 }
 
 // HandleRoutingError returns an appropriate error response for routing failures.

--- a/internal/api/routing_test.go
+++ b/internal/api/routing_test.go
@@ -98,8 +98,13 @@ func TestBuildHTTPRequest_PreservesMultiValueHeaders(t *testing.T) {
 	})
 
 	req := httptest.NewRequest("GET", "/test", nil)
-	// X-Forwarded-For: three proxy hops, each adds its own value.
-	// Via: two proxies in the chain.
+	// X-Forwarded-For: three proxy hops. As a client-controlled
+	// forwarding header it is now STRIPPED at the forward boundary
+	// (CVE-2026-45045 class hardening) — the forwarding node re-sets a
+	// single trusted value from the socket peer in router.go. See
+	// clientForwardingHeaders.
+	// Via: two proxies in the chain — NOT a forwarding/identity header,
+	// so it must still be preserved multi-value and in order.
 	req.Header.Add("X-Forwarded-For", "203.0.113.1")
 	req.Header.Add("X-Forwarded-For", "198.51.100.7")
 	req.Header.Add("X-Forwarded-For", "192.0.2.42")
@@ -111,13 +116,15 @@ func TestBuildHTTPRequest_PreservesMultiValueHeaders(t *testing.T) {
 	defer resp.Body.Close()
 	require.Equal(t, fiber.StatusOK, resp.StatusCode)
 
-	// Equal (not ElementsMatch): order matters for X-Forwarded-For and
-	// Via — each represents the sequential path of proxy hops, with
-	// leftmost = original client. Reordering corrupts rate-limit /
-	// geo / audit trails downstream. (Gemini PR #463 round 7.)
-	assert.Equal(t,
-		[]string{"203.0.113.1", "198.51.100.7", "192.0.2.42"}, capturedXFF,
-		"X-Forwarded-For values not preserved in chain order")
+	// Client-supplied X-Forwarded-For must not survive onto the
+	// inter-node forward — the forwarding node establishes the trusted
+	// value itself.
+	assert.Empty(t, capturedXFF,
+		"client X-Forwarded-For must be stripped at the forward boundary")
+
+	// Equal (not ElementsMatch): order matters for Via — it represents
+	// the sequential path of proxy hops. Multi-value preservation for
+	// non-forwarding headers is unchanged (Gemini PR #463 round 7).
 	assert.Equal(t,
 		[]string{"1.1 proxy1.example.com", "1.1 proxy2.example.com"}, capturedVia,
 		"Via values not preserved in chain order")
@@ -332,6 +339,119 @@ func TestShouldForwardQuery(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+// routerForRole builds a minimal Router whose local node has the given
+// role, so CanRouteLocally reflects that role's capabilities. No registry
+// or transport is needed because these tests only exercise the pre-forward
+// decision, never an actual forward.
+func routerForRole(role cluster.NodeRole) *cluster.Router {
+	return cluster.NewRouter(&cluster.RouterConfig{
+		LocalNode: cluster.NewNode("local", "Local", role, "test-cluster"),
+		Logger:    zerolog.Nop(),
+	})
+}
+
+// TestForwardDecision_ClientCannotForceLocal pins the CVE-2026-45045-class
+// hardening on the loop guard: a client-supplied X-Arc-Forwarded-By must
+// NOT let a caller force a node that cannot serve the request locally onto
+// a doomed local path. On a non-capable node a present marker yields
+// ForwardAlreadyForwarded (deterministic error), and on a capable node the
+// marker is ignored entirely.
+func TestForwardDecision_ClientCannotForceLocal(t *testing.T) {
+	tests := []struct {
+		name        string
+		role        cluster.NodeRole
+		isWrite     bool
+		forwardedBy string
+		want        ForwardDecision
+	}{
+		// Reader cannot ingest.
+		{"reader write, no marker -> forward", cluster.RoleReader, true, "", ForwardToPeer},
+		{"reader write, spoofed marker -> already-forwarded", cluster.RoleReader, true, "spoofed", ForwardAlreadyForwarded},
+		// Writer can ingest: marker is irrelevant, always local.
+		{"writer write, no marker -> local", cluster.RoleWriter, true, "", ForwardLocal},
+		{"writer write, spoofed marker -> local (marker ignored)", cluster.RoleWriter, true, "spoofed", ForwardLocal},
+		// Compactor cannot query.
+		{"compactor query, no marker -> forward", cluster.RoleCompactor, false, "", ForwardToPeer},
+		{"compactor query, spoofed marker -> already-forwarded", cluster.RoleCompactor, false, "spoofed", ForwardAlreadyForwarded},
+		// Reader can query: marker irrelevant.
+		{"reader query, spoofed marker -> local (marker ignored)", cluster.RoleReader, false, "spoofed", ForwardLocal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := fiber.New()
+			router := routerForRole(tt.role)
+			var got ForwardDecision
+			method := "GET"
+			if tt.isWrite {
+				method = "POST"
+			}
+			app.Add(method, "/decide", func(c *fiber.Ctx) error {
+				got = decideForward(router, c, tt.isWrite)
+				return c.SendStatus(fiber.StatusOK)
+			})
+
+			req := httptest.NewRequest(method, "/decide", nil)
+			if tt.forwardedBy != "" {
+				req.Header.Set(ForwardedByHeader, tt.forwardedBy)
+			}
+			_, err := app.Test(req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestBuildHTTPRequest_StripsClientForwardingHeaders pins that every
+// client-controlled forwarding/identity header is removed at the forward
+// boundary (CVE-2026-45045 class). The forwarding node re-establishes the
+// trusted values itself in internal/cluster/router.go.
+func TestBuildHTTPRequest_StripsClientForwardingHeaders(t *testing.T) {
+	app := fiber.New()
+
+	stripped := []string{
+		"X-Real-IP",
+		"X-Forwarded-For",
+		"X-Forwarded-Host",
+		"X-Forwarded-Proto",
+		"X-Forwarded-Port",
+		"Forwarded",
+		"X-Arc-Forwarded-By",
+		"X-Arc-Original-Host",
+		"X-Arc-Shard-Routed",
+		"True-Client-IP",
+		"CF-Connecting-IP",
+		"X-Client-IP",
+	}
+
+	var built *http.Request
+	app.Get("/test", func(c *fiber.Ctx) error {
+		var err error
+		built, err = BuildHTTPRequest(c)
+		require.NoError(t, err)
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	for _, h := range stripped {
+		req.Header.Set(h, "attacker-value")
+	}
+	// A legitimate end-to-end header must still pass through.
+	req.Header.Set("X-Arc-Database", "mydb")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	for _, h := range stripped {
+		assert.Empty(t, built.Header.Values(h),
+			"client-supplied %s must be stripped at the forward boundary", h)
+	}
+	assert.Equal(t, "mydb", built.Header.Get("X-Arc-Database"),
+		"legitimate application header must survive forwarding")
 }
 
 func TestHandleRoutingError(t *testing.T) {

--- a/internal/api/tle.go
+++ b/internal/api/tle.go
@@ -99,7 +99,14 @@ func (h *TLEHandler) handleWrite(c *fiber.Ctx) error {
 	}
 
 	// Check if this request should be forwarded to a writer node
-	if h.router != nil && ShouldForwardWrite(h.router, c) {
+	switch WriteForwardDecision(h.router, c) {
+	case ForwardAlreadyForwarded:
+		// Already-forwarded marker on a node that cannot ingest locally:
+		// a routing loop or a spoofed X-Arc-Forwarded-By header. Return a
+		// deterministic error instead of a doomed local write attempt.
+		h.totalErrors.Add(1)
+		return RespondAlreadyForwarded(c)
+	case ForwardToPeer:
 		h.logger.Debug().Msg("Forwarding TLE write request to writer node")
 
 		httpReq, err := BuildHTTPRequest(c)


### PR DESCRIPTION
## Summary

- Dependabot flagged [CVE-2026-45045 / GHSA-gcfq-8gqf-4876](https://github.com/advisories/GHSA-gcfq-8gqf-4876) in GoFiber (`X-Real-IP` spoofing via `Header.Add` in `BalancerForward`). **Arc is not affected by the CVE itself:** it does not import GoFiber's `middleware/proxy` (verified — not in the build graph), and nothing on the receive side trusts `X-Real-IP` / `X-Forwarded-*` (identity is socket-only via `c.IP()`; Fiber has no `EnableTrustedProxyCheck`/`ProxyHeader`). There is **no patched `fiber/v2` release** to bump to, so this closes the vulnerability *class* directly in Arc's own code as defense-in-depth.
- **Header stripping (defense-in-depth):** `BuildHTTPRequest` now strips client-controlled forwarding/identity headers before an inter-node forward — `X-Real-IP`, `X-Forwarded-For/Host/Proto/Port`, `Forwarded` (RFC 7239), `X-Arc-Forwarded-By`, `X-Arc-Original-Host`, `X-Arc-Shard-Routed`, and CDN client-IP headers `True-Client-IP` / `CF-Connecting-IP` / `X-Client-IP`. The forwarding node re-establishes the trusted values itself (`router.go`).
- **Loop-guard routing-integrity fix:** `decideForward()` makes the `X-Arc-Forwarded-By` loop guard **capability-first**. A capable node ignores the (client-settable) marker; a non-capable node carrying the marker returns **`508 Loop Detected`** instead of silently attempting a doomed local path. This closes an authenticated-only routing-integrity issue (CWE-290, bounded to routing behavior) reachable in role-separated clusters. The 508 path is unreachable via legitimate forwarding (peers only forward to capable targets).

**Single-node / OSS deployments are unaffected** — the forwarding path only executes with a cluster router.

## Not in scope

Adjacent to #504 item 2 (`doForward` forwarding client `Authorization`/`x-api-key` to peers) but **does not address it** — kept separate to avoid an RBAC regression (the receiving peer re-authenticates and RBAC-checks using the forwarded token). #504 reopened for that follow-up.

## Test plan

- [x] `go build ./cmd/... ./internal/...` clean
- [x] `gofmt -l` clean, `go vet ./internal/api/...` clean
- [x] `go test ./internal/api/... ./internal/cluster/...` pass (routing subset under `-race` too)
- [x] New tests: `TestForwardDecision_ClientCannotForceLocal` (capability-first ordering across reader/writer/compactor × marker), `TestBuildHTTPRequest_StripsClientForwardingHeaders` (all 12 stripped headers + legit header survives); updated `TestBuildHTTPRequest_PreservesMultiValueHeaders`
- [x] Ran the binary single-node: writes (204) + query (200) succeed with a spoofed `X-Arc-Forwarded-By` correctly ignored
- [x] Config matrix (6 rows) + failure-semantics table + deep reviewer + security-checklist reviewer + adversarial check — no Blockers/High/Medium
- [x] Release notes: `RELEASE_NOTES_2026.06.4.md`

Closes the remediation for Dependabot alert #12 (to be dismissed as not-affected + in-code hardening once merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)