### PR TITLE
fix(query): don't corrupt parenthesized args in date_trunc/time_bucket rewrite (#535)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -45,6 +45,16 @@ Separately, the pruner's two internal TTL caches (glob results and partition pat
 
 Reachable in every deployment mode (the pruner runs on every `FROM`/`JOIN` query); pre-existing on `main`, unrelated to any other work in this release.
 
+## Bug fixes
+
+### `date_trunc`/`time_bucket` epoch rewrite no longer corrupts parenthesized column arguments ([#535](https://github.com/Basekick-Labs/arc/issues/535))
+
+Arc rewrites `date_trunc('hour', col)` (and `time_bucket(...)`) into faster epoch arithmetic. The rewriter extracted the column argument with a paren-blind regex that stopped at the **first** `)` rather than the matching one. When the column argument itself contained parentheses — `coalesce(time, a)`, `(time)`, `CAST(ts AS TIMESTAMP)`, or any nested call — the capture was truncated and the `::BIGINT` cast was spliced into the wrong place, producing SQL that failed at the DuckDB binder (`No function matches ... 'epoch(BIGINT)'`) on a query DuckDB would otherwise have run correctly.
+
+This was an **availability** bug, not a wrong-answer bug: every corrupted form failed loudly at the binder rather than returning a wrong number.
+
+The fix leaves any `date_trunc`/`time_bucket` call whose column argument contains a parenthesis **unrewritten**, so DuckDB evaluates it natively — correct results, just without the epoch optimization for that one call. The common `date_trunc('hour', time)` bare-column form is unaffected and still gets the optimization; a query mixing both forms optimizes the bare one and passes the parenthesized one through. Introduced in `161be30` (2026-01-07); present on `main`.
+
 ## Impact by deployment mode
 
 The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -384,6 +384,15 @@ func rewriteTimeBucket(sql string) string {
 		column := strings.TrimSpace(parts[3])
 		origin := parts[4] // e.g., "2024-01-01 00:30:00"
 
+		// Paren-blind guard (#535): if the column arg contains parentheses the
+		// regex capture may be truncated at the wrong ')'. Leave the call
+		// unrewritten so DuckDB handles it natively. (For time_bucket the
+		// capture already fails to match most nested args, so this is belt-and-
+		// suspenders — but it keeps every rewrite path consistently safe.)
+		if strings.Contains(column, "(") {
+			return match
+		}
+
 		// Parse origin timestamp
 		originTime, err := parseTimeBucketOrigin(origin)
 		if err != nil {
@@ -415,6 +424,12 @@ func rewriteTimeBucket(sql string) string {
 		unit := strings.ToLower(strings.TrimSuffix(parts[2], "s"))
 		column := strings.TrimSpace(parts[3])
 
+		// Paren-blind guard (#535): see the 3-arg form above. If the column arg
+		// contains parentheses the capture may be truncated; leave it for DuckDB.
+		if strings.Contains(column, "(") {
+			return match
+		}
+
 		// Use epoch-based arithmetic for all intervals (2.5x faster than date_trunc)
 		seconds := intervalToSeconds(amount, unit)
 		if seconds == 0 {
@@ -444,6 +459,19 @@ func rewriteDateTrunc(sql string) string {
 
 		unit := strings.ToLower(parts[1])
 		column := strings.TrimSpace(parts[2])
+
+		// Paren-blind guard (#535): the column capture uses [^)]+, which stops
+		// at the FIRST ')' rather than the matching one. When the column arg
+		// itself contains parentheses — coalesce(time, a), (time), CAST(...),
+		// nested calls — the capture is truncated and splicing ::BIGINT onto it
+		// would corrupt the query (e.g. epoch(coalesce(time, a)::BIGINT // 3600)
+		// swallows the arithmetic inside epoch's arg list, producing a binder
+		// error on SQL DuckDB would have run fine). Detect a '(' in the captured
+		// column and leave the call unrewritten — DuckDB runs date_trunc()
+		// natively (correct, just without the epoch optimization).
+		if strings.Contains(column, "(") {
+			return match
+		}
 
 		// Get interval in seconds
 		seconds := intervalToSeconds("1", unit)

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -1655,6 +1655,19 @@ func TestRewriteTimeBucket(t *testing.T) {
 			input:    "SELECT time_bucket('1 days', time) AS bucket FROM cpu",
 			expected: "SELECT to_timestamp((epoch(time)::BIGINT // 86400) * 86400) AS bucket FROM cpu",
 		},
+		// #535: parenthesized column args must be left verbatim for DuckDB (the
+		// capture already fails to match most of these, but the guard makes the
+		// safety explicit and consistent with date_trunc).
+		{
+			name:     "coalesce column arg left unrewritten (#535)",
+			input:    "SELECT time_bucket('1 hour', coalesce(time, a)) AS bucket FROM cpu",
+			expected: "SELECT time_bucket('1 hour', coalesce(time, a)) AS bucket FROM cpu",
+		},
+		{
+			name:     "parenthesized column left unrewritten (#535)",
+			input:    "SELECT time_bucket('1 hour', (time)) AS bucket FROM cpu",
+			expected: "SELECT time_bucket('1 hour', (time)) AS bucket FROM cpu",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1835,6 +1848,34 @@ func TestRewriteDateTrunc(t *testing.T) {
 			name:     "date_trunc in WHERE clause",
 			input:    "SELECT * FROM cpu WHERE date_trunc('day', time) = '2024-01-01'",
 			expected: "SELECT * FROM cpu WHERE to_timestamp((epoch(time)::BIGINT // 86400) * 86400) = '2024-01-01'",
+		},
+		// #535: parenthesized column args must NOT be rewritten (paren-blind
+		// capture would corrupt them). Left verbatim for DuckDB to handle
+		// natively — correct, just not epoch-optimized.
+		{
+			name:     "coalesce column arg left unrewritten (#535 case 1)",
+			input:    "SELECT date_trunc('hour', coalesce(time, a)) FROM cpu",
+			expected: "SELECT date_trunc('hour', coalesce(time, a)) FROM cpu",
+		},
+		{
+			name:     "parenthesized column left unrewritten (#535 case 2)",
+			input:    "SELECT date_trunc('hour', (time)) FROM cpu",
+			expected: "SELECT date_trunc('hour', (time)) FROM cpu",
+		},
+		{
+			name:     "nested function arg left unrewritten (#535 case 3)",
+			input:    "SELECT date_trunc('hour', f(g(time))) FROM cpu",
+			expected: "SELECT date_trunc('hour', f(g(time))) FROM cpu",
+		},
+		{
+			name:     "CAST column arg left unrewritten (#535)",
+			input:    "SELECT date_trunc('day', CAST(ts AS TIMESTAMP)) FROM cpu",
+			expected: "SELECT date_trunc('day', CAST(ts AS TIMESTAMP)) FROM cpu",
+		},
+		{
+			name:     "bare column still optimized alongside a parenthesized one (#535)",
+			input:    "SELECT date_trunc('hour', time) AS h, date_trunc('day', coalesce(time, a)) AS d FROM cpu",
+			expected: "SELECT to_timestamp((epoch(time)::BIGINT // 3600) * 3600) AS h, date_trunc('day', coalesce(time, a)) AS d FROM cpu",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #535. The `date_trunc`/`time_bucket` → epoch rewrite in `internal/api/query.go` extracted the column argument with a paren-blind regex (`([^)]+)`) that stops at the **first** `)` instead of the matching one. When the column argument itself contained parentheses — `coalesce(time, a)`, `(time)`, `CAST(ts AS TIMESTAMP)`, or any nested call — the capture was truncated and the `::BIGINT` cast was spliced into the wrong place, corrupting the query into a DuckDB binder error (`No function matches ... 'epoch(BIGINT)'`) on SQL that DuckDB would otherwise run fine.

This is an **availability** bug, not a wrong-answer bug — every corrupted form failed loudly at the binder. Introduced in `161be30` (2026-01-07); present on `main`.

## Fix

Guard all three rewrite callbacks (`date_trunc`, `time_bucket` 2-arg, `time_bucket` 3-arg): if the captured column contains a `(`, leave the call **unrewritten** so DuckDB evaluates it natively — correct results, just without the epoch optimization for that one call. The common `date_trunc('hour', time)` bare-column form is unaffected and still optimized; a query mixing both forms optimizes the bare one and passes the parenthesized one through.

This is the low-risk mitigation the issue suggests — it matches the behavior `time_bucket` already had accidentally (its capture fails to match most nested args), now made explicit and consistent across all three paths.

## Test plan

- [x] 7 new regression cases in `TestRewriteDateTrunc`/`TestRewriteTimeBucket` covering every form from the issue (`coalesce`, `(time)`, nested `f(g(time))`, `CAST`) plus a mixed bare+parenthesized query that must optimize only the bare one.
- [x] Existing `TestRewrite*` suite unchanged and passing; `gofmt -l` clean, `go vet` clean, full build OK.
- [x] **Before/after on the real binary against demo data:** `date_trunc('hour', coalesce(time, time))` returns `Binder Error: epoch(BIGINT)` on `main` and correct results on this branch; `(time)` and `CAST(...)` forms succeed; bare-column control still epoch-rewrites.
- [x] Internal deep adversarial review — no findings (verified full-query preservation when the match ends before the outer `)`, no previously-passing rewrite lost, no paren-arg escapes the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)