### PR TITLE
fix(api): return 409/400 instead of 500 for RBAC client errors (#549)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -97,6 +97,18 @@ Both update methods now call `validateName` on the supplied name before any writ
 
 The API handlers now return **`400 Bad Request`** when name validation fails, so client-supplied invalid values get the correct status code. On the create path this replaces a `500 Internal Server Error` that was returned for every rule except the empty-name check (so `name` values containing spaces, or starting with a digit, previously surfaced as a server error). On the update path there was no status code to replace — the invalid name was accepted with `200 OK` and written to the database, which is the bug described above.
 
+### RBAC endpoints no longer return `500` for client errors ([#549](https://github.com/Basekick-Labs/arc/issues/549))
+
+Two remaining cases in the RBAC API reported client-supplied bad input as `500 Internal Server Error`. A 5xx tells the caller the server broke — it drives client retries, pages on-call, and burns error budgets — when the correct response is "fix your request".
+
+- **Duplicate organization/team names now return `409 Conflict`** (previously `500`) on all four create and update endpoints. Renaming an organization to a name already in use, or creating a team whose name is taken within its organization, is a conflict with existing state, not a server fault.
+- **`PATCH /api/v1/rbac/roles/:id` now returns `400 Bad Request`** (previously `500`) for an invalid `database_pattern` or an unrecognized entry in `permissions`. These were already validated — the errors simply were not mapped to a status code. The matching create endpoint already returned `400`, so create and update now agree.
+- **`POST /api/v1/rbac/roles/:role_id/measurements` now returns `400 Bad Request`** (previously `500`) for an invalid `measurement_pattern`, matching the sibling `permissions` check on the same endpoint, which already returned `400`.
+
+Error *messages* are unchanged — only the status codes differ. Clients that branch on the response body are unaffected; clients that branch on the status code get a correct one. A regression test pins the exact message text so this stays true.
+
+Internally, these paths now classify errors with typed sentinels (`errors.Is`) instead of matching on message text, so rewording one of them cannot change a status code. This covers the name-collision, name-validation, and role-input paths; a few other conditions in the RBAC handlers are still matched by error string and are left for follow-up work.
+
 ### Optional timestamp fields are now omitted when unset, and rendered in UTC ([#546](https://github.com/Basekick-Labs/arc/issues/546))
 
 Several API response fields typed as a Go `time.Time` carried an `omitempty` tag that does nothing — `encoding/json` never omits a `time.Time`, so an unset value rendered as the confusing placeholder `"0001-01-01T00:00:00Z"` rather than being absent. Fields where "unset" is a meaningful state are now proper optional fields (omitted when there is no value):

--- a/internal/api/rbac_routes.go
+++ b/internal/api/rbac_routes.go
@@ -3,7 +3,6 @@ package api
 import (
 	"errors"
 	"strconv"
-	"strings"
 
 	"github.com/basekick-labs/arc/internal/auth"
 	"github.com/gofiber/fiber/v2"
@@ -24,6 +23,39 @@ func NewRBACHandler(authManager *auth.AuthManager, rbacManager *auth.RBACManager
 		rbacManager: rbacManager,
 		logger:      logger.With().Str("component", "rbac-handler").Logger(),
 	}
+}
+
+// rbacErrorStatus maps an RBACManager error to an HTTP status code.
+//
+// Client-supplied bad input must not surface as 5xx: a 500 is what drives
+// client retries, alerting, and error budgets, and it gives the caller no
+// way to tell "the server broke" from "pick a different name". Detection
+// uses errors.Is against the exported sentinels, so rewording any error
+// these sentinels tag cannot change a status code (issue #549).
+//
+// Scope: this covers the name-collision, name-validation, and role-input
+// paths. Several other 400/404 conditions in this file are still matched
+// by exact error string at their call sites ("team not found", "database
+// pattern is required", and similar) and remain message-text dependent.
+// Converting those is deliberate future work, not something this helper
+// already delivers.
+//
+// Returns 0 when the error is not a recognised client error, leaving the
+// caller to apply its own default (500, or a handler-specific 404).
+func rbacErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, auth.ErrInvalidName), errors.Is(err, auth.ErrInvalidRoleInput):
+		return fiber.StatusBadRequest
+	case errors.Is(err, auth.ErrNameConflict):
+		return fiber.StatusConflict
+	case errors.Is(err, auth.ErrCascadeCapExceeded):
+		// Not reachable from the current callers — the cascade cap is
+		// only produced by the delete handlers, which match it directly.
+		// Kept so the mapping stays in one place if a delete path is
+		// ever routed through this helper.
+		return fiber.StatusConflict
+	}
+	return 0
 }
 
 // requireRBACLicense is a middleware that checks if RBAC feature is licensed
