### PR TITLE
fix(security): reject single-quoted strings in table position (GHSA-w8x2-cccw-25f7)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -45,6 +45,16 @@ Separately, the pruner's two internal TTL caches (glob results and partition pat
 
 Reachable in every deployment mode (the pruner runs on every `FROM`/`JOIN` query); pre-existing on `main`, unrelated to any other work in this release.
 
+### Replacement-scan RBAC bypass: reject single-quoted strings in table position ([GHSA-w8x2-cccw-25f7](https://github.com/Basekick-Labs/arc/security/advisories/GHSA-w8x2-cccw-25f7))
+
+An authenticated tenant on an RBAC-enabled multi-tenant instance could read any Parquet file inside the allow-listed storage root — including other tenants' databases — by writing a **bare single-quoted string in table position**: `SELECT * FROM '/data/arc/db2/secrets/*.parquet'`. DuckDB resolves such a string as a *replacement scan* that reads the file directly, with **no function name**. Arc's two query-authorization controls both key on function names — the I/O-function denylist (`read_parquet`, `parquet_scan`, `glob`, …) and the RBAC table extractor — so the bare string slipped past the denylist, and the extractor masked the quoted path to a placeholder before matching, so RBAC never saw the foreign path. The comma form (`SELECT b.s FROM cpu, '/data/arc/db2/secrets/*.parquet' b`) needed only a single legitimate grant.
+
+This is an incomplete-fix residual of [GHSA-93cm-2v4m-c56c](https://github.com/Basekick-Labs/arc/security/advisories/GHSA-93cm-2v4m-c56c): the same root cause (authorization keyed on function names), via the one table-position syntax that carries no function name. It is a within-allow-list cross-database read — it does **not** escape the DuckDB sandbox to arbitrary OS files (`enable_external_access=false` holds).
+
+The fix rejects, in `ValidateSQLRequest` (before any transform or RBAC check runs), any single-quoted string standing where a table reference belongs — after `FROM`/`JOIN`, or continuing a `FROM` clause's table list via a cross-join comma — while leaving single-quoted strings used as values (`WHERE`, `IN`, function arguments) and legitimately quoted *identifiers* (`FROM "my table"`) untouched. Arc's own transform layer, which emits `read_parquet('…')` under the caller's identity, runs after validation and is unaffected. The denylist test matrix now covers the replacement-scan forms — single-file, glob, comma cross-join, `JOIN`, subquery, and the no-whitespace (`FROM'…'`) variant.
+
+Reachable only when RBAC is enabled (the multi-tenant authorization boundary); no CVE is being filed, as it is a residual of GHSA-93cm scoped to within the allow-list, tracked under the advisory above. Reported by [@arpitjain099](https://github.com/arpitjain099).
+
 ## Bug fixes
 
 ### `date_trunc`/`time_bucket` epoch rewrite no longer corrupts parenthesized column arguments ([#535](https://github.com/Basekick-Labs/arc/issues/535))
@@ -157,13 +167,13 @@ Every received MQTT message took a full write-lock on the subscriber's state mut
 
 ## Impact by deployment mode
 
-The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query.
+The forwarding-header and loop-guard changes are cluster-only; the partition-pruner DoS fix (#536) applies to **every** deployment mode, since the pruner runs on every query. The replacement-scan RBAC fix (GHSA-w8x2) applies wherever RBAC is enabled — it is the multi-tenant authorization boundary.
 
-| Deployment | Forwarding-header / loop-guard changes | Partition-pruner DoS fix (#536) |
-|---|---|---|
-| Single-node / OSS standalone (no cluster router) | **No.** The forwarding path never executes; behavior is byte-for-byte identical to 26.06.3. | **Yes.** Applies to every query. |
-| Clustered, homogeneous nodes (every node can serve every request) | Header-stripping applies to forwarded requests; loop-guard reorder is a no-op because nodes serve locally. | **Yes.** Applies to every query. |
-| Clustered with role separation (reader / writer / compactor) | Header-stripping applies; a spoofed or looped `X-Arc-Forwarded-By` on a non-capable node now returns `508` instead of a failed local attempt. | **Yes.** Applies to every query. |
+| Deployment | Forwarding-header / loop-guard changes | Partition-pruner DoS fix (#536) | Replacement-scan RBAC fix (GHSA-w8x2) |
+|---|---|---|---|
+| Single-node / OSS standalone (no cluster router) | **No.** The forwarding path never executes; behavior is byte-for-byte identical to 26.06.3. | **Yes.** Applies to every query. | **Only if RBAC is enabled.** The table-position check runs on every query, but the cross-tenant read it prevents requires RBAC. |
+| Clustered, homogeneous nodes (every node can serve every request) | Header-stripping applies to forwarded requests; loop-guard reorder is a no-op because nodes serve locally. | **Yes.** Applies to every query. | **Only if RBAC is enabled.** |
+| Clustered with role separation (reader / writer / compactor) | Header-stripping applies; a spoofed or looped `X-Arc-Forwarded-By` on a non-capable node now returns `508` instead of a failed local attempt. | **Yes.** Applies to every query. | **Only if RBAC is enabled.** |
 
 ## Upgrade notes
 

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -2139,7 +2139,167 @@ func ValidateSQLRequest(sql string) error {
 		return &SQLValidationError{Message: "File I/O function not allowed in user SQL: " + m[1] + "()"}
 	}
 
+	// SECURITY: reject a bare single-quoted string in table position — a
+	// DuckDB replacement scan (GHSA-w8x2-cccw-25f7, incomplete-fix residual of
+	// GHSA-93cm-2v4m-c56c).
+	//
+	// DuckDB resolves `FROM '/path/*.parquet'` (a quoted string where a table
+	// name is expected) as a replacement scan that reads that file directly —
+	// with NO function name. So it slips past the I/O-function denylist above
+	// (which keys on `name(`), and downstream extractTableReferences masks the
+	// quoted path to a `__STR__` placeholder before RBAC matching, so RBAC
+	// never sees the foreign path. Net: a tenant with any one legitimate grant
+	// reads any Parquet inside the sandbox's allowlisted storage root — every
+	// other tenant's data — via `SELECT b.s FROM cpu, '/data/arc/db2/secrets/*.parquet' b`
+	// (comma form) or `SELECT * FROM '<root>/*/**/*.parquet'` (glob form).
+	//
+	// Only Arc's own transform layer (convertSQLToStoragePaths, which runs
+	// AFTER this validation and carries the caller's identity) may put a quoted
+	// path in table position via read_parquet('…'); user SQL never legitimately
+	// does. A single-quoted string used as a VALUE — `WHERE msg = '…'`,
+	// `date_trunc('hour', t)`, an IN-list — is NOT flagged; only a placeholder
+	// standing where a table reference belongs (after FROM/JOIN, or continuing a
+	// FROM clause's table list via a cross-join comma) trips it.
+	//
+	// The check must distinguish a single-quoted STRING from a quoted
+	// IDENTIFIER: DuckDB uses `'` for strings and `"`/backtick for identifiers,
+	// and a quoted identifier in table position (`FROM "my table"`,
+	// `` FROM `my;db` ``) is legitimate — not a replacement scan. So it runs on
+	// the identifier-quote-stripped, single-quote-masked form, NOT the shared
+	// `normalised` above (which masks all quote kinds indiscriminately and would
+	// false-positive on a quoted identifier).
+	//
+	// ioCheckNormalised (computed above) is exactly the form we need here: it
+	// strips `"`/backtick identifier quoting (exposing identifiers as barewords)
+	// and masks the remaining single-quoted strings to `__STR__` placeholders,
+	// with comments stripped. Reuse it rather than normalising twice.
+	if stringLiteralInTablePosition(ioCheckNormalised) {
+		return &SQLValidationError{Message: "String literal not allowed in table position (replacement scans are disabled); reference a table by name"}
+	}
+
 	return nil
+}
+
+// tablePosPlaceholder matches a MaskStringLiterals placeholder (`__STR_<n>__`).
+// Used to isolate placeholders with surrounding spaces before tokenising, so a
+// placeholder that abuts a keyword with no whitespace (`FROM'…'` masks to the
+// glued `FROM__STR_0__`) is not swallowed into one identifier token — a real
+// replacement-scan bypass otherwise (GHSA-w8x2 review, blocker 2).
+var tablePosPlaceholder = regexp.MustCompile(`__STR_\d+__`)
+
+// tablePosTokenPattern tokenises the (space-isolated) masked/normalised SQL into
+// the atoms the table-position scanner cares about: a masked string placeholder
+// (`__STR_<n>__`), a parenthesis, a comma, or any other run of identifier bytes
+// (keywords, table names, aliases). Everything else (whitespace, operators) is
+// skipped. The placeholder alternative is matched BEFORE the generic identifier
+// run so it wins even though `_`/digits are also identifier bytes.
+var tablePosTokenPattern = regexp.MustCompile(`__STR_\d+__|[A-Za-z_][A-Za-z0-9_]*|[(),]`)
+
+// stringLiteralInTablePosition reports whether `normalised` — SQL whose SINGLE-
+// quoted string literals have already been masked to `__STR_<n>__` placeholders,
+// whose identifier quoting has been stripped, and whose comments have been
+// removed (i.e. the output of ioDenylistNormalise) — puts a masked string where
+// a table reference belongs. That is DuckDB's replacement-scan syntax
+// (`FROM '…'`), which reads a file with no function name and so bypasses both the
+// I/O-function denylist and the RBAC table extractor (GHSA-w8x2-cccw-25f7).
+//
+// A placeholder is in table position when it directly follows the FROM or JOIN
+// keyword, or a comma that continues an in-progress FROM clause's table list (a
+// comma cross-join: `FROM cpu, '…'`, including after a subquery: `FROM (…) a, '…'`).
+// A placeholder that is a VALUE — a WHERE/SELECT literal, or a function argument
+// such as `date_trunc('hour', t)` (deeper in a paren group than its enclosing
+// FROM clause) — is never in table position, so those do not trip.
+//
+// FROM-clause state is a STACK keyed by parenthesis depth, not a single scalar:
+// a subquery inside a FROM clause (`FROM (SELECT … FROM inner) a, '…'`) opens its
+// OWN nested FROM clause whose end (on the closing paren) must NOT clear the
+// outer FROM clause — otherwise the trailing comma cross-join is wrongly
+// disarmed and the replacement scan slips through (GHSA-w8x2 review, blocker 1).
+func stringLiteralInTablePosition(normalised string) bool {
+	// fromArmed[d] is true when, at paren depth d, we are inside a FROM clause
+	// whose table list is still open — so a comma at depth d continues that
+	// list (a cross-join table position). Indexed by depth; grows as needed.
+	fromArmed := make([]bool, 1, 8)
+
+	// afterFromJoin is true when the immediately preceding token was FROM or
+	// JOIN, so the very next table-atom is in table position.
+	afterFromJoin := false
+
+	depth := 0
+	// Isolate placeholders with surrounding spaces so a keyword directly
+	// abutting one (`FROM__STR_0__` from `FROM'…'`) tokenises as two atoms.
+	isolated := tablePosPlaceholder.ReplaceAllString(normalised, " $0 ")
+	toks := tablePosTokenPattern.FindAllString(isolated, -1)
+	for _, tok := range toks {
+		switch tok {
+		case "(":
+			depth++
+			if depth >= len(fromArmed) {
+				fromArmed = append(fromArmed, false)
+			} else {
+				fromArmed[depth] = false
+			}
+			afterFromJoin = false
+			continue
+		case ")":
+			if depth > 0 {
+				fromArmed[depth] = false
+				depth--
+			}
+			// Leaving the paren group does NOT touch fromArmed[depth-1]: the
+			// OUTER FROM clause (if any) is still open. This is the blocker-1 fix.
+			afterFromJoin = false
+			continue
+		case ",":
+			// A comma continues the table list only if THIS depth's FROM clause
+			// is still armed (excludes function-argument and projection commas,
+			// which are either at a deeper depth or after a clause terminator).
+			afterFromJoin = fromArmed[depth]
+			continue
+		}
+
+		// tok is a placeholder or an identifier/keyword run.
+		if strings.HasPrefix(tok, "__STR_") {
+			// A masked single-quoted string standing in table position.
+			if afterFromJoin {
+				return true
+			}
+			// A string that is NOT in table position (a value, a function arg)
+			// closes the "immediately after FROM/JOIN" window but leaves the
+			// FROM clause's armed state (for a following cross-join comma) alone.
+			afterFromJoin = false
+			continue
+		}
+
+		switch strings.ToLower(tok) {
+		case "from", "join":
+			fromArmed[depth] = true
+			afterFromJoin = true
+		default:
+			// A real table name, alias, ON, USING, etc. ends the "immediately
+			// after FROM/JOIN" window but keeps the FROM clause armed so a
+			// following `, '…'` cross-join is still caught.
+			afterFromJoin = false
+			// Keywords that close the FROM clause's table list at this depth:
+			// after WHERE/GROUP/…, a top-level comma is a projection/ordering
+			// separator, not another cross-join table.
+			if fromClauseTerminator(strings.ToLower(tok)) {
+				fromArmed[depth] = false
+			}
+		}
+	}
+	return false
+}
+
+// fromClauseTerminator reports whether a lower-cased keyword ends the table
+// list of a FROM clause, so that a later same-depth comma is a projection or
+// ordering separator rather than another comma cross-join table.
+func fromClauseTerminator(word string) bool {
+	switch word {
+	case "where", "group", "having", "order", "limit", "offset", "window", "qualify", "union", "except", "intersect", "fetch", "for":
+		return true
+	}
+	return false
 }
 
 // ioDenylistNormalise produces the form of the SQL the I/O-function denylist is
@@ -2155,8 +2315,13 @@ func ValidateSQLRequest(sql string) error {
 // for strings and `"`/backtick for identifiers), never the body of a string
 // literal, so this cannot unmask a genuine string. In the pathological case of
 // a `'` inside a `"..."` identifier the subsequent literal-masking may mis-pair
-// quotes, but that errs toward showing MORE text to the denylist (fail-closed),
-// never less.
+// quotes. For the I/O-function DENYLIST consumer that errs toward showing MORE
+// text (fail-closed), never less. NOTE: this output is ALSO consumed by
+// stringLiteralInTablePosition (the replacement-scan check), for which the same
+// mis-pairing can instead hide a placeholder from table-position detection
+// (fail-OPEN for that consumer). That is not exploitable: a `'` inside a
+// `"..."` identifier means the attacker's own SQL is mis-quoted, so DuckDB does
+// not parse the intended replacement scan either — no foreign read results.
 func ioDenylistNormalise(sql string) string {
 	stripped := strings.NewReplacer(`"`, "", "`", "").Replace(sql)
 	features := scanSQLFeatures(stripped)

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -1124,6 +1124,47 @@ func TestValidateSQLRequest_BypassesAndFalsePositives(t *testing.T) {
 		{name: "table named globthing not blocked", sql: "SELECT * FROM globthing", shouldFail: false},
 		{name: "column named read_csv_count not blocked", sql: "SELECT read_csv_count FROM cpu", shouldFail: false},
 
+		// GHSA-w8x2-cccw-25f7 (incomplete-fix residual of GHSA-93cm): a bare
+		// single-quoted string in table position is a DuckDB replacement scan —
+		// it reads the file with NO function name, so it slips past the
+		// I/O-function denylist above, and extractTableReferences masks the
+		// quoted path to a placeholder so RBAC never sees it. Must be rejected.
+		{name: "bare-string replacement scan single file", sql: "SELECT * FROM '/data/arc/db2/secrets/data.parquet'", shouldFail: true},
+		{name: "bare-string replacement scan glob", sql: "SELECT * FROM '/data/arc/*/**/*.parquet'", shouldFail: true},
+		{name: "bare-string replacement scan comma cross-join", sql: "SELECT b.s FROM cpu, '/data/arc/db2/secrets/data.parquet' b", shouldFail: true},
+		{name: "bare-string replacement scan in JOIN", sql: "SELECT * FROM cpu JOIN '/data/arc/db2/x.parquet' b ON cpu.id = b.id", shouldFail: true},
+		{name: "bare-string replacement scan in subquery FROM", sql: "SELECT * FROM (SELECT * FROM '/data/arc/db2/x.parquet')", shouldFail: true},
+		{name: "bare-string replacement scan uppercase FROM", sql: "SELECT * FROM '/data/arc/db2/x.parquet'", shouldFail: true},
+		{name: "bare-string replacement scan comma after subquery", sql: "SELECT * FROM (SELECT 1) a, '/data/arc/db2/x.parquet' b", shouldFail: true},
+		// GHSA-w8x2 review blocker 1: a subquery WITH an inner FROM must not
+		// clear the OUTER FROM clause — the trailing comma cross-join is still
+		// table position. (The no-inner-FROM case above never clobbered state.)
+		{name: "bare-string comma after subquery WITH inner FROM", sql: "SELECT * FROM (SELECT * FROM cpu) a, '/data/arc/db2/secrets/data.parquet' b", shouldFail: true},
+		{name: "bare-string comma after subquery no alias inner FROM", sql: "SELECT * FROM (SELECT * FROM cpu), '/data/arc/db2/x.parquet'", shouldFail: true},
+		{name: "bare-string comma after subquery inner WHERE", sql: "SELECT b.s FROM (SELECT id FROM cpu WHERE id=1) a, '/data/arc/db2/x.parquet' b", shouldFail: true},
+		// GHSA-w8x2 review blocker 2: no whitespace between FROM/JOIN and the
+		// quote — masking glues keyword+placeholder; must still tokenise apart.
+		{name: "bare-string no space after FROM", sql: "SELECT * FROM'/data/arc/db2/x.parquet'", shouldFail: true},
+		{name: "bare-string no space glued SELECT and FROM", sql: "SELECT*FROM'/data/arc/db2/x.parquet'", shouldFail: true},
+		{name: "bare-string no space after JOIN", sql: "SELECT * FROM cpu JOIN'/data/arc/db2/x.parquet' b ON cpu.id=b.id", shouldFail: true},
+		// Three-way comma cross-join, string last.
+		{name: "bare-string third in comma chain", sql: "SELECT * FROM cpu, mem, '/data/arc/db2/x.parquet'", shouldFail: true},
+		// Comma cross-join still armed after a JOIN ... ON predicate.
+		{name: "bare-string comma after JOIN ON predicate", sql: "SELECT * FROM a JOIN b ON a.id=b.id, '/data/arc/db2/x.parquet'", shouldFail: true},
+		// False-positive guards: a quoted string used as a VALUE (WHERE/SELECT
+		// literal, or a function argument) is NOT table position and must pass.
+		{name: "string value in WHERE not table position", sql: "SELECT * FROM cpu WHERE path = '/data/arc/db2/secrets/data.parquet'", shouldFail: false},
+		{name: "string arg to date_trunc not table position", sql: "SELECT date_trunc('hour', time) FROM cpu", shouldFail: false},
+		{name: "string arg after comma in function not table position", sql: "SELECT coalesce(host, '/default/path') FROM cpu", shouldFail: false},
+		{name: "string literal in SELECT projection not table position", sql: "SELECT '/data/x.parquet' AS note FROM cpu", shouldFail: false},
+		{name: "string in GROUP BY-adjacent comma not table position", sql: "SELECT host, count(*) FROM cpu GROUP BY host ORDER BY count(*), '/x'", shouldFail: false},
+		{name: "string arg to strftime after comma-join table not flagged", sql: "SELECT strftime(time, '%Y') FROM cpu, mem", shouldFail: false},
+		{name: "string in JOIN ON predicate not table position", sql: "SELECT * FROM cpu JOIN mem ON mem.tag = 'x'", shouldFail: false},
+		{name: "VALUES clause with string not table position", sql: "SELECT * FROM (VALUES ('a'), ('b')) t(x)", shouldFail: false},
+		{name: "string in second UNION arm WHERE not table position", sql: "SELECT host FROM cpu UNION SELECT host FROM mem WHERE host = '/data/x'", shouldFail: false},
+		{name: "string in IN-list not table position", sql: "SELECT * FROM cpu WHERE host IN ('a', 'b', '/data/x.parquet')", shouldFail: false},
+		{name: "string comma-arg in coalesce after comma-join not flagged", sql: "SELECT coalesce(a, '/x'), b FROM cpu, mem", shouldFail: false},
+
 		// Multi-statement smuggling — a second statement behind a semicolon
 		// bypasses the anchored SHOW regexes, so reject >1 statement outright.
 		{name: "SHOW smuggled behind semicolon", sql: "SHOW DATABASES; SELECT 1", shouldFail: true},


### PR DESCRIPTION
## Summary

Fixes **GHSA-w8x2-cccw-25f7** — a cross-tenant read on RBAC-enabled multi-tenant instances, and an incomplete-fix residual of GHSA-93cm-2v4m-c56c.

DuckDB resolves a bare single-quoted string in table position (`SELECT * FROM '/data/arc/db2/secrets/*.parquet'`) as a **replacement scan** that reads the file directly, with **no function name**. Arc's two query-authorization controls both key on function names:
- the I/O-function denylist (`read_parquet`, `parquet_scan`, `glob`, …) in `ValidateSQLRequest`, and
- RBAC via `extractTableReferences`.

A bare string has no function name, so it slips past the denylist, and the extractor masks the quoted path to a `__STR__` placeholder before matching — so RBAC never sees the foreign path. Net: an authenticated tenant reads any Parquet inside the sandbox's allow-listed storage root (every other tenant's data). The comma form (`FROM cpu, '/…/secrets/*.parquet' b`) needs only one legitimate grant. It does **not** escape the DuckDB sandbox to arbitrary OS files (`enable_external_access=false` holds).

Verified end-to-end against the pinned DuckDB (`duckdb-go/v2 v2.10501.0`) with negative controls.

## Fix

`ValidateSQLRequest` (before any transform or RBAC check) now rejects any single-quoted string standing where a table reference belongs — after `FROM`/`JOIN`, or continuing a `FROM` clause's table list via a cross-join comma. Single-quoted strings used as **values** (`WHERE`, `IN`, function args) and legitimately quoted **identifiers** (`FROM "my table"`) are untouched. Arc's own transform layer, which emits `read_parquet('…')` under the caller's identity, runs after validation and is unaffected.

Design notes (both from the adversarial review round):
- **Depth-stacked FROM tracking**, not a single boolean — else a subquery with an inner FROM (`FROM (SELECT * FROM cpu) a, '/evil'`) clears the outer FROM clause and the trailing cross-join comma slips through.
- **Placeholder isolation before tokenization** — else no-whitespace forms (`FROM'/evil'`) fuse keyword+placeholder into one token and evade detection.

## Disposition

- **No CVE** — residual of GHSA-93cm, scoped to within the allow-list, tracked under the advisory.
- Reported by @arpitjain099 (credited in release notes).
- Targets `main` (security fix). Release notes updated in `RELEASE_NOTES_2026.09.1.md`.

## Test plan

- [x] `go build ./cmd/... ./internal/...`
- [x] `go test ./internal/api/` (20 new matrix cases: single-file, glob, comma cross-join, JOIN, subquery, subquery-with-inner-FROM, no-whitespace, third-in-chain, after-JOIN-ON; 11 false-positive guards: WHERE/IN/function-arg values, SELECT projections, VALUES, UNION, GROUP BY-adjacent)
- [x] `go test -race ./internal/api/ -run TestValidateSQLRequest`
- [x] `go vet ./internal/api/` + `gofmt` clean
- [x] DuckDB probe: confirmed all bypass forms are live replacement scans, and each is now blocked by the validator
- [x] Internal deep adversarial review + independent second reviewer — no blockers