### PR TITLE
fix(cq): make continuous-query output idempotent to stop duplicate rows (#521)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -55,6 +55,19 @@ This was an **availability** bug, not a wrong-answer bug: every corrupted form f
 
 The fix leaves any `date_trunc`/`time_bucket` call whose column argument contains a parenthesis **unrewritten**, so DuckDB evaluates it natively — correct results, just without the epoch optimization for that one call. The common `date_trunc('hour', time)` bare-column form is unaffected and still gets the optimization; a query mixing both forms optimizes the bare one and passes the parenthesized one through. Introduced in `161be30` (2026-01-07); present on `main`.
 
+### Continuous queries no longer produce duplicate aggregate rows ([#521](https://github.com/Basekick-Labs/arc/issues/521))
+
+Continuous-query output was append-only with no idempotency: a window could be aggregated and written more than once — after a crash between the destination write and the watermark advance, or a re-run over an overlapping range — leaving **duplicate rows** in the destination measurement. Separately, when the aggregation query selected no `time` column, every output row was stamped with `time.Now()` (the ingestion wall-clock) instead of the window time, so the rollup's timestamps were wrong and the duplicates weren't even dedupe-able.
+
+Two fixes, which together make CQ output **idempotent via compaction**:
+
+- **Window-time stamping.** A CQ that doesn't select a time column now stamps each output row with the window's start time (the `[start, end)` bucket boundary), not `time.Now()`. Timestamps are correct, and re-running the same window produces byte-identical `(dimensions, time)` keys.
+- **Dedup metadata on CQ output.** CQ output now carries the Parquet metadata compaction needs to collapse duplicate windows to one row. Declare the grouping dimensions in a new optional **`tag_columns`** field on the CQ definition (e.g. `"tag_columns": ["host"]` for `GROUP BY host`) — these are written as `arc:tags`, and compaction dedups on `(tags, time)`. A CQ with **no** grouping (one row per window, e.g. `SELECT avg(x) …`) is detected automatically and deduped on time alone. Duplicate emissions are collapsed the next time the destination partition compacts.
+
+**Safety:** a CQ that groups by a dimension but does **not** declare it in `tag_columns` is detected (its output has multiple rows per timestamp) and is **not** marked for time-only dedup — this avoids silently dropping series. Such a CQ logs a warning asking the operator to declare `tag_columns`. Existing CQ definitions are migrated automatically (a new nullable column); a CQ without `tag_columns` behaves exactly as before except for the corrected timestamp. This is the foundation for late-data reprocessing ([#522](https://github.com/Basekick-Labs/arc/issues/522)).
+
+Note: this makes output **eventually** idempotent (duplicates collapse at compaction), not atomically exactly-once — the write and the watermark advance remain separate steps. True exactly-once is tracked in #522.
+
 ## Impact by deployment mode
 
 The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.

--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -68,6 +68,13 @@ Two fixes, which together make CQ output **idempotent via compaction**:
 
 Note: this makes output **eventually** idempotent (duplicates collapse at compaction), not atomically exactly-once — the write and the watermark advance remain separate steps. True exactly-once is tracked in #522.
 
+**Upgrade impact — this is not a breaking change.** Existing continuous queries keep working: the CQ database is migrated automatically (a new nullable `tag_columns` column is added on startup), old definitions read and execute exactly as before, and `tag_columns` is optional. Two behavior changes to be aware of:
+
+- **Timestamps for CQs that don't select a `time` column.** These previously stamped output with `time.Now()` (ingestion wall-clock) and now stamp the window start. This corrects a real bug, but it means such a destination has a timestamp discontinuity at the upgrade point (old rows keep their `time.Now()` values, new rows get window-start values). CQs that *do* select a time column (the common case, e.g. `date_trunc('hour', time) AS time`) are completely unchanged.
+- **Dedup is opt-in for grouped CQs.** An existing `GROUP BY <dimension>` CQ gets no idempotency benefit until you add `tag_columns` (via an update); until then it behaves exactly as before (append-only). This is deliberate — a grouped CQ is **never** auto-deduped without declared tags, because deduping multi-series output on time alone would delete series. A genuinely ungrouped CQ (one row per window) is deduped automatically after the upgrade.
+
+No action is required to upgrade; add `tag_columns` to your grouped CQs when you want the duplicate-collapsing behavior.
+
 ## Impact by deployment mode
 
 The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.

--- a/internal/api/continuous_query.go
+++ b/internal/api/continuous_query.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"github.com/basekick-labs/arc/internal/ingest"
 	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/basekick-labs/arc/pkg/models"
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
@@ -73,29 +75,35 @@ type ContinuousQuery struct {
 	DestinationMeasurement string  `json:"destination_measurement"`
 	Query                  string  `json:"query"`
 	Interval               string  `json:"interval"`
-	RetentionDays          *int    `json:"retention_days"`
-	DeleteSourceAfterDays  *int    `json:"delete_source_after_days"`
-	IsActive               bool    `json:"is_active"`
-	LastExecutionTime      *string `json:"last_execution_time"`
-	LastExecutionStatus    *string `json:"last_execution_status"`
-	LastProcessedTime      *string `json:"last_processed_time"`
-	LastRecordsWritten     *int64  `json:"last_records_written"`
-	CreatedAt              string  `json:"created_at"`
-	UpdatedAt              string  `json:"updated_at"`
+	// TagColumns are the output columns that are grouping dimensions (not
+	// aggregates). They are written as Parquet `arc:tags` metadata so that
+	// compaction can dedup CQ output on (tags, time), making re-emitted windows
+	// idempotent (#521). Empty means no dedup key — duplicate windows accumulate.
+	TagColumns            []string `json:"tag_columns"`
+	RetentionDays         *int     `json:"retention_days"`
+	DeleteSourceAfterDays *int     `json:"delete_source_after_days"`
+	IsActive              bool     `json:"is_active"`
+	LastExecutionTime     *string  `json:"last_execution_time"`
+	LastExecutionStatus   *string  `json:"last_execution_status"`
+	LastProcessedTime     *string  `json:"last_processed_time"`
+	LastRecordsWritten    *int64   `json:"last_records_written"`
+	CreatedAt             string   `json:"created_at"`
+	UpdatedAt             string   `json:"updated_at"`
 }
 
 // ContinuousQueryRequest represents a request to create/update a CQ
 type ContinuousQueryRequest struct {
-	Name                   string  `json:"name"`
-	Description            *string `json:"description"`
-	Database               string  `json:"database"`
-	SourceMeasurement      string  `json:"source_measurement"`
-	DestinationMeasurement string  `json:"destination_measurement"`
-	Query                  string  `json:"query"`
-	Interval               string  `json:"interval"`
-	RetentionDays          *int    `json:"retention_days"`
-	DeleteSourceAfterDays  *int    `json:"delete_source_after_days"`
-	IsActive               bool    `json:"is_active"`
+	Name                   string   `json:"name"`
+	Description            *string  `json:"description"`
+	Database               string   `json:"database"`
+	SourceMeasurement      string   `json:"source_measurement"`
+	DestinationMeasurement string   `json:"destination_measurement"`
+	Query                  string   `json:"query"`
+	Interval               string   `json:"interval"`
+	TagColumns             []string `json:"tag_columns"`
+	RetentionDays          *int     `json:"retention_days"`
+	DeleteSourceAfterDays  *int     `json:"delete_source_after_days"`
+	IsActive               bool     `json:"is_active"`
 }
 
 // ExecuteCQRequest represents a request to execute a CQ
@@ -183,6 +191,7 @@ func (h *ContinuousQueryHandler) initTables() error {
 			destination_measurement TEXT NOT NULL,
 			query TEXT NOT NULL,
 			interval TEXT NOT NULL,
+			tag_columns TEXT,
 			retention_days INTEGER,
 			delete_source_after_days INTEGER,
 			is_active BOOLEAN DEFAULT TRUE,
@@ -193,6 +202,15 @@ func (h *ContinuousQueryHandler) initTables() error {
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to create continuous_queries table: %w", err)
+	}
+
+	// Migration: add tag_columns to pre-existing databases (#521). The column
+	// holds a JSON-encoded []string of grouping-dimension output columns, used
+	// as the Parquet arc:tags dedup key. A duplicate-column error means an
+	// already-migrated DB — ignore it; any other error is fatal.
+	if _, err = h.sqliteDB.Exec(`ALTER TABLE continuous_queries ADD COLUMN tag_columns TEXT`); err != nil &&
+		!strings.Contains(err.Error(), "duplicate column name") {
+		return fmt.Errorf("failed to add tag_columns column: %w", err)
 	}
 
 	// Execution history table
@@ -287,12 +305,23 @@ func (h *ContinuousQueryHandler) handleCreate(c *fiber.Ctx) error {
 		})
 	}
 
+	// Validate tag columns before storing — they end up in Parquet arc:tags
+	// metadata and compaction's PARTITION BY, so unsafe names must be rejected
+	// at the boundary (#521).
+	if err := validateTagColumns(req.TagColumns); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+	tagColumnsJSON, err := encodeTagColumns(req.TagColumns)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to encode tag_columns"})
+	}
+
 	// Insert query
 	result, err := h.sqliteDB.Exec(`
 		INSERT INTO continuous_queries
-		(name, description, database, source_measurement, destination_measurement, query, interval, retention_days, delete_source_after_days, is_active)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, req.Name, req.Description, req.Database, req.SourceMeasurement, req.DestinationMeasurement, req.Query, req.Interval, req.RetentionDays, req.DeleteSourceAfterDays, req.IsActive)
+		(name, description, database, source_measurement, destination_measurement, query, interval, tag_columns, retention_days, delete_source_after_days, is_active)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, req.Name, req.Description, req.Database, req.SourceMeasurement, req.DestinationMeasurement, req.Query, req.Interval, tagColumnsJSON, req.RetentionDays, req.DeleteSourceAfterDays, req.IsActive)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint") {
@@ -381,13 +410,21 @@ func (h *ContinuousQueryHandler) handleUpdate(c *fiber.Ctx) error {
 		})
 	}
 
+	if err := validateTagColumns(req.TagColumns); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+	tagColumnsJSON, err := encodeTagColumns(req.TagColumns)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to encode tag_columns"})
+	}
+
 	result, err := h.sqliteDB.Exec(`
 		UPDATE continuous_queries SET
 			name = ?, description = ?, database = ?, source_measurement = ?,
-			destination_measurement = ?, query = ?, interval = ?, retention_days = ?,
+			destination_measurement = ?, query = ?, interval = ?, tag_columns = ?, retention_days = ?,
 			delete_source_after_days = ?, is_active = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = ?
-	`, req.Name, req.Description, req.Database, req.SourceMeasurement, req.DestinationMeasurement, req.Query, req.Interval, req.RetentionDays, req.DeleteSourceAfterDays, req.IsActive, queryID)
+	`, req.Name, req.Description, req.Database, req.SourceMeasurement, req.DestinationMeasurement, req.Query, req.Interval, tagColumnsJSON, req.RetentionDays, req.DeleteSourceAfterDays, req.IsActive, queryID)
 
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to update continuous query")
@@ -635,8 +672,12 @@ func (h *ContinuousQueryHandler) handleExecute(c *fiber.Ctx) error {
 		})
 	}
 
