### PR TITLE
fix(mqtt): honor explicit QoS 0 instead of overwriting it to 1 (#326)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -75,6 +75,14 @@ Note: this makes output **eventually** idempotent (duplicates collapse at compac
 
 No action is required to upgrade; add `tag_columns` to your grouped CQs when you want the duplicate-collapsing behavior.
 
+### MQTT subscriptions honor an explicit QoS 0 ([#326](https://github.com/Basekick-Labs/arc/issues/326))
+
+Creating an MQTT subscription with `"qos": 0` (at-most-once / fire-and-forget) silently persisted it as QoS 1. The create request modeled `qos` as a plain integer, so an explicit `0` was indistinguishable from an omitted field, and the "default unset QoS to 1" step rewrote it. A subscription requested as fire-and-forget was quietly upgraded to at-least-once.
+
+The create request now models `qos` as optional: an omitted field still defaults to 1 (at-least-once, the safe ingestion default), but an explicit `0`, `1`, or `2` is preserved as written. QoS defaulting was moved out of the shared `SetDefaults` step so a persisted, explicitly-chosen QoS 0 can never be rewritten. (The update endpoint already handled this correctly.)
+
+Related fix in the same handler: an out-of-range or otherwise invalid subscription request now returns **`400 Bad Request`** with the validation message instead of `500 Internal Server Error`.
+
 ## Performance
 
 ### Faster local-storage directory listing ([#347](https://github.com/Basekick-Labs/arc/issues/347))

--- a/internal/api/mqtt_subscriptions.go
+++ b/internal/api/mqtt_subscriptions.go
@@ -103,6 +103,14 @@ func (h *MQTTSubscriptionHandler) handleCreate(c *fiber.Ctx) error {
 			})
 		}
 
+		// Validation failures are client errors (bad QoS, broker URL, …) → 400.
+		if errors.Is(err, mqtt.ErrValidation) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"success": false,
+				"error":   err.Error(),
+			})
+		}
+
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"success": false,
 			"error":   "Failed to create subscription",
@@ -173,6 +181,22 @@ func (h *MQTTSubscriptionHandler) handleUpdate(c *fiber.Ctx) error {
 		// Check for specific errors
 		if errors.Is(err, mqtt.ErrSubscriptionRunningCantUpdate) {
 			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"success": false,
+				"error":   err.Error(),
+			})
+		}
+
+		// Duplicate name on rename is a conflict (409), matching handleCreate.
+		if errors.Is(err, mqtt.ErrSubscriptionUniqueConstraint) {
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"success": false,
+				"error":   err.Error(),
+			})
+		}
+
+		// Validation failures are client errors → 400.
+		if errors.Is(err, mqtt.ErrValidation) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"success": false,
 				"error":   err.Error(),
 			})

