### PR TITLE
fix(mqtt): remove non-functional reconnect_min_seconds config (#327)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -83,6 +83,12 @@ The create request now models `qos` as optional: an omitted field still defaults
 
 Related fix in the same handler: an out-of-range or otherwise invalid subscription request now returns **`400 Bad Request`** with the validation message instead of `500 Internal Server Error`.
 
+### Removed the non-functional MQTT `reconnect_min_seconds` setting ([#327](https://github.com/Basekick-Labs/arc/issues/327))
+
+MQTT subscriptions accepted a `reconnect_min_seconds` field that was validated, defaulted, and persisted but **never applied** — the MQTT client library hardcodes the initial reconnect backoff at 1 second and exposes no setter for it, so the value had no effect. It has been removed from the API: create/update request bodies no longer accept it, and it no longer appears in `GET`/`LIST` subscription responses. `reconnect_max_seconds` is unaffected — it still caps the exponential backoff.
+
+This is not a breaking change: an omitted or extra `reconnect_min_seconds` in a request body is simply ignored, and existing MQTT subscription databases are untouched (the underlying column is left in place, unused, so no migration runs). The reconnect behavior itself is unchanged — the minimum was already a fixed 1 second in practice.
+
 ## Performance
 
 ### Faster local-storage directory listing ([#347](https://github.com/Basekick-Labs/arc/issues/347))

--- a/internal/mqtt/manager.go
+++ b/internal/mqtt/manager.go
@@ -163,7 +163,6 @@ func (m *SubscriptionManager) Create(ctx context.Context, req *CreateSubscriptio
 		TopicMapping:          req.TopicMapping,
 		KeepAliveSeconds:      req.KeepAliveSeconds,
 		ConnectTimeoutSeconds: req.ConnectTimeoutSeconds,
-		ReconnectMinSeconds:   req.ReconnectMinSeconds,
 		ReconnectMaxSeconds:   req.ReconnectMaxSeconds,
 		CleanSession:          req.CleanSession,
 		Status:                StatusStopped,
@@ -283,9 +282,6 @@ func (m *SubscriptionManager) Update(ctx context.Context, id string, req *Update
 	}
 	if req.ConnectTimeoutSeconds != nil {
 		sub.ConnectTimeoutSeconds = *req.ConnectTimeoutSeconds
-	}
-	if req.ReconnectMinSeconds != nil {
-		sub.ReconnectMinSeconds = *req.ReconnectMinSeconds
 	}
 	if req.ReconnectMaxSeconds != nil {
 		sub.ReconnectMaxSeconds = *req.ReconnectMaxSeconds

--- a/internal/mqtt/repository.go
+++ b/internal/mqtt/repository.go
@@ -178,11 +178,14 @@ func (r *Repository) Create(ctx context.Context, sub *Subscription) error {
 		username, password_encrypted, tls_enabled, tls_cert_path,
 		tls_key_path, tls_ca_path, tls_insecure_skip_verify, auto_start,
 		status, error_message, topic_mapping, keep_alive_seconds,
-		connect_timeout_seconds, reconnect_min_seconds, reconnect_max_seconds,
+		connect_timeout_seconds, reconnect_max_seconds,
 		clean_session, created_at, updated_at
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
+	// Note: reconnect_min_seconds is intentionally omitted — the column remains
+	// (nullable, DEFAULT 1) to avoid a destructive migration, but ReconnectMin is
+	// dead config that paho ignores, so it is no longer written or read (#327).
 	_, err = r.db.ExecContext(ctx, query,
 		sub.ID, sub.Name, sub.Broker, sub.ClientID, string(topicsJSON),
 		sub.QoS, sub.Database, sub.Username, sub.PasswordEncrypted,
@@ -190,7 +193,7 @@ func (r *Repository) Create(ctx context.Context, sub *Subscription) error {
 		sub.TLSCAPath, boolToInt(sub.TLSInsecureSkipVerify),
 		boolToInt(sub.AutoStart), string(sub.Status), sub.ErrorMessage,
 		nullableString(topicMappingJSON), sub.KeepAliveSeconds,
-		sub.ConnectTimeoutSeconds, sub.ReconnectMinSeconds,
+		sub.ConnectTimeoutSeconds,
 		sub.ReconnectMaxSeconds, boolToInt(sub.CleanSession),
 		sub.CreatedAt.Format(time.RFC3339),
 		sub.UpdatedAt.Format(time.RFC3339),
@@ -213,7 +216,7 @@ func (r *Repository) Get(ctx context.Context, id string) (*Subscription, error) 
 		username, password_encrypted, tls_enabled, tls_cert_path,
 		tls_key_path, tls_ca_path, tls_insecure_skip_verify, auto_start,
 		status, error_message, topic_mapping, keep_alive_seconds,
-		connect_timeout_seconds, reconnect_min_seconds, reconnect_max_seconds,
+		connect_timeout_seconds, reconnect_max_seconds,
 		clean_session, created_at, updated_at
 	FROM mqtt_subscriptions
 	WHERE id = ?
@@ -229,7 +232,7 @@ func (r *Repository) GetByName(ctx context.Context, name string) (*Subscription,
 		username, password_encrypted, tls_enabled, tls_cert_path,
 		tls_key_path, tls_ca_path, tls_insecure_skip_verify, auto_start,
 		status, error_message, topic_mapping, keep_alive_seconds,
-		connect_timeout_seconds, reconnect_min_seconds, reconnect_max_seconds,
+		connect_timeout_seconds, reconnect_max_seconds,
 		clean_session, created_at, updated_at
 	FROM mqtt_subscriptions
 	WHERE name = ?
@@ -245,7 +248,7 @@ func (r *Repository) List(ctx context.Context) ([]*Subscription, error) {
 		username, password_encrypted, tls_enabled, tls_cert_path,
 		tls_key_path, tls_ca_path, tls_insecure_skip_verify, auto_start,
 		status, error_message, topic_mapping, keep_alive_seconds,
-		connect_timeout_seconds, reconnect_min_seconds, reconnect_max_seconds,
+		connect_timeout_seconds, reconnect_max_seconds,
 		clean_session, created_at, updated_at
 	FROM mqtt_subscriptions
 	ORDER BY name
@@ -280,7 +283,7 @@ func (r *Repository) ListAutoStart(ctx context.Context) ([]*Subscription, error)
 		username, password_encrypted, tls_enabled, tls_cert_path,
 		tls_key_path, tls_ca_path, tls_insecure_skip_verify, auto_start,
 		status, error_message, topic_mapping, keep_alive_seconds,
-		connect_timeout_seconds, reconnect_min_seconds, reconnect_max_seconds,
+		connect_timeout_seconds, reconnect_max_seconds,
 		clean_session, created_at, updated_at
 	FROM mqtt_subscriptions
 	WHERE auto_start = 1
@@ -336,11 +339,13 @@ func (r *Repository) Update(ctx context.Context, sub *Subscription) error {
 		tls_ca_path = ?, tls_insecure_skip_verify = ?, auto_start = ?,
 		status = ?, error_message = ?, topic_mapping = ?,
 		keep_alive_seconds = ?, connect_timeout_seconds = ?,
-		reconnect_min_seconds = ?, reconnect_max_seconds = ?,
+		reconnect_max_seconds = ?,
 		clean_session = ?, updated_at = ?
 	WHERE id = ?
 	`
 
+	// reconnect_min_seconds is left untouched (dead config, see Create) — the
+	// column keeps its existing/default value and is never read back (#327).
 	result, err := r.db.ExecContext(ctx, query,
 		sub.Name, sub.Broker, sub.ClientID, string(topicsJSON),
 		sub.QoS, sub.Database, sub.Username, sub.PasswordEncrypted,
@@ -348,7 +353,7 @@ func (r *Repository) Update(ctx context.Context, sub *Subscription) error {
 		sub.TLSCAPath, boolToInt(sub.TLSInsecureSkipVerify),
 		boolToInt(sub.AutoStart), string(sub.Status), sub.ErrorMessage,
 		nullableString(topicMappingJSON), sub.KeepAliveSeconds,
-		sub.ConnectTimeoutSeconds, sub.ReconnectMinSeconds,
+		sub.ConnectTimeoutSeconds,
 		sub.ReconnectMaxSeconds, boolToInt(sub.CleanSession),
 		sub.UpdatedAt.Format(time.RFC3339),
 		sub.ID,
@@ -431,7 +436,7 @@ func (r *Repository) scanSubscription(row *sql.Row) (*Subscription, error) {
 		&tlsEnabled, &sub.TLSCertPath, &sub.TLSKeyPath, &sub.TLSCAPath,
 		&tlsInsecureSkipVerify, &autoStart, &status, &sub.ErrorMessage,
 		&topicMappingJSON, &sub.KeepAliveSeconds, &sub.ConnectTimeoutSeconds,
-		&sub.ReconnectMinSeconds, &sub.ReconnectMaxSeconds,
+		&sub.ReconnectMaxSeconds,
 		&cleanSession, &createdAt, &updatedAt,
 	)
 
@@ -484,7 +489,7 @@ func (r *Repository) scanSubscriptionRow(rows *sql.Rows) (*Subscription, error) 
 		&tlsEnabled, &sub.TLSCertPath, &sub.TLSKeyPath, &sub.TLSCAPath,
 		&tlsInsecureSkipVerify, &autoStart, &status, &sub.ErrorMessage,
 		&topicMappingJSON, &sub.KeepAliveSeconds, &sub.ConnectTimeoutSeconds,
-		&sub.ReconnectMinSeconds, &sub.ReconnectMaxSeconds,
+		&sub.ReconnectMaxSeconds,
 		&cleanSession, &createdAt, &updatedAt,
 	)
 

--- a/internal/mqtt/subscription.go
+++ b/internal/mqtt/subscription.go
@@ -65,11 +65,13 @@ type Subscription struct {
 	TopicMapping          map[string]string  `json:"topic_mapping,omitempty"`
 	KeepAliveSeconds      int                `json:"keep_alive_seconds"`
 	ConnectTimeoutSeconds int                `json:"connect_timeout_seconds"`
-	ReconnectMinSeconds   int                `json:"reconnect_min_seconds"`
-	ReconnectMaxSeconds   int                `json:"reconnect_max_seconds"`
-	CleanSession          bool               `json:"clean_session"`
-	CreatedAt             time.Time          `json:"created_at"`
-	UpdatedAt             time.Time          `json:"updated_at"`
+	// ReconnectMaxSeconds caps paho's exponential reconnect backoff. There is no
+	// ReconnectMinSeconds: paho hardcodes the initial backoff at 1s with no
+	// setter, so a configurable minimum was dead config and was removed (#327).
+	ReconnectMaxSeconds int       `json:"reconnect_max_seconds"`
+	CleanSession        bool      `json:"clean_session"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
 }
 
 // CreateSubscriptionRequest is the request body for creating a subscription
@@ -95,7 +97,6 @@ type CreateSubscriptionRequest struct {
 	TopicMapping          map[string]string `json:"topic_mapping,omitempty"`
 	KeepAliveSeconds      int               `json:"keep_alive_seconds"`
 	ConnectTimeoutSeconds int               `json:"connect_timeout_seconds"`
-	ReconnectMinSeconds   int               `json:"reconnect_min_seconds"`
 	ReconnectMaxSeconds   int               `json:"reconnect_max_seconds"`
 	CleanSession          bool              `json:"clean_session"`
 }
@@ -119,7 +120,6 @@ type UpdateSubscriptionRequest struct {
 	TopicMapping          *map[string]string `json:"topic_mapping,omitempty"`
 	KeepAliveSeconds      *int               `json:"keep_alive_seconds,omitempty"`
 	ConnectTimeoutSeconds *int               `json:"connect_timeout_seconds,omitempty"`
-	ReconnectMinSeconds   *int               `json:"reconnect_min_seconds,omitempty"`
 	ReconnectMaxSeconds   *int               `json:"reconnect_max_seconds,omitempty"`
 	CleanSession          *bool              `json:"clean_session,omitempty"`
 }
@@ -203,14 +203,8 @@ func (s *Subscription) Validate() error {
 	if s.ConnectTimeoutSeconds < 0 {
 		return errors.New("connect_timeout_seconds cannot be negative")
 	}
-	if s.ReconnectMinSeconds < 0 {
-		return errors.New("reconnect_min_seconds cannot be negative")
-	}
 	if s.ReconnectMaxSeconds < 0 {
 		return errors.New("reconnect_max_seconds cannot be negative")
-	}
-	if s.ReconnectMinSeconds > s.ReconnectMaxSeconds && s.ReconnectMaxSeconds > 0 {
-		return errors.New("reconnect_min_seconds cannot exceed reconnect_max_seconds")
 	}
 
 	return nil
@@ -249,9 +243,6 @@ func (s *Subscription) SetDefaults() {
 	}
 	if s.ConnectTimeoutSeconds == 0 {
 		s.ConnectTimeoutSeconds = 30
-	}
-	if s.ReconnectMinSeconds == 0 {
-		s.ReconnectMinSeconds = 1
 	}
 	if s.ReconnectMaxSeconds == 0 {
 		s.ReconnectMaxSeconds = 60
@@ -312,7 +303,6 @@ func ValidateCreateRequest(req *CreateSubscriptionRequest) error {
 		TLSCAPath:             req.TLSCAPath,
 		KeepAliveSeconds:      req.KeepAliveSeconds,
 		ConnectTimeoutSeconds: req.ConnectTimeoutSeconds,
-		ReconnectMinSeconds:   req.ReconnectMinSeconds,
 		ReconnectMaxSeconds:   req.ReconnectMaxSeconds,
 		CleanSession:          req.CleanSession,
 	}

--- a/internal/mqtt/subscription_test.go
+++ b/internal/mqtt/subscription_test.go
@@ -134,8 +134,8 @@ func TestSubscription_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "reconnect_min_exceeds_max",
-			modify:  func(s *Subscription) { s.ReconnectMinSeconds = 60; s.ReconnectMaxSeconds = 30 },
+			name:    "negative_reconnect_max",
+			modify:  func(s *Subscription) { s.ReconnectMaxSeconds = -1 },
 			wantErr: true,
 		},
 	}
@@ -169,9 +169,6 @@ func TestSubscription_SetDefaults(t *testing.T) {
 	}
 	if sub.ConnectTimeoutSeconds != 30 {
 		t.Errorf("Default ConnectTimeoutSeconds = %d, want 30", sub.ConnectTimeoutSeconds)
-	}
-	if sub.ReconnectMinSeconds != 1 {
-		t.Errorf("Default ReconnectMinSeconds = %d, want 1", sub.ReconnectMinSeconds)
 	}
 	if sub.ReconnectMaxSeconds != 60 {
 		t.Errorf("Default ReconnectMaxSeconds = %d, want 60", sub.ReconnectMaxSeconds)


### PR DESCRIPTION
## Summary

Fixes #327. MQTT subscriptions accepted a `reconnect_min_seconds` field that was validated, defaulted, persisted, and threaded through ~15 sites — but **never passed to the MQTT client**. paho v1.5.1 hardcodes the initial reconnect backoff at `1 * time.Second` (`client.go` `initSleep`) and exposes no `ClientOptions` setter for it, so the value had no effect. The issue asked to "remove or implement"; it is un-implementable with the current library, so this removes it.

`reconnect_max_seconds` **is** used (`SetMaxReconnectInterval`) and is untouched.

## What changed

- Removed `ReconnectMinSeconds` from all three structs (`Subscription`, `CreateSubscriptionRequest`, `UpdateSubscriptionRequest`), its validation (negative + min>max checks), its default, and the create/update mappings.
- Removed it from every repository SQL path: INSERT, UPDATE, the 4 SELECTs, and both Scan target lists.
- **Kept** the `reconnect_min_seconds INTEGER DEFAULT 1` SQLite column so existing subscription databases need no migration — the column is simply no longer read or written (the INSERT relies on its `DEFAULT`).

## Backward compatibility

Not a breaking change:
- A `reconnect_min_seconds` in a create/update body is silently ignored (Go's JSON decoder drops unknown fields — no 400).
- It no longer appears in `GET`/`LIST` responses; since it never had an effect, no client was getting actionable information.
- Existing MQTT databases are untouched (no migration; the column and its data stay).

## Test plan

- [x] `go test -race ./internal/mqtt/...` and the api MQTT tests — pass. Updated the obsolete validation/default test cases; added a `negative_reconnect_max` case exercising the surviving check.
- [x] `gofmt -l`, `go vet`, full build — clean.
- [x] **Binary run** (MQTT enabled): create with `reconnect_min_seconds:99` in the body → ignored (no error); `reconnect_max_seconds:45` → honored and persisted; response omits `reconnect_min_seconds`; SQLite confirms the kept column defaulted to `1` on the INSERT that omitted it.
- [x] Internal adversarial review + DeepSeek review — both approved. Both **hand-counted the SQL column/placeholder/arg/scan alignment** across all 7 sites (the one real risk of a middle-of-list column removal) and confirmed exact consistency.

Docs updated on docs.basekick.net (removed the field from the mqtt.md example + parameter table; clarified the fixed 1s reconnect floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)