### PR TITLE
perf(query): FNV-1a shard key + raw-string cache key for SQL transform cache (#331)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -94,6 +94,12 @@ The local storage backend's `List` and `ListObjects` now use `filepath.WalkDir` 
 
 The win is largest on cold caches and network filesystems, where the `lstat` syscall dominates. Local backend only; the returned results are unchanged.
 
+### Cheaper SQL-transform cache key ([#331](https://github.com/Basekick-Labs/arc/issues/331))
+
+The per-request SQL-transform cache (which memoizes rewriting `FROM db.measurement` into `read_parquet(...)`) derived its map key with SHA256 plus a hex-encode — a 256-bit cryptographic digest and an allocation, for an internal cache key with no adversarial-collision concern. The cache now stores the SQL string itself as the map key (an exact match, so there is **no** possibility of two different queries colliding onto one entry) and uses a fast FNV-1a hash **only** to pick a shard.
+
+Per-op benchmarks on the cache: `Get` **257 ns → 71 ns**, `Set` **269 ns → 86 ns**, and each drops from **192 B / 4 allocations to zero allocations**. This is a per-request improvement (it removes allocation pressure from the query path); it does not affect the time DuckDB spends executing a query, so end-to-end latency on large scans is unchanged. This change only swaps the hash and key — the cache's existing sharding, sizing, and eviction are untouched.
+
 ## Impact by deployment mode
 
 The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.

--- a/internal/database/sql_transform_cache.go
+++ b/internal/database/sql_transform_cache.go
@@ -1,8 +1,7 @@
 package database
 
 import (
-	"crypto/sha256"
-	"fmt"
+	"hash/fnv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -84,25 +83,30 @@ func NewQueryCache(ttl time.Duration, maxSize int) *SQLTransformCache {
 // QueryCache is an alias for SQLTransformCache (backwards compatibility)
 type QueryCache = SQLTransformCache
 
-// queryHash generates a cache key from SQL using SHA256
-func queryHash(sql string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(sql)))
-}
-
-// getShard returns the shard for a given hash using the first byte
-func (c *SQLTransformCache) getShard(hash string) *cacheShard {
-	// Use first byte of hash for shard selection (0-255 mod 16 = 0-15)
-	idx := uint8(hash[0]) % cacheShardCount
+// shardFor selects a shard for a cache key using FNV-1a.
+//
+// The full key string is stored as the map key (see Get/Set), so lookups are an
+// exact string match — there is NO risk of two different queries colliding onto
+// one entry, unlike a scheme that hashes the SQL into the key. This hash is used
+// ONLY to pick a shard: a hash collision here merely lands two distinct keys in
+// the same shard, which is harmless (they remain separate map entries). That
+// lets us use a fast non-cryptographic hash — SHA256 was needlessly expensive
+// (a 256-bit crypto digest plus a hex-encoding allocation) for an internal cache
+// key with no adversarial-collision concern (#331).
+func (c *SQLTransformCache) shardFor(key string) *cacheShard {
+	h := fnv.New32a()
+	// fnv Write never returns an error; ignore it.
+	_, _ = h.Write([]byte(key))
+	idx := h.Sum32() % cacheShardCount
 	return c.shards[idx]
 }
 
 // Get retrieves a cached transformed SQL if it exists and hasn't expired
 func (c *SQLTransformCache) Get(sql string) (string, bool) {
-	hash := queryHash(sql)
-	shard := c.getShard(hash)
+	shard := c.shardFor(sql)
 
 	shard.mu.RLock()
-	entry, ok := shard.entries[hash]
+	entry, ok := shard.entries[sql]
 	shard.mu.RUnlock()
 
 	if !ok {
@@ -121,8 +125,7 @@ func (c *SQLTransformCache) Get(sql string) (string, bool) {
 
 // Set stores a transformed SQL in the cache
 func (c *SQLTransformCache) Set(sql, transformed string) {
-	hash := queryHash(sql)
-	shard := c.getShard(hash)
+	shard := c.shardFor(sql)
 
 	shard.mu.Lock()
 
@@ -156,7 +159,7 @@ func (c *SQLTransformCache) Set(sql, transformed string) {
 		}
 	}
 
-	shard.entries[hash] = sqlTransformCacheEntry{
+	shard.entries[sql] = sqlTransformCacheEntry{
 		transformed: transformed,
 		expiresAt:   time.Now().Add(c.ttl),
 	}

--- a/internal/database/sql_transform_cache_test.go
+++ b/internal/database/sql_transform_cache_test.go
@@ -198,12 +198,68 @@ func BenchmarkQueryCache_Set(b *testing.B) {
 	}
 }
 
-// BenchmarkQueryCache_Hash benchmarks the hash function overhead
+// BenchmarkQueryCache_Hash benchmarks the per-call key-hashing overhead — the
+// FNV-1a shard selection that replaced the old SHA256+hex key derivation (#331).
 func BenchmarkQueryCache_Hash(b *testing.B) {
+	cache := NewQueryCache(time.Minute, 100)
 	testSQL := "SELECT * FROM mydb.cpu WHERE time > 1609459200000000 AND host = 'server01' GROUP BY time ORDER BY time DESC LIMIT 100"
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		queryHash(testSQL)
+		cache.shardFor(testSQL)
+	}
+}
+
+// TestQueryCache_DistinctKeysNoCollision verifies that different SQL strings are
+// stored as distinct entries even when they hash to the same shard — the map key
+// is the full SQL string, so there is no cross-query collision (#331). Uses many
+// distinct queries so some necessarily share a shard (pigeonhole: >16 keys).
+func TestQueryCache_DistinctKeysNoCollision(t *testing.T) {
+	cache := NewQueryCache(time.Minute, 100000)
+
+	const n = 500
+	for i := 0; i < n; i++ {
+		sql := fmt.Sprintf("SELECT * FROM db.m WHERE id = %d", i)
+		cache.Set(sql, fmt.Sprintf("transformed_%d", i))
+	}
+
+	// Every query must return its OWN transformed value, never another's.
+	for i := 0; i < n; i++ {
+		sql := fmt.Sprintf("SELECT * FROM db.m WHERE id = %d", i)
+		got, ok := cache.Get(sql)
+		if !ok {
+			t.Fatalf("query %d missing from cache", i)
+		}
+		want := fmt.Sprintf("transformed_%d", i)
+		if got != want {
+			t.Fatalf("query %d returned wrong value: got %q, want %q (cross-key collision)", i, got, want)
+		}
+	}
+}
+
+// TestQueryCache_ShardDistribution verifies FNV-1a spreads distinct keys across
+// all shards rather than piling them into a few (the old scheme keyed the shard
+// off the first hex character of a SHA256 digest). We don't require perfect
+// balance — just that every shard receives at least one of a large key set, so
+// no shard is starved and none is a hotspot for the whole workload.
+func TestQueryCache_ShardDistribution(t *testing.T) {
+	cache := NewQueryCache(time.Minute, 1000000)
+
+	used := make(map[*cacheShard]int)
+	for i := 0; i < 10000; i++ {
+		sql := fmt.Sprintf("SELECT col_%d FROM measurement_%d WHERE ts > %d", i%97, i%53, i)
+		used[cache.shardFor(sql)]++
+	}
+
+	if len(used) != cacheShardCount {
+		t.Errorf("expected all %d shards to receive keys, got %d distinct shards", cacheShardCount, len(used))
+	}
+	// Sanity: no shard should hold a wildly disproportionate share. With 10k keys
+	// over 16 shards the mean is 625; flag if any shard exceeds 3x the mean.
+	for shard, count := range used {
+		if count > 3*(10000/cacheShardCount) {
+			t.Errorf("shard %p over-loaded: %d keys (mean ~%d) — poor distribution", shard, count, 10000/cacheShardCount)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #331. The per-request SQL-transform cache (memoizes rewriting `FROM db.measurement` into `read_parquet(...)`) derived its map key with `fmt.Sprintf("%x", sha256.Sum256(...))` — a 256-bit cryptographic digest **plus** a hex-encoding allocation, for an internal cache key that has no adversarial-collision concern.

## What changed

- **The map key is now the SQL string itself** (`shard.entries[sql]`). This is an exact string match, so there is **zero** risk of two different queries colliding onto one entry — a hazard that a plain `FNV(sql)`-as-key would carry (a collision there would silently serve query A's `read_parquet` paths for query B). Trading a 64-char hex key for the full SQL string costs a few MB more for a 10k-entry cache — negligible.
- **FNV-1a is used only to pick a shard.** A hash collision here merely lands two distinct keys in the same shard, which is harmless (they remain separate map entries). That lets us drop the crypto hash entirely.

**Scope:** this PR changes only the hash and the key. The cache's existing 16-way sharding, per-shard sizing, and probabilistic eviction are pre-existing and untouched.

## Benchmarks (before/after, same machine, `-benchtime 2s -count 3`)

| Op | Before (SHA256 + hex) | After (FNV + raw key) | |
|---|---|---|---|
| `Get` | ~257 ns, 192 B, **4 allocs** | ~71 ns, **0 B, 0 allocs** | 3.6× |
| `Set` | ~269 ns, 192 B, **4 allocs** | ~86 ns, **0 B, 0 allocs** | 3.1× |

This is a **per-request** improvement — it removes allocation pressure from the query path. It does **not** change DuckDB's execution time, so end-to-end latency on large scans is unchanged: I confirmed on the 99.99M-row ClickBench dataset that the representative aggregation stays ~85–109 ms (the ~186 ns saved is ~0.0002% of that). The value here is the eliminated per-request allocation, not query latency.

## Test plan

- [x] `go test -race ./internal/database/ -run QueryCache` — all pass, including two new tests:
  - `TestQueryCache_DistinctKeysNoCollision` (500 distinct keys, every one round-trips to its own value — proves no cross-key collision).
  - `TestQueryCache_ShardDistribution` (10k realistic keys use all 16 shards, none over 3× mean — FNV distributes better than the old `hash[0]`-of-hex scheme).
- [x] `gofmt -l`, `go vet`, full build — clean.
- [x] Before/after benchmarks (above) via file-swap A/B on `main` vs this branch.
- [x] Binary run on ClickBench (99.99M rows): repeated queries return correct results and stay warm-cache fast; confirmed no end-to-end regression.
- [x] Internal adversarial review + DeepSeek review — both approved; shard-consistency and eviction/memory traced and confirmed correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)