@@ -113,8 +145,8 @@ func (h *RBACHandler) createOrganization(c *fiber.Ctx) error {
 	org, err := h.rbacManager.CreateOrganization(c.UserContext(), &req)
 	if err != nil {
 		status := fiber.StatusInternalServerError
-		if err.Error() == "organization name is required" || strings.Contains(err.Error(), "invalid organization name") {
-			status = fiber.StatusBadRequest
+		if s := rbacErrorStatus(err); s != 0 {
+			status = s
 		}
 		return c.Status(status).JSON(fiber.Map{
 			"success": false,
@@ -194,8 +226,8 @@ func (h *RBACHandler) updateOrganization(c *fiber.Ctx) error {
 				"error":   "Organization not found",
 			})
 		}
-		if strings.Contains(err.Error(), "invalid organization name") {
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+		if s := rbacErrorStatus(err); s != 0 {
+			return c.Status(s).JSON(fiber.Map{
 				"success": false,
 				"error":   err.Error(),
 			})
@@ -306,8 +338,15 @@ func (h *RBACHandler) createTeam(c *fiber.Ctx) error {
 	team, err := h.rbacManager.CreateTeam(c.UserContext(), orgID, &req)
 	if err != nil {
 		status := fiber.StatusInternalServerError
-		if err.Error() == "team name is required" || err.Error() == "organization not found" || strings.Contains(err.Error(), "invalid team name") {
+		if err.Error() == "organization not found" {
+			// Kept at 400 to preserve the pre-#549 contract. The org ID
+			// comes from the URL path, so 404 is arguably more correct,
+			// but changing it would break existing clients — out of
+			// scope here.
 			status = fiber.StatusBadRequest
+		}
+		if s := rbacErrorStatus(err); s != 0 {
+			status = s
 		}
 		return c.Status(status).JSON(fiber.Map{
 			"success": false,
@@ -387,8 +426,8 @@ func (h *RBACHandler) updateTeam(c *fiber.Ctx) error {
 				"error":   "Team not found",
 			})
 		}
-		if strings.Contains(err.Error(), "invalid team name") {
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+		if s := rbacErrorStatus(err); s != 0 {
+			return c.Status(s).JSON(fiber.Map{
 				"success": false,
 				"error":   err.Error(),
 			})
@@ -496,9 +535,11 @@ func (h *RBACHandler) createRole(c *fiber.Ctx) error {
 		errMsg := err.Error()
 		if errMsg == "database pattern is required" ||
 			errMsg == "at least one permission is required" ||
-			errMsg == "team not found" ||
-			len(errMsg) > 20 && errMsg[:20] == "invalid permission: " {
+			errMsg == "team not found" {
 			status = fiber.StatusBadRequest
+		}
+		if s := rbacErrorStatus(err); s != 0 {
+			status = s
 		}
 		return c.Status(status).JSON(fiber.Map{
 			"success": false,
@@ -576,6 +617,12 @@ func (h *RBACHandler) updateRole(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
 				"success": false,
 				"error":   "Role not found",
+			})
+		}
+		if s := rbacErrorStatus(err); s != 0 {
+			return c.Status(s).JSON(fiber.Map{
+				"success": false,
+				"error":   err.Error(),
 			})
 		}
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -674,9 +721,11 @@ func (h *RBACHandler) createMeasurementPermission(c *fiber.Ctx) error {
 		errMsg := err.Error()
 		if errMsg == "measurement pattern is required" ||
 			errMsg == "at least one permission is required" ||
-			errMsg == "role not found" ||
-			len(errMsg) > 20 && errMsg[:20] == "invalid permission: " {
+			errMsg == "role not found" {
 			status = fiber.StatusBadRequest
+		}
+		if s := rbacErrorStatus(err); s != 0 {
+			status = s
 		}
 		return c.Status(status).JSON(fiber.Map{
 			"success": false,

--- a/internal/api/rbac_routes_status_test.go
+++ b/internal/api/rbac_routes_status_test.go
@@ -1,0 +1,312 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// Pins the HTTP status contract for the RBAC handlers (issue #549).
+//
+// Client-supplied bad input must never surface as 5xx: a 500 drives client
+// retries, alerting, and error budgets, and gives the caller no way to tell
+// "the server broke" from "pick a different name". Before #549 a duplicate
+// name returned 500 and updateRole returned 500 for invalid patterns and
+// permissions.
+//
+// The license middleware is deliberately not mounted — these tests exercise
+// the handlers' error-to-status mapping, not the license gate (which is
+// covered by requireRBACLicense and returns 403 before any handler body).
+func setupRBACStatusTest(t *testing.T) (*fiber.App, *auth.RBACManager) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "arc-rbac-status-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	lg := zerolog.Nop()
+	am, err := auth.NewAuthManager(filepath.Join(dir, "auth.db"), 5*time.Minute, 100, lg)
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	t.Cleanup(func() { am.Close() })
+
+	rm := auth.NewRBACManager(&auth.RBACManagerConfig{DB: am.GetDB(), Logger: lg})
+	h := NewRBACHandler(am, rm, lg)
+
+	app := fiber.New()
+	app.Post("/orgs", h.createOrganization)
+	app.Patch("/orgs/:id", h.updateOrganization)
+	app.Post("/orgs/:org_id/teams", h.createTeam)
+	app.Patch("/teams/:id", h.updateTeam)
+	app.Post("/teams/:team_id/roles", h.createRole)
+	app.Patch("/roles/:id", h.updateRole)
+	app.Post("/roles/:role_id/measurements", h.createMeasurementPermission)
+
+	return app, rm
+}
+
+// doRBACRequest issues a request and returns the status code plus the decoded error field.
+func doRBACRequest(t *testing.T, app *fiber.App, method, path, body string) (int, string) {
+	t.Helper()
+
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, 5000)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		Error string `json:"error"`
+	}
+	// A body that does not decode is not fatal; the status is the assertion.
+	_ = json.NewDecoder(resp.Body).Decode(&payload)
+	return resp.StatusCode, payload.Error
+}
+
+// TestRBACDuplicateNameReturnsConflict covers finding 1 of #549: name
+// collisions returned 500 on all four org/team create+update handlers.
+func TestRBACDuplicateNameReturnsConflict(t *testing.T) {
+	app, rm := setupRBACStatusTest(t)
+	ctx := t.Context()
+
+	orgA, err := rm.CreateOrganization(ctx, &auth.CreateOrganizationRequest{Name: "org-alpha"})
+	if err != nil {
+		t.Fatalf("seed orgA: %v", err)
+	}
+	orgB, err := rm.CreateOrganization(ctx, &auth.CreateOrganizationRequest{Name: "org-bravo"})
+	if err != nil {
+		t.Fatalf("seed orgB: %v", err)
+	}
+	if _, err := rm.CreateTeam(ctx, orgA.ID, &auth.CreateTeamRequest{Name: "team-alpha"}); err != nil {
+		t.Fatalf("seed teamA: %v", err)
+	}
+	teamB, err := rm.CreateTeam(ctx, orgA.ID, &auth.CreateTeamRequest{Name: "team-bravo"})
+	if err != nil {
+		t.Fatalf("seed teamB: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name, method, path, body string
+	}{
+		{"create org duplicate", "POST", "/orgs", `{"name":"org-alpha"}`},
+		{"update org duplicate", "PATCH", fmt.Sprintf("/orgs/%d", orgB.ID), `{"name":"org-alpha"}`},
+		{"create team duplicate in org", "POST", fmt.Sprintf("/orgs/%d/teams", orgA.ID), `{"name":"team-alpha"}`},
+		{"update team duplicate in org", "PATCH", fmt.Sprintf("/teams/%d", teamB.ID), `{"name":"team-alpha"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, errMsg := doRBACRequest(t, app, tc.method, tc.path, tc.body)
+			if status != http.StatusConflict {
+				t.Errorf("status = %d, want %d (409 Conflict) — err=%q", status, http.StatusConflict, errMsg)
+			}
+			if !strings.Contains(errMsg, "already exists") {
+				t.Errorf("error message should explain the collision, got %q", errMsg)
+			}
+		})
+	}
+}
+
+// TestRBACInvalidNameReturnsBadRequest guards the #324 behavior against
+// regression now that detection moved from substring matching to errors.Is.
+func TestRBACInvalidNameReturnsBadRequest(t *testing.T) {
+	app, rm := setupRBACStatusTest(t)
+	ctx := t.Context()
+
+	org, err := rm.CreateOrganization(ctx, &auth.CreateOrganizationRequest{Name: "org-valid"})
+	if err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	team, err := rm.CreateTeam(ctx, org.ID, &auth.CreateTeamRequest{Name: "team-valid"})
+	if err != nil {
+		t.Fatalf("seed team: %v", err)
+	}
+
+	orgPath := fmt.Sprintf("/orgs/%d", org.ID)
+	teamPath := fmt.Sprintf("/teams/%d", team.ID)
+	teamsPath := fmt.Sprintf("/orgs/%d/teams", org.ID)
+	tooLong := "a" + strings.Repeat("b", 64) // 65 chars
+
+	for _, tc := range []struct {
+		name, method, path, body string
+	}{
+		{"create org empty", "POST", "/orgs", `{"name":""}`},
+		{"create org leading digit", "POST", "/orgs", `{"name":"9bad"}`},
+		{"create org spaces", "POST", "/orgs", `{"name":"has spaces"}`},
+		{"create org too long", "POST", "/orgs", `{"name":"` + tooLong + `"}`},
+		{"update org empty", "PATCH", orgPath, `{"name":""}`},
+		{"update org leading digit", "PATCH", orgPath, `{"name":"9bad"}`},
+		{"update org spaces", "PATCH", orgPath, `{"name":"has spaces"}`},
+		{"create team spaces", "POST", teamsPath, `{"name":"has spaces"}`},
+		{"update team leading digit", "PATCH", teamPath, `{"name":"9bad"}`},
+		{"update team empty", "PATCH", teamPath, `{"name":""}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if status, errMsg := doRBACRequest(t, app, tc.method, tc.path, tc.body); status != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 — err=%q", status, errMsg)
+			}
+		})
+	}
+}
+
+// TestUpdateRoleInvalidInputReturnsBadRequest covers finding 2 of #549:
+// updateRole had no 400 mapping, so manager-layer validation errors for
+// database_pattern and permissions surfaced as 500.
+func TestUpdateRoleInvalidInputReturnsBadRequest(t *testing.T) {
+	app, rm := setupRBACStatusTest(t)
+	ctx := t.Context()
+
+	org, err := rm.CreateOrganization(ctx, &auth.CreateOrganizationRequest{Name: "role-org"})
+	if err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	team, err := rm.CreateTeam(ctx, org.ID, &auth.CreateTeamRequest{Name: "role-team"})
+	if err != nil {
+		t.Fatalf("seed team: %v", err)
+	}
+	role, err := rm.CreateRole(ctx, team.ID, &auth.CreateRoleRequest{
+		DatabasePattern: "metrics",
+		Permissions:     []string{"read"},
+	})
+	if err != nil {
+		t.Fatalf("seed role: %v", err)
+	}
+
+	rolePath := fmt.Sprintf("/roles/%d", role.ID)
+
+	t.Run("invalid permission", func(t *testing.T) {
+		if status, errMsg := doRBACRequest(t, app, "PATCH", rolePath, `{"permissions":["not-a-permission"]}`); status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400 — err=%q", status, errMsg)
+		}
+	})
+
+	t.Run("invalid database pattern", func(t *testing.T) {
+		if status, errMsg := doRBACRequest(t, app, "PATCH", rolePath, `{"database_pattern":"../etc"}`); status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400 — err=%q", status, errMsg)
+		}
+	})
+
+	t.Run("invalid permission on create still 400", func(t *testing.T) {
+		body := `{"database_pattern":"metrics","permissions":["not-a-permission"]}`
+		if status, errMsg := doRBACRequest(t, app, "POST", fmt.Sprintf("/teams/%d/roles", team.ID), body); status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400 — err=%q", status, errMsg)
+		}
+	})
+
+	t.Run("valid update still succeeds", func(t *testing.T) {
+		if status, errMsg := doRBACRequest(t, app, "PATCH", rolePath, `{"permissions":["read","write"]}`); status != http.StatusOK {
+			t.Errorf("status = %d, want 200 — err=%q", status, errMsg)
+		}
+	})
+
+	// createMeasurementPermission validates a measurement pattern the same
+	// way createRole validates a database pattern. Both are client input;
+	// neither may surface as 5xx.
+	measPath := fmt.Sprintf("/roles/%d/measurements", role.ID)
+
+	t.Run("invalid measurement pattern", func(t *testing.T) {
+		body := `{"measurement_pattern":"../etc","permissions":["read"]}`
+		if status, errMsg := doRBACRequest(t, app, "POST", measPath, body); status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400 — err=%q", status, errMsg)
+		}
+	})
+
+	t.Run("invalid measurement permission", func(t *testing.T) {
+		body := `{"measurement_pattern":"cpu","permissions":["not-a-permission"]}`
+		if status, errMsg := doRBACRequest(t, app, "POST", measPath, body); status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400 — err=%q", status, errMsg)
+		}
+	})
+}
+
+// TestRBACErrorMessagesUnchanged pins the exact client-visible error text.
+//
+// Status-code classification uses sentinel errors attached via tagError,
+// which deliberately does NOT alter the message — an earlier iteration used
+// fmt.Errorf("%w: ...") and silently prefixed every message ("name already
+// exists: organization with name 'x' already exists"), a client-visible API
+// change. The release notes state messages are unchanged; this test is what
+// makes that claim enforceable.
+func TestRBACErrorMessagesUnchanged(t *testing.T) {
+	app, rm := setupRBACStatusTest(t)
+	ctx := t.Context()
+
+	if _, err := rm.CreateOrganization(ctx, &auth.CreateOrganizationRequest{Name: "msg-org"}); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name, method, path, body, want string
+	}{
+		{
+			name: "duplicate org", method: "POST", path: "/orgs",
+			body: `{"name":"msg-org"}`,
+			want: "organization with name 'msg-org' already exists",
+		},
+		{
+			name: "empty org name", method: "POST", path: "/orgs",
+			body: `{"name":""}`,
+			want: "organization name is required",
+		},
+		{
+			name: "invalid org name", method: "POST", path: "/orgs",
+			body: `{"name":"9bad"}`,
+			want: "invalid organization name: name must start with a letter, contain only alphanumeric characters, underscores, or hyphens, and be at most 64 characters",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, errMsg := doRBACRequest(t, app, tc.method, tc.path, tc.body)
+			if errMsg != tc.want {
+				t.Errorf("error message drifted:\n got: %q\nwant: %q", errMsg, tc.want)
+			}
+		})
+	}
+}
+
+// TestRBACNotFoundStillReturns404 proves the new client-error mapping does
+// not shadow the pre-existing not-found handling, and that an invalid name
+// on a missing ID cannot be used to probe whether that ID exists.
+func TestRBACNotFoundStillReturns404(t *testing.T) {
+	app, _ := setupRBACStatusTest(t)
+
+	t.Run("update org missing id, valid name", func(t *testing.T) {
+		if status, errMsg := doRBACRequest(t, app, "PATCH", "/orgs/99999", `{"name":"fine-name"}`); status != http.StatusNotFound {
+			t.Errorf("status = %d, want 404 — err=%q", status, errMsg)
+		}
+	})
+
+	t.Run("update team missing id, valid name", func(t *testing.T) {
+		if status, errMsg := doRBACRequest(t, app, "PATCH", "/teams/99999", `{"name":"fine-name"}`); status != http.StatusNotFound {
+			t.Errorf("status = %d, want 404 — err=%q", status, errMsg)
+		}
+	})
+
+	t.Run("update role missing id, valid input", func(t *testing.T) {
+		if status, errMsg := doRBACRequest(t, app, "PATCH", "/roles/99999", `{"permissions":["read"]}`); status != http.StatusNotFound {
+			t.Errorf("status = %d, want 404 — err=%q", status, errMsg)
+		}
+	})
+
+	// Validation runs before the existence lookup, so an invalid name is a
+	// 400 whether or not the ID exists. That ordering is deliberate: it
+	// means the status code cannot be used to probe for existence.
+	t.Run("invalid name does not leak existence", func(t *testing.T) {
+		missing, _ := doRBACRequest(t, app, "PATCH", "/orgs/99999", `{"name":"9bad"}`)
+		if missing != http.StatusBadRequest {
+			t.Errorf("missing-id invalid-name status = %d, want 400", missing)
+		}
+	})
+}

--- a/internal/auth/rbac_manager.go
+++ b/internal/auth/rbac_manager.go
@@ -303,10 +303,10 @@ func (rm *RBACManager) IsRBACEnabled() bool {
 // to local SQLite (unchanged from pre-Phase-A.1 behaviour).
 func (rm *RBACManager) CreateOrganization(ctx context.Context, req *CreateOrganizationRequest) (*Organization, error) {
 	if req.Name == "" {
-		return nil, errors.New("organization name is required")
+		return nil, tagError(ErrInvalidName, errors.New("organization name is required"))
 	}
 	if err := validateName(req.Name); err != nil {
-		return nil, fmt.Errorf("invalid organization name: %w", err)
+		return nil, tagError(ErrInvalidName, fmt.Errorf("invalid organization name: %w", err))
 	}
 
 	if rm.getProposer() != nil {
@@ -325,7 +325,7 @@ func (rm *RBACManager) CreateOrganization(ctx context.Context, req *CreateOrgani
 			// error string the OSS path returns, so handlers can keep their
 			// existing UX.
 			if strings.Contains(err.Error(), "already exists") {
-				return nil, fmt.Errorf("organization with name '%s' already exists", req.Name)
+				return nil, tagError(ErrNameConflict, fmt.Errorf("organization with name '%s' already exists", req.Name))
 			}
 			return nil, fmt.Errorf("failed to create organization: %w", err)
 		}
@@ -359,7 +359,7 @@ func (rm *RBACManager) CreateOrganization(ctx context.Context, req *CreateOrgani
 	`, req.Name, req.Description, now, now)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
-			return nil, fmt.Errorf("organization with name '%s' already exists", req.Name)
+			return nil, tagError(ErrNameConflict, fmt.Errorf("organization with name '%s' already exists", req.Name))
 		}
 		return nil, fmt.Errorf("failed to create organization: %w", err)
 	}
@@ -420,7 +420,7 @@ func (rm *RBACManager) ListOrganizations() ([]Organization, error) {
 func (rm *RBACManager) UpdateOrganization(ctx context.Context, id int64, req *UpdateOrganizationRequest) error {
 	if req.Name != nil {
 		if err := validateName(*req.Name); err != nil {
-			return fmt.Errorf("invalid organization name: %w", err)
+			return tagError(ErrInvalidName, fmt.Errorf("invalid organization name: %w", err))
 		}
 	}
 	if rm.getProposer() != nil {
@@ -448,7 +448,7 @@ func (rm *RBACManager) UpdateOrganization(ctx context.Context, id int64, req *Up
 				return errors.New("organization not found")
 			}
 			if strings.Contains(err.Error(), "already exists") {
-				return errors.New("organization with that name already exists")
+				return tagError(ErrNameConflict, errors.New("organization with that name already exists"))
 			}
 			return fmt.Errorf("failed to update organization: %w", err)
 		}
@@ -490,7 +490,7 @@ func (rm *RBACManager) UpdateOrganization(ctx context.Context, id int64, req *Up
 	result, err := rm.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
-			return errors.New("organization with that name already exists")
+			return tagError(ErrNameConflict, errors.New("organization with that name already exists"))
 		}
 		return fmt.Errorf("failed to update organization: %w", err)
 	}
@@ -579,10 +579,10 @@ func (rm *RBACManager) DeleteOrganization(ctx context.Context, id int64) error {
 // as CreateOrganization.
 func (rm *RBACManager) CreateTeam(ctx context.Context, orgID int64, req *CreateTeamRequest) (*Team, error) {
 	if req.Name == "" {
-		return nil, errors.New("team name is required")
+		return nil, tagError(ErrInvalidName, errors.New("team name is required"))
 	}
 	if err := validateName(req.Name); err != nil {
-		return nil, fmt.Errorf("invalid team name: %w", err)
+		return nil, tagError(ErrInvalidName, fmt.Errorf("invalid team name: %w", err))
 	}
 
 	if rm.getProposer() != nil {
@@ -602,7 +602,7 @@ func (rm *RBACManager) CreateTeam(ctx context.Context, orgID int64, req *CreateT
 				return nil, errors.New("organization not found")
 			}
 			if strings.Contains(err.Error(), "already exists") {
-				return nil, fmt.Errorf("team with name '%s' already exists in this organization", req.Name)
+				return nil, tagError(ErrNameConflict, fmt.Errorf("team with name '%s' already exists in this organization", req.Name))
 			}
 			return nil, fmt.Errorf("failed to create team: %w", err)
 		}
@@ -640,7 +640,7 @@ func (rm *RBACManager) CreateTeam(ctx context.Context, orgID int64, req *CreateT
 	`, orgID, req.Name, req.Description, now, now)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
-			return nil, fmt.Errorf("team with name '%s' already exists in this organization", req.Name)
+			return nil, tagError(ErrNameConflict, fmt.Errorf("team with name '%s' already exists in this organization", req.Name))
 		}
 		return nil, fmt.Errorf("failed to create team: %w", err)
 	}
@@ -701,7 +701,7 @@ func (rm *RBACManager) ListTeamsByOrganization(orgID int64) ([]Team, error) {
 func (rm *RBACManager) UpdateTeam(ctx context.Context, id int64, req *UpdateTeamRequest) error {
 	if req.Name != nil {
 		if err := validateName(*req.Name); err != nil {
-			return fmt.Errorf("invalid team name: %w", err)
+			return tagError(ErrInvalidName, fmt.Errorf("invalid team name: %w", err))
 		}
 	}
 	if rm.getProposer() != nil {
@@ -729,7 +729,7 @@ func (rm *RBACManager) UpdateTeam(ctx context.Context, id int64, req *UpdateTeam
 				return errors.New("team not found")
 			}
 			if strings.Contains(err.Error(), "already exists") {
-				return errors.New("team with that name already exists in this organization")
+				return tagError(ErrNameConflict, errors.New("team with that name already exists in this organization"))
 			}
 			return fmt.Errorf("failed to update team: %w", err)
 		}
@@ -770,7 +770,7 @@ func (rm *RBACManager) UpdateTeam(ctx context.Context, id int64, req *UpdateTeam
 	result, err := rm.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
-			return errors.New("team with that name already exists in this organization")
+			return tagError(ErrNameConflict, errors.New("team with that name already exists in this organization"))
 		}
 		return fmt.Errorf("failed to update team: %w", err)
 	}
@@ -859,11 +859,11 @@ func (rm *RBACManager) CreateRole(ctx context.Context, teamID int64, req *Create
 		return nil, errors.New("at least one permission is required")
 	}
 	if err := validatePattern(req.DatabasePattern); err != nil {
-		return nil, fmt.Errorf("invalid database pattern: %w", err)
+		return nil, tagError(ErrInvalidRoleInput, fmt.Errorf("invalid database pattern: %w", err))
 	}
 	for _, p := range req.Permissions {
 		if !IsValidPermission(p) {
-			return nil, fmt.Errorf("invalid permission: %s", p)
+			return nil, tagError(ErrInvalidRoleInput, fmt.Errorf("invalid permission: %s", p))
 		}
 	}
 
@@ -1009,13 +1009,13 @@ func (rm *RBACManager) UpdateRole(ctx context.Context, id int64, req *UpdateRole
 	if len(req.Permissions) > 0 {
 		for _, p := range req.Permissions {
 			if !IsValidPermission(p) {
-				return fmt.Errorf("invalid permission: %s", p)
+				return tagError(ErrInvalidRoleInput, fmt.Errorf("invalid permission: %s", p))
 			}
 		}
 	}
 	if req.DatabasePattern != nil {
 		if err := validatePattern(*req.DatabasePattern); err != nil {
-			return fmt.Errorf("invalid database pattern: %w", err)
+			return tagError(ErrInvalidRoleInput, fmt.Errorf("invalid database pattern: %w", err))
 		}
 	}
 
@@ -1129,11 +1129,11 @@ func (rm *RBACManager) CreateMeasurementPermission(ctx context.Context, roleID i
 		return nil, errors.New("at least one permission is required")
 	}
 	if err := validatePattern(req.MeasurementPattern); err != nil {
-		return nil, fmt.Errorf("invalid measurement pattern: %w", err)
+		return nil, tagError(ErrInvalidRoleInput, fmt.Errorf("invalid measurement pattern: %w", err))
 	}
 	for _, p := range req.Permissions {
 		if !IsValidPermission(p) {
-			return nil, fmt.Errorf("invalid permission: %s", p)
+			return nil, tagError(ErrInvalidRoleInput, fmt.Errorf("invalid permission: %s", p))
 		}
 	}
 
@@ -2144,6 +2144,57 @@ func (rm *RBACManager) countTeamCascadeDescendants(ctx context.Context, teamID i
 // rm.maxCascadeDescendants. HTTP handlers detect this via errors.Is and
 // map it to 409 Conflict. Phase A.2 Item 2.
 var ErrCascadeCapExceeded = errors.New("cascade exceeds configured limit")
+
+// ErrNameConflict is the sentinel tagging every organization/team
+// name-collision error, on both the OSS direct-SQLite path (UNIQUE
+// constraint violation) and the cluster Raft path ("already exists"
+// from the FSM apply). HTTP handlers detect it via errors.Is and map it
+// to 409 Conflict — a duplicate name is a client error, not a server
+// fault. Issue #549.
+var ErrNameConflict = errors.New("name already exists")
+
+// ErrInvalidName is the sentinel tagging validateName failures on the
+// organization and team create/update paths. HTTP handlers detect it via
+// errors.Is and map it to 400 Bad Request. Replaces the substring match
+// on "invalid organization name"/"invalid team name" added in #324.
+// Issue #549.
+var ErrInvalidName = errors.New("invalid name")
+
+// ErrInvalidRoleInput is the sentinel tagging CreateRole/UpdateRole and
+// CreateMeasurementPermission input-validation failures (database or
+// measurement pattern, permission list). HTTP handlers detect it via
+// errors.Is and map it to 400 Bad Request. Issue #549.
+var ErrInvalidRoleInput = errors.New("invalid role input")
+
+// taggedError attaches a classification sentinel to an error without
+// altering its message.
+//
+// fmt.Errorf("%w: ...", sentinel, ...) would prepend the sentinel's text
+// to every message — turning "organization with name 'x' already exists"
+// into "name already exists: organization with name 'x' already exists".
+// That is a client-visible API change: the JSON `error` field is what
+// callers read, and some match on it. Status-code classification is an
+// internal concern and must not leak into the message.
+//
+// Error() returns the underlying message verbatim; Unwrap() exposes both
+// the sentinel (for errors.Is classification) and the cause (so wrapped
+// detail stays reachable). Issue #549.
+type taggedError struct {
+	sentinel error
+	cause    error
+}
+
+func (e *taggedError) Error() string   { return e.cause.Error() }
+func (e *taggedError) Unwrap() []error { return []error{e.sentinel, e.cause} }
+
+// tagError classifies err with sentinel, leaving err's message untouched.
+// Returns nil if err is nil, so it is safe to apply unconditionally.
+func tagError(sentinel, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &taggedError{sentinel: sentinel, cause: err}
+}
 
 // nextProposerTimestamp returns a time.Time that is guaranteed to be
 // strictly increasing across concurrent callers within a single


### PR DESCRIPTION
Closes #549. Follow-up to #548.

## Summary

Three RBAC endpoints reported client-supplied bad input as `500 Internal Server Error`. A 5xx tells the caller the server broke — it drives client retries, pages on-call, and burns error budgets — when the correct answer is "fix your request".

| Endpoint | Input | Before | After |
|---|---|---|---|
| `POST`/`PATCH` `/organizations`, `/teams` | duplicate name | `500` | **`409`** |
| `PATCH /roles/:id` | invalid `database_pattern` or `permissions` | `500` | **`400`** |
| `POST /roles/:role_id/measurements` | invalid `measurement_pattern` | `500` | **`400`** |

The role and measurement create endpoints already returned `400` for these, so create and update now agree.

## Error messages are unchanged

Classification uses typed sentinels (`ErrNameConflict`, `ErrInvalidName`, `ErrInvalidRoleInput`) detected via `errors.Is`, replacing the previous `strings.Contains` and hand-rolled `errMsg[:20]` prefix matching.

The sentinels are attached with a `taggedError` wrapper rather than `fmt.Errorf("%w: ...")`. Prefix-wrapping would have prepended the sentinel text to every message — `organization with name 'x' already exists` becoming `name already exists: organization with name 'x' already exists` — a client-visible API change, since the JSON `error` field is what callers read. `taggedError.Error()` returns the cause verbatim and `Unwrap() []error` exposes both, so classification stays internal. `TestRBACErrorMessagesUnchanged` pins the exact text.

**Scope note:** this covers the name-collision, name-validation, and role-input paths. A few other 400/404 conditions in the handlers are still matched by exact error string; converting those is deliberate follow-up, and both the helper doc-comment and the release notes say so rather than overclaiming.

## Test plan

- [x] `go build ./...`, `go vet ./internal/api/ ./internal/auth/`, `gofmt -l` on touched files — clean
- [x] `go test ./internal/auth/... ./internal/api/... ./internal/cluster/...` — all pass
- [x] New `internal/api/rbac_routes_status_test.go`: 30 subtests across 5 test functions
- [x] **Verified the new tests fail without the fix** — every case returns `500` instead of `409`/`400`
- [x] Verified `TestRBACErrorMessagesUnchanged` passes both pre- and post-fix (proves messages really are untouched)
- [x] 404 regression guard: missing IDs with valid input still `404` on org, team, and role
- [x] Existence-leak guard: an invalid name returns `400` whether or not the ID exists, so status cannot probe existence
- [x] Binary run: started with auth enabled, confirmed `401` (no token) → `403` (license gate) ordering, `/health` 200, zero panics

### Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, auth disabled | No — RBAC construction and routes are inside `if authManager != nil` (`main.go:1635`) | N/A unreachable |
| OSS standalone, auth, no license | Partial — `requireRBACLicense` returns 403 before any handler body | `h.rbacManager` non-nil, same block as construction |
| **OSS standalone, auth + RBAC license** | **Yes — primary path.** Collisions arrive as `UNIQUE constraint failed`, get tagged, map to 409. All 7 rewired sites enumerated, including `createMeasurementPermission` | `rbacErrorStatus` takes `error` and only calls `errors.Is` — nil-safe, no deref added |
| Cluster, leader | Yes. Inbound detection unchanged: the manager still substring-matches the **FSM's own** `already exists` text (`rbac_manager.go:327`, `:450`) on the way in; only the outbound error is tagged | FSM text in `internal/cluster/raft/fsm_rbac.go` is untouched |
| Cluster, follower / FSM apply | No — applies construct no HTTP responses | Unchanged |
| **Cluster, RBAC seed path** | **Yes — the risk cell.** `isDuplicateErr` (`rbac_seed.go:240`) substring-matches `already exists` for idempotent re-run | Safe: it inspects the **proposer** error, upstream of tagging; and `taggedError` preserves the message verbatim, so the substring survives regardless. `./internal/cluster/...` passes |
| Delete endpoints | No — they match `ErrCascadeCapExceeded` directly and never call the helper | Both map it to 409, so the mechanisms agree |

**No new config keys. No new pointer dereferences. No changes to `cmd/arc/main.go`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