-	// Execute the aggregation query using DuckDB
-	ctx := context.Background()
+	// Execute the aggregation query using DuckDB. Derive from the request context
+	// (so a client disconnect cancels downstream context-aware work) and cap the
+	// runtime with the same 10-minute deadline the scheduler path uses, so a
+	// manual execute over a very wide range can't run unbounded.
+	ctx, cancel := context.WithTimeout(c.Context(), 10*time.Minute)
+	defer cancel()
 	recordsWritten, err := h.executeAggregation(ctx, cq, executedQuery, startTime, endTime)
 	if err != nil {
 		executionDuration := time.Since(start).Seconds()
@@ -701,8 +742,13 @@ func wrapSourceMeasurement(query, database, measurement, readParquetExpr string)
 	return pattern.ReplaceAllLiteralString(query, "FROM "+readParquetExpr)
 }
 
-// executeAggregation runs the aggregation query and writes results
-func (h *ContinuousQueryHandler) executeAggregation(ctx context.Context, cq *ContinuousQuery, query string, _, _ time.Time) (int64, error) {
+// executeAggregation runs the aggregation query and writes results.
+// startTime is the window's inclusive left boundary — it stamps output rows
+// when the aggregation query does not select a time column, so re-runs of the
+// same window produce identical (tags, time) rows that dedup at compaction (#521).
+// The window's end time is intentionally unused here: output rows are labelled by
+// the window START (bucket-start convention), so only startTime is needed.
+func (h *ContinuousQueryHandler) executeAggregation(ctx context.Context, cq *ContinuousQuery, query string, startTime, _ time.Time) (int64, error) {
 	// Build storage path for source measurement (supports local, S3, Azure)
 	measurementPath := storage.GetStoragePath(h.storage, cq.Database, cq.SourceMeasurement)
 
@@ -817,18 +863,76 @@ func (h *ContinuousQueryHandler) executeAggregation(ctx context.Context, cq *Con
 		}
 	}
 
-	// Ensure time column exists (as int64 microseconds)
+	// Ensure time column exists (as int64 microseconds).
+	// When the aggregation query does not select a time column, stamp every row
+	// with the WINDOW START time — not time.Now() (#521). time.Now() gave rows a
+	// wall-clock ingestion timestamp (wrong for a time-series) and made a re-run
+	// of the same window produce rows with a DIFFERENT timestamp, so they could
+	// never be deduped. The window start is stable across re-runs, so duplicate
+	// emissions land at the identical (tags, time) and collapse at compaction.
 	if _, hasTime := columnarData["time"]; !hasTime {
-		nowMicro := time.Now().UTC().UnixMicro()
+		windowMicro := startTime.UTC().UnixMicro()
 		times := make([]interface{}, len(records))
 		for i := range times {
-			times[i] = nowMicro
+			times[i] = windowMicro
 		}
 		columnarData["time"] = times
 	}
 
-	// Write using WriteColumnarDirect
-	if err := h.arrowBuffer.WriteColumnarDirect(ctx, cq.Database, cq.DestinationMeasurement, columnarData); err != nil {
+	// Determine which declared tag columns are actually present in the output.
+	// A tag name that isn't an output column must NOT reach the Parquet arc:tags
+	// metadata: compaction's dedup builds `PARTITION BY "<tag>", "time"` from that
+	// metadata, and a name with no matching column fails to bind and wedges the
+	// whole partition (it can never compact). Intersecting here makes a stale or
+	// mistaken tag_columns entry harmless rather than a compaction wedge (#521).
+	var tagColumns []string
+	for _, name := range cq.TagColumns {
+		if _, ok := columnarData[name]; ok {
+			tagColumns = append(tagColumns, name)
+		} else {
+			h.logger.Warn().
+				Str("query_name", cq.Name).
+				Str("tag_column", name).
+				Msg("Declared tag_column is not an output column of the CQ; skipping (would otherwise wedge compaction)")
+		}
+	}
+
+	// Decide whether to mark this output for time-only dedup (#521). This ONLY
+	// matters when there are no tag columns — with tags, arc:tags already drives
+	// dedup on (tags, time). The marker makes compaction dedup on time ALONE, so
+	// it is safe ONLY if time is a unique key in the output (one row per window).
+	//
+	// CRITICAL: we must NOT assume "no tag columns" means "one row per window". A
+	// grouped CQ (e.g. GROUP BY host) whose operator forgot to declare
+	// tag_columns produces MULTIPLE rows per timestamp with no tags — marking it
+	// for time-only dedup would make compaction keep one row per timestamp and
+	// silently DELETE every series but one. So we verify uniqueness against the
+	// actual output and, if time repeats without tags, skip the marker and warn
+	// the operator to declare tag_columns.
+	dedupTime := false
+	if len(tagColumns) == 0 {
+		if timeColumnIsUnique(columnarData["time"]) {
+			dedupTime = true
+		} else {
+			h.logger.Warn().
+				Str("query_name", cq.Name).
+				Msg("CQ output has multiple rows per timestamp but no tag_columns declared; " +
+					"skipping time-only dedup to avoid data loss. Declare tag_columns for the " +
+					"grouping dimensions to make this CQ idempotent (#521).")
+		}
+	}
+
+	// Write using WriteColumnarRecord so TagColumns (and the dedup-time marker)
+	// are preserved as Parquet metadata, enabling compaction to dedup CQ output.
+	// This goes through the identical buffer/flush/WAL path as WriteColumnarDirect.
+	record := &models.ColumnarRecord{
+		Measurement: cq.DestinationMeasurement,
+		Columnar:    true,
+		Columns:     columnarData,
+		TagColumns:  tagColumns,
+		DedupTime:   dedupTime,
+	}
+	if err := h.arrowBuffer.WriteColumnarRecord(ctx, cq.Database, record); err != nil {
 		return 0, fmt.Errorf("failed to write records: %w", err)
 	}
 
@@ -878,7 +982,7 @@ func (h *ContinuousQueryHandler) getQuery(queryID int64) (*ContinuousQuery, erro
 	row := h.sqliteDB.QueryRow(`
 		SELECT
 			cq.id, cq.name, cq.description, cq.database, cq.source_measurement, cq.destination_measurement,
-			cq.query, cq.interval, cq.retention_days, cq.delete_source_after_days, cq.is_active,
+			cq.query, cq.interval, cq.tag_columns, cq.retention_days, cq.delete_source_after_days, cq.is_active,
 			cq.last_processed_time, cq.created_at, cq.updated_at,
 			cqe.execution_time, cqe.status, cqe.records_written
 		FROM continuous_queries cq
@@ -891,15 +995,22 @@ func (h *ContinuousQueryHandler) getQuery(queryID int64) (*ContinuousQuery, erro
 	`, queryID)
 
 	var q ContinuousQuery
+	var tagColumnsRaw *string
 	err := row.Scan(
 		&q.ID, &q.Name, &q.Description, &q.Database, &q.SourceMeasurement, &q.DestinationMeasurement,
-		&q.Query, &q.Interval, &q.RetentionDays, &q.DeleteSourceAfterDays, &q.IsActive,
+		&q.Query, &q.Interval, &tagColumnsRaw, &q.RetentionDays, &q.DeleteSourceAfterDays, &q.IsActive,
 		&q.LastProcessedTime, &q.CreatedAt, &q.UpdatedAt,
 		&q.LastExecutionTime, &q.LastExecutionStatus, &q.LastRecordsWritten,
 	)
 	if err != nil {
 		return nil, err
 	}
+	tags, decErr := decodeTagColumns(tagColumnsRaw)
+	if decErr != nil {
+		h.logger.Warn().Err(decErr).Str("query_name", q.Name).
+			Msg("Ignoring corrupt tag_columns; CQ will not dedup until it is re-saved (#521)")
+	}
+	q.TagColumns = tags
 
 	return &q, nil
 }
@@ -909,7 +1020,7 @@ func (h *ContinuousQueryHandler) getQueries(database, isActiveStr string) ([]Con
 	query := `
 		SELECT
 			cq.id, cq.name, cq.description, cq.database, cq.source_measurement, cq.destination_measurement,
-			cq.query, cq.interval, cq.retention_days, cq.delete_source_after_days, cq.is_active,
+			cq.query, cq.interval, cq.tag_columns, cq.retention_days, cq.delete_source_after_days, cq.is_active,
 			cq.last_processed_time, cq.created_at, cq.updated_at,
 			cqe.execution_time, cqe.status, cqe.records_written
 		FROM continuous_queries cq
@@ -949,14 +1060,21 @@ func (h *ContinuousQueryHandler) getQueries(database, isActiveStr string) ([]Con
 	var queries []ContinuousQuery
 	for rows.Next() {
 		var q ContinuousQuery
+		var tagColumnsRaw *string
 		if err := rows.Scan(
 			&q.ID, &q.Name, &q.Description, &q.Database, &q.SourceMeasurement, &q.DestinationMeasurement,
-			&q.Query, &q.Interval, &q.RetentionDays, &q.DeleteSourceAfterDays, &q.IsActive,
+			&q.Query, &q.Interval, &tagColumnsRaw, &q.RetentionDays, &q.DeleteSourceAfterDays, &q.IsActive,
 			&q.LastProcessedTime, &q.CreatedAt, &q.UpdatedAt,
 			&q.LastExecutionTime, &q.LastExecutionStatus, &q.LastRecordsWritten,
 		); err != nil {
 			continue
 		}
+		tags, decErr := decodeTagColumns(tagColumnsRaw)
+		if decErr != nil {
+			h.logger.Warn().Err(decErr).Str("query_name", q.Name).
+				Msg("Ignoring corrupt tag_columns; CQ will not dedup until it is re-saved (#521)")
+		}
+		q.TagColumns = tags
 		queries = append(queries, q)
 	}
 
@@ -1008,6 +1126,100 @@ func (h *ContinuousQueryHandler) recordExecution(queryID int64, executionID, sta
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to record execution")
 	}
+}
+
+// encodeTagColumns serializes the tag column list for storage as a SQLite TEXT
+// column. An empty/nil list encodes to NULL (stored as a nil *string) so the
+// column round-trips cleanly and pre-migration rows read back as no tags.
+func encodeTagColumns(tags []string) (*string, error) {
+	if len(tags) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(tags)
+	if err != nil {
+		return nil, err
+	}
+	s := string(b)
+	return &s, nil
+}
+
+// decodeTagColumns parses the JSON tag column list read from SQLite. A NULL or
+// empty value (pre-migration rows, or CQs created without tags) decodes to nil
+// with no error. A non-empty value that fails to parse (corruption, a bad manual
+// edit) returns an error so the caller can warn — silently returning nil would
+// revert a CQ to no-dedup behavior with no signal, letting duplicates accumulate.
+func decodeTagColumns(raw *string) ([]string, error) {
+	if raw == nil || *raw == "" {
+		return nil, nil
+	}
+	var tags []string
+	if err := json.Unmarshal([]byte(*raw), &tags); err != nil {
+		return nil, fmt.Errorf("corrupt tag_columns value %q: %w", *raw, err)
+	}
+	return tags, nil
+}
+
+// maxUniquenessCheckRows caps how many rows timeColumnIsUnique will scan before
+// giving up and reporting "not unique" (i.e. not dedup-safe). A tagless CQ that
+// legitimately produces one row per window is tiny (one row per interval), so a
+// large output almost certainly means a grouping CQ that forgot to declare
+// tag_columns — exactly the case where time-only dedup would be unsafe. Bounding
+// the scan avoids building a huge map for that misconfiguration, and failing
+// closed (treat as not-unique → skip the marker) is the safe direction.
+const maxUniquenessCheckRows = 100_000
+
+// timeColumnIsUnique reports whether the time column has no duplicate values —
+// i.e. time alone is a unique key for the output. Used to decide whether a
+// tagless CQ is safe to mark for time-only dedup (#521): if two rows share a
+// timestamp with no tag to distinguish them, time-only dedup would lose one, so
+// the marker must be withheld. An empty/absent column is trivially unique.
+//
+// Fails closed: an output larger than maxUniquenessCheckRows returns false
+// (not dedup-safe) rather than building an unbounded map — a tagless CQ that big
+// is almost certainly a mis-declared grouping CQ, which must NOT be marked.
+func timeColumnIsUnique(times []interface{}) bool {
+	if len(times) <= 1 {
+		return true
+	}
+	if len(times) > maxUniquenessCheckRows {
+		return false
+	}
+	seen := make(map[interface{}]struct{}, len(times))
+	for _, t := range times {
+		// Comparable key: the time column is normalized to int64 micros before
+		// this runs, but be defensive about the underlying type. interface{}
+		// values are comparable as map keys when the dynamic type is comparable
+		// (all our time representations — int64, string, time.Time — are).
+		if _, dup := seen[t]; dup {
+			return false
+		}
+		seen[t] = struct{}{}
+	}
+	return true
+}
+
+// validateTagColumns rejects tag column names that aren't safe SQL identifiers.
+// The names are emitted verbatim into the Parquet arc:tags metadata and later
+// interpolated into compaction's `PARTITION BY "<name>"` dedup query, so an
+// unsafe name must never reach storage — validate at the API boundary. Rules
+// match internal/compaction/dedup.go#isValidIdentifier (alphanumeric, '_', '-').
+func validateTagColumns(tags []string) error {
+	for _, name := range tags {
+		if name == "" {
+			return fmt.Errorf("tag column name must not be empty")
+		}
+		// "time" is never a valid tag: compaction always appends "time" to the
+		// dedup key, so declaring it would produce PARTITION BY "time", "time".
+		if strings.EqualFold(name, "time") {
+			return fmt.Errorf("tag column %q is reserved: time is always part of the dedup key and must not be listed", name)
+		}
+		for _, c := range name {
+			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-') {
+				return fmt.Errorf("invalid tag column %q: only alphanumeric, underscore, and hyphen are allowed", name)
+			}
+		}
+	}
+	return nil
 }
 
 // updateLastProcessedTime updates the last processed time for a query

--- a/internal/api/continuous_query_test.go
+++ b/internal/api/continuous_query_test.go
@@ -1,6 +1,13 @@
 package api
 
-import "testing"
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+)
 
 func TestWrapSourceMeasurement(t *testing.T) {
 	const rp = "read_parquet('s3://b/db/m/**/*.parquet', union_by_name=true)"
@@ -100,5 +107,269 @@ func TestWrapSourceMeasurement(t *testing.T) {
 					tt.query, tt.database, tt.measurement, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestValidateTagColumns(t *testing.T) {
+	tests := []struct {
+		name    string
+		tags    []string
+		wantErr bool
+	}{
+		{"nil is valid", nil, false},
+		{"empty slice is valid", []string{}, false},
+		{"simple names", []string{"host", "region"}, false},
+		{"underscore and hyphen and digits", []string{"data_center", "az-1", "shard0"}, false},
+		{"empty name rejected", []string{"host", ""}, true},
+		{"space rejected", []string{"host name"}, true},
+		{"quote rejected (injection guard)", []string{"host\""}, true},
+		{"paren rejected", []string{"count(*)"}, true},
+		{"dot rejected", []string{"db.host"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTagColumns(tt.tags)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateTagColumns(%v): expected error, got nil", tt.tags)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validateTagColumns(%v): unexpected error: %v", tt.tags, err)
+			}
+		})
+	}
+}
+
+func TestTagColumnsRoundTrip(t *testing.T) {
+	// nil/empty encodes to NULL and decodes back to nil.
+	for _, empty := range [][]string{nil, {}} {
+		enc, err := encodeTagColumns(empty)
+		if err != nil {
+			t.Fatalf("encodeTagColumns(%v): %v", empty, err)
+		}
+		if enc != nil {
+			t.Errorf("encodeTagColumns(%v): expected nil (NULL), got %q", empty, *enc)
+		}
+		got, decErr := decodeTagColumns(enc)
+		if decErr != nil {
+			t.Errorf("decodeTagColumns(nil): unexpected error: %v", decErr)
+		}
+		if got != nil {
+			t.Errorf("decodeTagColumns(nil): expected nil, got %v", got)
+		}
+	}
+
+	// Non-empty round-trips exactly.
+	in := []string{"host", "region", "az-1"}
+	enc, err := encodeTagColumns(in)
+	if err != nil {
+		t.Fatalf("encodeTagColumns: %v", err)
+	}
+	if enc == nil {
+		t.Fatal("encodeTagColumns: expected non-nil for a non-empty list")
+	}
+	got, err := decodeTagColumns(enc)
+	if err != nil {
+		t.Fatalf("decodeTagColumns: %v", err)
+	}
+	if len(got) != len(in) {
+		t.Fatalf("round-trip length mismatch: got %v, want %v", got, in)
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Errorf("round-trip[%d]: got %q, want %q", i, got[i], in[i])
+		}
+	}
+}
+
+func TestDecodeTagColumnsMalformed(t *testing.T) {
+	// A corrupt value returns an error (caller warns) rather than panicking.
+	bad := "not-json"
+	if got, err := decodeTagColumns(&bad); got != nil || err == nil {
+		t.Errorf("decodeTagColumns(malformed): expected (nil, error), got (%v, %v)", got, err)
+	}
+	// Empty string is a legitimate no-tags value: nil, no error.
+	empty := ""
+	if got, err := decodeTagColumns(&empty); got != nil || err != nil {
+		t.Errorf("decodeTagColumns(empty string): expected (nil, nil), got (%v, %v)", got, err)
+	}
+}
+
+// newSQLiteOnlyCQHandler builds a handler wired to a temp SQLite DB only —
+// enough to exercise the create/get/list/migration paths that touch just
+// sqliteDB (no DuckDB/ArrowBuffer needed).
+func newSQLiteOnlyCQHandler(t *testing.T, dbPath string) *ContinuousQueryHandler {
+	t.Helper()
+	sqliteDB, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	h := &ContinuousQueryHandler{
+		sqliteDB: sqliteDB,
+		logger:   zerolog.Nop(),
+	}
+	if err := h.initTables(); err != nil {
+		t.Fatalf("initTables: %v", err)
+	}
+	return h
+}
+
+func TestCQTagColumnsPersistAndMigrate(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "cq.db")
+
+	// First handler: create the schema fresh (includes tag_columns).
+	h := newSQLiteOnlyCQHandler(t, dbPath)
+
+	// Insert a CQ with tag_columns directly (exercise the storage round-trip).
+	tagsJSON, err := encodeTagColumns([]string{"host", "region"})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	_, err = h.sqliteDB.Exec(`
+		INSERT INTO continuous_queries
+		(name, description, database, source_measurement, destination_measurement, query, interval, tag_columns, retention_days, delete_source_after_days, is_active)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, "cq1", nil, "db", "src", "dst", "SELECT 1 {start_time} {end_time}", "1h", tagsJSON, nil, nil, true)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, err := h.getQuery(1)
+	if err != nil {
+		t.Fatalf("getQuery: %v", err)
+	}
+	if len(got.TagColumns) != 2 || got.TagColumns[0] != "host" || got.TagColumns[1] != "region" {
+		t.Fatalf("tag_columns round-trip: got %v, want [host region]", got.TagColumns)
+	}
+	h.sqliteDB.Close()
+
+	// Second handler over the SAME file: initTables runs the ALTER migration
+	// guard against an already-migrated DB — must be idempotent (no error), and
+	// the existing row must still read back its tags.
+	h2 := newSQLiteOnlyCQHandler(t, dbPath)
+	defer h2.sqliteDB.Close()
+	got2, err := h2.getQuery(1)
+	if err != nil {
+		t.Fatalf("getQuery after re-init: %v", err)
+	}
+	if len(got2.TagColumns) != 2 {
+		t.Fatalf("tag_columns lost across re-init: got %v", got2.TagColumns)
+	}
+
+	// A CQ created without tags reads back nil (back-compat / no-dedup path).
+	_, err = h2.sqliteDB.Exec(`
+		INSERT INTO continuous_queries
+		(name, database, source_measurement, destination_measurement, query, interval, is_active)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, "cq2", "db", "src", "dst2", "SELECT 1 {start_time} {end_time}", "1h", true)
+	if err != nil {
+		t.Fatalf("insert cq2: %v", err)
+	}
+	got3, err := h2.getQuery(2)
+	if err != nil {
+		t.Fatalf("getQuery cq2: %v", err)
+	}
+	if got3.TagColumns != nil {
+		t.Errorf("expected nil tag_columns for CQ created without tags, got %v", got3.TagColumns)
+	}
+}
+
+// TestCQMigrationFromLegacySchema verifies the ALTER guard adds tag_columns to a
+// database created BEFORE the column existed (a real upgrade), and legacy rows
+// read back with nil tags.
+func TestCQMigrationFromLegacySchema(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "legacy.db")
+
+	// Build a legacy continuous_queries table WITHOUT tag_columns and seed a row.
+	legacy, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	_, err = legacy.Exec(`
+		CREATE TABLE continuous_queries (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT UNIQUE NOT NULL,
+			description TEXT,
+			database TEXT NOT NULL,
+			source_measurement TEXT NOT NULL,
+			destination_measurement TEXT NOT NULL,
+			query TEXT NOT NULL,
+			interval TEXT NOT NULL,
+			retention_days INTEGER,
+			delete_source_after_days INTEGER,
+			is_active BOOLEAN DEFAULT TRUE,
+			last_processed_time TIMESTAMP,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)`)
+	if err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	_, err = legacy.Exec(`INSERT INTO continuous_queries
+		(name, database, source_measurement, destination_measurement, query, interval, is_active)
+		VALUES ('legacy', 'db', 'src', 'dst', 'SELECT 1 {start_time} {end_time}', '1h', true)`)
+	if err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+	legacy.Close()
+
+	// Opening via the handler runs initTables → the ALTER migration.
+	h := newSQLiteOnlyCQHandler(t, dbPath)
+	defer h.sqliteDB.Close()
+
+	got, err := h.getQuery(1)
+	if err != nil {
+		t.Fatalf("getQuery legacy row after migration: %v", err)
+	}
+	if got.TagColumns != nil {
+		t.Errorf("legacy row should have nil tag_columns, got %v", got.TagColumns)
+	}
+	if got.Name != "legacy" {
+		t.Errorf("legacy row corrupted: name=%q", got.Name)
+	}
+}
+
+func TestTimeColumnIsUnique(t *testing.T) {
+	tests := []struct {
+		name  string
+		times []interface{}
+		want  bool
+	}{
+		{"empty is unique", nil, true},
+		{"single is unique", []interface{}{int64(100)}, true},
+		{"distinct int64 times", []interface{}{int64(100), int64(200), int64(300)}, true},
+		{"duplicate int64 times (grouped, no tags)", []interface{}{int64(100), int64(100)}, false},
+		{"duplicate among distinct", []interface{}{int64(100), int64(200), int64(100)}, false},
+		{"distinct strings", []interface{}{"2026-01-01", "2026-01-02"}, true},
+		{"duplicate strings", []interface{}{"2026-01-01", "2026-01-01"}, false},
+	}
+	// Fails closed above the scan cap: an all-distinct output larger than the cap
+	// returns false (not dedup-safe) rather than building an unbounded map.
+	huge := make([]interface{}, maxUniquenessCheckRows+1)
+	for i := range huge {
+		huge[i] = int64(i)
+	}
+	if timeColumnIsUnique(huge) {
+		t.Errorf("expected false for output larger than the uniqueness-check cap (fail closed)")
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := timeColumnIsUnique(tt.times); got != tt.want {
+				t.Errorf("timeColumnIsUnique(%v) = %v, want %v", tt.times, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateTagColumnsRejectsTime(t *testing.T) {
+	for _, name := range []string{"time", "TIME", "Time"} {
+		if err := validateTagColumns([]string{name}); err == nil {
+			t.Errorf("validateTagColumns([%q]): expected rejection of reserved 'time'", name)
+		}
+	}
+	// A non-time column alongside is fine.
+	if err := validateTagColumns([]string{"host", "region"}); err != nil {
+		t.Errorf("validateTagColumns([host region]): unexpected error: %v", err)
 	}
 }

--- a/internal/compaction/dedup.go
+++ b/internal/compaction/dedup.go
@@ -44,6 +44,33 @@ func readTagColumnsFromParquetFiles(ctx context.Context, db *sql.DB, filePaths [
 	return result, nil
 }
 
+// readDedupTimeFromParquetFiles reports whether ANY of the given Parquet files
+// carries the "arc:dedup_time" marker. That marker is written only by producers
+// whose data model is one-row-per-(tags,time) — continuous queries (#521) — and
+// tells compaction it is safe to dedup on time even when there are no tag
+// columns. A missing marker (all raw-ingest files) returns false, so ingest
+// dedup behavior is unchanged.
+func readDedupTimeFromParquetFiles(ctx context.Context, db *sql.DB, filePaths []string) (bool, error) {
+	for _, filePath := range filePaths {
+		query := fmt.Sprintf(
+			`SELECT value FROM parquet_kv_metadata('%s') WHERE key = 'arc:dedup_time'`,
+			escapeSQLPath(filePath),
+		)
+		var val string
+		err := db.QueryRowContext(ctx, query).Scan(&val)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("failed to read parquet dedup_time metadata: %w", err)
+		}
+		if val == "true" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // readTagColumnsFromParquet reads the "arc:tags" metadata from a single Parquet file.
 // Returns nil if no tag metadata is found (file written before dedup feature).
 func readTagColumnsFromParquet(ctx context.Context, db *sql.DB, filePath string) ([]string, error) {
@@ -105,15 +132,20 @@ const dedupStagingTable = "arc_compaction_staged"
 // buildCompactionQuery builds the DuckDB statement(s) for compaction. It returns
 // a slice of statements to execute in order on the same connection.
 //
-// When tagColumns is nil/empty, returns a single standard COPY (zero overhead).
-// When tagColumns is non-empty, returns two statements (CREATE OR REPLACE TEMP
-// TABLE ... AS <normalized read> ; COPY <dedup window over the table>) — see the
-// long comment on the dedup branch for why a temp table is required rather than
-// a CTE or subquery.
-func buildCompactionQuery(fileListSQL, orderByClause, outputFile string, tagColumns []string) []string {
+// Dedup runs when tagColumns is non-empty OR dedupTime is set. Without either,
+// returns a single standard COPY (zero overhead). When deduping, returns two
+// statements (CREATE OR REPLACE TEMP TABLE ... AS <normalized read> ; COPY
+// <dedup window over the table>) — see the long comment on the dedup branch for
+// why a temp table is required rather than a CTE or subquery.
+//
+// The dedup key is (tagColumns..., "time"). With no tag columns but dedupTime
+// set (a no-group-by continuous query, #521), the key is "time" alone — one row
+// per timestamp. This is safe ONLY because dedupTime is written exclusively by
+// producers whose data is one-row-per-time; raw ingest never sets it.
+func buildCompactionQuery(fileListSQL, orderByClause, outputFile string, tagColumns []string, dedupTime bool) []string {
 	escapedOutput := escapeSQLPath(outputFile)
 
-	if len(tagColumns) == 0 {
+	if len(tagColumns) == 0 && !dedupTime {
 		// Standard compaction — no dedup overhead.
 		// Normalize "time" to TIMESTAMP so a partition that mixes file schemas
 		// (some time=TIMESTAMP, some time=VARCHAR from a misbehaving writer)
@@ -167,14 +199,18 @@ func buildCompactionQuery(fileListSQL, orderByClause, outputFile string, tagColu
 	// PARTITION BY all tag columns + time: rows with identical (tags, time) are
 	// duplicates; one is kept. This is the dedup key, not the output order — the
 	// output is sorted by the separate orderByClause (time).
-	var quotedTags []string
+	// Build the PARTITION BY key: all tag columns plus "time". When there are no
+	// tag columns (a no-group-by CQ reaching here via dedupTime), the key is
+	// "time" alone — build the list without a dangling leading comma.
+	quotedKeys := make([]string, 0, len(tagColumns)+1)
 	for _, tag := range tagColumns {
 		// Double-quote escaping: DuckDB treats "" inside a quoted identifier as a literal "
 		// (same as PostgreSQL). This prevents identifier breakout even if validation is bypassed.
 		escaped := strings.ReplaceAll(tag, `"`, `""`)
-		quotedTags = append(quotedTags, fmt.Sprintf(`"%s"`, escaped))
+		quotedKeys = append(quotedKeys, fmt.Sprintf(`"%s"`, escaped))
 	}
-	partitionBy := strings.Join(quotedTags, ", ")
+	quotedKeys = append(quotedKeys, `"time"`)
+	partitionBy := strings.Join(quotedKeys, ", ")
 
 	stage := fmt.Sprintf(
 		`CREATE OR REPLACE TEMP TABLE %s AS SELECT * REPLACE (%s) FROM read_parquet(%s, union_by_name=true)`,
@@ -184,7 +220,7 @@ func buildCompactionQuery(fileListSQL, orderByClause, outputFile string, tagColu
 		COPY (
 			SELECT * FROM %s
 			QUALIFY ROW_NUMBER() OVER (
-				PARTITION BY %s, "time"
+				PARTITION BY %s
 				ORDER BY "time" DESC
 			) = 1
 			%s

--- a/internal/compaction/dedup_integration_test.go
+++ b/internal/compaction/dedup_integration_test.go
@@ -17,20 +17,20 @@ import (
 // on a single pinned connection — mirroring the production caller in job.go. The
 // pin is required, not cosmetic: the dedup path's TEMP table is connection-local
 // and database/sql does not guarantee two ExecContext calls share a connection.
-func execCompaction(ctx context.Context, db *sql.DB, fileListSQL, orderByClause, outputFile string, tagColumns []string) error {
+func execCompaction(ctx context.Context, db *sql.DB, fileListSQL, orderByClause, outputFile string, tagColumns []string, dedupTime bool) error {
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if len(tagColumns) > 0 {
+		if len(tagColumns) > 0 || dedupTime {
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			_, _ = conn.ExecContext(cleanupCtx, "DROP TABLE IF EXISTS "+dedupStagingTable)
 		}
 		conn.Close()
 	}()
-	for _, stmt := range buildCompactionQuery(fileListSQL, orderByClause, outputFile, tagColumns) {
+	for _, stmt := range buildCompactionQuery(fileListSQL, orderByClause, outputFile, tagColumns, dedupTime) {
 		if _, err := conn.ExecContext(ctx, stmt); err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func TestBuildCompactionQuery_DedupMixedTimeType(t *testing.T) {
 	}
 
 	fileList := fmt.Sprintf("['%s', '%s']", escapeSQLPath(fileTZ), escapeSQLPath(fileStr))
-	if err := execCompaction(ctx, db, fileList, `ORDER BY "time"`, out, []string{"host"}); err != nil {
+	if err := execCompaction(ctx, db, fileList, `ORDER BY "time"`, out, []string{"host"}, false); err != nil {
 		t.Fatalf("compaction query failed (bind error regression?): %v", err)
 	}
 
@@ -163,7 +163,7 @@ func TestBuildCompactionQuery_StandardMixedTimeType(t *testing.T) {
 
 	fileList := fmt.Sprintf("['%s', '%s']", escapeSQLPath(fileTZ), escapeSQLPath(fileStr))
 	// nil tagColumns → standard branch.
-	if err := execCompaction(ctx, db, fileList, `ORDER BY "time"`, out, nil); err != nil {
+	if err := execCompaction(ctx, db, fileList, `ORDER BY "time"`, out, nil, false); err != nil {
 		t.Fatalf("standard compaction query failed (bind error regression?): %v", err)
 	}
 
@@ -182,5 +182,55 @@ func TestBuildCompactionQuery_StandardMixedTimeType(t *testing.T) {
 	}
 	if colType != "TIMESTAMP WITH TIME ZONE" {
 		t.Errorf("output time type = %q, want TIMESTAMP WITH TIME ZONE", colType)
+	}
+}
+
+// TestBuildCompactionQuery_DedupTimeOnly is the #521 no-group-by CQ path against
+// real DuckDB: NO tag columns, dedupTime=true. Two files carry the SAME "time"
+// (a window re-emitted twice by a crash-retry); dedup on time alone must collapse
+// them to exactly one row. Without the dedupTime flag these would both survive
+// (the standard branch keeps distinct rows), so this proves the marker is what
+// makes a tagless CQ idempotent.
+func TestBuildCompactionQuery_DedupTimeOnlyDuckDB(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, "SET TimeZone='Etc/GMT+3'"); err != nil {
+		t.Fatalf("set tz: %v", err)
+	}
+
+	fileA := filepath.ToSlash(filepath.Join(dir, "a.parquet"))
+	fileB := filepath.ToSlash(filepath.Join(dir, "b.parquet"))
+	out := filepath.ToSlash(filepath.Join(dir, "out.parquet"))
+
+	// Same window (same "time"), no tag column — two emissions of a no-group-by
+	// aggregate. avg differs (2.0 vs 2.5) but they are the same window; dedup
+	// keeps the newest by "time" DESC (a tie here, so exactly one survives).
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		`COPY (SELECT make_timestamptz(1609459200000000) AS "time", 2.0 AS avg_v) TO '%s' (FORMAT PARQUET)`, escapeSQLPath(fileA))); err != nil {
+		t.Fatalf("write fixture a: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		`COPY (SELECT make_timestamptz(1609459200000000) AS "time", 2.5 AS avg_v) TO '%s' (FORMAT PARQUET)`, escapeSQLPath(fileB))); err != nil {
+		t.Fatalf("write fixture b: %v", err)
+	}
+
+	fileList := fmt.Sprintf("['%s', '%s']", escapeSQLPath(fileA), escapeSQLPath(fileB))
+	// nil tagColumns, dedupTime=true → PARTITION BY "time" alone.
+	if err := execCompaction(ctx, db, fileList, `ORDER BY "time"`, out, nil, true); err != nil {
+		t.Fatalf("dedup-time compaction failed: %v", err)
+	}
+
+	var rows int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM read_parquet('%s')`, escapeSQLPath(out))).Scan(&rows); err != nil {
+		t.Fatalf("count output: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("dedup-time produced %d rows, want 1 (same-time rows must collapse)", rows)
 	}
 }

--- a/internal/compaction/dedup_realpartition_test.go
+++ b/internal/compaction/dedup_realpartition_test.go
@@ -72,7 +72,7 @@ func TestDedupCompaction_RealPartition(t *testing.T) {
 
 	// Step 1: real files only (all TIMESTAMPTZ) — must bind.
 	out1 := filepath.ToSlash(filepath.Join(t.TempDir(), "real.parquet"))
-	if err := execCompaction(ctx, db, quote(files), `ORDER BY "time"`, out1, []string{"host"}); err != nil {
+	if err := execCompaction(ctx, db, quote(files), `ORDER BY "time"`, out1, []string{"host"}, false); err != nil {
 		t.Fatalf("dedup compaction wedged on real all-TIMESTAMPTZ files: %v", err)
 	}
 	var baseRows int
@@ -98,7 +98,7 @@ func TestDedupCompaction_RealPartition(t *testing.T) {
 		t.Fatalf("write varchar dup: %v", err)
 	}
 	out2 := filepath.ToSlash(filepath.Join(tmp, "withdup.parquet"))
-	if err := execCompaction(ctx, db, quote(append(files, vc)), `ORDER BY "time"`, out2, []string{"host"}); err != nil {
+	if err := execCompaction(ctx, db, quote(append(files, vc)), `ORDER BY "time"`, out2, []string{"host"}, false); err != nil {
 		t.Fatalf("dedup compaction wedged with injected VARCHAR-time file: %v", err)
 	}
 	var dupRows int

--- a/internal/compaction/dedup_scale_integration_test.go
+++ b/internal/compaction/dedup_scale_integration_test.go
@@ -88,7 +88,7 @@ func TestBuildCompactionQuery_DedupMixedTimeAtScale(t *testing.T) {
 				out := filepath.ToSlash(filepath.Join(dir, "out.parquet"))
 
 				// Dedup branch (host tag) — the one that wedged.
-				if err := execCompaction(ctx, db, fileList, `ORDER BY "time"`, out, []string{"host"}); err != nil {
+				if err := execCompaction(ctx, db, fileList, `ORDER BY "time"`, out, []string{"host"}, false); err != nil {
 					t.Fatalf("dedup compaction wedged (temp-table materialization missing?): %v", err)
 				}
 

--- a/internal/compaction/dedup_test.go
+++ b/internal/compaction/dedup_test.go
@@ -8,12 +8,12 @@ import (
 // buildCompactionSQL joins the statement(s) buildCompactionQuery returns into a
 // single string for the string-assertion unit tests below. The dedup path
 // returns two statements (CREATE TEMP TABLE + COPY); the standard path one.
-func buildCompactionSQL(fileListSQL, orderByClause, outputFile string, tagColumns []string) string {
-	return strings.Join(buildCompactionQuery(fileListSQL, orderByClause, outputFile, tagColumns), "\n;\n")
+func buildCompactionSQL(fileListSQL, orderByClause, outputFile string, tagColumns []string, dedupTime bool) string {
+	return strings.Join(buildCompactionQuery(fileListSQL, orderByClause, outputFile, tagColumns, dedupTime), "\n;\n")
 }
 
 func TestBuildCompactionQuery_NoDedup(t *testing.T) {
-	query := buildCompactionSQL("['a.parquet', 'b.parquet']", `ORDER BY "time"`, "/tmp/out.parquet", nil)
+	query := buildCompactionSQL("['a.parquet', 'b.parquet']", `ORDER BY "time"`, "/tmp/out.parquet", nil, false)
 
 	if strings.Contains(query, "ROW_NUMBER") {
 		t.Error("expected no ROW_NUMBER without dedup keys")
@@ -32,6 +32,7 @@ func TestBuildCompactionQuery_WithDedup(t *testing.T) {
 		`ORDER BY "time"`,
 		"/tmp/out.parquet",
 		[]string{"host", "region"},
+		false,
 	)
 
 	if !strings.Contains(query, "ROW_NUMBER") {
@@ -59,15 +60,45 @@ func TestBuildCompactionQuery_WithDedup(t *testing.T) {
 }
 
 func TestBuildCompactionQuery_EmptyDedup(t *testing.T) {
-	query := buildCompactionSQL("['a.parquet']", "", "/tmp/out.parquet", []string{})
+	query := buildCompactionSQL("['a.parquet']", "", "/tmp/out.parquet", []string{}, false)
 
 	if strings.Contains(query, "ROW_NUMBER") {
 		t.Error("expected no ROW_NUMBER with empty dedup keys")
 	}
 }
 
+// TestBuildCompactionQuery_DedupTimeOnly covers the #521 no-group-by CQ path:
+// no tag columns but dedupTime=true → dedup on "time" alone (PARTITION BY "time"
+// with no leading comma).
+func TestBuildCompactionQuery_DedupTimeOnly(t *testing.T) {
+	query := buildCompactionSQL("['a.parquet', 'b.parquet']", `ORDER BY "time"`, "/tmp/out.parquet", nil, true)
+
+	if !strings.Contains(query, "QUALIFY ROW_NUMBER") {
+		t.Errorf("expected dedup (QUALIFY ROW_NUMBER) when dedupTime is set, got: %s", query)
+	}
+	if !strings.Contains(query, `PARTITION BY "time"`) {
+		t.Errorf("expected PARTITION BY \"time\" alone, got: %s", query)
+	}
+	// Must NOT have a dangling leading comma from an empty tag list.
+	if strings.Contains(query, `PARTITION BY , "time"`) || strings.Contains(query, `PARTITION BY ,"time"`) {
+		t.Errorf("dangling comma in PARTITION BY with no tags: %s", query)
+	}
+	if !strings.Contains(query, "make_timestamptz") {
+		t.Error("dedup-time branch must still normalize time to TIMESTAMPTZ")
+	}
+}
+
+// TestBuildCompactionQuery_DedupTimeWithTags: dedupTime is a no-op when tags are
+// already present — the key stays (tags, time), same as the tag-only branch.
+func TestBuildCompactionQuery_DedupTimeWithTags(t *testing.T) {
+	withFlag := buildCompactionSQL("['a.parquet']", "", "/tmp/o.parquet", []string{"host"}, true)
+	if !strings.Contains(withFlag, `PARTITION BY "host", "time"`) {
+		t.Errorf("expected (host, time) key when both tags and dedupTime present, got: %s", withFlag)
+	}
+}
+
 func TestBuildCompactionQuery_SpecialCharsInPath(t *testing.T) {
-	query := buildCompactionSQL("['a.parquet']", "", "/tmp/it's out.parquet", []string{"host"})
+	query := buildCompactionSQL("['a.parquet']", "", "/tmp/it's out.parquet", []string{"host"}, false)
 
 	if !strings.Contains(query, "it''s") {
 		t.Error("expected escaped single quote in output path")
@@ -76,7 +107,7 @@ func TestBuildCompactionQuery_SpecialCharsInPath(t *testing.T) {
 
 func TestBuildCompactionQuery_IdentifierEscaping(t *testing.T) {
 	// Defense-in-depth: even if validation is bypassed, identifiers are properly escaped
-	query := buildCompactionSQL("['a.parquet']", "", "/tmp/out.parquet", []string{`host"injection`})
+	query := buildCompactionSQL("['a.parquet']", "", "/tmp/out.parquet", []string{`host"injection`}, false)
 
 	// Double-quote inside identifier should be doubled
 	if !strings.Contains(query, `"host""injection"`) {
@@ -138,8 +169,8 @@ func TestReadTagColumnsValidation(t *testing.T) {
 // file never wedges compaction. String-only (no DuckDB), so it lives here in the
 // untagged test file rather than the duckdb_arrow-gated integration test.
 func TestBuildCompactionQuery_DedupNonDedupBothNormalizeTime(t *testing.T) {
-	withTags := buildCompactionSQL("['a.parquet']", "", "/tmp/o.parquet", []string{"host"})
-	noTags := buildCompactionSQL("['a.parquet']", "", "/tmp/o.parquet", nil)
+	withTags := buildCompactionSQL("['a.parquet']", "", "/tmp/o.parquet", []string{"host"}, false)
+	noTags := buildCompactionSQL("['a.parquet']", "", "/tmp/o.parquet", nil, false)
 	for name, q := range map[string]string{"dedup": withTags, "non-dedup": noTags} {
 		if !strings.Contains(q, "make_timestamptz") || !strings.Contains(q, "TIMESTAMPTZ") {
 			t.Errorf("%s branch does not normalize time to TIMESTAMPTZ:\n%s", name, q)

--- a/internal/compaction/job.go
+++ b/internal/compaction/job.go
@@ -649,6 +649,7 @@ func (j *Job) compactFiles(ctx context.Context, files []downloadedFile, tempDir 
 	// If tags are present, dedup on (tags, time) keeping one row per unique key.
 	// Files without tag metadata (pre-dedup or msgpack columnar) are compacted normally.
 	var tagColumns []string
+	var dedupTime bool
 	if len(validLocalPaths) > 0 {
 		tags, err := readTagColumnsFromParquetFiles(ctx, db, validLocalPaths)
 		if err != nil {
@@ -660,6 +661,21 @@ func (j *Job) compactFiles(ctx context.Context, files []downloadedFile, tempDir 
 				Int("files", len(validLocalPaths)).
 				Msg("Auto-dedup enabled: found tag metadata in parquet files")
 		}
+
+		// arc:dedup_time marker (continuous-query output, #521) enables dedup on
+		// time even when there are no tag columns — a no-group-by CQ produces one
+		// row per window, so duplicate emissions collapse on time alone.
+		dt, err := readDedupTimeFromParquetFiles(ctx, db, validLocalPaths)
+		if err != nil {
+			j.logger.Warn().Err(err).Msg("Failed to read dedup_time metadata from parquet, skipping time-only dedup")
+		} else if dt {
+			dedupTime = true
+			if len(tagColumns) == 0 {
+				j.logger.Info().
+					Int("files", len(validLocalPaths)).
+					Msg("Auto-dedup enabled: arc:dedup_time marker present, deduping on time")
+			}
+		}
 	}
 
 	// Build and execute compaction statement(s) (with dedup if tag metadata found).
@@ -669,8 +685,8 @@ func (j *Job) compactFiles(ctx context.Context, files []downloadedFile, tempDir 
 	// could land on a different connection and fail to see the staged table. We
 	// pin both statements to a single dedicated connection via db.Conn. Closing it
 	// also deterministically drops the temp table (no leak on partial failure).
-	dedupBranch := len(tagColumns) > 0
-	stmts := buildCompactionQuery(fileListSQL, orderByClause, outputFile, tagColumns)
+	dedupBranch := len(tagColumns) > 0 || dedupTime
+	stmts := buildCompactionQuery(fileListSQL, orderByClause, outputFile, tagColumns, dedupTime)
 
 	// When dedup is active, count rows before compaction using parquet metadata (no data scan)
 	var rowsBefore int64

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -384,7 +384,7 @@ func sortColumnsTimeFirst(colNames []string) {
 // =============================================================================
 
 // getSchema gets or infers Arrow schema for columnar data (LRU cached per measurement)
-func (w *ArrowWriter) getSchema(measurement string, columns map[string]interface{}, tagColumns []string, decimalCols map[string]config.DecimalSpec) (*arrow.Schema, error) {
+func (w *ArrowWriter) getSchema(measurement string, columns map[string]interface{}, tagColumns []string, dedupTime bool, decimalCols map[string]config.DecimalSpec) (*arrow.Schema, error) {
 	// Create cache key from column names and types
 	var colNames []string
 	var typeNames []string
@@ -419,8 +419,9 @@ func (w *ArrowWriter) getSchema(measurement string, columns map[string]interface
 		}
 	}
 
-	// Create cache key (includes tag columns to ensure metadata correctness)
-	cacheKey := fmt.Sprintf("%s:%v:%v:%v", measurement, colNames, typeNames, tagColumns)
+	// Create cache key (includes tag columns and the dedup-time marker to ensure
+	// metadata correctness — the flag changes the emitted arc:dedup_time key)
+	cacheKey := fmt.Sprintf("%s:%v:%v:%v:%t", measurement, colNames, typeNames, tagColumns, dedupTime)
 
 	// Check LRU cache
 	if schema := w.schemaCache.get(cacheKey); schema != nil {
@@ -428,7 +429,7 @@ func (w *ArrowWriter) getSchema(measurement string, columns map[string]interface
 	}
 
 	// Cache miss - infer schema
-	schema, err := w.inferSchema(columns, tagColumns, decimalCols)
+	schema, err := w.inferSchema(columns, tagColumns, dedupTime, decimalCols)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +448,7 @@ func (w *ArrowWriter) getSchema(measurement string, columns map[string]interface
 // inferSchema infers Arrow schema from columnar data.
 // tagColumns optionally lists which columns are tags (stored as schema metadata for compaction dedup).
 // decimalCols optionally maps column names to DecimalSpec for Decimal128 columns.
-func (w *ArrowWriter) inferSchema(columns map[string]interface{}, tagColumns []string, decimalCols map[string]config.DecimalSpec) (*arrow.Schema, error) {
+func (w *ArrowWriter) inferSchema(columns map[string]interface{}, tagColumns []string, dedupTime bool, decimalCols map[string]config.DecimalSpec) (*arrow.Schema, error) {
 	var fields []arrow.Field
 
 	for name, col := range columns {
@@ -513,6 +514,15 @@ func (w *ArrowWriter) inferSchema(columns map[string]interface{}, tagColumns []s
 		metaValues = append(metaValues, strings.Join(sorted, ","))
 	}
 
+	// Mark data as safe to dedup on time even without tag columns. Written only
+	// by producers whose data model is one-row-per-(tags,time) — continuous
+	// queries (#521). Compaction reads this to dedup a no-group-by CQ's duplicate
+	// window emissions (PARTITION BY "time" alone). Raw ingest never sets it.
+	if dedupTime {
+		metaKeys = append(metaKeys, "arc:dedup_time")
+		metaValues = append(metaValues, "true")
+	}
+
 	// Store decimal column specs for self-describing Parquet files
 	if len(decimalCols) > 0 {
 		var parts []string
@@ -537,10 +547,11 @@ func (w *ArrowWriter) inferSchema(columns map[string]interface{}, tagColumns []s
 // validity is an optional map of column name → []bool where false means null.
 // Columns without a validity entry (or when validity is nil) are treated as fully valid.
 // tagColumns optionally lists which columns are tags (stored as Parquet metadata for compaction dedup).
+// dedupTime, when true, marks the file with arc:dedup_time so compaction dedups on time even with no tags.
 // decimalCols optionally maps column names to DecimalSpec for Decimal128 type inference.
-func (w *ArrowWriter) WriteParquetColumnar(ctx context.Context, measurement string, columns map[string]interface{}, validity map[string][]bool, tagColumns []string, decimalCols map[string]config.DecimalSpec) ([]byte, error) {
+func (w *ArrowWriter) WriteParquetColumnar(ctx context.Context, measurement string, columns map[string]interface{}, validity map[string][]bool, tagColumns []string, dedupTime bool, decimalCols map[string]config.DecimalSpec) ([]byte, error) {
 	// Get or infer schema (with caching)
-	schema, err := w.getSchema(measurement, columns, tagColumns, decimalCols)
+	schema, err := w.getSchema(measurement, columns, tagColumns, dedupTime, decimalCols)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema: %w", err)
 	}
@@ -699,7 +710,11 @@ type TypedColumnBatch struct {
 	Data       map[string]interface{} // typed arrays ([]int64, []float64, []string, []bool)
 	Validity   map[string][]bool      // per-column null bitmap; nil entry = all valid
 	TagColumns []string               // tag column names (for Parquet metadata, enables auto-dedup)
-	Signature  string                 // sorted column-name string; cached to avoid per-write recomputation
+	// DedupTime propagates ColumnarRecord.DedupTime: when true, the Parquet
+	// footer gets an arc:dedup_time marker so compaction dedups on time even with
+	// no tag columns. See ColumnarRecord.DedupTime — CQ output only (#521).
+	DedupTime bool
+	Signature string // sorted column-name string; cached to avoid per-write recomputation
 }
 
 type bufferShard struct {
@@ -1318,6 +1333,16 @@ func (b *ArrowBuffer) WriteColumnarRecord(ctx context.Context, database string, 
 
 // WriteColumnarDirectNoWAL writes columnar data without writing to WAL.
 // Used during WAL recovery to avoid re-writing recovered data back to WAL.
+//
+// Note (#521): the WAL stores flattened rows and does NOT carry TagColumns or
+// the DedupTime marker (both are json:"-"), so a Parquet file produced purely
+// from WAL replay has neither arc:tags nor arc:dedup_time. In practice this
+// self-heals: compaction unions metadata across all files in a partition, so
+// a replayed file dedups against any marked sibling written normally for the
+// same window. It only fails to dedup if the replayed copy and a marked copy
+// land in different compaction batches — a transient duplicate, never data
+// loss. This matches the pre-existing arc:tags WAL behavior; propagating the
+// markers through the WAL is a separate, larger change (WAL schema).
 func (b *ArrowBuffer) WriteColumnarDirectNoWAL(ctx context.Context, database, measurement string, columns map[string][]interface{}) error {
 	record := &models.ColumnarRecord{
 		Measurement: measurement,
@@ -1589,6 +1614,8 @@ func (b *ArrowBuffer) writeColumnarInternal(ctx context.Context, database string
 
 	// Propagate tag column names for Parquet metadata (enables auto-dedup in compaction)
 	typedColumns.TagColumns = record.TagColumns
+	// Propagate the dedup-on-time marker (CQ output only — see ColumnarRecord.DedupTime)
+	typedColumns.DedupTime = record.DedupTime
 
 	// Column signature for schema evolution detection (pre-computed in convertColumnsToTyped)
 	newSignature := typedColumns.Signature
@@ -2448,7 +2475,7 @@ func (b *ArrowBuffer) flushPartitionedData(ctx context.Context, bufferKey, datab
 		// Single hour - sort once and write one file
 		sorted := sortTypedColumnBatchByKeys(merged, sortKeys)
 
-		parquetData, err := b.writer.WriteParquetColumnar(ctx, measurement, sorted.Data, sorted.Validity, sorted.TagColumns, decimalCols)
+		parquetData, err := b.writer.WriteParquetColumnar(ctx, measurement, sorted.Data, sorted.Validity, sorted.TagColumns, sorted.DedupTime, decimalCols)
 		if err != nil {
 			return fmt.Errorf("failed to write Parquet: %w", err)
 		}
@@ -2526,7 +2553,7 @@ func (b *ArrowBuffer) flushPartitionedData(ctx context.Context, bufferKey, datab
 		sorted := sortTypedColumnBatchByKeys(hourBatch, sortKeys)
 
 		// Write Parquet file for this hour
-		parquetData, err := b.writer.WriteParquetColumnar(ctx, measurement, sorted.Data, sorted.Validity, sorted.TagColumns, decimalCols)
+		parquetData, err := b.writer.WriteParquetColumnar(ctx, measurement, sorted.Data, sorted.Validity, sorted.TagColumns, sorted.DedupTime, decimalCols)
 		if err != nil {
 			return fmt.Errorf("failed to write Parquet for hour %d: %w", hourID, err)
 		}
@@ -2678,6 +2705,10 @@ func (b *ArrowBuffer) mergeBatches(batches []interface{}) (*TypedColumnBatch, er
 
 	// Union of tag columns across all batches (for Parquet metadata)
 	tagColumnSet := make(map[string]struct{})
+	// Dedup-time marker is sticky: if ANY merged batch carries it, the output
+	// does (all writes to one measurement share the same producer, so this only
+	// ORs identical values in practice — the OR is defensive).
+	mergedDedupTime := false
 
 	// First pass: count total rows using time column
 	for _, batch := range batches {
@@ -2690,6 +2721,9 @@ func (b *ArrowBuffer) mergeBatches(batches []interface{}) (*TypedColumnBatch, er
 			}
 			for _, tag := range b.TagColumns {
 				tagColumnSet[tag] = struct{}{}
+			}
+			if b.DedupTime {
+				mergedDedupTime = true
 			}
 		case map[string]interface{}:
 			cols = b
@@ -2861,7 +2895,7 @@ func (b *ArrowBuffer) mergeBatches(batches []interface{}) (*TypedColumnBatch, er
 		}
 	}
 
-	return &TypedColumnBatch{Data: merged, Validity: mergedValidity, TagColumns: mergedTagColumns}, nil
+	return &TypedColumnBatch{Data: merged, Validity: mergedValidity, TagColumns: mergedTagColumns, DedupTime: mergedDedupTime}, nil
 }
 
 // sortColumnsByTime sorts all columns by the time column in-place
@@ -3204,7 +3238,7 @@ func sortTypedColumnBatchByKeys(batch *TypedColumnBatch, sortKeys []string) *Typ
 
 	// nil indices means data was already sorted — no permutation needed
 	if indices == nil || batch.Validity == nil {
-		return &TypedColumnBatch{Data: sorted, Validity: batch.Validity, TagColumns: batch.TagColumns, Signature: batch.Signature}
+		return &TypedColumnBatch{Data: sorted, Validity: batch.Validity, TagColumns: batch.TagColumns, DedupTime: batch.DedupTime, Signature: batch.Signature}
 	}
 
 	// Apply the same permutation to validity bitmaps (no second sort)
@@ -3222,7 +3256,7 @@ func sortTypedColumnBatchByKeys(batch *TypedColumnBatch, sortKeys []string) *Typ
 		sortedValidity[name] = newValid
 	}
 
-	return &TypedColumnBatch{Data: sorted, Validity: sortedValidity, TagColumns: batch.TagColumns, Signature: batch.Signature}
+	return &TypedColumnBatch{Data: sorted, Validity: sortedValidity, TagColumns: batch.TagColumns, DedupTime: batch.DedupTime, Signature: batch.Signature}
 }
 
 // sliceTypedColumnBatchByIndices extracts rows from a TypedColumnBatch by index list,
@@ -3231,7 +3265,7 @@ func sliceTypedColumnBatchByIndices(batch *TypedColumnBatch, indices []int) *Typ
 	slicedData := sliceColumnsByIndices(batch.Data, indices)
 
 	if batch.Validity == nil {
-		return &TypedColumnBatch{Data: slicedData, Validity: nil, TagColumns: batch.TagColumns, Signature: batch.Signature}
+		return &TypedColumnBatch{Data: slicedData, Validity: nil, TagColumns: batch.TagColumns, DedupTime: batch.DedupTime, Signature: batch.Signature}
 	}
 
 	slicedValidity := make(map[string][]bool, len(batch.Validity))
@@ -3252,7 +3286,7 @@ func sliceTypedColumnBatchByIndices(batch *TypedColumnBatch, indices []int) *Typ
 		slicedValidity[name] = newValid
 	}
 
-	return &TypedColumnBatch{Data: slicedData, Validity: slicedValidity, TagColumns: batch.TagColumns, Signature: batch.Signature}
+	return &TypedColumnBatch{Data: slicedData, Validity: slicedValidity, TagColumns: batch.TagColumns, DedupTime: batch.DedupTime, Signature: batch.Signature}
 }
 
 // microPerHour is the number of microseconds in one hour (3600 * 1,000,000)

--- a/internal/ingest/arrow_writer_test.go
+++ b/internal/ingest/arrow_writer_test.go
@@ -471,7 +471,7 @@ func TestDecimal128_WriteParquetRoundTrip(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	data, err := writer.WriteParquetColumnar(ctx, "trades", columns, nil, nil, decimalCols)
+	data, err := writer.WriteParquetColumnar(ctx, "trades", columns, nil, nil, false, decimalCols)
 	if err != nil {
 		t.Fatalf("WriteParquetColumnar failed: %v", err)
 	}
@@ -551,7 +551,7 @@ func TestDecimal128_SchemaMetadata(t *testing.T) {
 		"price": {Precision: 18, Scale: 8},
 	}
 
-	schema, err := writer.getSchema("trades", columns, nil, decimalCols)
+	schema, err := writer.getSchema("trades", columns, nil, false, decimalCols)
 	if err != nil {
 		t.Fatalf("getSchema failed: %v", err)
 	}
@@ -583,7 +583,7 @@ func TestInferSchema_TimeColumnTypeEnforcement(t *testing.T) {
 		schema, err := writer.getSchema("m_int", map[string]interface{}{
 			"time":  []int64{1609459200000000},
 			"value": []float64{1.5},
-		}, nil, nil)
+		}, nil, false, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -600,7 +600,7 @@ func TestInferSchema_TimeColumnTypeEnforcement(t *testing.T) {
 		_, err := writer.getSchema("m_str", map[string]interface{}{
 			"time":  []string{"2021-01-01T00:00:00Z"},
 			"value": []float64{1.5},
-		}, nil, nil)
+		}, nil, false, nil)
 		if err == nil {
 			t.Fatal("expected error for string time column, got nil (would write VARCHAR time)")
 		}
@@ -610,7 +610,7 @@ func TestInferSchema_TimeColumnTypeEnforcement(t *testing.T) {
 		_, err := writer.getSchema("m_float", map[string]interface{}{
 			"time":  []float64{1609459200.5},
 			"value": []float64{1.5},
-		}, nil, nil)
+		}, nil, false, nil)
 		if err == nil {
 			t.Fatal("expected error for float64 time column, got nil (would write DOUBLE time)")
 		}

--- a/pkg/models/record.go
+++ b/pkg/models/record.go
@@ -18,9 +18,15 @@ type ColumnarRecord struct {
 	Measurement string                   `json:"measurement"`
 	Columnar    bool                     `json:"_columnar"` // Marker for columnar format
 	Columns     map[string][]interface{} `json:"columns"`   // Column name -> array of values
-	TagColumns  []string                 `json:"-"`          // Tag column names (for Parquet metadata, enables auto-dedup)
-	TimeUnit    string                   `json:"_time_unit,omitempty"`
-	RawPayload  []byte                   `json:"-"` // Original msgpack bytes for zero-copy WAL
+	TagColumns  []string                 `json:"-"`         // Tag column names (for Parquet metadata, enables auto-dedup)
+	// DedupTime, when true, makes compaction dedup this data on the time column
+	// even when TagColumns is empty (keeping one row per timestamp). Set ONLY by
+	// producers whose data model guarantees one row per (tags, time) — continuous
+	// queries (#521). MUST stay false for raw ingest, where many distinct rows
+	// legitimately share a timestamp and time-only dedup would destroy data.
+	DedupTime  bool   `json:"-"`
+	TimeUnit   string `json:"_time_unit,omitempty"`
+	RawPayload []byte `json:"-"` // Original msgpack bytes for zero-copy WAL
 }
 
 // MsgPackPayload represents the top-level MessagePack payload structure


### PR DESCRIPTION
## Summary

Fixes #521. Continuous-query output was append-only with no idempotency: a window could be aggregated and written more than once — after a crash between the destination write and the watermark advance, a retry, or an overlapping manual run — leaving **duplicate aggregate rows** in the destination. Separately, a CQ that selected no `time` column stamped every output row with `time.Now()` (ingestion wall-clock) instead of the window time, so timestamps were wrong and duplicates weren't even dedupe-able.

Arc has no upsert primitive, and the destination write (Parquet) and the watermark (SQLite) are two stores with no cross-store transaction, so write+watermark can't be made atomic. The fix instead makes CQ output **idempotent via the existing compaction dedup** (which keeps `ROW_NUMBER()=1` over a `PARTITION BY` key), plus corrects the timestamps.

## What changed

- **Window-time stamping** — a no-time-column CQ now stamps each output row with the window's start time (`[start, end)` bucket boundary), not `time.Now()`. Re-running the same window produces byte-identical `(dimensions, time)` keys.
- **`tag_columns` field** — new optional field on the CQ definition (SQLite column + JSON, `ALTER TABLE` migration guard, validated at create/update, threaded through INSERT/UPDATE/both scans). Written as Parquet `arc:tags` so compaction dedups grouped CQs on `(tags, time)`. Intersected with actual output columns so a misdeclared tag can't wedge compaction.
- **`arc:dedup_time` marker** — for a no-group-by CQ (one row per window), a new marker makes compaction dedup on `time` alone. `DedupTime` is threaded `ColumnarRecord` → `TypedColumnBatch` → schema; the compaction gate becomes `len(tags)>0 || dedupTime`, with `PARTITION BY "time"` when there are no tags. Raw ingest never sets it (verified: 0 `arc:*` keys on ingest parquet).
- **Data-loss guard** — `DedupTime` is set only when the output's timestamps are unique. A grouped CQ that groups by a dimension but forgot to declare `tag_columns` is detected (multiple rows per timestamp), left **un-deduped**, and logs a warning — it never silently drops distinct series. `tag_columns` rejects `time`; the uniqueness check is bounded and fails closed.
- **handleExecute context** — now `context.WithTimeout(c.Context(), 10m)` (was `context.Background()` with no deadline), matching the scheduler; a corrupt `tag_columns` value now warns instead of silently disabling dedup.

## Behavior matrix (all verified on a live binary)

| CQ shape | `arc:tags` | `arc:dedup_time` | Dedup key |
|---|---|---|---|
| No group-by (`SELECT avg(x)`) | — | `true` | `time` |
| Grouped + `tag_columns:["host"]` | `host` | — | `(host, time)` |
| Grouped, **no** `tag_columns` declared | — | — (withheld + warn) | not deduped — **no data loss** |
| Raw ingest | (unchanged) | — | unchanged |

## Test plan

- [x] Unit + DuckDB-integration tests: SQLite migration (incl. real legacy schema), tag round-trip, `timeColumnIsUnique` (incl. fail-closed cap), `validateTagColumns` (incl. `time` rejection), dedup-time SQL generation, and a DuckDB test proving a tagless `dedup_time` partition collapses same-time rows to one.
- [x] `go test -race`, `gofmt -l`, `go vet`, full build — all clean.
- [x] **Binary run against demo data** (per CLAUDE.md): all four shapes above confirmed, including the grouped-without-tags case keeping both series and logging the warning, and raw ingest carrying no forced markers.
- [x] Internal deep adversarial review — found and fixed a data-loss blocker (unconditional `DedupTime`); DeepSeek review pass — fixed the missing execute timeout + two robustness items.

## Notes

- Makes output **eventually** idempotent (duplicates collapse at compaction), not atomic exactly-once — write and watermark advance remain separate. True exactly-once is #522, which this unblocks.
- Docs updated on docs.basekick.net (continuous-queries page: `tag_columns` + an "Idempotency" section).