### PR TITLE
refactor(throttle): centralize 30s memory-release debounce into internal/throttle (#421)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -100,6 +100,10 @@ The per-request SQL-transform cache (which memoizes rewriting `FROM db.measureme
 
 Per-op benchmarks on the cache: `Get` **257 ns → 71 ns**, `Set` **269 ns → 86 ns**, and each drops from **192 B / 4 allocations to zero allocations**. This is a per-request improvement (it removes allocation pressure from the query path); it does not affect the time DuckDB spends executing a query, so end-to-end latency on large scans is unchanged. This change only swaps the hash and key — the cache's existing sharding, sizing, and eviction are untouched.
 
+### Centralized memory-release throttle ([#421](https://github.com/Basekick-Labs/arc/issues/421))
+
+The three copies of the 30-second memory-release debounce (the post-delete/retention `debug.FreeOSMemory` throttle, the `/api/v1/debug/free-os-memory` endpoint, and the Linux `malloc_trim` throttle) are now a single `internal/throttle.Debouncer`. Behavior is unchanged — same monotonic-clock window and the same first-call sentinel that fires the very first request rather than throttling it. One minor improvement: when two callers race the `/api/v1/debug/free-os-memory` endpoint at the same instant and one loses, the loser's `429` response now includes a `retry_after_seconds` hint (previously it was omitted only in that narrow race).
+
 ## Impact by deployment mode
 
 The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.

--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -7,26 +7,18 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/basekick-labs/arc/internal/auth"
 	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/throttle"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
 )
 
-// freeOSMemoryDebounce debounces /debug/free-os-memory so polled callers
+// debugFreeOSMemoryDebounce debounces /debug/free-os-memory so polled callers
 // can't pin the runtime in stop-the-world GC.
-const freeOSMemoryDebounce = 30 * time.Second
-
-// debugProcessStart anchors the debounce to the monotonic clock so wall-clock
-// adjustments (NTP steps, manual `date` changes) cannot misbehave.
-var debugProcessStart = time.Now()
-
-// debugFreeOSMemoryLastNanos stores nanoseconds since debugProcessStart
-// (monotonic) of the last /debug/free-os-memory call that wasn't throttled.
-var debugFreeOSMemoryLastNanos atomic.Int64
+var debugFreeOSMemoryDebounce = throttle.New(30 * time.Second)
 
 // DebugHandler exposes process- and DuckDB-level memory diagnostics. Used to
 // attribute RSS to Go heap, DuckDB native heap, or glibc arenas during
@@ -165,18 +157,23 @@ func (h *DebugHandler) handleDuckDBMemory(c *fiber.Ctx) error {
 
 // handleFreeOSMemory triggers debug.FreeOSMemory and returns the delta in
 // HeapReleased so callers can see how many bytes the runtime returned to the
-// OS. Throttled to one call per freeOSMemoryDebounce; debug.FreeOSMemory is
+// OS. Throttled to one call per debugFreeOSMemoryDebounce; debug.FreeOSMemory is
 // stop-the-world and a tight polling loop would tank ingest throughput.
 func (h *DebugHandler) handleFreeOSMemory(c *fiber.Ctx) error {
-	now := time.Since(debugProcessStart).Nanoseconds()
-	last := debugFreeOSMemoryLastNanos.Load()
-	// last==0 means "never fired" — first call always proceeds.
-	if last != 0 && now-last < int64(freeOSMemoryDebounce) {
+	if !debugFreeOSMemoryDebounce.TryAcquire() {
 		// Round the remaining wait UP to the next whole second so a client
 		// retrying after retry_after_seconds is past the throttle window.
 		// Truncating could return 0 when 500ms remains and cause immediate
-		// retry storms.
-		remaining := freeOSMemoryDebounce - time.Duration(now-last)
+		// retry storms. Remaining() can be 0 here if the window elapsed in the
+		// brief gap between TryAcquire() and this Remaining() call (the acquire
+		// still lost the race for this interval, but the next one is already
+		// eligible); in that case omit retry_after_seconds rather than emit 0.
+		remaining := debugFreeOSMemoryDebounce.Remaining()
+		if remaining <= 0 {
+			return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+				"error": "throttled",
+			})
+		}
 		retryAfter := int64(remaining / time.Second)
 		if remaining%time.Second != 0 {
 			retryAfter++
@@ -184,11 +181,6 @@ func (h *DebugHandler) handleFreeOSMemory(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
 			"error":               "throttled",
 			"retry_after_seconds": retryAfter,
-		})
-	}
-	if !debugFreeOSMemoryLastNanos.CompareAndSwap(last, now) {
-		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
-			"error": "throttled",
 		})
 	}
 

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/basekick-labs/arc/internal/auth"
@@ -20,6 +19,7 @@ import (
 	"github.com/basekick-labs/arc/internal/config"
 	"github.com/basekick-labs/arc/internal/database"
 	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/basekick-labs/arc/internal/throttle"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
 )
