### PR TITLE
perf(storage): use filepath.WalkDir for local List/ListObjects (#347)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -75,6 +75,17 @@ Note: this makes output **eventually** idempotent (duplicates collapse at compac
 
 No action is required to upgrade; add `tag_columns` to your grouped CQs when you want the duplicate-collapsing behavior.
 
+## Performance
+
+### Faster local-storage directory listing ([#347](https://github.com/Basekick-Labs/arc/issues/347))
+
+The local storage backend's `List` and `ListObjects` now use `filepath.WalkDir` instead of `filepath.Walk`. `WalkDir` reads directory entries without an `lstat(2)` per entry:
+
+- **`List`** needs only the entry name and is-dir bit (both free on `fs.DirEntry`), so it now does **no** per-entry stat at all — down from one stat on every file, directory, and hidden file. Benchmarked at ~19% fewer allocations and ~38% less allocated memory on a 2,000-file partition tree.
+- **`ListObjects`** needs each returned file's size and mod-time, so it still stats those — but skips the stat on directories and hidden files (matched by name first). The saving grows with the fraction of the tree that is directories/dotfiles.
+
+The win is largest on cold caches and network filesystems, where the `lstat` syscall dominates. Local backend only; the returned results are unchanged.
+
 ## Impact by deployment mode
 
 The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.

--- a/internal/storage/backend_test.go
+++ b/internal/storage/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -529,5 +530,127 @@ func BenchmarkLocalBackend_Read(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = backend.Read(ctx, testPath)
+	}
+}
+
+// TestLocalBackend_ListSkipsHiddenFiles verifies that both List and ListObjects
+// skip dotfiles (e.g. .DS_Store). This guards the hidden-file skip across the
+// filepath.Walk -> filepath.WalkDir conversion (#347), where the name now comes
+// from fs.DirEntry rather than os.FileInfo.
+func TestLocalBackend_ListSkipsHiddenFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "arc-storage-hidden-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	backend, err := NewLocalBackend(tmpDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create LocalBackend: %v", err)
+	}
+	defer backend.Close()
+
+	ctx := context.Background()
+
+	if err := backend.Write(ctx, "h/real.parquet", []byte("data")); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	// A hidden file written directly to disk (Write may sanitize a leading dot,
+	// so create it on the filesystem to be sure the walk encounters it).
+	if err := os.WriteFile(filepath.Join(tmpDir, "h", ".DS_Store"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write hidden file: %v", err)
+	}
+
+	listed, err := backend.List(ctx, "h/")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	for _, p := range listed {
+		if filepath.Base(p) == ".DS_Store" {
+			t.Errorf("List returned hidden file: %s", p)
+		}
+	}
+	if len(listed) != 1 {
+		t.Errorf("List: expected 1 non-hidden file, got %d (%v)", len(listed), listed)
+	}
+
+	objects, err := backend.ListObjects(ctx, "h/")
+	if err != nil {
+		t.Fatalf("ListObjects failed: %v", err)
+	}
+	for _, obj := range objects {
+		if filepath.Base(obj.Path) == ".DS_Store" {
+			t.Errorf("ListObjects returned hidden file: %s", obj.Path)
+		}
+	}
+	if len(objects) != 1 {
+		t.Errorf("ListObjects: expected 1 non-hidden object, got %d", len(objects))
+	}
+}
+
+// benchmarkListTree builds a partition-shaped tree (dirs with one file at each
+// leaf, plus a hidden file per leaf) and returns a backend rooted at it. This
+// is the shape List/ListObjects walk in production:
+// {db}/{measurement}/{y}/{m}/{d}/{h}/file.parquet.
+func benchmarkListTree(b *testing.B, leaves int) (*LocalBackend, string) {
+	b.Helper()
+	tmpDir, err := os.MkdirTemp("", "arc-storage-bench-*")
+	if err != nil {
+		b.Fatalf("temp dir: %v", err)
+	}
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	backend, err := NewLocalBackend(tmpDir, logger)
+	if err != nil {
+		b.Fatalf("backend: %v", err)
+	}
+	ctx := context.Background()
+	for i := 0; i < leaves; i++ {
+		// Vary the path so we get many intermediate directories, like real
+		// year/month/day/hour partitions.
+		p := filepath.Join("bench",
+			"m", // measurement
+			"2026",
+			// spread across months/days/hours so the tree has real fan-out
+			fmt.Sprintf("%02d", (i%12)+1),
+			fmt.Sprintf("%02d", (i%28)+1),
+			fmt.Sprintf("%02d", i%24),
+			fmt.Sprintf("f_%d.parquet", i),
+		)
+		if err := backend.Write(ctx, p, []byte("x")); err != nil {
+			b.Fatalf("write: %v", err)
+		}
+		// A hidden file at the same leaf, to exercise the skip path.
+		leafDir := filepath.Join(tmpDir, filepath.Dir(p))
+		_ = os.WriteFile(filepath.Join(leafDir, ".DS_Store"), []byte("x"), 0o600)
+	}
+	return backend, tmpDir
+}
+
+func BenchmarkLocalBackend_List(b *testing.B) {
+	backend, tmpDir := benchmarkListTree(b, 2000)
+	defer os.RemoveAll(tmpDir)
+	defer backend.Close()
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := backend.List(ctx, "bench/"); err != nil {
+			b.Fatalf("List: %v", err)
+		}
+	}
+}
+
+func BenchmarkLocalBackend_ListObjects(b *testing.B) {
+	backend, tmpDir := benchmarkListTree(b, 2000)
+	defer os.RemoveAll(tmpDir)
+	defer backend.Close()
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := backend.ListObjects(ctx, "bench/"); err != nil {
+			b.Fatalf("ListObjects: %v", err)
+		}
 	}
 }

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -416,8 +416,11 @@ func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error
 	}
 	var results []string
 
