### PR TITLE
fix(compaction): copy file slices when splitting candidate batches (#292)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -57,6 +57,14 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### Compaction batch splitting no longer produces aliased file slices ([#292](https://github.com/Basekick-Labs/arc/issues/292))
+
+`SplitCandidateIntoBatches` partitioned a candidate's file list into batches using `c.Files[start:end]` sub-slices, which share the original's backing array — so every batch pointed into the same underlying memory. The same pattern existed in `compactFilesAdaptively`, which split a failed batch in half with `files[:mid]` / `files[mid:]`.
+
+No current code path mutates a batch's `Files` in place, so this was latent rather than an active source of corruption — compaction jobs never produced wrong file lists because of it. But it left every future caller one in-place sort or append away from silently rewriting sibling batches, with no error or log signal.
+
+Both sites now copy into independent backing arrays, including the single-batch (`len(Files) <= MaxFilesPerBatch`) path that previously returned the caller's slice unchanged. Batch isolation no longer depends on file count: mutating any returned batch cannot affect another batch or the original candidate.
+
 ### `date_trunc`/`time_bucket` epoch rewrite no longer corrupts parenthesized column arguments ([#535](https://github.com/Basekick-Labs/arc/issues/535))
 
 Arc rewrites `date_trunc('hour', col)` (and `time_bucket(...)`) into faster epoch arithmetic. The rewriter extracted the column argument with a paren-blind regex that stopped at the **first** `)` rather than the matching one. When the column argument itself contained parentheses — `coalesce(time, a)`, `(time)`, `CAST(ts AS TIMESTAMP)`, or any nested call — the capture was truncated and the `::BIGINT` cast was spliced into the wrong place, producing SQL that failed at the DuckDB binder (`No function matches ... 'epoch(BIGINT)'`) on a query DuckDB would otherwise have run correctly.

--- a/internal/compaction/manager.go
+++ b/internal/compaction/manager.go
@@ -454,10 +454,12 @@ func (m *Manager) compactFilesAdaptively(ctx context.Context, candidate Candidat
 		return err
 	}
 
-	// Split batch in half and try each half
+	// Split batch in half and try each half (copy to independent backing arrays)
 	mid := len(files) / 2
-	firstHalf := files[:mid]
-	secondHalf := files[mid:]
+	firstHalf := make([]string, mid)
+	copy(firstHalf, files[:mid])
+	secondHalf := make([]string, len(files)-mid)
+	copy(secondHalf, files[mid:])
 
 	m.logger.Warn().
 		Int("depth", depth).

--- a/internal/compaction/tier.go
+++ b/internal/compaction/tier.go
@@ -31,9 +31,15 @@ type Candidate struct {
 // SplitCandidateIntoBatches splits a candidate with many files into multiple candidates,
 // each with at most MaxFilesPerBatch files. This prevents DuckDB segfaults when processing
 // thousands of files in a single read_parquet() call.
+//
+// Every returned batch owns an independent Files backing array, including the
+// single-batch case. Callers may mutate a batch's Files without affecting the
+// input candidate or any sibling batch.
 func SplitCandidateIntoBatches(c Candidate) []Candidate {
 	if len(c.Files) <= MaxFilesPerBatch {
-		return []Candidate{c}
+		single := c
+		single.Files = append([]string(nil), c.Files...)
+		return []Candidate{single}
 	}
 
 	// Calculate number of batches needed
@@ -47,11 +53,14 @@ func SplitCandidateIntoBatches(c Candidate) []Candidate {
 			end = len(c.Files)
 		}
 
+		filesCopy := make([]string, end-start)
+		copy(filesCopy, c.Files[start:end])
+
 		batch := Candidate{
 			Database:      c.Database,
 			Measurement:   c.Measurement,
 			PartitionPath: c.PartitionPath,
-			Files:         c.Files[start:end],
+			Files:         filesCopy,
 			FileCount:     end - start,
 			Tier:          c.Tier,
 			PartitionTime: c.PartitionTime,

--- a/internal/compaction/tier_test.go
+++ b/internal/compaction/tier_test.go
@@ -1,0 +1,223 @@
+package compaction
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestSplitCandidateIntoBatches_NoAlias(t *testing.T) {
+	files := make([]string, MaxFilesPerBatch*3+5)
+	for i := range files {
+		files[i] = fmt.Sprintf("file_%d.parquet", i)
+	}
+
+	c := Candidate{
+		Database:      "db",
+		Measurement:   "cpu",
+		PartitionPath: "2026/07/28",
+		Files:         files,
+		FileCount:     len(files),
+		Tier:          "hourly",
+		PartitionTime: time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC),
+	}
+
+	batches := SplitCandidateIntoBatches(c)
+
+	// Mutate every batch's Files slice.
+	for i := range batches {
+		for j := range batches[i].Files {
+			batches[i].Files[j] = "MUTATED"
+		}
+	}
+
+	// Verify: original candidate must be untouched.
+	for i, f := range c.Files {
+		if f == "MUTATED" {
+			t.Fatalf("original candidate Files[%d] was mutated through batch slice — aliased backing array", i)
+		}
+	}
+
+	// Verify: batches must not alias each other.
+	// Reset and mutate only batch 0.
+	batches2 := SplitCandidateIntoBatches(c)
+	if len(batches2) < 2 {
+		t.Fatal("expected at least 2 batches")
+	}
+	for j := range batches2[0].Files {
+		batches2[0].Files[j] = "BATCH0"
+	}
+	for i := 1; i < len(batches2); i++ {
+		for j, f := range batches2[i].Files {
+			if f == "BATCH0" {
+				t.Fatalf("batch[%d].Files[%d] aliased with batch[0].Files — shared backing array", i, j)
+			}
+		}
+	}
+}
+
+func TestSplitCandidateIntoBatches_SingleBatchNoAlias(t *testing.T) {
+	// The <= MaxFilesPerBatch early-return path must copy too, so batch
+	// isolation does not silently depend on file count.
+	files := []string{"a.parquet", "b.parquet", "c.parquet"}
+	c := Candidate{
+		Database:    "db",
+		Measurement: "cpu",
+		Files:       files,
+		FileCount:   len(files),
+	}
+
+	batches := SplitCandidateIntoBatches(c)
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch, got %d", len(batches))
+	}
+
+	batches[0].Files[0] = "MUTATED"
+	if files[0] == "MUTATED" {
+		t.Fatal("single-batch path aliased the caller's backing array")
+	}
+	if c.Files[0] == "MUTATED" {
+		t.Fatal("single-batch path aliased the input candidate's backing array")
+	}
+}
+
+func TestSplitCandidateIntoBatches_EmptyFiles(t *testing.T) {
+	c := Candidate{
+		Database:    "db",
+		Measurement: "cpu",
+		Files:       []string{},
+		FileCount:   0,
+	}
+
+	batches := SplitCandidateIntoBatches(c)
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch for empty files, got %d", len(batches))
+	}
+	if len(batches[0].Files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(batches[0].Files))
+	}
+}
+
+func TestSplitCandidateIntoBatches_MinimalSplit(t *testing.T) {
+	// MaxFilesPerBatch+1 is the minimum case that exercises the multi-batch path.
+	files := make([]string, MaxFilesPerBatch+1)
+	for i := range files {
+		files[i] = fmt.Sprintf("file_%d.parquet", i)
+	}
+	c := Candidate{
+		Database:    "db",
+		Measurement: "cpu",
+		Files:       files,
+		FileCount:   len(files),
+	}
+
+	batches := SplitCandidateIntoBatches(c)
+	if len(batches) != 2 {
+		t.Fatalf("expected 2 batches, got %d", len(batches))
+	}
+	if len(batches[0].Files) != MaxFilesPerBatch {
+		t.Fatalf("batch 0: expected %d files, got %d", MaxFilesPerBatch, len(batches[0].Files))
+	}
+	if len(batches[1].Files) != 1 {
+		t.Fatalf("batch 1: expected 1 file, got %d", len(batches[1].Files))
+	}
+
+	// Verify no aliasing between the two batches.
+	batches[0].Files[0] = "CHANGED"
+	if batches[1].Files[0] == "CHANGED" {
+		t.Fatal("batch[1].Files[0] aliased with batch[0].Files[0]")
+	}
+}
+
+func TestSplitCandidateIntoBatches_UnderLimit(t *testing.T) {
+	c := Candidate{
+		Database:    "db",
+		Measurement: "cpu",
+		Files:       []string{"a.parquet", "b.parquet"},
+		FileCount:   2,
+	}
+
+	batches := SplitCandidateIntoBatches(c)
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch, got %d", len(batches))
+	}
+	if len(batches[0].Files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(batches[0].Files))
+	}
+}
+
+func TestSplitCandidateIntoBatches_ExactLimit(t *testing.T) {
+	files := make([]string, MaxFilesPerBatch)
+	for i := range files {
+		files[i] = fmt.Sprintf("f_%d.parquet", i)
+	}
+	c := Candidate{
+		Database:    "db",
+		Measurement: "cpu",
+		Files:       files,
+		FileCount:   MaxFilesPerBatch,
+	}
+
+	batches := SplitCandidateIntoBatches(c)
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch for exactly MaxFilesPerBatch files, got %d", len(batches))
+	}
+}
+
+func TestSplitCandidateIntoBatches_CorrectPartitioning(t *testing.T) {
+	n := MaxFilesPerBatch*2 + 3
+	files := make([]string, n)
+	for i := range files {
+		files[i] = fmt.Sprintf("file_%d.parquet", i)
+	}
+	c := Candidate{
+		Database:      "db",
+		Measurement:   "cpu",
+		PartitionPath: "2026/07/28",
+		Files:         files,
+		FileCount:     n,
+		Tier:          "daily",
+	}
+
+	batches := SplitCandidateIntoBatches(c)
+
+	expectedBatches := 3
+	if len(batches) != expectedBatches {
+		t.Fatalf("expected %d batches, got %d", expectedBatches, len(batches))
+	}
+
+	// First batch: full.
+	if len(batches[0].Files) != MaxFilesPerBatch {
+		t.Fatalf("batch 0: expected %d files, got %d", MaxFilesPerBatch, len(batches[0].Files))
+	}
+	// Second batch: full.
+	if len(batches[1].Files) != MaxFilesPerBatch {
+		t.Fatalf("batch 1: expected %d files, got %d", MaxFilesPerBatch, len(batches[1].Files))
+	}
+	// Last batch: remainder.
+	if len(batches[2].Files) != 3 {
+		t.Fatalf("batch 2: expected 3 files, got %d", len(batches[2].Files))
+	}
+
+	// Verify batch numbering.
+	for i, b := range batches {
+		if b.BatchNumber != i+1 {
+			t.Errorf("batch %d: BatchNumber = %d, want %d", i, b.BatchNumber, i+1)
+		}
+		if b.TotalBatches != expectedBatches {
+			t.Errorf("batch %d: TotalBatches = %d, want %d", i, b.TotalBatches, expectedBatches)
+		}
+	}
+
+	// Verify file contents are correct (not just counts).
+	want := 0
+	for _, b := range batches {
+		for _, f := range b.Files {
+			expected := fmt.Sprintf("file_%d.parquet", want)
+			if f != expected {
+				t.Errorf("file mismatch at index %d: got %q, want %q", want, f, expected)
+			}
+			want++
+		}
+	}
+}


