### PR TITLE
fix(auth): serialize last_used_at updates through a single writer (#325)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -57,6 +57,14 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### Auth `last_used_at` updates no longer outlive shutdown ([#325](https://github.com/Basekick-Labs/arc/issues/325))
+
+Every token verification that missed the auth cache spawned a fire-and-forget goroutine to run `UPDATE api_tokens SET last_used_at = ?`. Nothing tracked those goroutines, so `AuthManager.Close()` could close the database out from under one still in flight; it then failed with `sql: database is closed` and logged at **Error** level, making an otherwise clean shutdown look like a failure. The update itself was also lost.
+
+The same pattern had a second cost independent of shutdown. The auth database runs with `SetMaxOpenConns(1)` — SQLite has a single writer — so a burst of verifications against distinct tokens could pile an unbounded number of goroutines onto that one connection, competing with the live authentication queries sharing it.
+
+Both are now handled by a single writer goroutine fed by a bounded queue. Verification hands off the update and returns immediately, so the authentication hot path never blocks; at most one `UPDATE` is ever in flight; and `Close()` drains the queue before closing the database, so pending updates are persisted rather than lost. If the queue is full the update is dropped (logged at debug) rather than blocking a request — `last_used_at` is a coarse "when was this token last seen" statistic, and under a burst large enough to fill the queue the dropped updates carry essentially the same timestamp as the queued ones.
+
 ### Compaction batch splitting no longer produces aliased file slices ([#292](https://github.com/Basekick-Labs/arc/issues/292))
 
 `SplitCandidateIntoBatches` partitioned a candidate's file list into batches using `c.Files[start:end]` sub-slices, which share the original's backing array — so every batch pointed into the same underlying memory. The same pattern existed in `compactFilesAdaptively`, which split a failed batch in half with `files[:mid]` / `files[mid:]`.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -78,6 +78,23 @@ type cacheEntry struct {
 	expiresAt time.Time
 }
 
+// lastUsedUpdate is a pending "this token was used at this time" record,
+// applied asynchronously by lastUsedLoop.
+type lastUsedUpdate struct {
+	tokenID int64
+	at      time.Time
+}
+
+// lastUsedBufferSize bounds the number of pending last_used_at updates.
+//
+// Updates are only produced on a cache miss (a cache hit returns before the
+// send), so in steady state this queue is nearly empty. The buffer absorbs a
+// burst of distinct tokens; past that, sends are dropped rather than blocking
+// the authentication hot path. Dropping is safe: last_used_at is a coarse
+// observability stat, and under a burst the surviving updates carry
+// approximately the same information.
+const lastUsedBufferSize = 256
+
 // AuthManager handles API token authentication with SQLite storage
 type AuthManager struct {
 	db           *sql.DB
@@ -92,7 +109,21 @@ type AuthManager struct {
 	cacheEvictions atomic.Int64
 
 	cleanupDone chan struct{}
-	logger      zerolog.Logger
+
+	// lastUsedCh carries token IDs whose last_used_at needs updating. A single
+	// writer goroutine (lastUsedLoop) drains it, so the number of concurrent
+	// UPDATEs is bounded at one regardless of request volume — important
+	// because the auth DB is limited to a single connection (SetMaxOpenConns(1),
+	// SQLite has one writer). Sends never block: a full channel drops the
+	// update, which is acceptable for a best-effort "when was this token last
+	// seen" statistic.
+	lastUsedCh chan lastUsedUpdate
+	// lastUsedWG tracks lastUsedLoop so Close can wait for the final drain
+	// before closing the database, rather than letting an in-flight UPDATE
+	// race db.Close() and log a spurious "sql: database is closed" error.
+	lastUsedWG sync.WaitGroup
+
+	logger zerolog.Logger
 
 	// proposer is the Raft seam for cluster-wide auth state replication.
 	// When non-nil (Enterprise cluster mode), every write method routes
@@ -177,6 +208,7 @@ func NewAuthManager(dbPath string, cacheTTL time.Duration, maxCacheSize int, log
 		maxCacheSize: maxCacheSize,
 		cache:        make(map[string]cacheEntry),
 		cleanupDone:  make(chan struct{}),
+		lastUsedCh:   make(chan lastUsedUpdate, lastUsedBufferSize),
 		logger:       logger.With().Str("component", "auth").Logger(),
 	}
 
@@ -225,6 +257,10 @@ func NewAuthManager(dbPath string, cacheTTL time.Duration, maxCacheSize int, log
 
 	// Start background cleanup
 	go am.cleanupLoop()
+
+	// Start the single last_used_at writer
+	am.lastUsedWG.Add(1)
+	go am.lastUsedLoop()
 
 	am.logger.Debug().
 		Str("db_path", dbPath).
@@ -434,6 +470,70 @@ func (am *AuthManager) cleanupLoop() {
 		case <-am.cleanupDone:
 			return
 		}
+	}
+}
+
+// recordLastUsed queues a last_used_at update for the given token.
+//
+// This runs on the authentication hot path, so it must never block: if the
+// buffer is full the update is dropped. last_used_at is a best-effort stat,
+// and a burst large enough to fill the buffer is one where the dropped
+// updates would have carried nearly the same timestamp as the queued ones.
+func (am *AuthManager) recordLastUsed(tokenID int64, at time.Time) {
+	select {
+	case am.lastUsedCh <- lastUsedUpdate{tokenID: tokenID, at: at}:
+	default:
+		// Queue full — drop. Debug rather than Warn: under sustained load this
+		// would otherwise emit one line per authentication.
+		am.logger.Debug().
+			Int64("token_id", tokenID).
+			Msg("last_used_at update queue full, dropping update")
+	}
+}
+
+// lastUsedLoop is the single writer applying last_used_at updates.
+//
+// Serializing through one goroutine bounds concurrent UPDATEs at one, which
+// matters because the auth DB runs with SetMaxOpenConns(1) — the previous
+// fire-and-forget goroutine-per-verification could pile an unbounded number of
+// writers onto that single connection, competing with live authentication
+// queries.
+//
+// On shutdown it drains whatever is already queued before returning, so Close
+// can wait for it and no UPDATE races db.Close().
+func (am *AuthManager) lastUsedLoop() {
+	defer am.lastUsedWG.Done()
+
+	for {
+		select {
+		case u := <-am.lastUsedCh:
+			am.applyLastUsed(u)
+		case <-am.cleanupDone:
+			// Drain what is already queued, then stop. Only updates already in
+			// the buffer are applied — VerifyToken may still be sending
+			// concurrently, and those are dropped rather than waited on, since
+			// the database is about to close.
+			for {
+				select {
+				case u := <-am.lastUsedCh:
+					am.applyLastUsed(u)
+				default:
+					return
+				}
+			}
+		}
+	}
+}
+
+// applyLastUsed performs the UPDATE for a single queued record.
+func (am *AuthManager) applyLastUsed(u lastUsedUpdate) {
+	if _, err := am.db.Exec(
+		"UPDATE api_tokens SET last_used_at = ? WHERE id = ?", u.at, u.tokenID,
+	); err != nil {
+		am.logger.Error().
+			Err(err).
+			Int64("token_id", u.tokenID).
+			Msg("Failed to update last_used_at")
 	}
 }
 
@@ -777,13 +877,10 @@ func (am *AuthManager) VerifyToken(token string) *TokenInfo {
 			return nil
 		}
 
-		// Update last used timestamp (fire and forget)
-		go func(tokenID int64) {
-			_, err := am.db.Exec("UPDATE api_tokens SET last_used_at = ? WHERE id = ?", now, tokenID)
-			if err != nil {
-				am.logger.Error().Err(err).Int64("token_id", tokenID).Msg("Failed to update last_used_at")
-			}
-		}(id)
+		// Hand the last_used_at update to the single writer goroutine. Never
+		// blocks the authentication path: if the queue is full the update is
+		// dropped (see lastUsedBufferSize).
+		am.recordLastUsed(id, now)
 
 		// Build token info
 		info := &TokenInfo{
@@ -1400,9 +1497,15 @@ func (am *AuthManager) GetCacheStats() map[string]interface{} {
 	}
 }
 
-// Close shuts down the auth manager
+// Close shuts down the auth manager.
+//
+// It waits for the last_used_at writer to drain before closing the database.
+// Without that wait an in-flight UPDATE races db.Close() and fails with
+// "sql: database is closed", logging a spurious error on every shutdown that
+// happened to catch a cache miss in flight (#325).
 func (am *AuthManager) Close() error {
 	close(am.cleanupDone)
+	am.lastUsedWG.Wait()
 	return am.db.Close()
 }
 

--- a/internal/auth/last_used_test.go
+++ b/internal/auth/last_used_test.go
@@ -1,0 +1,215 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// syncBuffer is a concurrency-safe io.Writer for capturing log output while
+// background goroutines are still running.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// setupLoggingAuthManager builds an AuthManager whose logs are captured, so a
+// test can assert on what shutdown did (or did not) emit.
+func setupLoggingAuthManager(t *testing.T) (*AuthManager, *syncBuffer) {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "arc-auth-lastused-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	logs := &syncBuffer{}
+	logger := zerolog.New(logs).Level(zerolog.DebugLevel)
+
+	am, err := NewAuthManager(filepath.Join(tmpDir, "auth.db"), 5*time.Minute, 100, logger)
+	if err != nil {
+		t.Fatalf("failed to create AuthManager: %v", err)
+	}
+	return am, logs
+}
+
+// Regression guard for #325: the last_used_at update must not outlive Close().
+//
+// Previously VerifyToken spawned a fire-and-forget goroutine running
+// db.Exec(UPDATE ...). A Close() that landed between the spawn and the Exec
+// closed the database out from under it, and the goroutine logged
+// "sql: database is closed" at Error level on an otherwise clean shutdown.
+func TestLastUsed_NoErrorLoggedWhenClosedImmediatelyAfterVerify(t *testing.T) {
+	// Repeat: the original race was timing-dependent, so a single iteration
+	// proves little. Kept small because each iteration pays PBKDF2 token
+	// creation — the pre-fix code fails on the first iteration in practice.
+	iterations := 10
+	if testing.Short() {
+		iterations = 2
+	}
+	for i := 0; i < iterations; i++ {
+		am, logs := setupLoggingAuthManager(t)
+
+		token, err := am.CreateToken(context.Background(), "tok", "", "admin", nil)
+		if err != nil {
+			t.Fatalf("failed to create token: %v", err)
+		}
+
+		// Force a cache miss so the last_used_at path actually runs: a cache
+		// hit returns before the update is ever queued.
+		am.InvalidateCache()
+		if info := am.VerifyToken(token); info == nil {
+			t.Fatal("expected token to verify")
+		}
+
+		// Close immediately — this is the race window.
+		if err := am.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+
+		if out := logs.String(); strings.Contains(out, "database is closed") {
+			t.Fatalf("iteration %d: shutdown logged a closed-database error:\n%s", i, out)
+		}
+	}
+}
+
+// The update must actually be applied, not merely not-crash: a fix that
+// silently dropped every update would pass the race test above.
+func TestLastUsed_IsPersistedAfterClose(t *testing.T) {
+	am, _ := setupLoggingAuthManager(t)
+
+	token, err := am.CreateToken(context.Background(), "tok", "", "admin", nil)
+	if err != nil {
+		t.Fatalf("failed to create token: %v", err)
+	}
+
+	// A freshly created token has never been used.
+	tokens, err := am.ListTokens()
+	if err != nil {
+		t.Fatalf("ListTokens failed: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(tokens))
+	}
+	if tokens[0].LastUsedAt != nil {
+		t.Fatalf("expected LastUsedAt to be unset before use, got %v", tokens[0].LastUsedAt)
+	}
+
+	am.InvalidateCache()
+	if info := am.VerifyToken(token); info == nil {
+		t.Fatal("expected token to verify")
+	}
+
+	// Close drains the queue, so the update must be durable afterwards.
+	if err := am.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	reopened, err := NewAuthManager(am.dbPath, 5*time.Minute, 100, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("failed to reopen AuthManager: %v", err)
+	}
+	defer reopened.Close()
+
+	tokens, err = reopened.ListTokens()
+	if err != nil {
+		t.Fatalf("ListTokens after reopen failed: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token after reopen, got %d", len(tokens))
+	}
+	if tokens[0].LastUsedAt == nil {
+		t.Fatal("last_used_at was not persisted — the queued update was dropped on shutdown")
+	}
+}
+
+// A full queue must never block the authentication hot path.
+func TestRecordLastUsed_DoesNotBlockWhenQueueFull(t *testing.T) {
+	am := &AuthManager{
+		lastUsedCh: make(chan lastUsedUpdate, 2),
+		logger:     zerolog.Nop(),
+	}
+
+	// Fill the buffer, then overshoot it substantially. No reader is draining,
+	// so any blocking send would deadlock this test.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 1000; i++ {
+			am.recordLastUsed(int64(i), time.Now())
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recordLastUsed blocked when the queue was full")
+	}
+
+	if got := len(am.lastUsedCh); got != 2 {
+		t.Errorf("expected queue to stay at capacity 2, got %d", got)
+	}
+}
+
+// Close must be safe when updates are still being produced concurrently.
+func TestLastUsed_ConcurrentVerifyDuringClose(t *testing.T) {
+	am, logs := setupLoggingAuthManager(t)
+
+	token, err := am.CreateToken(context.Background(), "tok", "", "admin", nil)
+	if err != nil {
+		t.Fatalf("failed to create token: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					am.InvalidateCache()
+					am.VerifyToken(token)
+				}
+			}
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	closeErr := am.Close()
+	close(stop)
+	wg.Wait()
+
+	if closeErr != nil {
+		t.Fatalf("Close failed: %v", closeErr)
+	}
+	// Verifications racing Close may legitimately fail (the DB is closing), but
+	// the drain itself must not report a closed database.
+	if out := logs.String(); strings.Contains(out, "Failed to update last_used_at") &&
+		strings.Contains(out, "database is closed") {
+		t.Errorf("last_used_at writer ran against a closed database:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #325.

## Summary

Every token verification that missed the auth cache spawned a fire-and-forget goroutine running `UPDATE api_tokens SET last_used_at`. Nothing tracked those goroutines, so `AuthManager.Close()` could close the database out from under one still in flight — it then failed with `sql: database is closed`, logged at **Error** level, and the update was lost.

## Severity, verified rather than assumed

The issue's diagnosis is correct; the failure mode is narrower than "goroutine fires after Close" suggests, and worth stating precisely.

I checked what `database/sql` actually does with a fake driver rather than reasoning about it:

```
post-close err  = sql: database is closed
== ErrConnDone  = false
Is ErrConnDone  = false
```

`DB.Exec` after `Close()` is a **mutex-synchronized error return** — not a panic, not a data race (both sides take `db.mu`). So the user-visible symptom is a spurious `Error`-level log line on shutdown plus a lost timestamp. Three things bound it further:

- The goroutine fires **only on a cache miss** — a cache hit returns before the update is queued (auth.go:745-750). Not a per-request cost in steady state.
- The HTTP drain hook completes before any component `Close()` (shutdown.go:143-200; `PriorityHTTPServer`=10 vs `PriorityAuth`=70).
- Double-close is impossible: `shutdownOnce.Do` guards `Shutdown()`, and auth registers once (main.go:942).

## Why not just a WaitGroup

The issue suggests a `WaitGroup`. That fixes the shutdown race and leaves a second problem untouched.

The auth database runs with **`SetMaxOpenConns(1)`** (auth.go:153) — SQLite has one writer. A burst of verifications against distinct tokens could pile an *unbounded* number of goroutines onto that single connection, competing with the live authentication queries sharing it. A `WaitGroup` bounds nothing; it only makes shutdown wait for however many accumulated.

A single writer goroutine fed by a bounded channel fixes both:

- `VerifyToken` hands off via a **non-blocking send** — the authentication hot path never blocks. A full queue drops the update and logs at debug: `last_used_at` is a coarse "when was this token last seen" stat, and a burst large enough to fill a 256-slot queue is one where dropped updates carry essentially the same timestamp as queued ones.
- **At most one `UPDATE` in flight** against the single connection.
- `Close()` **drains the queue** before closing the database, so pending updates are persisted rather than lost.

Also worth noting: `cleanupDone` reads like it governs shutdown broadly, but it only covered the cache janitor (auth.go:430-437), which never touches the DB. That naming is part of why this gap existed.

## Configuration matrix

Confined to `internal/auth`. No new config keys, no new pointer dereferences.

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS, `auth.enabled = false` | No — `AuthManager` never constructed (main.go:942 is inside `if cfg.Auth.Enabled`) | n/a |
| OSS, auth enabled, cache hit | No — returns at auth.go:750 before the send | n/a |
| **OSS, auth enabled, cache miss** | **Yes** — `recordLastUsed` | `lastUsedCh` created in the constructor before `lastUsedLoop` starts; constructor error paths call `db.Close()` directly and return nil, never `am.Close()`, so a partially-built manager is never closed |
| Shutdown with an update in flight | Yes — `Close()` drain | `lastUsedWG.Add(1)` precedes `go lastUsedLoop()`; `Wait()` returns immediately if the loop already exited |
| Cluster mode (Raft proposer set) | Unchanged | `last_used_at` was never proposed through Raft — it stays a node-local stat |

## Test plan

- [x] `TestLastUsed_NoErrorLoggedWhenClosedImmediatelyAfterVerify` (new) — **verified it fails against the pre-fix code**, reproducing the exact issue symptom: `{"level":"error",...,"error":"sql: database is closed","message":"Failed to update last_used_at"}`
- [x] `TestLastUsed_IsPersistedAfterClose` (new) — guards the opposite failure: a "fix" that silently dropped every update would pass the race test. Asserts the timestamp survives `Close()` and a reopen.
- [x] `TestRecordLastUsed_DoesNotBlockWhenQueueFull` — 1000 sends into a 2-slot queue with no reader; would deadlock if the send ever blocked
- [x] `TestLastUsed_ConcurrentVerifyDuringClose` — 4 goroutines verifying while `Close()` runs
- [x] `go test -race ./internal/auth/ -run 'TestLastUsed|TestRecordLastUsed'` — all 4 pass, no races
- [x] Full `go test ./internal/auth/` passes; build / vet / gofmt clean

**Binary run** (per CLAUDE.md, since this touches shutdown wiring):
- Started `arc` with `auth.enabled = true`, drove 8 authenticated requests → `200` each, `last_used_at` written
- Fired a verification and **immediately** `SIGTERM`ed — the #325 race window → `Graceful shutdown complete`, **zero** `database is closed` lines in the whole log
- Restarted and confirmed `last_used_at` survived the drain

Note on `-race` for the full package: `TestRequirePermission` / `TestGetTokenInfo` fail with `test: timeout error 1000ms`. I confirmed this reproduces on **clean main with my changes stashed** — it is the known pre-existing PBKDF2-under-race flake against Fiber's 1s `app.Test` timeout, not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)