### PR TITLE
fix(backup): stream files instead of buffering them in memory (#322)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -65,6 +65,18 @@ No current code path mutates a batch's `Files` in place, so this was latent rath
 
 Both sites now copy into independent backing arrays, including the single-batch (`len(Files) <= MaxFilesPerBatch`) path that previously returned the caller's slice unchanged. Batch isolation no longer depends on file count: mutating any returned batch cannot affect another batch or the original candidate.
 
+### Backup no longer loads entire files into memory ([#322](https://github.com/Basekick-Labs/arc/issues/322))
+
+`CreateBackup` read each Parquet file entirely into memory (`dataStorage.Read` → `backupStorage.Write`) before writing it to backup storage. With large Parquet files (the default 1M buffer size produces ~10–14MB files each; partitions can have hundreds), a backup of a moderately-sized database could spike process memory to gigabytes, triggering OOM kills or swapping.
+
+Backup now streams each file through a temp file: `dataStorage.ReadTo` writes the source into a temp file on disk, then `backupStorage.WriteReader` streams the temp file to backup storage. Peak memory per file is bounded by the I/O buffer size (typically 32KB) instead of the file size. The SQLite metadata backup uses the same streaming pattern (`os.Open` → `WriteReader`) instead of `os.ReadFile`. The pattern matches the existing restore path (`streamRestoreFile`), which already streamed in both directions.
+
+Failure handling is deliberately narrow about what it tolerates. Only a failure to **read the source file** is skippable — that file may legitimately have been removed by compaction or retention between the listing and the copy, and aborting a whole backup over that benign race would be wrong. Every other failure (temp file creation, seek, backup-storage write) is fatal and aborts the backup: those indicate a broken environment, not a race, and a backup that silently omits files while reporting success is worse than one that fails loudly.
+
+Skipped files are now counted in the backup manifest (`skipped_files`) and in the progress API, so an incomplete backup is visible without reading logs — the manifest's `total_files` describes what was inventoried, not necessarily what was stored. If **every** file proves unreadable, the backup now fails rather than producing an empty backup that reports success.
+
+**Operational note:** streaming trades memory pressure for temp disk usage. Each file being backed up requires temp disk space equal to its size. In container environments with a small `/tmp` (tmpfs), set `TMPDIR` to a volume with sufficient space, or ensure the default temp directory has room for the largest Parquet file. If the temp directory is unusable the backup fails with a clear error rather than silently skipping files.
+
 ### `date_trunc`/`time_bucket` epoch rewrite no longer corrupts parenthesized column arguments ([#535](https://github.com/Basekick-Labs/arc/issues/535))
 
 Arc rewrites `date_trunc('hour', col)` (and `time_bucket(...)`) into faster epoch arithmetic. The rewriter extracted the column argument with a paren-blind regex that stopped at the **first** `)` rather than the matching one. When the column argument itself contained parentheses — `coalesce(time, a)`, `(time)`, `CAST(ts AS TIMESTAMP)`, or any nested call — the capture was truncated and the `::BIGINT` cast was spliced into the wrong place, producing SQL that failed at the DuckDB binder (`No function matches ... 'epoch(BIGINT)'`) on a query DuckDB would otherwise have run correctly.

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,25 @@ import (
 
 	"github.com/basekick-labs/arc/internal/storage"
 )
+
+// errBackupRead marks a failure reading the SOURCE file from data storage.
+//
+// Only source-read failures are skippable: the file may legitimately have been
+// deleted by compaction or retention between the listing and the copy, and
+// aborting the whole backup for that benign race would be wrong.
+//
+// Every other failure — temp file creation, seek, backup-storage write — is
+// fatal. Those indicate a broken environment (no temp space, unwritable or
+// unreachable backup storage), not a race, and continuing would produce a
+// backup that silently omits files while reporting success.
+//
+// Classification is deliberately positive rather than by exclusion: a failure
+// mode added here later is fatal by default until someone marks it skippable.
+var errBackupRead = errors.New("backup source read failed")
+
+func isSourceReadError(err error) bool {
+	return errors.Is(err, errBackupRead)
+}
 
 // BackupOptions controls what gets backed up and where.
 type BackupOptions struct {
@@ -148,6 +168,10 @@ func (m *Manager) CreateBackup(ctx context.Context, opts BackupOptions) (*Backup
 	}
 
 	// ── 5. Write manifest ───────────────────────────────────────────────
+	// Record files that were inventoried but proved unreadable, so the manifest
+	// does not claim contents the backup does not actually hold.
+	manifest.SkippedFiles = atomic.LoadInt64(&progress.SkippedFiles)
+
 	manifestData, err := MarshalManifest(manifest)
 	if err != nil {
 		progress.Status = "failed"
@@ -168,6 +192,7 @@ func (m *Manager) CreateBackup(ctx context.Context, opts BackupOptions) (*Backup
 		Str("backup_id", backupID).
 		Int64("files", manifest.TotalFiles).
 		Int64("bytes", manifest.TotalSizeBytes).
+		Int64("skipped", manifest.SkippedFiles).
 		Dur("duration", duration).
 		Msg("Backup completed")
 
@@ -175,7 +200,13 @@ func (m *Manager) CreateBackup(ctx context.Context, opts BackupOptions) (*Backup
 }
 
 // copyDataFiles copies parquet files from data storage to backup storage.
+//
+// Files whose source cannot be read are skipped (see errBackupRead) and counted
+// in progress.SkippedFiles. Every other failure aborts the backup. If every file
+// was skipped, the backup fails rather than reporting success over an empty set.
 func (m *Manager) copyDataFiles(ctx context.Context, backupID string, files []storage.ObjectInfo, progress *Progress) error {
+	var skipped int64
+
 	for _, obj := range files {
 		select {
 		case <-ctx.Done():
@@ -183,19 +214,23 @@ func (m *Manager) copyDataFiles(ctx context.Context, backupID string, files []st
 		default:
 		}
 
-		srcData, err := m.dataStorage.Read(ctx, obj.Path)
+		destPath := fmt.Sprintf("%s/data/%s", backupID, obj.Path)
+		written, err := m.streamBackupFile(ctx, obj.Path, destPath)
 		if err != nil {
+			// Only a source-read failure is skippable — the file may have been
+			// deleted by compaction/retention between listing and copy. Anything
+			// else (temp file, seek, backup write) means the environment is broken
+			// and continuing would silently drop files from the backup.
+			if !isSourceReadError(err) {
+				return fmt.Errorf("failed to back up %s: %w", obj.Path, err)
+			}
+			skipped++
 			m.logger.Warn().Str("path", obj.Path).Err(err).Msg("Failed to read data file, skipping")
 			continue
 		}
 
-		destPath := fmt.Sprintf("%s/data/%s", backupID, obj.Path)
-		if err := m.backupStorage.Write(ctx, destPath, srcData); err != nil {
-			return fmt.Errorf("failed to write backup file %s: %w", destPath, err)
-		}
-
 		atomic.AddInt64(&progress.ProcessedFiles, 1)
-		atomic.AddInt64(&progress.ProcessedBytes, obj.Size)
+		atomic.AddInt64(&progress.ProcessedBytes, written)
 
 		if atomic.LoadInt64(&progress.ProcessedFiles)%100 == 0 {
 			m.logger.Info().
@@ -204,11 +239,73 @@ func (m *Manager) copyDataFiles(ctx context.Context, backupID string, files []st
 				Msg("Backup progress")
 		}
 	}
+
+	atomic.StoreInt64(&progress.SkippedFiles, skipped)
+
+	// Every single file failed to read. That is an unreadable source storage,
+	// not the benign delete-during-backup race that skipping exists to tolerate.
+	// Reporting success here would produce an empty backup that looks valid.
+	if skipped > 0 && atomic.LoadInt64(&progress.ProcessedFiles) == 0 {
+		return fmt.Errorf("backup failed: all %d data files were unreadable", skipped)
+	}
+
+	if skipped > 0 {
+		m.logger.Warn().
+			Int64("skipped", skipped).
+			Int64("copied", atomic.LoadInt64(&progress.ProcessedFiles)).
+			Msg("Backup completed with skipped files — backup is incomplete")
+	}
+
 	return nil
+}
+
+// streamBackupFile streams a file from data storage to backup storage via a temp file,
+// avoiding loading the entire file into memory (important for large Parquet files).
+// It returns the number of bytes actually copied.
+//
+// Only a source-read failure is wrapped with errBackupRead (making it skippable by
+// the caller); temp file, seek, and write failures are returned unwrapped and are
+// fatal to the backup.
+func (m *Manager) streamBackupFile(ctx context.Context, srcPath, destPath string) (int64, error) {
+	tmpFile, err := os.CreateTemp("", "arc-backup-*.parquet")
+	if err != nil {
+		return 0, fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+	defer tmpFile.Close()
+
+	// Stream from data storage to temp file
+	if err := m.dataStorage.ReadTo(ctx, srcPath, tmpFile); err != nil {
+		return 0, fmt.Errorf("failed to read from data storage: %w: %w", errBackupRead, err)
+	}
+
+	// Size the upload from the temp file rather than the listing: the listing is a
+	// point-in-time snapshot that compaction or retention may have invalidated, and
+	// a declared size that disagrees with the reader can truncate the upload on
+	// backends that send it as Content-Length. Matches streamRestoreFile.
+	info, err := tmpFile.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("failed to stat temp file: %w", err)
+	}
+	size := info.Size()
+
+	// Rewind for upload
+	if _, err := tmpFile.Seek(0, 0); err != nil {
+		return 0, fmt.Errorf("failed to seek temp file: %w", err)
+	}
+
+	// Stream from temp file to backup storage
+	if err := m.backupStorage.WriteReader(ctx, destPath, tmpFile, size); err != nil {
+		return 0, fmt.Errorf("failed to write to backup storage: %w", err)
+	}
+
+	return size, nil
 }
 
 // backupSQLite copies the SQLite database file into the backup.
 // It performs a WAL checkpoint first to ensure a consistent copy.
+// The file is streamed via a temp file to avoid loading the entire database into memory.
 func (m *Manager) backupSQLite(ctx context.Context, backupID string) error {
 	// Checkpoint WAL to ensure all data is flushed to the main DB file.
 	db, err := sql.Open("sqlite3", m.sqliteDBPath)
@@ -221,17 +318,26 @@ func (m *Manager) backupSQLite(ctx context.Context, backupID string) error {
 	}
 	db.Close()
 
-	data, err := os.ReadFile(m.sqliteDBPath)
+	// Get file size for WriteReader
+	info, err := os.Stat(m.sqliteDBPath)
 	if err != nil {
-		return fmt.Errorf("failed to read SQLite database: %w", err)
+		return fmt.Errorf("failed to stat SQLite database: %w", err)
 	}
+	size := info.Size()
+
+	// Stream via temp file to avoid loading entire DB into memory
+	f, err := os.Open(m.sqliteDBPath)
+	if err != nil {
+		return fmt.Errorf("failed to open SQLite database: %w", err)
+	}
+	defer f.Close()
 
 	destPath := fmt.Sprintf("%s/metadata/arc.db", backupID)
-	if err := m.backupStorage.Write(ctx, destPath, data); err != nil {
+	if err := m.backupStorage.WriteReader(ctx, destPath, f, size); err != nil {
 		return fmt.Errorf("failed to write SQLite backup: %w", err)
 	}
 
-	m.logger.Info().Str("backup_id", backupID).Int("bytes", len(data)).Msg("SQLite database backed up")
+	m.logger.Info().Str("backup_id", backupID).Int64("bytes", size).Msg("SQLite database backed up")
 	return nil
 }
 

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,0 +1,384 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+func TestStreamBackupFile(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	// Set up data storage with a test file
+	dataDir := t.TempDir()
+	dataStorage, err := storage.NewLocalBackend(dataDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create data storage: %v", err)
+	}
+
+	// Set up backup storage
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   dataStorage,
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+
+	// Write a test file to data storage
+	testData := bytes.Repeat([]byte("parquet-data-line\n"), 1000)
+	srcPath := "testdb/cpu/2026/07/28/00/data_001.parquet"
+	if err := dataStorage.Write(ctx, srcPath, testData); err != nil {
+		t.Fatalf("failed to write test data: %v", err)
+	}
+
+	// Keep temp files inside the test's own dir so the cleanup assertion below
+	// cannot be confused by unrelated processes using the shared temp dir.
+	t.Setenv("TMPDIR", t.TempDir())
+
+	// Stream backup
+	destPath := "backup-123/data/" + srcPath
+	written, err := m.streamBackupFile(ctx, srcPath, destPath)
+	if err != nil {
+		t.Fatalf("streamBackupFile failed: %v", err)
+	}
+	if written != int64(len(testData)) {
+		t.Errorf("streamBackupFile returned %d bytes, want %d", written, len(testData))
+	}
+
+	// Verify the backup file exists and has correct content
+	backedUp, err := m.backupStorage.Read(ctx, destPath)
+	if err != nil {
+		t.Fatalf("failed to read backup file: %v", err)
+	}
+	if !bytes.Equal(backedUp, testData) {
+		t.Errorf("backup data mismatch: got %d bytes, want %d bytes", len(backedUp), len(testData))
+	}
+
+	// Verify no temp files left behind
+	matches, _ := filepath.Glob(filepath.Join(os.TempDir(), "arc-backup-*.parquet"))
+	if len(matches) != 0 {
+		t.Errorf("temp files not cleaned up: %v", matches)
+	}
+}
+
+func TestStreamBackupFile_SourceNotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	dataDir := t.TempDir()
+	dataStorage, err := storage.NewLocalBackend(dataDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create data storage: %v", err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   dataStorage,
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+
+	_, err = m.streamBackupFile(ctx, "nonexistent.parquet", "backup/data/nonexistent.parquet")
+	if err == nil {
+		t.Fatal("expected error for nonexistent source file")
+	}
+	// A missing source must classify as a skippable read error, otherwise a
+	// benign delete-during-backup race would abort the whole backup.
+	if !isSourceReadError(err) {
+		t.Errorf("missing source should be a skippable read error, got %v", err)
+	}
+}
+
+func TestCopyDataFiles_StreamsMultipleFiles(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	dataDir := t.TempDir()
+	dataStorage, err := storage.NewLocalBackend(dataDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create data storage: %v", err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   dataStorage,
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+
+	// Write test files to data storage
+	files := []storage.ObjectInfo{
+		{Path: "db1/cpu/2026/07/28/00/f1.parquet", Size: 500},
+		{Path: "db1/cpu/2026/07/28/00/f2.parquet", Size: 300},
+		{Path: "db2/mem/2026/07/28/00/f3.parquet", Size: 200},
+	}
+	for _, f := range files {
+		data := bytes.Repeat([]byte("x"), int(f.Size))
+		if err := dataStorage.Write(ctx, f.Path, data); err != nil {
+			t.Fatalf("failed to write test file %s: %v", f.Path, err)
+		}
+	}
+
+	backupID := "backup-test-stream"
+	progress := &Progress{
+		Operation:  "backup",
+		BackupID:   backupID,
+		Status:     "running",
+		TotalFiles: int64(len(files)),
+	}
+
+	if err := m.copyDataFiles(ctx, backupID, files, progress); err != nil {
+		t.Fatalf("copyDataFiles failed: %v", err)
+	}
+
+	// Verify all files were backed up
+	if progress.ProcessedFiles != 3 {
+		t.Errorf("expected 3 processed files, got %d", progress.ProcessedFiles)
+	}
+	if progress.ProcessedBytes != 1000 {
+		t.Errorf("expected 1000 processed bytes, got %d", progress.ProcessedBytes)
+	}
+
+	// Verify each file exists in backup storage
+	for _, f := range files {
+		destPath := backupID + "/data/" + f.Path
+		backedUp, err := m.backupStorage.Read(ctx, destPath)
+		if err != nil {
+			t.Errorf("backup file %s not found: %v", destPath, err)
+			continue
+		}
+		if int64(len(backedUp)) != f.Size {
+			t.Errorf("backup file %s: got %d bytes, want %d", destPath, len(backedUp), f.Size)
+		}
+	}
+}
+
+func TestCopyDataFiles_SkipsFailedFiles(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	dataDir := t.TempDir()
+	dataStorage, err := storage.NewLocalBackend(dataDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create data storage: %v", err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   dataStorage,
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+
+	// Write only one file; the other will fail to read
+	goodFile := storage.ObjectInfo{Path: "db/cpu/2026/07/28/00/good.parquet", Size: 100}
+	if err := dataStorage.Write(ctx, goodFile.Path, bytes.Repeat([]byte("y"), 100)); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	badFile := storage.ObjectInfo{Path: "db/cpu/2026/07/28/00/missing.parquet", Size: 100}
+
+	backupID := "backup-test-skip"
+	progress := &Progress{
+		Operation:  "backup",
+		BackupID:   backupID,
+		Status:     "running",
+		TotalFiles: 2,
+	}
+
+	// Should not return error — failed files are skipped
+	if err := m.copyDataFiles(ctx, backupID, []storage.ObjectInfo{badFile, goodFile}, progress); err != nil {
+		t.Fatalf("copyDataFiles should not fail on individual file errors: %v", err)
+	}
+
+	// Only the good file should have been processed
+	if progress.ProcessedFiles != 1 {
+		t.Errorf("expected 1 processed file (skipped bad file), got %d", progress.ProcessedFiles)
+	}
+}
+
+func TestIsSourceReadError(t *testing.T) {
+	readErr := fmt.Errorf("failed to read from data storage: %w: %w", errBackupRead, fmt.Errorf("file not found"))
+	if !isSourceReadError(readErr) {
+		t.Error("source read error should be classified as skippable")
+	}
+
+	// Everything not explicitly tagged must be fatal — classification is positive,
+	// not by exclusion, so new failure modes default to aborting the backup.
+	for _, err := range []error{
+		fmt.Errorf("failed to create temp file: %w", fmt.Errorf("no space left on device")),
+		fmt.Errorf("failed to stat temp file: %w", fmt.Errorf("bad fd")),
+		fmt.Errorf("failed to seek temp file: %w", fmt.Errorf("bad fd")),
+		fmt.Errorf("failed to write to backup storage: %w", fmt.Errorf("disk full")),
+	} {
+		if isSourceReadError(err) {
+			t.Errorf("non-source-read error must be fatal, got skippable: %v", err)
+		}
+	}
+}
+
+// Regression guard for the silent-skip bug: when the temp directory is unusable
+// (small/absent tmpfs in a container), os.CreateTemp fails for every file. That
+// must abort the backup, not skip every file and report success.
+func TestCopyDataFiles_TempFileFailureIsFatal(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	dataDir := t.TempDir()
+	dataStorage, err := storage.NewLocalBackend(dataDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create data storage: %v", err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   dataStorage,
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+
+	files := []storage.ObjectInfo{
+		{Path: "db/cpu/2026/07/28/00/a.parquet", Size: 10},
+		{Path: "db/cpu/2026/07/28/00/b.parquet", Size: 10},
+	}
+	for _, f := range files {
+		if err := dataStorage.Write(ctx, f.Path, bytes.Repeat([]byte("z"), int(f.Size))); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+	}
+
+	// Unusable temp dir => os.CreateTemp fails for every file.
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	progress := &Progress{Operation: "backup", TotalFiles: int64(len(files))}
+	err = m.copyDataFiles(ctx, "bkid", files, progress)
+
+	if err == nil {
+		t.Fatalf("expected fatal error when temp files cannot be created; got nil with %d/%d files copied",
+			progress.ProcessedFiles, len(files))
+	}
+	if isSourceReadError(err) {
+		t.Errorf("temp file failure must not be classified as a skippable read error: %v", err)
+	}
+}
+
+// A backup whose every file is unreadable must fail rather than silently
+// producing an empty backup that reports success.
+func TestCopyDataFiles_AllFilesSkippedIsFatal(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	dataDir := t.TempDir()
+	dataStorage, err := storage.NewLocalBackend(dataDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create data storage: %v", err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   dataStorage,
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+
+	// None of these exist in data storage — every read fails.
+	files := []storage.ObjectInfo{
+		{Path: "db/cpu/2026/07/28/00/gone1.parquet", Size: 10},
+		{Path: "db/cpu/2026/07/28/00/gone2.parquet", Size: 10},
+	}
+
+	progress := &Progress{Operation: "backup", TotalFiles: int64(len(files))}
+	if err := m.copyDataFiles(ctx, "bkid", files, progress); err == nil {
+		t.Fatal("expected error when every file is skipped, got nil (empty backup would report success)")
+	}
+}
+
+// A partial skip is tolerated (the file may have been compacted away mid-backup)
+// but must be counted so the manifest does not overstate the backup's contents.
+func TestCopyDataFiles_PartialSkipRecordsCount(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	dataDir := t.TempDir()
+	dataStorage, err := storage.NewLocalBackend(dataDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create data storage: %v", err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   dataStorage,
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+
+	good := storage.ObjectInfo{Path: "db/cpu/2026/07/28/00/good.parquet", Size: 100}
+	if err := dataStorage.Write(ctx, good.Path, bytes.Repeat([]byte("y"), 100)); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+	missing := storage.ObjectInfo{Path: "db/cpu/2026/07/28/00/missing.parquet", Size: 100}
+
+	progress := &Progress{Operation: "backup", TotalFiles: 2}
+	if err := m.copyDataFiles(ctx, "bkid", []storage.ObjectInfo{missing, good}, progress); err != nil {
+		t.Fatalf("partial skip should not fail the backup: %v", err)
+	}
+
+	if progress.ProcessedFiles != 1 {
+		t.Errorf("ProcessedFiles = %d, want 1", progress.ProcessedFiles)
+	}
+	if progress.SkippedFiles != 1 {
+		t.Errorf("SkippedFiles = %d, want 1", progress.SkippedFiles)
+	}
+}
+
+// Progress bytes must reflect what was actually copied, not the (possibly stale)
+// size from the listing.
+func TestCopyDataFiles_ProgressUsesActualBytes(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	dataDir := t.TempDir()
+	dataStorage, err := storage.NewLocalBackend(dataDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create data storage: %v", err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   dataStorage,
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+
+	// Actual file is 50 bytes, but the listing claims 999 (stale entry).
+	path := "db/cpu/2026/07/28/00/stale.parquet"
+	if err := dataStorage.Write(ctx, path, bytes.Repeat([]byte("q"), 50)); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+	files := []storage.ObjectInfo{{Path: path, Size: 999}}
+
+	progress := &Progress{Operation: "backup", TotalFiles: 1}
+	if err := m.copyDataFiles(ctx, "bkid", files, progress); err != nil {
+		t.Fatalf("copyDataFiles failed: %v", err)
+	}
+
+	if progress.ProcessedBytes != 50 {
+		t.Errorf("ProcessedBytes = %d, want 50 (actual bytes, not the stale listing size)", progress.ProcessedBytes)
+	}
+}
+
+func mustLocalBackend(t *testing.T, dir string, logger zerolog.Logger) storage.Backend {
+	t.Helper()
+	b, err := storage.NewLocalBackend(dir, logger)
+	if err != nil {
+		t.Fatalf("failed to create local backend at %s: %v", dir, err)
+	}
+	return b
+}

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -15,8 +15,13 @@ type Manifest struct {
 	Databases      []DatabaseInfo `json:"databases"`
 	TotalFiles     int64          `json:"total_files"`
 	TotalSizeBytes int64          `json:"total_size_bytes"`
-	HasMetadata    bool           `json:"has_metadata"`
-	HasConfig      bool           `json:"has_config"`
+	// SkippedFiles counts files that were listed and inventoried above but could
+	// not be read from source storage at copy time. When non-zero the backup is
+	// incomplete: TotalFiles/TotalSizeBytes describe what was inventoried, not
+	// what was actually stored.
+	SkippedFiles int64 `json:"skipped_files,omitempty"`
+	HasMetadata  bool  `json:"has_metadata"`
+	HasConfig    bool  `json:"has_config"`
 }
 
 // DatabaseInfo describes a single database within a backup.
@@ -51,6 +56,7 @@ type Progress struct {
 	Status         string     `json:"status"` // "running", "completed", "failed"
 	TotalFiles     int64      `json:"total_files"`
 	ProcessedFiles int64      `json:"processed_files"`
+	SkippedFiles   int64      `json:"skipped_files"`
 	TotalBytes     int64      `json:"total_bytes"`
 	ProcessedBytes int64      `json:"processed_bytes"`
 	StartedAt      time.Time  `json:"started_at"`


### PR DESCRIPTION
Closes #322.

## Summary

`CreateBackup` read each Parquet file entirely into memory (`dataStorage.Read` → `backupStorage.Write`). With ~10–14MB files and partitions holding hundreds, a backup could spike process memory to gigabytes and trigger OOM kills.

Both copy paths now stream through a temp file (`ReadTo` → `WriteReader`), bounding peak memory per file by the I/O buffer rather than the file size. `backupSQLite` streams via `os.Open` instead of `os.ReadFile`. This matches the existing `streamRestoreFile` pattern.

## Failure classification is positive, not by exclusion

Streaming introduces a **temp-file dependency the old code did not have**, so an unusable temp dir (small tmpfs `/tmp` in a container) is a new failure mode. An earlier iteration of this change classified errors by exclusion — only write errors were fatal, everything else was skipped — which meant `os.CreateTemp` and `Seek` failures fell through to `continue`. Verified consequence:

```
copyDataFiles returned err=<nil>
ProcessedFiles=0 (of 3)
```

Because the manifest is built from the listing *before* any copy runs (backup.go:95-131) and `progress.Status` is set to `"completed"`, that produced **an empty backup reporting success whose manifest claimed every file was present** — discoverable only at restore time.

Now only a **source-read** failure is skippable (the file may legitimately have been removed by compaction/retention between listing and copy). Temp file, seek, and write failures are fatal. A failure mode added later is fatal until someone deliberately marks it skippable.

Additionally:
- If **every** file is skipped, the backup fails rather than producing an empty backup that reports success.
- Skipped files are counted in the manifest (`skipped_files`, `omitempty`) and the progress API, so an incomplete backup is visible without reading logs. `total_files` describes what was inventoried, not necessarily what was stored.
- Upload size comes from `tmpFile.Stat()` rather than the listing entry, matching `streamRestoreFile`. The listing is a point-in-time snapshot compaction can invalidate, and a declared size disagreeing with the reader can truncate uploads on backends that send it as `Content-Length`. Progress bytes now reflect bytes actually copied.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS, backup API unused | No — `Manager` never constructed | n/a |
| OSS + backup, local `dataStorage`, roomy `/tmp` | Yes — backup.go:207 | `dataStorage` non-nil (manager.go:39); `backupStorage` always `LocalBackend` (manager.go:53, sole assignment) |
| **Backup + `TMPDIR` unset/small in container (NON-DEFAULT)** | **Yes** | **Was the bug: `os.CreateTemp` failed → silent skip → empty backup reported success. Now fatal.** |
| Backup + S3/Azure `dataStorage` | Yes | `size` only ever reaches `LocalBackend.WriteReader`, which ignores it (local.go:157-215 never references `size`) |
| Backup + `IncludeMetadata` (SQLite) | Yes — `backupSQLite` | Caller treats failure as non-fatal (backup.go:143-145) — unchanged behavior |

The `TMPDIR` row is the one this diff introduces and the one that broke — the same "new dependency at a non-default value" shape as #534.

## Test plan

- [x] `TestCopyDataFiles_TempFileFailureIsFatal` (new) — **verified it fails against the pre-fix behavior**: `expected fatal error when temp files cannot be created; got nil with 0/2 files copied`
- [x] `TestCopyDataFiles_AllFilesSkippedIsFatal` (new) — **verified it fails against the pre-fix behavior**: `expected error when every file is skipped, got nil (empty backup would report success)`
- [x] `TestIsSourceReadError` — asserts temp/stat/seek/write errors are all fatal; only tagged read errors skippable
- [x] `TestStreamBackupFile_SourceNotFound` — missing source still classifies as skippable (benign race preserved)
- [x] `TestCopyDataFiles_PartialSkipRecordsCount` — partial skip succeeds, `SkippedFiles` recorded
- [x] `TestCopyDataFiles_ProgressUsesActualBytes` — stale listing size (999) vs actual (50); progress records 50
- [x] `TestStreamBackupFile` — round-trip correctness + byte count; temp-dir assertion isolated via `t.Setenv("TMPDIR", t.TempDir())`
- [x] End-to-end through the real `CreateBackup`: healthy run → `completed`, 2 files, `skipped_files` absent. Broken `TMPDIR` → `status="failed"` with a precise error (previously `"completed"` with 0 files).
- [x] `go build ./cmd/... ./internal/...` clean
- [x] `go test ./internal/backup/...` — 14/14 pass
- [x] `go test -race ./internal/backup/...` clean
- [x] `go vet` + `gofmt -l` clean

## Follow-ups (deliberately not in this PR)

- `.part` files leak into backup storage on write failure — `LocalBackend.WriteReader` leaves them for resume (local.go:151-156), a semantic backup does not use.
- Partial-skip ratio threshold: an S3 outage skipping 40% of files still "succeeds". The all-skipped guard catches the total case; a ratio threshold is a policy decision worth deciding separately.