### PR TITLE
perf(mqtt): use atomic for lastMessageAt instead of a per-message mutex (#328)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -110,6 +110,10 @@ Per-op benchmarks on the cache: `Get` **257 ns → 71 ns**, `Set` **269 ns → 8
 
 The three copies of the 30-second memory-release debounce (the post-delete/retention `debug.FreeOSMemory` throttle, the `/api/v1/debug/free-os-memory` endpoint, and the Linux `malloc_trim` throttle) are now a single `internal/throttle.Debouncer`. Behavior is unchanged — same monotonic-clock window and the same first-call sentinel that fires the very first request rather than throttling it. One minor improvement: when two callers race the `/api/v1/debug/free-os-memory` endpoint at the same instant and one loses, the loser's `429` response now includes a `retry_after_seconds` hint (previously it was omitted only in that narrow race).
 
+### MQTT message hot path no longer takes a mutex per message ([#328](https://github.com/Basekick-Labs/arc/issues/328))
+
+Every received MQTT message took a full write-lock on the subscriber's state mutex just to update the `last_message_at` timestamp. That serialized the message hot path against itself and against the stats endpoint. The timestamp is now an `atomic.Int64` (Unix nanoseconds), so the per-message stat update is lock-free — matching the other per-message counters, which were already atomic. The stats-reporting output is unchanged. Under contention the per-message stat update is ~19% faster in a microbenchmark; the real benefit is removing the serialization point from a high-throughput ingest path.
+
 ## Impact by deployment mode
 
 The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.

--- a/internal/mqtt/subscriber.go
+++ b/internal/mqtt/subscriber.go
@@ -31,17 +31,21 @@ type Subscriber struct {
 	encryptor      PasswordEncryptor
 	onStatusChange func(id string, status SubscriptionStatus, errMsg string)
 
-	// Runtime state
+	// Runtime state. mu guards the lifecycle fields (running, connectedSince),
+	// which change only on connect/start/stop — not on the message hot path.
 	mu             sync.RWMutex
 	running        bool
 	connectedSince time.Time
-	lastMessageAt  time.Time
 
-	// Statistics
-	messagesReceived atomic.Int64
-	messagesFailed   atomic.Int64
-	bytesReceived    atomic.Int64
-	reconnects       atomic.Int64
+	// Statistics. All updated on the message hot path without the mutex.
+	// lastMessageAtNanos holds the last-message time as Unix nanoseconds (0 =
+	// no message received yet); it was a mutex-guarded time.Time, which took a
+	// full lock on every received message (#328).
+	messagesReceived   atomic.Int64
+	messagesFailed     atomic.Int64
+	bytesReceived      atomic.Int64
+	reconnects         atomic.Int64
+	lastMessageAtNanos atomic.Int64
 
 	// Shutdown
 	ctx    context.Context
@@ -148,11 +152,22 @@ func (s *Subscriber) IsRunning() bool {
 // GetStats returns current statistics
 func (s *Subscriber) GetStats() *SubscriptionStats {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	status := "stopped"
 	if s.running {
 		status = "running"
+	}
+	connectedSince := s.connectedSince
+	s.mu.RUnlock()
+
+	// lastMessageAt lives in an atomic (off the message hot path). 0 nanos means
+	// no message has been received yet — map it to the zero time.Time so the
+	// response renders exactly as before (0001-01-01T00:00:00Z; note encoding/json
+	// does not actually omit a zero time.Time despite the omitempty tag). The 0
+	// sentinel collides with the Unix epoch instant, but time.Now() never returns
+	// it in practice, so a real message can't be misread as "never received".
+	var lastMessageAt time.Time
+	if nanos := s.lastMessageAtNanos.Load(); nanos != 0 {
+		lastMessageAt = time.Unix(0, nanos)
 	}
 
 	return &SubscriptionStats{
@@ -162,8 +177,8 @@ func (s *Subscriber) GetStats() *SubscriptionStats {
 		MessagesReceived: s.messagesReceived.Load(),
 		MessagesFailed:   s.messagesFailed.Load(),
 		BytesReceived:    s.bytesReceived.Load(),
-		LastMessageAt:    s.lastMessageAt,
-		ConnectedSince:   s.connectedSince,
+		LastMessageAt:    lastMessageAt,
+		ConnectedSince:   connectedSince,
 		Reconnects:       s.reconnects.Load(),
 	}
 }
@@ -300,10 +315,8 @@ func (s *Subscriber) onReconnecting(client pahomqtt.Client, opts *pahomqtt.Clien
 func (s *Subscriber) onMessage(client pahomqtt.Client, msg pahomqtt.Message) {
 	s.messagesReceived.Add(1)
 	s.bytesReceived.Add(int64(len(msg.Payload())))
-
-	s.mu.Lock()
-	s.lastMessageAt = time.Now()
-	s.mu.Unlock()
+	// Atomic store — no mutex on the message hot path (#328).
+	s.lastMessageAtNanos.Store(time.Now().UnixNano())
 
 	// Update metrics
 	metrics.Get().IncMQTTMessagesReceived()

--- a/internal/mqtt/subscriber_test.go
+++ b/internal/mqtt/subscriber_test.go
@@ -1,0 +1,117 @@
+package mqtt
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// newStatsSubscriber builds a minimal Subscriber sufficient to exercise the
+// stats path (GetStats reads config.Name). It does not connect to a broker.
+func newStatsSubscriber() *Subscriber {
+	return &Subscriber{
+		id:     "sub-1",
+		config: &Subscription{ID: "sub-1", Name: "test"},
+		logger: zerolog.Nop(),
+	}
+}
+
+// TestGetStats_LastMessageAt verifies the atomic lastMessageAt (#328): it is the
+// zero time.Time before any message (so omitempty omits it), and reflects the
+// stored nanos after a message.
+func TestGetStats_LastMessageAt(t *testing.T) {
+	s := newStatsSubscriber()
+
+	// Before any message: zero value, so the JSON omitempty tag drops it.
+	if got := s.GetStats().LastMessageAt; !got.IsZero() {
+		t.Errorf("LastMessageAt before any message = %v, want zero", got)
+	}
+
+	// Simulate a message arriving: store the current time as nanos (this is what
+	// onMessage does on the hot path).
+	now := time.Now()
+	s.lastMessageAtNanos.Store(now.UnixNano())
+
+	got := s.GetStats().LastMessageAt
+	if got.IsZero() {
+		t.Fatal("LastMessageAt after a message should be non-zero")
+	}
+	// Reconstructed time must equal the stored instant to nanosecond precision.
+	if !got.Equal(now) {
+		t.Errorf("LastMessageAt = %v, want %v (nanos round-trip)", got, now)
+	}
+}
+
+// TestGetStats_ConcurrentMessageUpdates is the #328 race guard: concurrent
+// hot-path updates (lastMessageAtNanos.Store) and GetStats reads must be
+// race-free. Run with -race. Before the fix this path took a full mutex on
+// every message; the atomic must be equally safe.
+func TestGetStats_ConcurrentMessageUpdates(t *testing.T) {
+	s := newStatsSubscriber()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers: mimic onMessage's hot-path stat updates.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					s.messagesReceived.Add(1)
+					s.bytesReceived.Add(128)
+					s.lastMessageAtNanos.Store(time.Now().UnixNano())
+				}
+			}
+		}()
+	}
+
+	// Readers: mimic the stats endpoint.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = s.GetStats()
+				}
+			}
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	// Sanity: at least one message was counted and a last-message time was set.
+	if s.GetStats().MessagesReceived == 0 {
+		t.Error("expected some messages counted")
+	}
+	if s.GetStats().LastMessageAt.IsZero() {
+		t.Error("expected LastMessageAt to be set after concurrent updates")
+	}
+}
+
+// BenchmarkOnMessageStatUpdate isolates the per-message stat bookkeeping that
+// onMessage does (the part changed in #328): counters + lastMessageAt. Run with
+// -cpu to see contention. The atomic path replaces a full mutex lock per message.
+func BenchmarkOnMessageStatUpdate(b *testing.B) {
+	s := newStatsSubscriber()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			s.messagesReceived.Add(1)
+			s.bytesReceived.Add(128)
+			s.lastMessageAtNanos.Store(time.Now().UnixNano())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #328. `onMessage` took a full write-lock on the subscriber's state mutex on **every received message** just to update `lastMessageAt`, serializing the message hot path against itself and against the stats endpoint. The other per-message counters (`messagesReceived`, `bytesReceived`, `reconnects`) were already `atomic.Int64`; `lastMessageAt` was the lone mutex-guarded field on that path.

## What changed

- Struct field `lastMessageAt time.Time` (mutex-guarded) → `lastMessageAtNanos atomic.Int64` (Unix nanoseconds; `0` = no message yet).
- `onMessage`: `s.mu.Lock(); s.lastMessageAt = time.Now(); s.mu.Unlock()` → a lock-free `s.lastMessageAtNanos.Store(time.Now().UnixNano())`.
- `GetStats`: takes the RLock only to snapshot the lifecycle fields (`running`, `connectedSince`), releases it, then loads the atomic and reconstructs the `time.Time` (`0` → zero time, else `time.Unix(0, nanos)`).
- The mutex `s.mu` now guards only lifecycle state, which changes on connect/start/stop — never per message.

## Behaviorally transparent

The stats JSON is byte-for-byte identical: a never-received subscription still renders `"last_message_at": "0001-01-01T00:00:00Z"`, and a real timestamp round-trips to nanosecond precision with the same timezone rendering (verified across UTC / Europe/Madrid / America/New_York).

## Test plan

- [x] `go test -race ./internal/mqtt/...` — new tests: nanosecond round-trip fidelity, and an 8-writer / 4-reader concurrent test proving the lock-free path is race-free.
- [x] `gofmt -l`, `go vet`, full build — clean.
- [x] **A/B benchmark** (8-way contention): mutex `182 ns/op` → atomic `147 ns/op` (~19% faster), 0 allocs. Honest framing — the real win is removing the serialization point from a high-throughput ingest path, not the single-op cost.
- [x] Binary run: the MQTT stats endpoint returns correct JSON with the new atomic path.
- [x] Internal adversarial review + DeepSeek review — both approved, no blockers. Highest-risk concerns (timezone/JSON rendering fidelity, epoch-0 sentinel) empirically validated. Two comment inaccuracies the reviewer flagged were fixed.

## Follow-up (out of scope)

The `omitempty` tag on `SubscriptionStats.LastMessageAt`/`ConnectedSince` is a no-op — Go's `encoding/json` never omits a zero `time.Time`, so those fields render `0001-01-01T00:00:00Z` before a value is set. This is pre-existing and cosmetic; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)