### PR TITLE
fix(auth): validate name on UpdateOrganization/UpdateTeam (#324)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -93,7 +93,9 @@ This is not a breaking change: an omitted or extra `reconnect_min_seconds` in a 
 
 `UpdateOrganization` and `UpdateTeam` accepted any string as a new name — including empty strings and names starting with a digit — because the `validateName` check that `CreateOrganization` and `CreateTeam` apply was missing from the update path. An invalid name could be written to the database and later cause confusing errors or inconsistent behavior downstream.
 
-Both update methods now call `validateName` on the supplied name before any write (OSS direct-SQLite path and cluster Raft path). The validation rules are the same as create: must start with a letter, alphanumeric plus underscore/hyphen, at most 64 characters. An invalid name returns an error and the update is rejected. The API handlers for both create and update now return **`400 Bad Request`** (instead of `500 Internal Server Error`) when name validation fails, so client-supplied invalid values get the correct status code.
+Both update methods now call `validateName` on the supplied name before any write (OSS direct-SQLite path and cluster Raft path). The validation rules are the same as create: must start with a letter, alphanumeric plus underscore/hyphen, at most 64 characters. An invalid name returns an error and the update is rejected.
+
+The API handlers now return **`400 Bad Request`** when name validation fails, so client-supplied invalid values get the correct status code. On the create path this replaces a `500 Internal Server Error` that was returned for every rule except the empty-name check (so `name` values containing spaces, or starting with a digit, previously surfaced as a server error). On the update path there was no status code to replace — the invalid name was accepted with `200 OK` and written to the database, which is the bug described above.
 
 ### Optional timestamp fields are now omitted when unset, and rendered in UTC ([#546](https://github.com/Basekick-Labs/arc/issues/546))
 

--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -93,7 +93,7 @@ This is not a breaking change: an omitted or extra `reconnect_min_seconds` in a 
 
 `UpdateOrganization` and `UpdateTeam` accepted any string as a new name — including empty strings and names starting with a digit — because the `validateName` check that `CreateOrganization` and `CreateTeam` apply was missing from the update path. An invalid name could be written to the database and later cause confusing errors or inconsistent behavior downstream.
 
-Both update methods now call `validateName` on the supplied name before any write (OSS direct-SQLite path and cluster Raft path). The validation rules are the same as create: must start with a letter, alphanumeric plus underscore/hyphen, at most 64 characters. An invalid name returns an error and the update is rejected.
+Both update methods now call `validateName` on the supplied name before any write (OSS direct-SQLite path and cluster Raft path). The validation rules are the same as create: must start with a letter, alphanumeric plus underscore/hyphen, at most 64 characters. An invalid name returns an error and the update is rejected. The API handlers for both create and update now return **`400 Bad Request`** (instead of `500 Internal Server Error`) when name validation fails, so client-supplied invalid values get the correct status code.
 
 ### Optional timestamp fields are now omitted when unset, and rendered in UTC ([#546](https://github.com/Basekick-Labs/arc/issues/546))
 

--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -89,6 +89,12 @@ MQTT subscriptions accepted a `reconnect_min_seconds` field that was validated, 
 
 This is not a breaking change: an omitted or extra `reconnect_min_seconds` in a request body is simply ignored, and existing MQTT subscription databases are untouched (the underlying column is left in place, unused, so no migration runs). The reconnect behavior itself is unchanged — the minimum was already a fixed 1 second in practice.
 
+### `UpdateOrganization`/`UpdateTeam` now validate the name on update ([#324](https://github.com/Basekick-Labs/arc/issues/324))
+
+`UpdateOrganization` and `UpdateTeam` accepted any string as a new name — including empty strings and names starting with a digit — because the `validateName` check that `CreateOrganization` and `CreateTeam` apply was missing from the update path. An invalid name could be written to the database and later cause confusing errors or inconsistent behavior downstream.
+
+Both update methods now call `validateName` on the supplied name before any write (OSS direct-SQLite path and cluster Raft path). The validation rules are the same as create: must start with a letter, alphanumeric plus underscore/hyphen, at most 64 characters. An invalid name returns an error and the update is rejected.
+
 ### Optional timestamp fields are now omitted when unset, and rendered in UTC ([#546](https://github.com/Basekick-Labs/arc/issues/546))
 
 Several API response fields typed as a Go `time.Time` carried an `omitempty` tag that does nothing — `encoding/json` never omits a `time.Time`, so an unset value rendered as the confusing placeholder `"0001-01-01T00:00:00Z"` rather than being absent. Fields where "unset" is a meaningful state are now proper optional fields (omitted when there is no value):

--- a/internal/api/rbac_routes.go
+++ b/internal/api/rbac_routes.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"strconv"
+	"strings"
 
 	"github.com/basekick-labs/arc/internal/auth"
 	"github.com/gofiber/fiber/v2"
@@ -112,7 +113,7 @@ func (h *RBACHandler) createOrganization(c *fiber.Ctx) error {
 	org, err := h.rbacManager.CreateOrganization(c.UserContext(), &req)
 	if err != nil {
 		status := fiber.StatusInternalServerError
-		if err.Error() == "organization name is required" {
+		if err.Error() == "organization name is required" || strings.Contains(err.Error(), "invalid organization name") {
 			status = fiber.StatusBadRequest
 		}
 		return c.Status(status).JSON(fiber.Map{
@@ -191,6 +192,12 @@ func (h *RBACHandler) updateOrganization(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
 				"success": false,
 				"error":   "Organization not found",
+			})
+		}
+		if strings.Contains(err.Error(), "invalid organization name") {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"success": false,
+				"error":   err.Error(),
 			})
 		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -299,7 +306,7 @@ func (h *RBACHandler) createTeam(c *fiber.Ctx) error {
 	team, err := h.rbacManager.CreateTeam(c.UserContext(), orgID, &req)
 	if err != nil {
 		status := fiber.StatusInternalServerError
-		if err.Error() == "team name is required" || err.Error() == "organization not found" {
+		if err.Error() == "team name is required" || err.Error() == "organization not found" || strings.Contains(err.Error(), "invalid team name") {
 			status = fiber.StatusBadRequest
 		}
 		return c.Status(status).JSON(fiber.Map{
@@ -378,6 +385,12 @@ func (h *RBACHandler) updateTeam(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
 				"success": false,
 				"error":   "Team not found",
+			})
+		}
+		if strings.Contains(err.Error(), "invalid team name") {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"success": false,
+				"error":   err.Error(),
 			})
 		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{

--- a/internal/auth/rbac_manager.go
+++ b/internal/auth/rbac_manager.go
@@ -418,6 +418,11 @@ func (rm *RBACManager) ListOrganizations() ([]Organization, error) {
 // UpdateOrganization updates an organization. Same dual-path shape as
 // CreateOrganization.
 func (rm *RBACManager) UpdateOrganization(ctx context.Context, id int64, req *UpdateOrganizationRequest) error {
+	if req.Name != nil {
+		if err := validateName(*req.Name); err != nil {
+			return fmt.Errorf("invalid organization name: %w", err)
+		}
+	}
 	if rm.getProposer() != nil {
 		payload := updateOrganizationPayloadWire{
 			ID:                id,
@@ -694,6 +699,11 @@ func (rm *RBACManager) ListTeamsByOrganization(orgID int64) ([]Team, error) {
 
 // UpdateTeam updates a team.
 func (rm *RBACManager) UpdateTeam(ctx context.Context, id int64, req *UpdateTeamRequest) error {
+	if req.Name != nil {
+		if err := validateName(*req.Name); err != nil {
+			return fmt.Errorf("invalid team name: %w", err)
+		}
+	}
 	if rm.getProposer() != nil {
 		payload := updateTeamPayloadWire{
 			ID:                id,

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -203,6 +204,56 @@ func TestUpdateOrganization(t *testing.T) {
 			t.Error("Expected error for non-existent organization")
 		}
 	})
+
+	t.Run("invalid name rejected", func(t *testing.T) {
+		badName := "123-invalid"
+		err := rm.UpdateOrganization(context.Background(), org.ID, &UpdateOrganizationRequest{
+			Name: &badName,
+		})
+		if err == nil {
+			t.Error("Expected error for invalid organization name")
+		}
+	})
+
+	t.Run("empty name rejected", func(t *testing.T) {
+		empty := ""
+		err := rm.UpdateOrganization(context.Background(), org.ID, &UpdateOrganizationRequest{
+			Name: &empty,
+		})
+		if err == nil {
+			t.Error("Expected error for empty organization name")
+		}
+	})
+
+	t.Run("name too long rejected", func(t *testing.T) {
+		longName := "a" + strings.Repeat("b", 64) // 65 chars
+		err := rm.UpdateOrganization(context.Background(), org.ID, &UpdateOrganizationRequest{
+			Name: &longName,
+		})
+		if err == nil {
+			t.Error("Expected error for name exceeding 64 characters")
+		}
+	})
+
+	t.Run("name with spaces rejected", func(t *testing.T) {
+		spaceName := "valid start but invalid"
+		err := rm.UpdateOrganization(context.Background(), org.ID, &UpdateOrganizationRequest{
+			Name: &spaceName,
+		})
+		if err == nil {
+			t.Error("Expected error for name with spaces")
+		}
+	})
+
+	t.Run("update description only skips name validation", func(t *testing.T) {
+		desc := "new description"
+		err := rm.UpdateOrganization(context.Background(), org.ID, &UpdateOrganizationRequest{
+			Description: &desc,
+		})
+		if err != nil {
+			t.Fatalf("UpdateOrganization with description only should succeed: %v", err)
+		}
+	})
 }
 
 func TestDeleteOrganization(t *testing.T) {
@@ -278,6 +329,91 @@ func TestCreateTeam(t *testing.T) {
 		_, err := rm.CreateTeam(context.Background(), org.ID, &CreateTeamRequest{Name: "Duplicate Team"})
 		if err == nil {
 			t.Error("Expected error for duplicate team name in same org")
+		}
+	})
+}
+
+func TestUpdateTeam(t *testing.T) {
+	rm, _, cleanup := setupTestRBACManager(t)
+	defer cleanup()
+
+	org, _ := rm.CreateOrganization(context.Background(), &CreateOrganizationRequest{Name: "update-team-org"})
+	team, _ := rm.CreateTeam(context.Background(), org.ID, &CreateTeamRequest{
+		Name:        "original-team",
+		Description: "Original description",
+	})
+
+	t.Run("update name", func(t *testing.T) {
+		newName := "renamed-team"
+		err := rm.UpdateTeam(context.Background(), team.ID, &UpdateTeamRequest{
+			Name: &newName,
+		})
+		if err != nil {
+			t.Fatalf("UpdateTeam failed: %v", err)
+		}
+		updated, _ := rm.GetTeam(team.ID)
+		if updated.Name != "renamed-team" {
+			t.Errorf("Name = %s, want %s", updated.Name, "renamed-team")
+		}
+	})
+
+	t.Run("invalid name rejected", func(t *testing.T) {
+		badName := "123-invalid"
+		err := rm.UpdateTeam(context.Background(), team.ID, &UpdateTeamRequest{
+			Name: &badName,
+		})
+		if err == nil {
+			t.Error("Expected error for invalid team name")
+		}
+	})
+
+	t.Run("empty name rejected", func(t *testing.T) {
+		empty := ""
+		err := rm.UpdateTeam(context.Background(), team.ID, &UpdateTeamRequest{
+			Name: &empty,
+		})
+		if err == nil {
+			t.Error("Expected error for empty team name")
+		}
+	})
+
+	t.Run("non-existent team", func(t *testing.T) {
+		newName := "new-name"
+		err := rm.UpdateTeam(context.Background(), 99999, &UpdateTeamRequest{
+			Name: &newName,
+		})
+		if err == nil {
+			t.Error("Expected error for non-existent team")
+		}
+	})
+
+	t.Run("name too long rejected", func(t *testing.T) {
+		longName := "a" + strings.Repeat("b", 64) // 65 chars
+		err := rm.UpdateTeam(context.Background(), team.ID, &UpdateTeamRequest{
+			Name: &longName,
+		})
+		if err == nil {
+			t.Error("Expected error for name exceeding 64 characters")
+		}
+	})
+
+	t.Run("name with spaces rejected", func(t *testing.T) {
+		spaceName := "valid start but invalid"
+		err := rm.UpdateTeam(context.Background(), team.ID, &UpdateTeamRequest{
+			Name: &spaceName,
+		})
+		if err == nil {
+			t.Error("Expected error for name with spaces")
+		}
+	})
+
+	t.Run("update description only skips name validation", func(t *testing.T) {
+		desc := "new description"
+		err := rm.UpdateTeam(context.Background(), team.ID, &UpdateTeamRequest{
+			Description: &desc,
+		})
+		if err != nil {
+			t.Fatalf("UpdateTeam with description only should succeed: %v", err)
 		}
 	})
 }

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -235,6 +235,18 @@ func TestUpdateOrganization(t *testing.T) {
 		}
 	})
 
+	// Boundary: 64 is the inclusive maximum. Pins the `{0,63}` quantifier
+	// in nameValidationRegex against an off-by-one.
+	t.Run("name at 64 char limit accepted", func(t *testing.T) {
+		maxName := "a" + strings.Repeat("b", 63) // exactly 64 chars
+		err := rm.UpdateOrganization(context.Background(), org.ID, &UpdateOrganizationRequest{
+			Name: &maxName,
+		})
+		if err != nil {
+			t.Fatalf("UpdateOrganization with a 64-character name should succeed: %v", err)
+		}
+	})
+
 	t.Run("name with spaces rejected", func(t *testing.T) {
 		spaceName := "valid start but invalid"
 		err := rm.UpdateOrganization(context.Background(), org.ID, &UpdateOrganizationRequest{


### PR DESCRIPTION
Closes #324.

## Summary

- `UpdateOrganization` and `UpdateTeam` accepted any string as a new name — including empty strings, names starting with a digit, and names with spaces — because the `validateName` check applied by `CreateOrganization`/`CreateTeam` was missing from the update path. An invalid name was written to the database with `200 OK`.
- Both update methods now call `validateName` **before** the `if rm.getProposer() != nil` branch, so a single check covers both the OSS direct-SQLite path and the cluster Raft path. An invalid name can never enter the Raft log.
- The `req.Name != nil` guard preserves PATCH semantics: description-only and enabled-only updates do not trip name validation.
- API handlers now return **`400 Bad Request`** for name-validation failures. On the create path this replaces a `500` that was returned for every rule except the empty-name check (spaces and leading-digit names previously surfaced as server errors). On the update path there was no status to replace — the invalid name was simply accepted.

FSM apply paths (`ApplyUpdateOrganization`, `ApplyUpdateTeam`) deliberately do **not** validate: applies must be deterministic and must not reject already-committed state. Validation happens on the proposing node pre-commit.

## Test plan

- [x] `go build ./...`, `go vet ./internal/api/ ./internal/auth/`, `gofmt -l` on touched files — all clean
- [x] `go test ./internal/auth/... ./internal/api/...` passes
- [x] `go test -race ./internal/auth/` (the changed code) passes
- [x] New unit tests: invalid/empty/too-long/spaces rejected, 64-char boundary accepted, description-only update skips validation, for both org and team
- [x] Verified the new tests genuinely fail when the validation is reverted
- [x] HTTP-level verification of all four handlers: 400 for empty / leading-digit / spaces / >64 chars / non-ASCII / trailing-newline; 404 preserved for missing IDs with a valid name; 200 for valid and description-only updates
- [x] Confirmed duplicate-name errors still return 500 (not misclassified as 400) and that a name literally spelled `invalid organization name` is not spoofable into a 400 — the regex rejects spaces, so no interpolated error can contain the match phrase
- [x] Confirmed 400-vs-404 does not leak org/team existence: an invalid name returns 400 identically for existing and non-existing IDs
- [x] Binary run: built and started with auth enabled, verified `401` (no token) → `403` (no license) ordering, `/health` 200, zero panics

### Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, auth disabled (`authManager == nil`) | No — RBAC construction and route registration are both inside `if authManager != nil` (`main.go:1635`) | N/A, unreachable |
| OSS standalone, auth enabled, no license | Partial — `requireRBACLicense` (`rbac_routes.go:29-37`) returns 403 before any handler body | `h.rbacManager` non-nil: constructed `main.go:1672`, passed `main.go:1694`, same block |
| OSS standalone, auth + RBAC license | **Yes — primary path.** `getProposer()` nil, direct-SQLite branch runs after validation | `req` is `&`-of-stack-struct (`rbac_routes.go:181`); `req.Name` deref guarded by `!= nil` (`rbac_manager.go:421`) |
| Cluster, leader | **Yes.** Validation at `rbac_manager.go:421-425`/`703-707` precedes the proposer branch | `proposer` read under `proposerMu.RLock()` (`cluster_rbac_apply.go:45-49`) |
| Cluster, follower / FSM apply | No — by design (determinism); also required so `SeedRBACFromLocalSQLite` can migrate legacy rows | Committed entries were validated pre-commit on the proposer |
| Proposer set concurrently with in-flight update | Yes, both branches safe — validation is outside the branch | The race selects only the write path, never whether validation ran |

**No new config keys.** `cluster.rbac.max_cascade_descendants` is delete-path only and untouched.

### Known follow-ups (out of scope, tracked separately)

- Duplicate-name errors return `500` on both create and update (`rbac_routes.go:203`, `:396`) — should be `409 Conflict`
- `updateRole` (`rbac_routes.go:433`) has no 400 mapping; its `invalid database pattern` / `invalid permission` errors return `500`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
