### PR TITLE
fix(iceberg): warehouseRelKey must trim the storage root, not the warehouse

### DIFF
--- a/internal/iceberg/exporter.go
+++ b/internal/iceberg/exporter.go
@@ -541,14 +541,31 @@ func (e *Exporter) writeVersionHint(ctx context.Context, tbl *icetable.Table) {
 	}
 }
 
-// warehouseRelKey converts a full metadata URI to a STORAGE-RELATIVE key (backend Read/Write
-// operate on relative keys). Returns ok=false if the URI isn't under the warehouse root.
+// warehouseRelKey converts a full metadata URI to a STORAGE-RELATIVE key, since backend
+// Read/Write operate on keys relative to the STORAGE ROOT — not to the warehouse. Returns
+// ok=false if the URI isn't under the configured warehouse.
 //
-//	metaLoc="file:///wh/arc_db.db/cpu/metadata/00004-<uuid>.metadata.json", warehouse="file:///wh"
-//	-> "arc_db.db/cpu/metadata/00004-<uuid>.metadata.json"
+// The two bases coincide only when iceberg.warehouse is the storage root (the default), so
+// trimming the warehouse silently produced a key missing the warehouse's own path segment
+// whenever an operator pointed iceberg.warehouse at a SUBDIRECTORY — the version-hint and
+// v<N>.metadata.json copies then landed outside the warehouse, where directory-based readers
+// (DuckDB, Spark) could not resolve the current snapshot. Gate on the warehouse, trim the root.
+//
+//	storage root "file:///data", warehouse "file:///data/wh",
+//	metaLoc "file:///data/wh/arc_db.db/cpu/metadata/00004-<uuid>.metadata.json"
+//	-> "wh/arc_db.db/cpu/metadata/00004-<uuid>.metadata.json"
 func (e *Exporter) warehouseRelKey(metaLoc string) (string, bool) {
-	rel := strings.TrimPrefix(metaLoc, e.warehouse)
+	if !strings.HasPrefix(metaLoc, e.warehouse) {
+		return "", false
+	}
+	// No backend (tests/no-op mode): warehouse is the only base we have.
+	if e.backend == nil {
+		return strings.TrimPrefix(strings.TrimPrefix(metaLoc, e.warehouse), "/"), true
+	}
+	root := DefaultWarehouse(e.backend)
+	rel := strings.TrimPrefix(metaLoc, root)
 	if rel == metaLoc {
+		// Warehouse is outside the storage root entirely — the backend cannot address it.
 		return "", false
 	}
 	return strings.TrimPrefix(rel, "/"), true

--- a/internal/iceberg/exporter.go
+++ b/internal/iceberg/exporter.go
@@ -555,7 +555,7 @@ func (e *Exporter) writeVersionHint(ctx context.Context, tbl *icetable.Table) {
 //	metaLoc "file:///data/wh/arc_db.db/cpu/metadata/00004-<uuid>.metadata.json"
 //	-> "wh/arc_db.db/cpu/metadata/00004-<uuid>.metadata.json"
 func (e *Exporter) warehouseRelKey(metaLoc string) (string, bool) {
-	if !strings.HasPrefix(metaLoc, e.warehouse) {
+	if !isUnderDir(metaLoc, e.warehouse) {
 		return "", false
 	}
 	// No backend (tests/no-op mode): warehouse is the only base we have.
@@ -563,12 +563,21 @@ func (e *Exporter) warehouseRelKey(metaLoc string) (string, bool) {
 		return strings.TrimPrefix(strings.TrimPrefix(metaLoc, e.warehouse), "/"), true
 	}
 	root := DefaultWarehouse(e.backend)
-	rel := strings.TrimPrefix(metaLoc, root)
-	if rel == metaLoc {
+	if !isUnderDir(metaLoc, root) {
 		// Warehouse is outside the storage root entirely — the backend cannot address it.
 		return "", false
 	}
-	return strings.TrimPrefix(rel, "/"), true
+	return strings.TrimPrefix(strings.TrimPrefix(metaLoc, root), "/"), true
+}
+
+// isUnderDir reports whether p is dir itself or lies beneath it, matching only at a path
+// boundary. A bare strings.HasPrefix would accept a sibling whose name merely starts with dir's
+// ("file:///data/wh" would match "file:///data/wh-other/…"), which for warehouseRelKey means
+// accepting another warehouse's metadata as our own — and pruneOldVersionFiles DELETES files
+// under the key it derives, so the gate has to match on real path segments.
+func isUnderDir(p, dir string) bool {
+	dir = strings.TrimSuffix(dir, "/")
+	return p == dir || strings.HasPrefix(p, dir+"/")
 }
 
 // parseVersionAndMetaDir derives, from a full metadata-file URI, the version integer (e.g.

--- a/internal/iceberg/scheduler_test.go
+++ b/internal/iceberg/scheduler_test.go
@@ -499,3 +499,52 @@ func TestMergeSchemas(t *testing.T) {
 		t.Error("expected an error for a conflicting type on column 'host', got nil")
 	}
 }
+
+// TestCustomWarehouseSubdir covers iceberg.warehouse pointed at a SUBDIRECTORY of the storage
+// root (a supported config: the key defaults to the storage root but operators can override it).
+// backend Read/Write take keys relative to the STORAGE ROOT, not the warehouse — trimming the
+// warehouse instead dropped its own path segment, so version-hint.text and the v<N> copies
+// landed outside the warehouse and directory-based readers (DuckDB/Spark) could not resolve the
+// current snapshot.
+func TestCustomWarehouseSubdir(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	backend, err := storage.NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeArcStyleParquet(t, filepath.Join(root, "mydb/cpu/2023/11/14/22/a.parquet"), 1_700_000_000_000_000, 20)
+
+	db, err := sql.Open("sqlite3", filepath.Join(root, "arc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Warehouse is <root>/warehouse, NOT <root>.
+	exp, err := NewExporter(db, backend, "file://"+filepath.Join(root, "warehouse"), "arc", 3, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sched := NewScheduler(SchedulerConfig{Exporter: exp, Source: NewStorageWalkSource(backend, "arc"), Logger: zerolog.Nop()})
+	sched.runPass(ctx)
+
+	// version-hint.text must live INSIDE the configured warehouse.
+	hint := filepath.Join(root, "warehouse", "arc_mydb.db", "cpu", "metadata", "version-hint.text")
+	if _, err := os.Stat(hint); err != nil {
+		t.Fatalf("version-hint.text not inside the configured warehouse: %v", err)
+	}
+	// ...and must NOT have leaked to the storage root (the pre-fix behaviour).
+	if _, err := os.Stat(filepath.Join(root, "arc_mydb.db", "cpu", "metadata", "version-hint.text")); err == nil {
+		t.Error("version-hint.text leaked to the storage root, outside the configured warehouse")
+	}
+
+	// The table must still be readable/registered (the file made it into the table).
+	lt, err := exp.EnsureTable(ctx, "mydb", "cpu", ArcSchema{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f, _ := exp.tableDataFiles(ctx, lt); len(f) != 1 {
+		t.Errorf("want 1 file registered with a custom warehouse, got %d", len(f))
+	}
+}

--- a/internal/iceberg/scheduler_test.go
+++ b/internal/iceberg/scheduler_test.go
@@ -521,8 +521,9 @@ func TestCustomWarehouseSubdir(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Warehouse is <root>/warehouse, NOT <root>.
-	exp, err := NewExporter(db, backend, "file://"+filepath.Join(root, "warehouse"), "arc", 3, zerolog.Nop())
+	// Warehouse is <root>/warehouse, NOT <root>. Built via localFileURI so it matches what
+	// DefaultWarehouse produces (absolute + forward slashes) on every platform.
+	exp, err := NewExporter(db, backend, localFileURI(filepath.Join(root, "warehouse")), "arc", 3, zerolog.Nop())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -546,5 +547,38 @@ func TestCustomWarehouseSubdir(t *testing.T) {
 	}
 	if f, _ := exp.tableDataFiles(ctx, lt); len(f) != 1 {
 		t.Errorf("want 1 file registered with a custom warehouse, got %d", len(f))
+	}
+}
+
+// TestIsUnderDir pins the path-boundary matching that warehouseRelKey's gate depends on. A bare
+// strings.HasPrefix accepts a sibling directory whose name merely starts with the warehouse's
+// ("file:///data/wh" vs "file:///data/wh-other"), which would let another warehouse's metadata
+// be treated as ours — and pruneOldVersionFiles deletes files under the derived key.
+func TestIsUnderDir(t *testing.T) {
+	const dir = "file:///data/wh"
+	tests := []struct {
+		p    string
+		want bool
+	}{
+		{"file:///data/wh", true}, // the dir itself
+		{"file:///data/wh/arc_db.db/cpu/metadata/v1.metadata.json", true}, // beneath it
+		{"file:///data/wh/", true},                                        // trailing slash
+		// Siblings that share a name prefix must NOT match.
+		{"file:///data/wh-other/arc_db.db/cpu/metadata/v1.metadata.json", false},
+		{"file:///data/wharf/x.json", false},
+		{"file:///data/whx", false},
+		// Unrelated / parent paths.
+		{"file:///data/other/x.json", false},
+		{"file:///data", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isUnderDir(tt.p, dir); got != tt.want {
+			t.Errorf("isUnderDir(%q, %q) = %v, want %v", tt.p, dir, got, tt.want)
+		}
+	}
+	// A dir configured WITH a trailing slash must behave identically.
+	if !isUnderDir("file:///data/wh/a.json", "file:///data/wh/") {
+		t.Error("isUnderDir should normalize a trailing slash on dir")
 	}
 }


### PR DESCRIPTION
Follow-up to #532, from a Gemini finding on the #533 tracking PR. Real bug, reproduced before fixing.

## Summary

- Storage backends' `Read`/`Write` take keys relative to the **storage root**, but `warehouseRelKey` trimmed `e.warehouse`. Those two bases are the same string only when `iceberg.warehouse` is the storage root — which is the default, and is why every test and every prior binary run missed this.
- Pointing `iceberg.warehouse` at a **subdirectory** (a supported config: the key exists and is passed straight through when set) silently dropped that subdirectory from every key. `version-hint.text` and the `v<N>.metadata.json` reader copies landed at the storage root instead of inside the warehouse, so directory-based readers (DuckDB, Spark) could not resolve the current snapshot.
- Fix: keep gating on the warehouse prefix (unchanged "is this ours?" semantics), but derive the key by trimming `DefaultWarehouse(e.backend)`.
- Also returns `ok=false` when the warehouse sits entirely outside the storage root — the backend cannot address it, and the suggested patch would have produced a key that silently escaped the root.

## Reproduced first

With `warehouse=<root>/warehouse`:

```
before: version-hint.text -> <root>/arc_mydb.db/cpu/metadata/version-hint.text          (leaked to root)
after:  version-hint.text -> <root>/warehouse/arc_mydb.db/cpu/metadata/version-hint.text (correct)
```

## Test plan

- [x] `TestCustomWarehouseSubdir` regression test: hint lands inside the configured warehouse, does **not** leak to the storage root, and the data file is still registered.
- [x] Full `internal/iceberg` suite green under `-race` (default-warehouse path unaffected).
- [x] `gofmt` / `go vet` / `go build -tags duckdb_arrow ./cmd/... ./internal/...` clean.
- [x] **Binary-verified** with `iceberg.warehouse` set to a subdirectory: warehouse writes under `data/warehouse/`, nothing leaks to the storage root, and `duckdb iceberg_scan` resolves via `version-hint.text` and reads 40 rows — the exact path that failed before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)