-	// Use filepath.Walk to recursively list files
-	err = filepath.Walk(searchPath, func(path string, info os.FileInfo, err error) error {
+	// Use filepath.WalkDir to recursively list files. WalkDir passes an
+	// fs.DirEntry (from the directory read) instead of an os.FileInfo, so it
+	// avoids an lstat(2) per entry — this path only needs the name and
+	// is-dir bit, both available on DirEntry, so no per-entry Info() call.
+	err = filepath.WalkDir(searchPath, func(path string, d os.DirEntry, err error) error {
 		// Respect context cancellation (important for large directory trees)
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -432,12 +435,12 @@ func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error
 		}
 
 		// Skip directories
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
 		// Skip hidden files (e.g., .DS_Store on macOS)
-		if strings.HasPrefix(info.Name(), ".") {
+		if strings.HasPrefix(d.Name(), ".") {
 			return nil
 		}
 
@@ -620,7 +623,12 @@ func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]Object
 
 	var results []ObjectInfo
 
-	err = filepath.Walk(searchPath, func(path string, info os.FileInfo, err error) error {
+	// Use filepath.WalkDir: it avoids an lstat(2) per entry by passing an
+	// fs.DirEntry. This path needs per-file size/mod-time, but only for files
+	// we keep — so we skip dirs and hidden files first (name + is-dir come from
+	// the DirEntry with no stat) and call d.Info() only on the surviving files.
+	// Net: no stat on directories or hidden files, one stat per kept file.
+	err = filepath.WalkDir(searchPath, func(path string, d os.DirEntry, err error) error {
 		// Respect context cancellation (important for large directory trees)
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -634,18 +642,29 @@ func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]Object
 		}
 
 		// Skip directories
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
 		// Skip hidden files
-		if strings.HasPrefix(info.Name(), ".") {
+		if strings.HasPrefix(d.Name(), ".") {
 			return nil
 		}
 
 		// Get relative path from base
 		relPath, err := filepath.Rel(b.basePath, path)
 		if err != nil {
+			return err
+		}
+
+		// Metadata (size, mod-time) is not on DirEntry — stat the kept file.
+		info, err := d.Info()
+		if err != nil {
+			// Race: the file was removed between the dir read and Info().
+			// Skip it rather than failing the whole listing.
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
## Summary

Fixes #347. The local storage backend's `List` and `ListObjects` used `filepath.Walk`, which `lstat(2)`s every entry it visits. `filepath.WalkDir` instead passes an `fs.DirEntry` obtained from the directory read, so per-entry stats become opt-in.

- **`List`** needs only the entry name and is-dir bit — both available on `DirEntry` with no stat — so it now does **zero** per-entry stats (was one on every file, directory, and hidden file).
- **`ListObjects`** needs each returned file's size and mod-time, so it stats those via `d.Info()`, but only *after* skipping directories and hidden files by name — so no stat on dirs or dotfiles.

## Benchmarks (2,000-file partition tree, `-benchtime 20x`)

Measured Walk → WalkDir on the same tree:

- `List`: **~19% fewer allocations, ~38% less allocated memory** (drops `Info()` entirely).
- `ListObjects`: roughly flat on warm local disk (it trades per-dir/hidden-file stats for a per-kept-file `Info()`); the win shows on cold caches and network filesystems where the `lstat` syscall dominates.

Benchmarks added (`BenchmarkLocalBackend_List`, `BenchmarkLocalBackend_ListObjects`) so the numbers are reproducible and regressions are caught.

## Correctness

- Results are unchanged. `DirEntry.Info()` uses `Lstat` semantics identical to `Walk` — verified empirically that symlinks are **not** followed (`d.IsDir()` is false for a symlink-to-dir; `Info().Mode()` reports the link, not the target), so no behavior change even though Arc's storage tree never contains symlinks.
- Error handling preserved: `err`-before-`d` ordering, `os.IsNotExist` → skip, empty-slice (not error) on missing directory. Added a `d.Info()` race guard (file removed between dir-read and stat → skip that entry, don't fail the listing).

## Test plan

- [x] `go test -race ./internal/storage/...` — existing List/ListObjects tests pass; new `TestLocalBackend_ListSkipsHiddenFiles` guards the dotfile skip across the `Walk`→`WalkDir` conversion (name now from `fs.DirEntry`).
- [x] `gofmt -l`, `go vet`, full build — clean.
- [x] A/B benchmark run to substantiate (and correct) the perf claim.

Local backend only — S3/Azure backends untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)