@@ -64,24 +64,13 @@ func fileMetadata(path string) (sizeBytes int64, sha256hex string, err error) {
 	return n, fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-// freeOSMemoryProcessStart anchors the throttle to the monotonic clock so wall
-// clock adjustments (NTP steps, manual `date` changes) cannot misbehave.
-var freeOSMemoryProcessStart = time.Now()
-
-// lastFreeOSMemoryNanos is the time freeOSMemoryThrottled last fired, stored
-// as nanoseconds since freeOSMemoryProcessStart (monotonic).
-var lastFreeOSMemoryNanos atomic.Int64
+// deleteFreeOSMemoryDebounce throttles freeOSMemoryThrottled to once per 30s, process-wide.
+var deleteFreeOSMemoryDebounce = throttle.New(30 * time.Second)
 
 // freeOSMemoryThrottled fires debug.FreeOSMemory in a goroutine at most once every 30 seconds.
 // This prevents GC storms when multiple concurrent delete/retention requests complete together.
 func freeOSMemoryThrottled() {
-	now := time.Since(freeOSMemoryProcessStart).Nanoseconds()
-	last := lastFreeOSMemoryNanos.Load()
-	// last==0 means "never fired" — first call always proceeds.
-	if last != 0 && now-last < int64(30*time.Second) {
-		return
-	}
-	if lastFreeOSMemoryNanos.CompareAndSwap(last, now) {
+	if deleteFreeOSMemoryDebounce.TryAcquire() {
 		go debug.FreeOSMemory()
 	}
 }

--- a/internal/memtrim/memtrim_linux.go
+++ b/internal/memtrim/memtrim_linux.go
@@ -14,40 +14,25 @@ static int malloc_trim(size_t pad) { (void)pad; return 0; }
 import "C"
 
 import (
-	"sync/atomic"
 	"time"
+
+	"github.com/basekick-labs/arc/internal/throttle"
 )
 
-// minTrimInterval throttles ReleaseToOS so concurrent retention/delete/compaction
+// trimDebounce throttles ReleaseToOS so concurrent retention/delete/compaction
 // callers can't serialize the process under glibc's allocator lock.
-const minTrimInterval = 30 * time.Second
-
-// processStart anchors the throttle to the monotonic clock so wall-clock
-// adjustments (NTP steps, daylight saving, manual `date` changes) cannot
-// cause the throttle window to misbehave.
-var processStart = time.Now()
-
-// lastTrimNanos stores nanoseconds since processStart (monotonic).
-var lastTrimNanos atomic.Int64
+var trimDebounce = throttle.New(30 * time.Second)
 
 // ReleaseToOS asks glibc to return free heap pages to the OS via malloc_trim(0).
 // debug.FreeOSMemory only releases Go-managed memory; CGo allocations from the
 // DuckDB httpfs extension live in glibc arenas that need an explicit trim.
 //
-// Throttled to once per minTrimInterval across the whole process. Calls that
-// arrive inside the window return false without invoking the C function.
+// Throttled to once per 30s across the whole process. Calls that arrive inside
+// the window return false without invoking the C function.
 // On non-glibc Linux libcs (musl, uClibc) the C call is a stub and always
 // returns 0; outside Linux see memtrim_other.go.
 func ReleaseToOS() bool {
-	now := time.Since(processStart).Nanoseconds()
-	last := lastTrimNanos.Load()
-	// last==0 means "never fired" — that's not a real moment in monotonic
-	// time on a process that has been alive for any nonzero duration, so
-	// we treat it as eligible.
-	if last != 0 && now-last < int64(minTrimInterval) {
-		return false
-	}
-	if !lastTrimNanos.CompareAndSwap(last, now) {
+	if !trimDebounce.TryAcquire() {
 		return false
 	}
 	return C.malloc_trim(0) == 1

--- a/internal/throttle/throttle.go
+++ b/internal/throttle/throttle.go
@@ -1,0 +1,94 @@
+// Package throttle provides a small, allocation-free debounce primitive shared
+// by the process-wide memory-release throttles (debug.FreeOSMemory, glibc
+// malloc_trim). All three call sites previously duplicated the same eight lines
+// of throttle bookkeeping; this centralizes them (#421).
+//
+// The pattern, and every subtlety it encodes, comes from the #420 review:
+//
+//   - The window is anchored to the MONOTONIC clock (Go's time.Since over a
+//     process-start instant), so an NTP step or a manual `date` change cannot
+//     move the throttle window. Storing wall-clock nanoseconds would let a clock
+//     jump either fire early or wedge the throttle.
+//
+//   - The stored "last fired" value is nanoseconds-since-process-start in an
+//     atomic.Int64, and a stored value of 0 means "never fired". This sentinel
+//     is load-bearing, not cosmetic: because time.Since(processStart) is a SMALL
+//     duration early in the process's life (a few seconds), `now - 0` is less
+//     than any practical interval, so without the sentinel the very FIRST call
+//     would be throttled instead of firing. That exact bug shipped once during
+//     #420 and cost ~25 MB of idle RSS before it was caught by the memory repro.
+//     The wall-clock version accidentally avoided it (now - 0 was ~1.78e18, huge);
+//     the monotonic version must handle it explicitly.
+package throttle
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Debouncer allows an action to proceed at most once per interval, process-wide.
+// It is safe for concurrent use: many goroutines may call TryAcquire; at most
+// one wins per interval. The zero value is not usable — construct with New.
+type Debouncer struct {
+	interval     time.Duration
+	processStart time.Time
+	lastNanos    atomic.Int64
+}
+
+// minInterval is the floor New clamps a non-positive interval up to. A zero or
+// negative interval would make the time check degenerate (every call passes it,
+// leaving only the CAS to gate — a race-per-call gate, not a throttle), which is
+// never what a caller means. Clamping rather than panicking keeps a config
+// mistake from crashing the process at init on a memory-release path.
+const minInterval = time.Millisecond
+
+// New returns a Debouncer that lets an action proceed at most once per interval.
+// A non-positive interval is clamped up to a small floor (see minInterval). The
+// monotonic anchor is captured now, at construction time.
+func New(interval time.Duration) *Debouncer {
+	if interval < minInterval {
+		interval = minInterval
+	}
+	return &Debouncer{
+		interval:     interval,
+		processStart: time.Now(),
+	}
+}
+
+// TryAcquire reports whether the caller may proceed. It returns true for the
+// first caller in each interval and false for everyone else until the interval
+// elapses. When it returns true it has already recorded the firing time, so the
+// caller should perform the throttled action; when it returns false the caller
+// must skip it.
+//
+// A lost CompareAndSwap (another goroutine acquired concurrently) also returns
+// false — exactly one caller wins per interval.
+func (d *Debouncer) TryAcquire() bool {
+	now := time.Since(d.processStart).Nanoseconds()
+	last := d.lastNanos.Load()
+	// last==0 means "never fired" — the first call always proceeds. See the
+	// package comment for why this sentinel is required with monotonic time.
+	if last != 0 && now-last < int64(d.interval) {
+		return false
+	}
+	return d.lastNanos.CompareAndSwap(last, now)
+}
+
+// Remaining reports how long until the next TryAcquire would be eligible on the
+// time axis (it does not account for a concurrent winner). It returns 0 when a
+// call would be eligible now — including before the first fire (last==0). Useful
+// for building an HTTP 429 Retry-After; callers that need whole seconds should
+// round up themselves, so a sub-second remainder never rounds to an immediate
+// retry.
+func (d *Debouncer) Remaining() time.Duration {
+	last := d.lastNanos.Load()
+	if last == 0 {
+		return 0
+	}
+	now := time.Since(d.processStart).Nanoseconds()
+	elapsed := time.Duration(now - last)
+	if elapsed >= d.interval {
+		return 0
+	}
+	return d.interval - elapsed
+}

--- a/internal/throttle/throttle_test.go
+++ b/internal/throttle/throttle_test.go
@@ -1,0 +1,132 @@
+package throttle
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestDebouncer_FirstCallProceeds is the regression guard for the #420 bug: with
+// a monotonic anchor, time.Since(processStart) is small early in the process's
+// life, so `now - 0` is INSIDE any practical interval. Without the last==0
+// sentinel the very first call would be throttled. It must fire.
+func TestDebouncer_FirstCallProceeds(t *testing.T) {
+	d := New(30 * time.Second)
+	if !d.TryAcquire() {
+		t.Fatal("first TryAcquire must succeed (last==0 sentinel); it was throttled")
+	}
+}
+
+// TestDebouncer_SecondCallThrottled verifies the window actually throttles: after
+// a successful acquire, an immediate second call is rejected.
+func TestDebouncer_SecondCallThrottled(t *testing.T) {
+	d := New(30 * time.Second)
+	if !d.TryAcquire() {
+		t.Fatal("first acquire should succeed")
+	}
+	if d.TryAcquire() {
+		t.Fatal("second acquire within the window should be throttled")
+	}
+}
+
+// TestDebouncer_ReAcquiresAfterInterval verifies eligibility returns once the
+// interval elapses. Uses a tiny interval so the test is fast.
+func TestDebouncer_ReAcquiresAfterInterval(t *testing.T) {
+	d := New(10 * time.Millisecond)
+	if !d.TryAcquire() {
+		t.Fatal("first acquire should succeed")
+	}
+	if d.TryAcquire() {
+		t.Fatal("immediate re-acquire should be throttled")
+	}
+	time.Sleep(15 * time.Millisecond)
+	if !d.TryAcquire() {
+		t.Fatal("acquire after the interval elapsed should succeed")
+	}
+}
+
+// TestDebouncer_NonPositiveIntervalClamped verifies New clamps a zero or
+// negative interval to the floor rather than producing a degenerate throttle
+// (where the time check always passes). The first call still fires (sentinel),
+// and an immediate second call is throttled by the clamped floor.
+func TestDebouncer_NonPositiveIntervalClamped(t *testing.T) {
+	for _, iv := range []time.Duration{0, -1 * time.Second} {
+		d := New(iv)
+		if !d.TryAcquire() {
+			t.Fatalf("New(%v): first call should fire", iv)
+		}
+		if d.TryAcquire() {
+			t.Fatalf("New(%v): immediate second call should be throttled by the clamped floor, not allowed through", iv)
+		}
+	}
+}
+
+// TestDebouncer_ConcurrentSingleWinner is the CAS-contention test: many
+// goroutines race on the first acquire; exactly one must win.
+func TestDebouncer_ConcurrentSingleWinner(t *testing.T) {
+	d := New(30 * time.Second)
+
+	const goroutines = 200
+	var winners atomic.Int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start // release all at once to maximize contention
+			if d.TryAcquire() {
+				winners.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := winners.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 winner under concurrent contention, got %d", got)
+	}
+}
+
+// TestDebouncer_Remaining verifies the remaining-time accounting used for HTTP
+// 429 retry-after.
+func TestDebouncer_Remaining(t *testing.T) {
+	// Before any fire, a call would be eligible now → 0.
+	d := New(30 * time.Second)
+	if r := d.Remaining(); r != 0 {
+		t.Errorf("Remaining before first fire = %v, want 0", r)
+	}
+
+	// After firing, remaining should be > 0 and <= interval.
+	if !d.TryAcquire() {
+		t.Fatal("acquire should succeed")
+	}
+	r := d.Remaining()
+	if r <= 0 || r > 30*time.Second {
+		t.Errorf("Remaining after fire = %v, want (0, 30s]", r)
+	}
+
+	// After the interval elapses, remaining is 0 again.
+	d2 := New(10 * time.Millisecond)
+	d2.TryAcquire()
+	time.Sleep(15 * time.Millisecond)
+	if r := d2.Remaining(); r != 0 {
+		t.Errorf("Remaining after interval elapsed = %v, want 0", r)
+	}
+}
+
+// TestDebouncer_RemainingRoundsUpForCaller documents the contract debug.go
+// relies on: Remaining returns a sub-second value in the last part of the
+// window, which the caller rounds UP to avoid retry storms. Here we just assert
+// Remaining is a positive sub-interval so the caller's round-up has something to
+// work with.
+func TestDebouncer_RemainingSubSecond(t *testing.T) {
+	d := New(500 * time.Millisecond)
+	d.TryAcquire()
+	time.Sleep(50 * time.Millisecond)
+	r := d.Remaining()
+	if r <= 0 || r >= 500*time.Millisecond {
+		t.Errorf("Remaining mid-window = %v, want in (0, 500ms)", r)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #421. The same ~8-line 30-second debounce throttle was copied across three sites. This extracts it into a small `internal/throttle` package and converts all three call sites to one-liners.

**The three sites (all now use `throttle.Debouncer`):**
- `internal/api/delete.go` — `freeOSMemoryThrottled` (post-delete/retention `debug.FreeOSMemory`)
- `internal/api/debug.go` — `handleFreeOSMemory` (the `POST /api/v1/debug/free-os-memory` endpoint; uses `Remaining()` for the `429` retry-after)
- `internal/memtrim/memtrim_linux.go` — `ReleaseToOS` (glibc `malloc_trim(0)`)

## Behavioral identity (the whole point of a refactor)

- **The `last==0` first-call sentinel is preserved.** This is load-bearing, not cosmetic: with the monotonic anchor, `time.Since(processStart)` is small early in a process's life, so `now - 0` falls *inside* the 30s window — without the sentinel the very first call is throttled instead of firing. That exact bug shipped once in #420 and cost ~25 MB of idle RSS before it was caught. Documented in the package comment and guarded by `TestDebouncer_FirstCallProceeds`.
- `delete.go` and `memtrim` are byte-for-byte equivalent (`if TryAcquire() { … }` / `if !TryAcquire() { return false }`).
- **One minor improvement** in `debug.go`: when two callers race the endpoint and one loses the CAS, its `429` now includes a `retry_after_seconds` hint (previously omitted only in that narrow race). Strictly better — the client gets an actionable retry.
- `New()` clamps a non-positive interval to a 1ms floor so a future caller of the now-shared primitive can't create a degenerate throttle.

## Test plan

- [x] New `internal/throttle` tests (all `-race`): first-call sentinel (#420 regression), throttle-within-window, re-acquire after interval, **concurrent single-winner** (200 goroutines released at once → exactly 1 wins), interval clamp, and `Remaining()` accounting.
- [x] `gofmt -l`, `go vet`, full build clean; `GOOS=linux go vet ./internal/memtrim/...` clean (the cgo path type-checks under `//go:build linux && cgo`).
- [x] **Binary run** of `POST /api/v1/debug/free-os-memory`: first call fires (200 with a real `heap_released_delta`), second is throttled (`429` with `retry_after_seconds`), and the retry-after correctly counts down as the window elapses (30 → 16).
- [x] Internal adversarial review + DeepSeek review — both approved. Fixes applied for a mis-attributed comment, two stale identifiers, and the interval clamp.

`~60` lines of duplicated bookkeeping removed; the new package + tests are net additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)