### PR DESCRIPTION
Closes #292.

## Summary

- `SplitCandidateIntoBatches` partitioned a candidate's file list using `c.Files[start:end]` sub-slices, which share the original's backing array — every batch pointed into the same underlying memory.
- The same pattern existed in `compactFilesAdaptively`, which split a failed batch in half with `files[:mid]` / `files[mid:]`.
- Both sites now copy into independent backing arrays, **including the single-batch `len(Files) <= MaxFilesPerBatch` early return** that previously handed back the caller's slice unchanged. Batch isolation no longer depends on file count.

## Severity: latent, not an active bug

Worth stating plainly, because the issue was filed as `high`: **no current code path mutates a batch's `Files` in place**, so this never corrupted anything in production. Traced end to end:

`SplitCandidateIntoBatches` (manager.go:660) → goroutine → `compactFilesAdaptively` (manager.go:683, read-only) → `CompactPartition` (manager.go:242) → `json.Marshal` → **a separate OS process**, which deserializes its own copy and cannot touch the parent's array. No element write, no `sort`, no `append` into a shared array anywhere on that path.

What the aliasing did leave behind is a footgun: any future caller was one in-place sort or append away from silently rewriting sibling batches, with no error or log signal. That is what this fixes. The release-notes entry is worded to match — it does not claim a corruption that never occurred.