--- a/internal/mqtt/manager.go
+++ b/internal/mqtt/manager.go
@@ -130,7 +130,7 @@ func (m *SubscriptionManager) Shutdown(ctx context.Context) error {
 func (m *SubscriptionManager) Create(ctx context.Context, req *CreateSubscriptionRequest, password string) (*Subscription, error) {
 	// Validate request
 	if err := ValidateCreateRequest(req); err != nil {
-		return nil, fmt.Errorf("validation error: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrValidation, err)
 	}
 
 	// Encrypt password if provided
@@ -149,7 +149,7 @@ func (m *SubscriptionManager) Create(ctx context.Context, req *CreateSubscriptio
 		Broker:                req.Broker,
 		ClientID:              req.ClientID,
 		Topics:                req.Topics,
-		QoS:                   req.QoS,
+		QoS:                   resolveQoS(req.QoS),
 		Database:              req.Database,
 		Username:              req.Username,
 		PasswordEncrypted:     encryptedPassword,
@@ -296,7 +296,7 @@ func (m *SubscriptionManager) Update(ctx context.Context, id string, req *Update
 
 	// Validate updated subscription
 	if err := sub.Validate(); err != nil {
-		return nil, fmt.Errorf("validation error: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrValidation, err)
 	}
 
 	if err := m.repo.Update(ctx, sub); err != nil {

--- a/internal/mqtt/manager_test.go
+++ b/internal/mqtt/manager_test.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -64,5 +65,89 @@ func TestSubscriptionManager_GetAllStats_NilSubscriber(t *testing.T) {
 	}
 	if got.Status != string(sub.Status) {
 		t.Errorf("Status: got %q, want %q (DB fallback)", got.Status, sub.Status)
+	}
+}
+
+// newTestManager builds a manager backed by a temp SQLite repo (no encryption).
+func newTestManager(t *testing.T) *SubscriptionManager {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "mqtt.db")
+	repo, err := NewRepository(dbPath, nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRepository: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	encryptor, err := NewPasswordEncryptor(nil)
+	if err != nil {
+		t.Fatalf("NewPasswordEncryptor: %v", err)
+	}
+	return NewSubscriptionManager(repo, encryptor, nil, zerolog.Nop())
+}
+
+// TestManager_Create_QoSZeroPersisted is the end-to-end #326 regression: an
+// explicit QoS 0 survives Create + the repository round-trip as 0, and an
+// omitted QoS becomes the default 1.
+func TestManager_Create_QoSZeroPersisted(t *testing.T) {
+	mgr := newTestManager(t)
+	ctx := context.Background()
+
+	zero := 0
+	sub, err := mgr.Create(ctx, &CreateSubscriptionRequest{
+		Name:     "qos0",
+		Broker:   "tcp://localhost:1883",
+		ClientID: "c0",
+		Topics:   []string{"sensors/#"},
+		QoS:      &zero,
+		Database: "iot",
+	}, "")
+	if err != nil {
+		t.Fatalf("Create with QoS 0: %v", err)
+	}
+	if sub.QoS != 0 {
+		t.Errorf("Create rewrote explicit QoS 0 to %d (#326)", sub.QoS)
+	}
+	// Read it back from the repo to prove persistence, not just the in-memory value.
+	got, err := mgr.repo.Get(ctx, sub.ID)
+	if err != nil {
+		t.Fatalf("repo.Get: %v", err)
+	}
+	if got.QoS != 0 {
+		t.Errorf("persisted QoS = %d, want 0", got.QoS)
+	}
+
+	// Omitted QoS → default 1.
+	sub2, err := mgr.Create(ctx, &CreateSubscriptionRequest{
+		Name:     "qosdef",
+		Broker:   "tcp://localhost:1883",
+		ClientID: "cd",
+		Topics:   []string{"sensors/#"},
+		Database: "iot",
+	}, "")
+	if err != nil {
+		t.Fatalf("Create with omitted QoS: %v", err)
+	}
+	if sub2.QoS != 1 {
+		t.Errorf("omitted QoS = %d, want default 1", sub2.QoS)
+	}
+}
+
+// TestManager_Create_InvalidQoSIsValidationError verifies an out-of-range QoS
+// surfaces as ErrValidation so the handler can map it to 400 (not 500).
+func TestManager_Create_InvalidQoSIsValidationError(t *testing.T) {
+	mgr := newTestManager(t)
+	three := 3
+	_, err := mgr.Create(context.Background(), &CreateSubscriptionRequest{
+		Name:     "bad",
+		Broker:   "tcp://localhost:1883",
+		ClientID: "cb",
+		Topics:   []string{"sensors/#"},
+		QoS:      &three,
+		Database: "iot",
+	}, "")
+	if err == nil {
+		t.Fatal("expected error for QoS 3, got nil")
+	}
+	if !errors.Is(err, ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
 	}
 }

--- a/internal/mqtt/subscription.go
+++ b/internal/mqtt/subscription.go
@@ -36,6 +36,10 @@ var (
 	ErrSubscriptionNotRunning        = errors.New("subscription not running")
 	ErrSubscriptionRunningCantUpdate = errors.New("cannot update running subscription - stop it first")
 	ErrSubscriptionUniqueConstraint  = errors.New("subscription name already exists")
+	// ErrValidation wraps a request that failed validation (bad QoS, broker URL,
+	// missing field, …). Handlers map it to 400 Bad Request rather than 500 —
+	// it's a client error, not a server fault.
+	ErrValidation = errors.New("validation error")
 )
 
 // Subscription represents an MQTT subscription configuration
@@ -70,11 +74,15 @@ type Subscription struct {
 
 // CreateSubscriptionRequest is the request body for creating a subscription
 type CreateSubscriptionRequest struct {
-	Name                  string            `json:"name"`
-	Broker                string            `json:"broker"`
-	ClientID              string            `json:"client_id"`
-	Topics                []string          `json:"topics"`
-	QoS                   int               `json:"qos"`
+	Name     string   `json:"name"`
+	Broker   string   `json:"broker"`
+	ClientID string   `json:"client_id"`
+	Topics   []string `json:"topics"`
+	// QoS is a pointer so an explicit "qos": 0 (at-most-once) is distinguishable
+	// from an omitted field. A plain int would make both indistinguishable, and
+	// the default logic would silently rewrite an explicit 0 to 1 (#326). nil
+	// means "use the default" (see defaultQoS / resolveQoS).
+	QoS                   *int              `json:"qos,omitempty"`
 	Database              string            `json:"database"`
 	Username              string            `json:"username,omitempty"`
 	Password              string            `json:"password,omitempty"`
@@ -208,13 +216,33 @@ func (s *Subscription) Validate() error {
 	return nil
 }
 
-// SetDefaults sets default values for optional fields
+// defaultQoS is the QoS applied when a create request omits the field.
+// At-least-once (1) is the safe default for ingestion — at-most-once (0) can
+// silently drop messages.
+const defaultQoS = 1
+
+// resolveQoS turns an optional QoS from a request into a concrete value: nil
+// (field omitted) becomes the default; an explicit value — including 0 — is
+// used as-is. This is the fix for #326: an explicit "qos": 0 must not be
+// rewritten to 1.
+func resolveQoS(qos *int) int {
+	if qos == nil {
+		return defaultQoS
+	}
+	return *qos
+}
+
+// SetDefaults sets default values for optional fields.
+//
+// Note: QoS is intentionally NOT defaulted here. By the time a Subscription
+// exists its QoS is already resolved from the create request via resolveQoS
+// (nil → defaultQoS, explicit value — including 0 — kept). Re-applying an
+// "if QoS == 0 { QoS = 1 }" rule here would reintroduce #326, silently turning
+// a persisted, explicitly-chosen QoS 0 back into 1 on any code path that
+// rebuilds-and-defaults a subscription.
 func (s *Subscription) SetDefaults() {
 	if s.ClientID == "" {
 		s.ClientID = generateClientID()
-	}
-	if s.QoS == 0 {
-		s.QoS = 1 // Default to at-least-once
 	}
 	if s.KeepAliveSeconds == 0 {
 		s.KeepAliveSeconds = 60
@@ -277,7 +305,7 @@ func ValidateCreateRequest(req *CreateSubscriptionRequest) error {
 		Broker:                req.Broker,
 		ClientID:              req.ClientID,
 		Topics:                req.Topics,
-		QoS:                   req.QoS,
+		QoS:                   resolveQoS(req.QoS),
 		Database:              req.Database,
 		TLSCertPath:           req.TLSCertPath,
 		TLSKeyPath:            req.TLSKeyPath,

--- a/internal/mqtt/subscription_test.go
+++ b/internal/mqtt/subscription_test.go
@@ -157,8 +157,12 @@ func TestSubscription_SetDefaults(t *testing.T) {
 	sub := &Subscription{}
 	sub.SetDefaults()
 
-	if sub.QoS != 1 {
-		t.Errorf("Default QoS = %d, want 1", sub.QoS)
+	// SetDefaults intentionally does NOT default QoS (#326) — an empty struct
+	// keeps QoS at its zero value here. QoS defaulting happens earlier, when a
+	// create request is mapped to a Subscription (see resolveQoS / the create
+	// tests below), so an explicit "qos": 0 is never rewritten.
+	if sub.QoS != 0 {
+		t.Errorf("SetDefaults should not touch QoS; got %d, want 0 (unchanged)", sub.QoS)
 	}
 	if sub.KeepAliveSeconds != 60 {
 		t.Errorf("Default KeepAliveSeconds = %d, want 60", sub.KeepAliveSeconds)
@@ -174,6 +178,71 @@ func TestSubscription_SetDefaults(t *testing.T) {
 	}
 	if sub.Status != StatusStopped {
 		t.Errorf("Default Status = %s, want %s", sub.Status, StatusStopped)
+	}
+}
+
+// TestResolveQoS is the core #326 regression: an omitted QoS defaults to 1, but
+// an explicit value — including 0 — is preserved.
+func TestResolveQoS(t *testing.T) {
+	zero, one, two := 0, 1, 2
+	tests := []struct {
+		name string
+		in   *int
+		want int
+	}{
+		{"omitted defaults to at-least-once", nil, defaultQoS},
+		{"explicit 0 is preserved (the bug)", &zero, 0},
+		{"explicit 1 is preserved", &one, 1},
+		{"explicit 2 is preserved", &two, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveQoS(tt.in); got != tt.want {
+				t.Errorf("resolveQoS(%v) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateCreateRequest_QoSZeroPreserved verifies the full create-request
+// mapping keeps an explicit QoS 0 (#326): the request maps to a Subscription
+// whose QoS is 0, not silently rewritten to 1, and still validates.
+func TestValidateCreateRequest_QoSZeroPreserved(t *testing.T) {
+	base := func(qos *int) *CreateSubscriptionRequest {
+		return &CreateSubscriptionRequest{
+			Name:     "s",
+			Broker:   "tcp://localhost:1883",
+			ClientID: "c",
+			Topics:   []string{"sensors/#"},
+			QoS:      qos,
+			Database: "iot",
+		}
+	}
+
+	zero := 0
+	// Explicit 0 must validate (it's a legal QoS).
+	if err := ValidateCreateRequest(base(&zero)); err != nil {
+		t.Fatalf("explicit QoS 0 should be valid: %v", err)
+	}
+
+	// And it must map to a Subscription with QoS 0, not 1.
+	sub := &Subscription{
+		Name:     "s",
+		Broker:   "tcp://localhost:1883",
+		ClientID: "c",
+		Topics:   []string{"sensors/#"},
+		QoS:      resolveQoS(base(&zero).QoS),
+		Database: "iot",
+	}
+	sub.SetDefaults()
+	if sub.QoS != 0 {
+		t.Errorf("explicit QoS 0 was overwritten to %d (#326 regression)", sub.QoS)
+	}
+
+	// Omitted QoS defaults to 1.
+	omitted := resolveQoS(base(nil).QoS)
+	if omitted != 1 {
+		t.Errorf("omitted QoS = %d, want default 1", omitted)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #326. Creating an MQTT subscription with `"qos": 0` (at-most-once / fire-and-forget) silently persisted it as QoS 1. `CreateSubscriptionRequest.QoS` was a plain `int`, so an explicit `0` was indistinguishable from an omitted field, and `SetDefaults`' `if s.QoS == 0 { s.QoS = 1 }` rewrote it. A subscription requested as fire-and-forget was quietly upgraded to at-least-once.

## What changed

- **`CreateSubscriptionRequest.QoS` → `*int`.** `nil` (omitted) resolves to the default `1`; an explicit `0`, `1`, or `2` is preserved. Resolution is centralized in a `resolveQoS(*int) int` helper, applied at both create sites (`manager.Create` and `ValidateCreateRequest`). The update request already used `*int` and was correct.
- **QoS defaulting removed from `SetDefaults`.** By the time a `Subscription` exists its QoS is already resolved, so the old zero-check would only re-break an explicit 0. A comment documents why it must not be re-added.
- **Handler error mapping hardened (in the same block):** subscription validation failures now return **`400 Bad Request`** (via a new `ErrValidation` sentinel) instead of `500`, and a **duplicate name on update returns `409`** (matching create) instead of `500`.

## Backward compatibility

No SQLite schema change — the persisted `Subscription.QoS` stays `int`, existing subscriptions read back unchanged, and there is no migration. (Subscriptions that were silently rewritten to QoS 1 by the bug are indistinguishable from intentional QoS 1 in the stored data; operators who want QoS 0 re-save the subscription with the fixed binary.)

## Test plan

- [x] Unit: `resolveQoS` (nil→1, &0→0, &1, &2), `ValidateCreateRequest` preserves explicit 0, `SetDefaults` no longer touches QoS, `Create` returns `ErrValidation` for an out-of-range QoS.
- [x] Manager + repo round-trip: create with QoS 0 → read back from SQLite → assert 0; omitted → 1.
- [x] `go test -race`, `gofmt -l`, `go vet`, full build — clean.
- [x] **Binary run** (MQTT enabled): `qos:0`→persists 0, omitted→1, `qos:2`→2, `qos:3`→**HTTP 400** (was 500).
- [x] Internal adversarial review + DeepSeek review — both approved; the 409-on-update fix came out of the internal pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)