### PR TITLE
fix(pruning): cap partition-path generation to defuse amplification DoS (#536)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -1,0 +1,67 @@
+# Arc v2026.09.1 Release Notes
+
+> **Status:** In development.
+
+## Security hardening
+
+### Strip client-controlled forwarding headers at the inter-node boundary (CVE-2026-45045 class)
+
+Dependabot flagged [CVE-2026-45045 / GHSA-gcfq-8gqf-4876](https://github.com/advisories/GHSA-gcfq-8gqf-4876) in GoFiber: the `BalancerForward` proxy helper injects `X-Real-IP` with `Header.Add()` instead of `Header.Set()`, appending the real client IP as a *second* header value so upstreams that read the first value trust an attacker-supplied IP.
+
+**Arc is not affected by the CVE itself.** Arc does not import or use GoFiber's `middleware/proxy` package — `BalancerForward` is not compiled into the binary (verified against the full build graph). Arc's own reverse-proxy path (the cluster request router) already uses `Header.Set()` for `X-Forwarded-For`, and — critically — **no Arc code on the receiving side trusts `X-Real-IP`, `X-Forwarded-For`, `Forwarded`, or `X-Arc-Original-Host` for anything.** Client IP for audit logs, query attribution, and every other decision is derived exclusively from the TCP socket via Fiber's `c.IP()`, and Fiber is not configured to trust proxy headers (`EnableTrustedProxyCheck` / `ProxyHeader` are unset). So the spoofing primitive the CVE describes has no consumer in Arc.
+
+Because there is **no patched GoFiber v2 release** to bump to (the fix landed only in v3), and because migrating the entire HTTP layer to Fiber v3 would be disproportionate for a vulnerability that does not affect us, we have instead **closed the vulnerability class directly in Arc's own code** as defense-in-depth:
+
+- When a clustered node forwards a write or query to a peer, it now **strips all client-supplied forwarding/identity headers** before the request leaves the node: `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-Port`, `Forwarded` (RFC 7239), `X-Arc-Forwarded-By`, `X-Arc-Original-Host`, `X-Arc-Shard-Routed`, and the CDN client-IP headers `True-Client-IP`, `CF-Connecting-IP`, and `X-Client-IP`. The forwarding node re-establishes the trustworthy values itself from the socket peer and its own node identity.
+- This guarantees a peer can never receive an attacker-injected forwarding header, keeping the "nothing downstream trusts these" property true regardless of what future code on a receiving node might choose to read.
+
+Legitimate end-to-end headers (`Authorization`, `Content-Type`, `x-arc-database`, custom application headers, and non-identity multi-value headers such as `Via`) are unchanged and still forwarded verbatim.
+
+### Routing-integrity fix: `X-Arc-Forwarded-By` loop guard is no longer client-influenceable
+
+While hardening the forwarding path we found a related, lower-severity issue reachable in **clustered** deployments. Arc uses the `X-Arc-Forwarded-By` header as a loop guard: a request that already carries it is treated as "already forwarded, handle locally." That header is client-settable, and the check ran *before* the node's capability check. An **authenticated** caller could therefore set `X-Arc-Forwarded-By` on a direct request to a node that cannot serve it locally (e.g. a write to a reader node, or a query to a compactor node) and suppress the forward — forcing the node onto a local path that is structurally guaranteed to fail.
+
+This was never a privilege escalation, data-exposure, or cross-tenant issue — the peer re-authenticates the forwarded `Authorization` token, and identity is always socket-derived. It was a self-inflicted routing break available only to already-authenticated callers (CWE-290, authentication-bypass-by-spoofing class, but bounded to routing behavior).
+
+The fix reorders the decision so the header can no longer force a doomed local path:
+
+- If the node **can** serve the request type locally, it does — the `X-Arc-Forwarded-By` header is not consulted at all (the common case).
+- If the node **cannot** serve locally and the request carries the marker, this is a genuine routing loop *or* a spoofed header; the node now returns a deterministic **`508 Loop Detected`** (`request already forwarded and cannot be served by this node`) instead of silently attempting local processing.
+- If the node cannot serve locally and there is no marker, it forwards to a capable peer as before.
+
+Genuine peer-to-peer loops (which should never happen in a healthy cluster) now terminate cleanly with the same clear error instead of a confusing local failure.
+
+### Partition-pruner amplification DoS: cap path generation, floor the start date, cancel on disconnect ([#536](https://github.com/Basekick-Labs/arc/issues/536))
+
+The query partition pruner (`internal/pruning`) generated one storage path per hour plus one per day across a query's time range, with **no upper bound on the number of paths, no start-date floor, and no cancellation**. A single small request with a very wide range — e.g. `WHERE time >= '0001-01-01'` — forced the server to materialize on the order of a million path strings and then glob (local) or LIST (S3/Azure) every one of them: an amplification DoS turning one HTTP request into large server CPU, memory, and object-storage LIST billing.
+
+The fix closes the amplification at three points:
+
+- **Path-count cap.** Path generation is now bounded by a hard cap (`maxPartitionPaths = 50,000`, ~5 years of hourly pruning). The count is estimated *before* any allocation; a range over the cap returns no paths and the query falls back to the single unpruned `/**/*.parquet` glob — correct results, just not partition-pruned. Millions of path strings are never allocated.
+- **Epoch floor on the start date.** A query start earlier than `1970-01-01 UTC` is clamped up to the epoch before path generation. Arc has no data before the epoch, so clamping is lossless — a legitimate multi-decade range still prunes from 1970 through its end, no rows dropped — while the degenerate unbounded-downward case (`0001-01-01`) can no longer drive a huge pre-data range.
+- **Cancellation on client disconnect.** Path generation now honors the request `context.Context`; a client disconnect or deadline aborts the loop instead of running to completion server-side.
+
+Separately, the pruner's two internal TTL caches (glob results and partition paths) are now **bounded**: expired entries are evicted on read, and each cache refuses new keys past a `10,000`-entry cap (after first dropping expired entries). This closes a slow-growth vector where an attacker varying the time literal per request pinned attacker-controlled memory for the process lifetime.
+
+Reachable in every deployment mode (the pruner runs on every `FROM`/`JOIN` query); pre-existing on `main`, unrelated to any other work in this release.
+
+## Impact by deployment mode
+
+The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.
+
+| Deployment | Forwarding-header / loop-guard changes | Partition-pruner DoS fix (#536) |
+|---|---|---|
+| Single-node / OSS standalone (no cluster router) | **No.** The forwarding path never executes; behavior is byte-for-byte identical to 26.06.3. | **Yes.** Applies to every query. |
+| Clustered, homogeneous nodes (every node can serve every request) | Header-stripping applies to forwarded requests; loop-guard reorder is a no-op because nodes serve locally. | **Yes.** Applies to every query. |
+| Clustered with role separation (reader / writer / compactor) | Header-stripping applies; a spoofed or looped `X-Arc-Forwarded-By` on a non-capable node now returns `508` instead of a failed local attempt. | **Yes.** Applies to every query. |
+
+## Upgrade notes
+
+1. **No configuration change required.** Drop in the new binary; existing `arc.toml` and license keys work as-is. The partition-pruner limits (#536) are hardcoded safety bounds, not tunable config keys.
+2. **No API or on-disk format changes.** Reads, queries, and storage layout are untouched. Queries with a start date earlier than `1970-01-01` are pruned from the epoch forward; since Arc stores no pre-epoch data, results are unchanged.
+3. **Clustered operators:** if any external tooling deliberately sets `X-Arc-Forwarded-By`, `X-Real-IP`, or `X-Forwarded-*` headers on requests to Arc and expects them to survive an inter-node forward, note that these are now stripped on the forwarding hop and re-established by Arc. Client IP has never been derived from these headers, so log/audit attribution is unchanged.
+4. **Active licenses keep working.** No re-activation required.
+
+## Dependencies
+
+No product dependency changes in this release. GoFiber remains at `v2.52.13`; Dependabot alert #12 (CVE-2026-45045) is addressed by the in-code hardening above rather than a dependency bump, because no patched v2 release exists and the vulnerable code path (`middleware/proxy.BalancerForward`) is not present in Arc's build graph.

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1520,7 +1520,7 @@ localProcessing:
 	}
 
 	// Convert SQL to storage paths and check for parallel execution opportunity
-	convertedSQL, parallelInfo, cached := h.getTransformedSQLForParallel(req.SQL, headerDB)
+	convertedSQL, parallelInfo, cached := h.getTransformedSQLForParallel(c.Context(), req.SQL, headerDB)
 
 	if h.debugEnabled {
 		h.logger.Debug().
@@ -2181,7 +2181,7 @@ var ioTableFunctionPattern = regexp.MustCompile(`(?i)\b(` + strings.Join([]strin
 // getTransformedSQL returns the transformed SQL with caching.
 // If headerDB is non-empty, uses the optimized path with that database for all tables.
 // Returns the transformed SQL and whether it was a cache hit.
-func (h *QueryHandler) getTransformedSQL(sql string, headerDB string) (string, bool) {
+func (h *QueryHandler) getTransformedSQL(ctx context.Context, sql string, headerDB string) (string, bool) {
 	// Fast path: queries already using read_parquet don't need transformation
 	sqlLower := strings.ToLower(sql)
 	if strings.Contains(sqlLower, "read_parquet") {
@@ -2208,9 +2208,9 @@ func (h *QueryHandler) getTransformedSQL(sql string, headerDB string) (string, b
 	// Transform using appropriate method
 	var transformed string
 	if headerDB != "" {
-		transformed = h.convertSQLToStoragePathsWithHeaderDB(sql, headerDB)
+		transformed = h.convertSQLToStoragePathsWithHeaderDB(ctx, sql, headerDB)
 	} else {
-		transformed = h.convertSQLToStoragePaths(sql)
+		transformed = h.convertSQLToStoragePaths(ctx, sql)
 	}
 
 	h.queryCache.Set(cacheKey, transformed)
@@ -2221,7 +2221,7 @@ func (h *QueryHandler) getTransformedSQL(sql string, headerDB string) (string, b
 // This variant checks if the query can benefit from parallel partition scanning.
 // Only simple single-table queries with header DB can use parallel execution.
 // Returns (sql, parallel_info, cache_hit).
-func (h *QueryHandler) getTransformedSQLForParallel(sql string, headerDB string) (string, *ParallelQueryInfo, bool) {
+func (h *QueryHandler) getTransformedSQLForParallel(ctx context.Context, sql string, headerDB string) (string, *ParallelQueryInfo, bool) {
 	sqlLower := strings.ToLower(sql)
 
 	// Fast paths that don't support parallel execution
@@ -2235,7 +2235,7 @@ func (h *QueryHandler) getTransformedSQLForParallel(sql string, headerDB string)
 	// Parallel execution only supported for simple single-table queries with header DB
 	// Complex queries (JOINs, subqueries, CTEs) fall back to standard execution
 	if headerDB == "" || !isSingleTableQuery(sqlLower) || strings.Contains(sqlLower, "with ") {
-		transformed, cached := h.getTransformedSQL(sql, headerDB)
+		transformed, cached := h.getTransformedSQL(ctx, sql, headerDB)
 		return transformed, nil, cached
 	}
 
@@ -2243,7 +2243,7 @@ func (h *QueryHandler) getTransformedSQLForParallel(sql string, headerDB string)
 	// SUBSTRING/TRIM/OVERLAY need the slow path's FROM-keyword mask.
 	features := scanSQLFeatures(sql)
 	if features.hasQuotes || features.hasDashComment || features.hasBlockComment || sqlutil.ContainsFromKeywordFunction(sql) {
-		transformed, cached := h.getTransformedSQL(sql, headerDB)
+		transformed, cached := h.getTransformedSQL(ctx, sql, headerDB)
 		return transformed, nil, cached
 	}
 
@@ -2255,7 +2255,7 @@ func (h *QueryHandler) getTransformedSQLForParallel(sql string, headerDB string)
 	}
 
 	// Use parallel-aware conversion
-	convertedSQL, parallelInfo := h.convertSingleTableQueryForParallel(sql, sqlLower, headerDB)
+	convertedSQL, parallelInfo := h.convertSingleTableQueryForParallel(ctx, sql, sqlLower, headerDB)
 	return convertedSQL, parallelInfo, false
 }
 
@@ -2266,7 +2266,7 @@ func (h *QueryHandler) getTransformedSQLForParallel(sql string, headerDB string)
 // Converts: JOIN measurement -> JOIN read_parquet('path/**/*.parquet')
 // CTE names are extracted and excluded from conversion to avoid replacing virtual table references.
 // String literals and comments are protected from regex matching.
-func (h *QueryHandler) convertSQLToStoragePaths(sql string) string {
+func (h *QueryHandler) convertSQLToStoragePaths(ctx context.Context, sql string) string {
 	originalSQL := sql
 
 	// Phase 0a: Rewrite regex functions to faster string functions BEFORE masking
@@ -2314,7 +2314,7 @@ func (h *QueryHandler) convertSQLToStoragePaths(sql string) string {
 			return match
 		}
 		path := h.getStoragePath(parts[1], parts[2])
-		return h.buildReadParquetExpr(path, originalSQL, "FROM")
+		return h.buildReadParquetExpr(ctx, path, originalSQL, "FROM")
 	})
 
 	// Handle JOIN database.table references (includes LATERAL JOIN)
@@ -2324,7 +2324,7 @@ func (h *QueryHandler) convertSQLToStoragePaths(sql string) string {
 			return match
 		}
 		path := h.getStoragePath(parts[1], parts[2])
-		return h.buildReadParquetExpr(path, originalSQL, "JOIN")
+		return h.buildReadParquetExpr(ctx, path, originalSQL, "JOIN")
 	})
 
 	// Handle FROM simple_table references
@@ -2357,7 +2357,7 @@ func (h *QueryHandler) convertSQLToStoragePaths(sql string) string {
 		}
 
 		path := h.getStoragePath("default", parts[1])
-		return h.buildReadParquetExpr(path, originalSQL, "FROM")
+		return h.buildReadParquetExpr(ctx, path, originalSQL, "FROM")
 	})
 
 	// Handle JOIN simple_table references (includes LATERAL JOIN)
@@ -2390,7 +2390,7 @@ func (h *QueryHandler) convertSQLToStoragePaths(sql string) string {
 		}
 
 		path := h.getStoragePath("default", parts[1])
-		return h.buildReadParquetExpr(path, originalSQL, "JOIN")
+		return h.buildReadParquetExpr(ctx, path, originalSQL, "JOIN")
 	})
 
 	// Restore masked FROM keywords and string literals. Both use content-
@@ -2440,7 +2440,7 @@ type ParallelQueryInfo struct {
 // buildReadParquetExpr builds a read_parquet expression with optional partition pruning.
 // keyword is "FROM" or "JOIN" to prepend to the result.
 // If tiering is enabled and cold tier has data, builds a UNION ALL query across tiers.
-func (h *QueryHandler) buildReadParquetExpr(path, originalSQL, keyword string) string {
+func (h *QueryHandler) buildReadParquetExpr(ctx context.Context, path, originalSQL, keyword string) string {
 	// Check if tiering is enabled and cold tier is configured
 	if h.tieringManager != nil {
 		router := h.tieringManager.GetRouter()
@@ -2467,7 +2467,7 @@ func (h *QueryHandler) buildReadParquetExpr(path, originalSQL, keyword string) s
 	options := buildReadParquetOptions()
 
 	// Apply partition pruning
-	optimizedPath, wasOptimized := h.pruner.OptimizeTablePath(path, originalSQL)
+	optimizedPath, wasOptimized := h.pruner.OptimizeTablePath(ctx, path, originalSQL)
 
 	if wasOptimized {
 		// Check if it's a list of paths or a single path
@@ -2496,7 +2496,7 @@ func (h *QueryHandler) buildReadParquetExpr(path, originalSQL, keyword string) s
 // buildReadParquetExprForMeasurement builds a read_parquet expression for a database/measurement pair.
 // This is the tiering-aware version used by the fast path that takes database and measurement
 // separately instead of a pre-constructed path, allowing proper tiering metadata lookup.
-func (h *QueryHandler) buildReadParquetExprForMeasurement(database, measurement, originalSQL, keyword string) string {
+func (h *QueryHandler) buildReadParquetExprForMeasurement(ctx context.Context, database, measurement, originalSQL, keyword string) string {
 	// Check if tiering is enabled and cold tier is configured
 	if h.tieringManager != nil {
 		router := h.tieringManager.GetRouter()
@@ -2517,17 +2517,17 @@ func (h *QueryHandler) buildReadParquetExprForMeasurement(database, measurement,
 
 	// Fall back to single-tier behavior (hot tier only)
 	path := h.getStoragePath(database, measurement)
-	return h.buildReadParquetExpr(path, originalSQL, keyword)
+	return h.buildReadParquetExpr(ctx, path, originalSQL, keyword)
 }
 
 // buildReadParquetExprForParallel builds a read_parquet expression and returns
 // parallel execution info if the query can benefit from parallel partition scanning.
 // Returns (sql_expression, parallel_info) where parallel_info is non-nil if parallel is recommended.
-func (h *QueryHandler) buildReadParquetExprForParallel(path, originalSQL, keyword string) (string, *ParallelQueryInfo) {
+func (h *QueryHandler) buildReadParquetExprForParallel(ctx context.Context, path, originalSQL, keyword string) (string, *ParallelQueryInfo) {
 	options := buildReadParquetOptions()
 
 	// Apply partition pruning
-	optimizedPath, wasOptimized := h.pruner.OptimizeTablePath(path, originalSQL)
+	optimizedPath, wasOptimized := h.pruner.OptimizeTablePath(ctx, path, originalSQL)
 
 	if wasOptimized {
 		if pathList, ok := optimizedPath.([]string); ok {
@@ -2729,7 +2729,7 @@ func (h *QueryHandler) buildMultiTierReadParquet(database, measurement string, t
 
 // convertSingleTableQuery is a fast path for simple single-table queries.
 // It avoids regex entirely by using simple string manipulation.
-func (h *QueryHandler) convertSingleTableQuery(sql, sqlLower, database string) string {
+func (h *QueryHandler) convertSingleTableQuery(ctx context.Context, sql, sqlLower, database string) string {
 	// Find "FROM table" position
 	idx := strings.Index(sqlLower, "from ")
 	if idx < 0 {
@@ -2761,14 +2761,14 @@ func (h *QueryHandler) convertSingleTableQuery(sql, sqlLower, database string) s
 	}
 
 	// Build replacement - use tiering-aware method that checks both hot and cold tiers
-	replacement := h.buildReadParquetExprForMeasurement(database, tableName, sql, "FROM")
+	replacement := h.buildReadParquetExprForMeasurement(ctx, database, tableName, sql, "FROM")
 
 	return sql[:idx] + replacement + sql[end:]
 }
 
 // convertSingleTableQueryForParallel is a variant that returns parallel execution info.
 // Returns (converted_sql, parallel_info) where parallel_info is non-nil if parallel execution is recommended.
-func (h *QueryHandler) convertSingleTableQueryForParallel(sql, sqlLower, database string) (string, *ParallelQueryInfo) {
+func (h *QueryHandler) convertSingleTableQueryForParallel(ctx context.Context, sql, sqlLower, database string) (string, *ParallelQueryInfo) {
 	// Find "FROM table" position
 	idx := strings.Index(sqlLower, "from ")
 	if idx < 0 {
@@ -2814,7 +2814,7 @@ func (h *QueryHandler) convertSingleTableQueryForParallel(sql, sqlLower, databas
 
 	// Build replacement with parallel info (hot tier only)
 	path := h.getStoragePath(database, tableName)
-	replacement, parallelInfo := h.buildReadParquetExprForParallel(path, sql, "FROM")
+	replacement, parallelInfo := h.buildReadParquetExprForParallel(ctx, path, sql, "FROM")
 
 	convertedSQL := sql[:idx] + replacement + sql[end:]
 
@@ -2830,7 +2830,7 @@ func (h *QueryHandler) convertSingleTableQueryForParallel(sql, sqlLower, databas
 // the database specified in the x-arc-database header. This is an optimized path that
 // skips the database.table regex patterns since all tables use the header-specified database.
 // This provides ~50% reduction in regex operations compared to convertSQLToStoragePaths.
-func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(sql string, database string) string {
+func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(ctx context.Context, sql string, database string) string {
 	originalSQL := sql
 	sqlLower := strings.ToLower(sql)
 
@@ -2853,7 +2853,7 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(sql string, database
 				sql = rewriteDateTrunc(sql)
 				sqlLower = strings.ToLower(sql)
 			}
-			return h.convertSingleTableQuery(sql, sqlLower, database)
+			return h.convertSingleTableQuery(ctx, sql, sqlLower, database)
 		}
 	}
 
@@ -2919,7 +2919,7 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(sql string, database
 
 		// Use header database instead of "default"
 		path := h.getStoragePath(database, parts[1])
-		return h.buildReadParquetExpr(path, originalSQL, "FROM")
+		return h.buildReadParquetExpr(ctx, path, originalSQL, "FROM")
 	})
 
 	// Handle JOIN simple_table references - apply header database
@@ -2953,7 +2953,7 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(sql string, database
 
 		// Use header database instead of "default"
 		path := h.getStoragePath(database, parts[1])
-		return h.buildReadParquetExpr(path, originalSQL, "JOIN")
+		return h.buildReadParquetExpr(ctx, path, originalSQL, "JOIN")
 	})
 
 	// Restore masked FROM keywords and original string literals.
@@ -3470,7 +3470,7 @@ func (h *QueryHandler) estimateQuery(c *fiber.Ctx) error {
 	}
 
 	// Convert SQL to storage paths (with caching)
-	convertedSQL, _ := h.getTransformedSQL(req.SQL, headerDB)
+	convertedSQL, _ := h.getTransformedSQL(c.Context(), req.SQL, headerDB)
 
 	// Create a COUNT(*) version of the query
 	countSQL := "SELECT COUNT(*) FROM (" + convertedSQL + ") AS t"
@@ -3830,7 +3830,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 
 	// Convert SQL to storage paths (with caching)
 	// Note: This endpoint builds its own db.measurement SQL, so no header optimization
-	convertedSQL, _ := h.getTransformedSQL(sql, "")
+	convertedSQL, _ := h.getTransformedSQL(c.Context(), sql, "")
 
 	h.logger.Debug().
 		Str("measurement", measurement).

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -138,7 +138,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 
 	// Convert SQL to storage paths (with caching)
 	// If headerDB is set, uses optimized path that skips db.table regex patterns
-	convertedSQL, _ := h.getTransformedSQL(req.SQL, headerDB)
+	convertedSQL, _ := h.getTransformedSQL(c.Context(), req.SQL, headerDB)
 
 	h.logger.Debug().
 		Str("original_sql", req.SQL).

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -438,7 +438,7 @@ func TestConvertSQLWithCTE(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := h.convertSQLToStoragePaths(tt.inputSQL)
+			result := h.convertSQLToStoragePaths(context.Background(), tt.inputSQL)
 
 			for _, substr := range tt.shouldContain {
 				if !strings.Contains(result, substr) {
@@ -566,7 +566,7 @@ func TestConvertSQLToStoragePaths_FromKeywordFunctions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := h.convertSQLToStoragePaths(tt.input)
+			result := h.convertSQLToStoragePaths(context.Background(), tt.input)
 			for _, substr := range tt.shouldContain {
 				if !strings.Contains(result, substr) {
 					t.Errorf("Result should contain %q.\nInput:  %s\nResult: %s", substr, tt.input, result)
@@ -637,7 +637,7 @@ func TestConvertSQLToStoragePaths_ExtractAfterFrom(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := h.convertSQLToStoragePaths(tt.input)
+			result := h.convertSQLToStoragePaths(context.Background(), tt.input)
 			for _, substr := range tt.shouldContain {
 				if !strings.Contains(result, substr) {
 					t.Errorf("Result should contain %q.\nInput:  %s\nResult: %s", substr, tt.input, result)
@@ -662,7 +662,7 @@ func TestConvertSQLToStoragePathsWithHeaderDB_FromKeywordFunctions(t *testing.T)
 	}
 
 	input := "SELECT EXTRACT(YEAR FROM time) FROM citibike_trips"
-	result := h.convertSQLToStoragePathsWithHeaderDB(input, "mydb")
+	result := h.convertSQLToStoragePathsWithHeaderDB(context.Background(), input, "mydb")
 
 	if !strings.Contains(result, "EXTRACT(YEAR FROM time)") {
 		t.Errorf("inner EXTRACT expression was mutated.\nGot: %s", result)
@@ -1463,7 +1463,7 @@ func BenchmarkConvertSQLToStoragePaths(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				h.convertSQLToStoragePaths(tc.sql)
+				h.convertSQLToStoragePaths(context.Background(), tc.sql)
 			}
 		})
 	}
@@ -1503,16 +1503,16 @@ func BenchmarkGetTransformedSQL(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				h.queryCache.Invalidate() // Force cache miss
-				h.getTransformedSQL(tc.sql, "")
+				h.getTransformedSQL(context.Background(), tc.sql, "")
 			}
 		})
 
 		// Benchmark cache hit (pre-populated)
 		b.Run(tc.name+"_cache_hit", func(b *testing.B) {
-			h.getTransformedSQL(tc.sql, "") // Pre-populate cache
+			h.getTransformedSQL(context.Background(), tc.sql, "") // Pre-populate cache
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				h.getTransformedSQL(tc.sql, "")
+				h.getTransformedSQL(context.Background(), tc.sql, "")
 			}
 		})
 	}

--- a/internal/pruning/partition_pruner.go
+++ b/internal/pruning/partition_pruner.go
@@ -26,22 +26,26 @@ type globCacheEntry struct {
 // globCache provides a TTL cache for filepath.Glob results
 // This avoids expensive filesystem operations for repeated queries
 type globCache struct {
-	mu      sync.RWMutex
-	entries map[string]globCacheEntry
-	ttl     time.Duration
-	hits    atomic.Int64
-	misses  atomic.Int64
+	mu         sync.RWMutex
+	entries    map[string]globCacheEntry
+	ttl        time.Duration
+	maxEntries int
+	hits       atomic.Int64
+	misses     atomic.Int64
 }
 
 // newGlobCache creates a new glob cache with the specified TTL
 func newGlobCache(ttl time.Duration) *globCache {
 	return &globCache{
-		entries: make(map[string]globCacheEntry),
-		ttl:     ttl,
+		entries:    make(map[string]globCacheEntry),
+		ttl:        ttl,
+		maxEntries: maxCacheEntries,
 	}
 }
 
-// get retrieves a cached glob result if it exists and hasn't expired
+// get retrieves a cached glob result if it exists and hasn't expired.
+// Expired entries are evicted on read so that a workload with distinct
+// (path, sql) keys can't grow the map monotonically between janitor sweeps.
 func (c *globCache) get(pattern string) ([]string, bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[pattern]
@@ -54,6 +58,14 @@ func (c *globCache) get(pattern string) ([]string, bool) {
 
 	if time.Now().After(entry.expiresAt) {
 		c.misses.Add(1)
+		// Evict-on-read: remove the stale entry so it can't accumulate.
+		c.mu.Lock()
+		// Re-check under the write lock: another goroutine may have
+		// refreshed this key with a still-valid entry in the meantime.
+		if e, ok := c.entries[pattern]; ok && time.Now().After(e.expiresAt) {
+			delete(c.entries, pattern)
+		}
+		c.mu.Unlock()
 		return nil, false
 	}
 
@@ -71,11 +83,32 @@ func (c *globCache) set(pattern string, matches []string) {
 	copy(cached, matches)
 
 	c.mu.Lock()
+	// Bound the cache: if inserting a new key would exceed maxEntries,
+	// drop expired entries first, and if still full, refuse the insert.
+	// This caps attacker-controlled memory from varying the time literal
+	// per request. Refreshing an existing key is always allowed.
+	if _, exists := c.entries[pattern]; !exists && len(c.entries) >= c.maxEntries {
+		c.evictExpiredLocked()
+		if len(c.entries) >= c.maxEntries {
+			c.mu.Unlock()
+			return
+		}
+	}
 	c.entries[pattern] = globCacheEntry{
 		matches:   cached,
 		expiresAt: time.Now().Add(c.ttl),
 	}
 	c.mu.Unlock()
+}
+
+// evictExpiredLocked removes all expired entries. Caller must hold c.mu.
+func (c *globCache) evictExpiredLocked() {
+	now := time.Now()
+	for pattern, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, pattern)
+		}
+	}
 }
 
 // invalidate removes all entries from the cache
@@ -153,6 +186,37 @@ const GlobCacheTTL = 30 * time.Second
 // PartitionCacheTTL is the default TTL for partition path caching (60 seconds)
 const PartitionCacheTTL = 60 * time.Second
 
+// maxCacheEntries bounds the number of live keys in each of the glob and
+// partition caches. Without a cap, an attacker varying the time literal per
+// request produces distinct (path, sql) keys that grow the maps for the
+// process lifetime (see #536 and the comment on StartCleanup). At this size
+// the two caches together hold on the order of a few MB even with long paths;
+// well above any realistic dashboard's distinct-query working set.
+const maxCacheEntries = 10_000
+
+// maxPartitionPaths caps how many partition paths GeneratePartitionPaths will
+// materialize for a single query. Arc's partition layout yields ~1 path/hour
+// plus ~1 path/day, so ~9,150 paths per year of range; 50k covers ~5 years of
+// hourly pruning. Above the cap the pruner returns no paths and the caller
+// falls back to the single unpruned /**/*.parquet glob — correct, just not
+// pruned. This defuses the amplification DoS in #536: a WHERE time >=
+// '0001-01-01' request can no longer force the server to allocate millions of
+// path strings and glob/LIST each one.
+const maxPartitionPaths = 50_000
+
+// minPartitionDate is the floor the pruner clamps a query's start time up to
+// before generating partition paths. It exists only to bound the degenerate
+// unbounded-downward case (e.g. '0001-01-01'), not to constrain real data:
+// 1970-01-01 UTC (the Unix epoch) is below any plausible telemetry timestamp,
+// including multi-decade aerospace archives. Clamping UP to this floor is
+// lossless — Arc has no data before the epoch, so no real partition is skipped
+// — while it caps the number of pre-data hours the loop would otherwise walk.
+// We clamp rather than reject so a two-sided query like
+// `time >= '1960-01-01' AND time < '2024-06-01'` still prunes to
+// [1970, 2024-06) instead of silently substituting a later floor and dropping
+// legitimate pre-2020 rows.
+var minPartitionDate = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+
 // partitionCacheEntry represents a cached partition path result
 type partitionCacheEntry struct {
 	result    interface{} // string or []string
@@ -163,18 +227,20 @@ type partitionCacheEntry struct {
 // partitionCache provides a TTL cache for OptimizeTablePath results
 // This avoids repeated partition calculations for the same queries
 type partitionCache struct {
-	mu      sync.RWMutex
-	entries map[string]partitionCacheEntry
-	ttl     time.Duration
-	hits    atomic.Int64
-	misses  atomic.Int64
+	mu         sync.RWMutex
+	entries    map[string]partitionCacheEntry
+	ttl        time.Duration
+	maxEntries int
+	hits       atomic.Int64
+	misses     atomic.Int64
 }
 
 // newPartitionCache creates a new partition cache with the specified TTL
 func newPartitionCache(ttl time.Duration) *partitionCache {
 	return &partitionCache{
-		entries: make(map[string]partitionCacheEntry),
-		ttl:     ttl,
+		entries:    make(map[string]partitionCacheEntry),
+		ttl:        ttl,
+		maxEntries: maxCacheEntries,
 	}
 }
 
@@ -185,7 +251,9 @@ func (c *partitionCache) cacheKey(originalPath, sql string) string {
 	return h
 }
 
-// get retrieves a cached partition result
+// get retrieves a cached partition result. Expired entries are evicted on
+// read so distinct (path, sql) keys can't grow the map monotonically between
+// janitor sweeps.
 func (c *partitionCache) get(key string) (interface{}, bool, bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[key]
@@ -198,6 +266,13 @@ func (c *partitionCache) get(key string) (interface{}, bool, bool) {
 
 	if time.Now().After(entry.expiresAt) {
 		c.misses.Add(1)
+		// Evict-on-read: remove the stale entry so it can't accumulate.
+		c.mu.Lock()
+		// Re-check under the write lock in case another goroutine refreshed it.
+		if e, ok := c.entries[key]; ok && time.Now().After(e.expiresAt) {
+			delete(c.entries, key)
+		}
+		c.mu.Unlock()
 		return nil, false, false
 	}
 
@@ -208,12 +283,32 @@ func (c *partitionCache) get(key string) (interface{}, bool, bool) {
 // set stores a partition result in the cache
 func (c *partitionCache) set(key string, result interface{}, optimized bool) {
 	c.mu.Lock()
+	// Bound the cache: if inserting a new key would exceed maxEntries, drop
+	// expired entries first, and if still full, refuse the insert. Refreshing
+	// an existing key is always allowed.
+	if _, exists := c.entries[key]; !exists && len(c.entries) >= c.maxEntries {
+		c.evictExpiredLocked()
+		if len(c.entries) >= c.maxEntries {
+			c.mu.Unlock()
+			return
+		}
+	}
 	c.entries[key] = partitionCacheEntry{
 		result:    result,
 		optimized: optimized,
 		expiresAt: time.Now().Add(c.ttl),
 	}
 	c.mu.Unlock()
+}
+
+// evictExpiredLocked removes all expired entries. Caller must hold c.mu.
+func (c *partitionCache) evictExpiredLocked() {
+	now := time.Now()
+	for key, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, key)
+		}
+	}
 }
 
 // invalidate removes all entries from the cache
@@ -469,13 +564,10 @@ func (p *PartitionPruner) ExtractTimeRange(sqlStr string) *TimeRange {
 //
 // Arc's partition structure: {database}/{measurement}/{year}/{month}/{day}/{hour}/file.parquet
 // Example: default/cpu/2024/03/15/14/cpu_20240315_140000_1000.parquet
-func (p *PartitionPruner) GeneratePartitionPaths(basePath, database, measurement string, timeRange *TimeRange) []string {
+func (p *PartitionPruner) GeneratePartitionPaths(ctx context.Context, basePath, database, measurement string, timeRange *TimeRange) []string {
 	if timeRange == nil {
 		return nil
 	}
-
-	paths := []string{}
-	daysMap := make(map[string]bool)
 
 	// Detect if this is a remote path (S3/Azure) - use string concatenation instead of filepath.Join
 	// because filepath.Join will mangle URLs like s3://bucket to s3:/bucket
@@ -485,7 +577,57 @@ func (p *PartitionPruner) GeneratePartitionPaths(basePath, database, measurement
 	current := timeRange.Start.Truncate(time.Hour)
 	end := timeRange.End
 
+	// Clamp the start up to the epoch floor. Arc has no data before 1970, so
+	// this is lossless (no real partition is skipped), and it bounds the number
+	// of empty pre-data hours a degenerate start (e.g. '0001-01-01') would
+	// otherwise force the loop to walk. We clamp rather than reject so a
+	// two-sided query with a very old start still prunes correctly instead of
+	// dropping legitimate rows (#536).
+	if current.Before(minPartitionDate) {
+		current = minPartitionDate
+	}
+
+	// Cap the number of paths BEFORE allocating anything. The path count is
+	// ~1 per hour plus ~1 per covered day; bound it by an over-estimate of the
+	// total (hours rounded up, plus one day per 24 hours) so the guard never
+	// under-counts the paths the loop actually materializes. Above the cap we
+	// return nil so the caller falls back to the single unpruned glob —
+	// correct, just not pruned. This prevents a very wide time range from
+	// forcing the server to materialize millions of path strings and
+	// glob/LIST each one (#536).
+	if span := end.Sub(current); span > 0 {
+		// ceil(span / hour) hourly paths, plus at most ceil(hours/24)+1 daily.
+		hourlyPaths := int64((span + time.Hour - 1) / time.Hour)
+		dailyPaths := hourlyPaths/24 + 1
+		if estPaths := hourlyPaths + dailyPaths; estPaths > int64(maxPartitionPaths) {
+			p.logger.Warn().
+				Int64("estimated_paths", estPaths).
+				Int("max_partition_paths", maxPartitionPaths).
+				Time("start", current).
+				Time("end", timeRange.End).
+				Msg("Time range too wide for partition pruning; falling back to unpruned glob")
+			return nil
+		}
+	}
+
+	paths := []string{}
+	daysMap := make(map[string]bool)
+
+	// ctxCheckInterval bounds how often we poll ctx.Err() inside the loop.
+	// The loop is already bounded to <= maxPartitionPaths iterations by the cap
+	// above; this just lets a client disconnect / deadline abort even that work.
+	const ctxCheckInterval = 4096
+	iter := 0
+
 	for current.Before(end) {
+		if iter%ctxCheckInterval == 0 && ctx.Err() != nil {
+			p.logger.Warn().
+				Int("paths_so_far", len(paths)).
+				Msg("Partition path generation cancelled")
+			return nil
+		}
+		iter++
+
 		year := current.Format("2006")
 		month := current.Format("01")
 		day := current.Format("02")
@@ -536,7 +678,7 @@ func (p *PartitionPruner) GeneratePartitionPaths(basePath, database, measurement
 // OptimizeTablePath optimizes a table path based on WHERE clause predicates
 //
 // Returns the optimized path (string or []string) and whether optimization was applied
-func (p *PartitionPruner) OptimizeTablePath(originalPath, sql string) (interface{}, bool) {
+func (p *PartitionPruner) OptimizeTablePath(ctx context.Context, originalPath, sql string) (interface{}, bool) {
 	if !p.enabled {
 		return originalPath, false
 	}
@@ -578,7 +720,7 @@ func (p *PartitionPruner) OptimizeTablePath(originalPath, sql string) (interface
 		Msg("Parsed path components")
 
 	// Generate optimized partition paths
-	partitionPaths := p.GeneratePartitionPaths(basePath, database, measurement, timeRange)
+	partitionPaths := p.GeneratePartitionPaths(ctx, basePath, database, measurement, timeRange)
 
 	if len(partitionPaths) == 0 {
 		p.logger.Info().Msg("No partitions found, using fallback")

--- a/internal/pruning/partition_pruner_test.go
+++ b/internal/pruning/partition_pruner_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -290,7 +291,7 @@ func TestGeneratePartitionPaths(t *testing.T) {
 		end, _ := parseDateTime("2024-03-15 11:00:00")
 		tr := &TimeRange{Start: start, End: end}
 
-		paths := p.GeneratePartitionPaths("/data", "mydb", "cpu", tr)
+		paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", tr)
 
 		// Should have hourly path + daily path
 		if len(paths) < 1 {
@@ -315,7 +316,7 @@ func TestGeneratePartitionPaths(t *testing.T) {
 		end, _ := parseDateTime("2024-03-15 14:00:00")
 		tr := &TimeRange{Start: start, End: end}
 
-		paths := p.GeneratePartitionPaths("/data", "mydb", "cpu", tr)
+		paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", tr)
 
 		// Should have 4 hourly paths + 1 daily path = 5
 		if len(paths) != 5 {
@@ -328,7 +329,7 @@ func TestGeneratePartitionPaths(t *testing.T) {
 		end, _ := parseDateTime("2024-03-17 00:00:00")
 		tr := &TimeRange{Start: start, End: end}
 
-		paths := p.GeneratePartitionPaths("/data", "mydb", "cpu", tr)
+		paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", tr)
 
 		// 48 hourly paths + 2 daily paths
 		expectedHourly := 48
@@ -339,7 +340,7 @@ func TestGeneratePartitionPaths(t *testing.T) {
 	})
 
 	t.Run("nil time range", func(t *testing.T) {
-		paths := p.GeneratePartitionPaths("/data", "mydb", "cpu", nil)
+		paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", nil)
 
 		if paths != nil {
 			t.Errorf("Expected nil for nil time range, got %v", paths)
@@ -356,7 +357,7 @@ func TestOptimizeTablePath(t *testing.T) {
 		path := "/data/mydb/cpu/**/*.parquet"
 		sql := "SELECT * FROM cpu WHERE host = 'server1'"
 
-		result, optimized := p.OptimizeTablePath(path, sql)
+		result, optimized := p.OptimizeTablePath(context.Background(), path, sql)
 
 		if optimized {
 			t.Error("Should not be optimized without time range")
@@ -371,7 +372,7 @@ func TestOptimizeTablePath(t *testing.T) {
 		path := "s3://bucket/mydb/cpu/**/*.parquet"
 		sql := "SELECT * FROM cpu WHERE time >= '2024-03-15' AND time < '2024-03-16'"
 
-		result, optimized := p.OptimizeTablePath(path, sql)
+		result, optimized := p.OptimizeTablePath(context.Background(), path, sql)
 
 		if !optimized {
 			t.Error("Should be optimized with time range for non-local path")
@@ -407,7 +408,7 @@ func TestOptimizeTablePath(t *testing.T) {
 		path := "/invalid/path"
 		sql := "SELECT * FROM cpu WHERE time >= '2024-03-15' AND time < '2024-03-16'"
 
-		result, optimized := p.OptimizeTablePath(path, sql)
+		result, optimized := p.OptimizeTablePath(context.Background(), path, sql)
 
 		if optimized {
 			t.Error("Invalid path should not be optimized")
@@ -422,7 +423,7 @@ func TestOptimizeTablePath(t *testing.T) {
 		path := "/data/mydb/cpu/**/*.parquet"
 		sql := "SELECT * FROM cpu WHERE time >= '2024-03-15' AND time < '2024-03-16'"
 
-		result, optimized := p.OptimizeTablePath(path, sql)
+		result, optimized := p.OptimizeTablePath(context.Background(), path, sql)
 
 		if optimized {
 			t.Error("Disabled pruner should not optimize")
@@ -604,7 +605,7 @@ func TestPrunerStats(t *testing.T) {
 	// Generate some partition paths (this increments QueriesOptimized)
 	start, _ := parseDateTime("2024-03-15")
 	end, _ := parseDateTime("2024-03-16")
-	p.GeneratePartitionPaths("/data", "db", "cpu", &TimeRange{Start: start, End: end})
+	p.GeneratePartitionPaths(context.Background(), "/data", "db", "cpu", &TimeRange{Start: start, End: end})
 
 	stats = p.GetStats()
 	if stats.QueriesOptimized != 1 {
@@ -1210,7 +1211,7 @@ func TestOptimizeTablePath_S3WithMissingPartitions(t *testing.T) {
 	originalPath := "s3://mybucket/default/cpu/**/*.parquet"
 	sql := "SELECT * FROM cpu WHERE time >= '2026-01-15 10:00:00' AND time < '2026-01-15 14:00:00'"
 
-	result, optimized := p.OptimizeTablePath(originalPath, sql)
+	result, optimized := p.OptimizeTablePath(context.Background(), originalPath, sql)
 
 	// The result depends on whether filtering works correctly
 	// If optimization applied, we should have filtered paths
@@ -1468,4 +1469,206 @@ func TestStartCleanup_Idempotent(t *testing.T) {
 	}
 	_, _, size := pruner.globCache.stats()
 	t.Fatalf("janitor goroutine appears dead after repeat StartCleanup calls: glob size = %d", size)
+}
+
+// TestGeneratePartitionPathsClampsStartToEpoch verifies that a start before the
+// epoch floor is clamped UP to 1970-01-01 (not rejected), so a degenerate old
+// start doesn't drive a huge pre-data range but a two-sided query with an old
+// start still prunes to [1970, end) instead of dropping legitimate rows (#536,
+// reviewer finding H1).
+func TestGeneratePartitionPathsClampsStartToEpoch(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+
+	// Start well before the epoch, end just after it: without clamping this
+	// would either be rejected (dropping data) or walk millions of empty hours.
+	// With clamping the loop starts at 1970-01-01 and generates a small range.
+	start := time.Date(0001, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(1970, 1, 1, 3, 0, 0, 0, time.UTC) // 3 hours past epoch
+	paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", &TimeRange{Start: start, End: end})
+
+	if len(paths) == 0 {
+		t.Fatal("expected clamped range to still produce paths, got none")
+	}
+	// 3 hourly + 1 daily = 4 paths; must NOT be an enormous count.
+	if len(paths) > 10 {
+		t.Fatalf("start was not clamped to epoch: got %d paths for a 3-hour post-epoch window", len(paths))
+	}
+	// Every path must be at 1970 or later — no pre-epoch partitions.
+	for _, path := range paths {
+		if strings.Contains(path, "/0001/") || strings.Contains(path, "/1969/") {
+			t.Errorf("generated a pre-epoch partition path: %s", path)
+		}
+		if !strings.Contains(path, "/1970/") {
+			t.Errorf("expected path within the 1970 window, got: %s", path)
+		}
+	}
+}
+
+// TestGeneratePartitionPathsClampIsLossless verifies clamping doesn't reduce
+// coverage for real (post-epoch) data: a two-sided query whose start is old but
+// whose end is modern still prunes from 1970 through the end (no rows dropped).
+func TestGeneratePartitionPathsClampIsLossless(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+
+	// Old start, modern end, but a span narrow enough (measured from the 1970
+	// clamp) to stay under the cap: 1970-01-01 .. 1970-06-01 is ~3,624 hours.
+	start := time.Date(1960, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(1970, 6, 1, 0, 0, 0, 0, time.UTC)
+	paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", &TimeRange{Start: start, End: end})
+
+	if len(paths) == 0 {
+		t.Fatal("expected paths from the clamped start through end, got none")
+	}
+	// First hour partition must be exactly 1970/01/01/00 — coverage starts at
+	// the floor, so any post-epoch data in [1970, end) is included.
+	foundEpochHour := false
+	for _, path := range paths {
+		if strings.Contains(path, "/1970/01/01/00/") {
+			foundEpochHour = true
+			break
+		}
+	}
+	if !foundEpochHour {
+		t.Error("expected coverage to start at the 1970-01-01 00:00 partition")
+	}
+}
+
+// TestGeneratePartitionPathsCap verifies the path-count cap defuses the
+// amplification DoS: an over-wide range returns nil (caller falls back to the
+// unpruned glob) instead of materializing millions of path strings (#536).
+func TestGeneratePartitionPathsCap(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+
+	t.Run("under cap generates paths", func(t *testing.T) {
+		// ~1 year is well under the 50k cap (~9,150 hourly paths).
+		start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := start.AddDate(1, 0, 0)
+		paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", &TimeRange{Start: start, End: end})
+		if len(paths) == 0 {
+			t.Fatal("expected paths for a 1-year range under the cap, got none")
+		}
+		if len(paths) > maxPartitionPaths {
+			t.Fatalf("under-cap range should not exceed cap: got %d > %d", len(paths), maxPartitionPaths)
+		}
+	})
+
+	t.Run("over cap returns nil", func(t *testing.T) {
+		// 200 years -> ~1.75M hourly paths, far over the 50k cap.
+		start := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := start.AddDate(200, 0, 0)
+		paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", &TimeRange{Start: start, End: end})
+		if paths != nil {
+			t.Fatalf("expected nil for over-cap range (fallback to unpruned glob), got %d paths", len(paths))
+		}
+	})
+
+	t.Run("just under cap generates paths, actual count never exceeds cap", func(t *testing.T) {
+		// Pick an hourly count H such that H + (H/24 + 1) <= maxPartitionPaths.
+		// With H = 47000: daily = 47000/24 + 1 = 1959, total est = 48959 < 50000.
+		start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := start.Add(47000 * time.Hour)
+		paths := p.GeneratePartitionPaths(context.Background(), "/data", "mydb", "cpu", &TimeRange{Start: start, End: end})
+		if paths == nil {
+			t.Fatal("expected paths for a range just under the cap, got nil")
+		}
+		// The estimate must be a true upper bound: the materialized count must
+		// never exceed the cap (reviewer finding M1 — estimate must not
+		// under-count vs the loop's ceil + daily paths).
+		if len(paths) > maxPartitionPaths {
+			t.Fatalf("materialized %d paths, exceeds cap %d (estimate under-counted)", len(paths), maxPartitionPaths)
+		}
+	})
+}
+
+// TestGeneratePartitionPathsContextCancel verifies a cancelled context aborts
+// path generation so a client disconnect / deadline stops the work (#536).
+func TestGeneratePartitionPathsContextCancel(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	// A range large enough to reach the loop but under the cap so the cap
+	// branch doesn't short-circuit first.
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(1, 0, 0)
+	paths := p.GeneratePartitionPaths(ctx, "/data", "mydb", "cpu", &TimeRange{Start: start, End: end})
+	if paths != nil {
+		t.Fatalf("expected nil when context is cancelled, got %d paths", len(paths))
+	}
+}
+
+// TestGlobCacheEvictOnRead verifies expired glob entries are removed on read,
+// not merely reported as a miss, so distinct keys can't accumulate (#536).
+func TestGlobCacheEvictOnRead(t *testing.T) {
+	c := newGlobCache(10 * time.Millisecond)
+	c.set("pattern-a", []string{"file1"})
+
+	if _, _, size := c.stats(); size != 1 {
+		t.Fatalf("expected 1 entry after set, got %d", size)
+	}
+
+	time.Sleep(15 * time.Millisecond)
+
+	if _, ok := c.get("pattern-a"); ok {
+		t.Fatal("expected expired entry to be a miss")
+	}
+	if _, _, size := c.stats(); size != 0 {
+		t.Fatalf("expected expired entry to be evicted on read, got size %d", size)
+	}
+}
+
+// TestPartitionCacheEvictOnRead is the partitionCache analogue.
+func TestPartitionCacheEvictOnRead(t *testing.T) {
+	c := newPartitionCache(10 * time.Millisecond)
+	c.set("key-a", "some-path", true)
+
+	if _, _, size := c.stats(); size != 1 {
+		t.Fatalf("expected 1 entry after set, got %d", size)
+	}
+
+	time.Sleep(15 * time.Millisecond)
+
+	if _, _, ok := c.get("key-a"); ok {
+		t.Fatal("expected expired entry to be a miss")
+	}
+	if _, _, size := c.stats(); size != 0 {
+		t.Fatalf("expected expired entry to be evicted on read, got size %d", size)
+	}
+}
+
+// TestGlobCacheMaxEntries verifies the glob cache refuses new keys past its cap
+// (after evicting expired entries) so attacker-varied keys can't grow it
+// unbounded (#536). Uses a long TTL so nothing expires during the test.
+func TestGlobCacheMaxEntries(t *testing.T) {
+	c := newGlobCache(1 * time.Hour)
+	c.maxEntries = 3
+
+	for i := 0; i < 10; i++ {
+		c.set("pattern-"+strconv.Itoa(i), []string{"f"})
+	}
+
+	if _, _, size := c.stats(); size > 3 {
+		t.Fatalf("cache exceeded maxEntries: got %d, want <= 3", size)
+	}
+
+	// Refreshing an existing key must still be allowed even at capacity.
+	c.set("pattern-0", []string{"f", "g"})
+	if _, _, size := c.stats(); size > 3 {
+		t.Fatalf("refreshing existing key grew cache past cap: got %d", size)
+	}
+}
+
+// TestPartitionCacheMaxEntries is the partitionCache analogue.
+func TestPartitionCacheMaxEntries(t *testing.T) {
+	c := newPartitionCache(1 * time.Hour)
+	c.maxEntries = 3
+
+	for i := 0; i < 10; i++ {
+		c.set("key-"+strconv.Itoa(i), "path", true)
+	}
+
+	if _, _, size := c.stats(); size > 3 {
+		t.Fatalf("cache exceeded maxEntries: got %d, want <= 3", size)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #536. `PartitionPruner.GeneratePartitionPaths` generated one storage path per hour + per day across a query's time range with **no upper bound on path count, no `context.Context`, and no floor on the accepted start date**. A single small request with a very wide range — e.g. `WHERE time >= '0001-01-01'` — forced the server to materialize on the order of a million path strings and then glob (local) or LIST (S3/Azure) every one of them: an amplification DoS turning one HTTP request into large server CPU, memory, and object-storage LIST billing. Pre-existing on `main`; reachable via `OptimizeTablePath` on every `FROM`/`JOIN` query.

## What changed

- **Path-count cap** (`maxPartitionPaths = 50,000`, ~5 years of hourly pruning). The count is over-estimated (ceil hourly + daily paths) *before* any allocation; a range over the cap returns no paths and the query falls back to the single unpruned `/**/*.parquet` glob — correct results, just not partition-pruned. Millions of path strings are never allocated.
- **Epoch floor** on the start date. A start earlier than `1970-01-01 UTC` is **clamped up** to the epoch (not rejected) before path generation. Clamping is lossless — Arc stores no pre-epoch data — so a two-sided query with an old start (`time >= '1960-01-01' AND time < '2024-06-01'`) still prunes from 1970 through its end instead of silently substituting a later floor and dropping legitimate rows. The degenerate `0001-01-01` case can no longer drive a huge pre-data range.
- **Cancellation** — path generation honors the request `context.Context`, threaded from the handler entry points through the query transform chain. `ctx.Err()` is checked every 4096 loop iterations, so a client disconnect / deadline aborts the work.
- **Bounded caches** — the pruner's glob and partition-path caches now evict expired entries on read and refuse new keys past `maxCacheEntries = 10,000` (after dropping expired), closing the vary-the-time-literal memory-growth vector the code's own comment flagged.

## Test plan

- [x] `go test -race ./internal/pruning/...` — new tests: cap over/under boundary, epoch clamp (lossless H1 regression), context-cancel, cache evict-on-read, maxEntries.
- [x] `go test ./internal/api/...` transform-path tests pass; ctx threaded through all call sites.
- [x] `gofmt -l` clean, `go vet` clean, full build OK.
- [x] **Binary run against demo data** (per CLAUDE.md): `0001-01-01` payload clamps → caps → falls back in ~1ms (`estimated_paths=516394 > 50000`); two-sided `1960→1970-04` query prunes from the 1970 epoch (2160 hourly paths = the post-epoch window); normal narrow + full-scan queries return correct data.

## Notes

- No config keys introduced — the limits are hardcoded safety bounds.
- Internal adversarial review found and fixed a correctness regression (rejecting an old start would have routed a two-sided query into a pre-existing 2020 fallback, dropping pre-2020 rows) — fixed by clamping instead of rejecting — and a cap-overshoot (estimate now includes daily paths so the materialized count never exceeds the cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)