The single-batch early return is included because leaving it aliased made isolation depend on file count: a caller that sorts `batches[0].Files` would behave differently above and below 30 files. That inconsistency is exactly the class of surprise the fix exists to prevent.

## Configuration matrix

Pure-logic change to slice construction. No new config keys, no new pointer dereferences, no new struct fields, no startup wiring touched.

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone (no cluster, no compaction) | No — compaction manager never constructed | n/a |
| OSS + compaction enabled | Yes — `SplitCandidateIntoBatches` at manager.go:660, both paths | No new derefs; `c.Files` may be nil and `append([]string(nil), nil...)` is valid |
| Cluster + no compaction | No | n/a |
| Cluster + compaction (either TLS flag) | Yes — same call site, unchanged by cluster/TLS state | Identical to OSS + compaction; no cluster/license field touched |

Every "yes" row reaches the same two functions with no dependency on `clusterCoordinator`, `licenseClient`, or `authManager`.

## Test plan

- [x] `TestSplitCandidateIntoBatches_SingleBatchNoAlias` (new) — pins the early-return path. **Verified it fails against the pre-fix code** (`single-batch path aliased the caller's backing array`) and passes after, so it is a real regression guard rather than a test that would pass either way.
- [x] `TestSplitCandidateIntoBatches_NoAlias` — multi-batch: mutating a batch affects neither the original candidate nor sibling batches.
- [x] `TestSplitCandidateIntoBatches_CorrectPartitioning` — asserts file *contents* per batch, not just counts, so a bad `copy` offset fails loudly.
- [x] Edge cases: empty `Files`, exactly `MaxFilesPerBatch`, `MaxFilesPerBatch+1` (minimal split), under-limit.
- [x] `go build ./cmd/... ./internal/...` clean
- [x] `go test ./internal/compaction/...` — 7/7 pass
- [x] `go test -race ./internal/compaction/...` clean
- [x] `go vet ./internal/compaction/...` clean
- [x] `gofmt -l` clean on all three touched Go files

Not binary-run: the change alters no startup path, no configuration handling, and no observable runtime behavior — there is no live path where old and new code differ today, which is precisely the "latent" finding above.