### PR TITLE
fix(startup): share the auth SQLite handle with MQTT, audit and tiering (#329)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -57,6 +57,16 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### MQTT, audit and tiering share the auth manager's SQLite handle ([#329](https://github.com/Basekick-Labs/arc/issues/329))
+
+Arc keeps auth, audit, tiering and MQTT metadata in a single SQLite file (`auth.db_path`, default `./data/arc.db`). Each of those features opened its **own** connection to that file, so a default deployment ran several independent connection pools — each capped at one connection, since SQLite has a single writer — competing for the same write lock. MQTT, audit and tiering now borrow the auth manager's existing handle instead.
+
+Two of those handles were also **leaked**: nothing closed the audit or tiering connections on shutdown. When these features now open their own handle (see below) it is closed on every path, including the failure paths that previously returned early.
+
+MQTT initialization moved after auth initialization in startup so the handle exists to be borrowed. MQTT's repository tracks whether it owns its handle and closes it only if so — MQTT shuts down at ingest priority, well before the auth manager closes the shared handle, so closing a borrowed connection there would have taken the database out from under every component still shutting down.
+
+**Auth-disabled deployments are unaffected in behavior:** MQTT, audit and tiering are each enabled independently of auth, so when auth is off they open and own a handle exactly as before. That path is now hardened to match what the auth manager does: the parent directory is created, and the database file is pre-created with owner-only (0600) permissions rather than being left at the process umask (typically 0644, world-readable). The file holds audit logs, tiering metadata and encrypted MQTT broker credentials. Previously, an MQTT-enabled deployment with auth disabled and no existing data directory **failed to start**.
+
 ### Compaction subprocesses no longer drop the S3 prefix ([#560](https://github.com/Basekick-Labs/arc/issues/560))
 
 Compaction runs in a forked subprocess for DuckDB memory isolation, and the child rebuilds its storage backend from the parent's `Type()` and `ConfigJSON()`. `S3Backend.ConfigJSON()` emitted `prefix`, but the subprocess's parse struct had no matching field, so `json.Unmarshal` silently discarded it and the rebuilt backend was left with an empty prefix.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -872,51 +872,10 @@ func main() {
 			Msg("Periodic WAL maintenance enabled")
 	}
 
-	// Initialize MQTT Subscription Manager (if enabled)
+	// MQTT is initialized after the auth manager (below) so it can share the
+	// auth manager's SQLite handle rather than opening a second connection to
+	// the same file (#329).
 	var mqttManager mqtt.Manager
-	if cfg.MQTT.Enabled {
-		// Get encryption key from environment (required for subscriptions with passwords)
-		encryptionKey, keyErr := mqtt.GetEncryptionKey()
-		if keyErr != nil {
-			log.Fatal().Err(keyErr).Msg("Invalid ARC_ENCRYPTION_KEY - must be 32 bytes (base64 or hex encoded)")
-		}
-		if encryptionKey == nil {
-			log.Warn().Msg("ARC_ENCRYPTION_KEY not set - MQTT subscriptions with passwords will be rejected")
-		}
-
-		// Create password encryptor (will be NilEncryptor if no key - rejects passwords)
-		encryptor, err := mqtt.NewPasswordEncryptor(encryptionKey)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to create password encryptor")
-		}
-
-		// Create SQLite repository for MQTT subscriptions (use shared DB path from auth config)
-		mqttDBPath := cfg.Auth.DBPath
-		if mqttDBPath == "" {
-			mqttDBPath = "./data/arc.db" // Use shared SQLite database
-		}
-		mqttRepo, err := mqtt.NewSQLiteRepository(mqttDBPath, encryptionKey, logger.Get("mqtt-repo"))
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to initialize MQTT repository")
-		}
-
-		// Create subscription manager
-		mqttManager = mqtt.NewSubscriptionManager(mqttRepo, encryptor, arrowBuffer, logger.Get("mqtt"))
-
-		// Start manager (loads and starts auto_start subscriptions)
-		if err := mqttManager.Start(context.Background()); err != nil {
-			log.Warn().Err(err).Msg("Some MQTT subscriptions failed to auto-start")
-		}
-
-		// Register shutdown hook
-		shutdownCoordinator.RegisterHook("mqtt-manager", func(ctx context.Context) error {
-			return mqttManager.Shutdown(ctx)
-		}, shutdown.PriorityIngest)
-
-		log.Info().Bool("encryption_enabled", encryptionKey != nil).Msg("MQTT subscription manager enabled")
-	} else {
-		log.Debug().Msg("MQTT subscription manager is disabled")
-	}
 
 	// Initialize AuthManager (if enabled)
 	var authManager *auth.AuthManager
@@ -1033,6 +992,67 @@ func main() {
 			Msg("Authentication enabled")
 	} else {
 		log.Warn().Msg("Authentication is DISABLED - all endpoints are public")
+	}
+
+	// Initialize MQTT Subscription Manager (if enabled).
+	//
+	// Placed after the auth manager so it can borrow that SQLite handle. MQTT
+	// metadata lives in the same file as auth (cfg.Auth.DBPath); opening a
+	// second pool against it put two independent single-connection writers in
+	// contention for one write lock (#329).
+	if cfg.MQTT.Enabled {
+		// Get encryption key from environment (required for subscriptions with passwords)
+		encryptionKey, keyErr := mqtt.GetEncryptionKey()
+		if keyErr != nil {
+			log.Fatal().Err(keyErr).Msg("Invalid ARC_ENCRYPTION_KEY - must be 32 bytes (base64 or hex encoded)")
+		}
+		if encryptionKey == nil {
+			log.Warn().Msg("ARC_ENCRYPTION_KEY not set - MQTT subscriptions with passwords will be rejected")
+		}
+
+		// Create password encryptor (will be NilEncryptor if no key - rejects passwords)
+		encryptor, err := mqtt.NewPasswordEncryptor(encryptionKey)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create password encryptor")
+		}
+
+		// Borrow the auth manager's handle when there is one. MQTT and auth are
+		// enabled independently, so authManager may be nil here; in that case
+		// the repository opens and owns its own handle, as it always did.
+		mqttDBPath := cfg.Auth.DBPath
+		if mqttDBPath == "" {
+			mqttDBPath = "./data/arc.db" // Shared SQLite database
+		}
+
+		var mqttRepo *mqtt.Repository
+		if authManager != nil {
+			mqttRepo, err = mqtt.NewRepository(authManager.GetDB(), encryptionKey, logger.Get("mqtt-repo"))
+		} else {
+			mqttRepo, err = mqtt.NewSQLiteRepository(mqttDBPath, encryptionKey, logger.Get("mqtt-repo"))
+		}
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to initialize MQTT repository")
+		}
+
+		// Create subscription manager
+		mqttManager = mqtt.NewSubscriptionManager(mqttRepo, encryptor, arrowBuffer, logger.Get("mqtt"))
+
+		// Start manager (loads and starts auto_start subscriptions)
+		if err := mqttManager.Start(context.Background()); err != nil {
+			log.Warn().Err(err).Msg("Some MQTT subscriptions failed to auto-start")
+		}
+
+		// Register shutdown hook
+		shutdownCoordinator.RegisterHook("mqtt-manager", func(ctx context.Context) error {
+			return mqttManager.Shutdown(ctx)
+		}, shutdown.PriorityIngest)
+
+		log.Info().
+			Bool("encryption_enabled", encryptionKey != nil).
+			Bool("shared_db", authManager != nil).
+			Msg("MQTT subscription manager enabled")
+	} else {
+		log.Debug().Msg("MQTT subscription manager is disabled")
 	}
 
 	// Initialize Compaction (if enabled)
@@ -1855,7 +1875,11 @@ func main() {
 		} else if !licenseClient.CanUseAuditLogging() {
 			log.Warn().Msg("License does not include audit_logging feature - feature disabled")
 		} else {
-			auditDB, err := sql.Open("sqlite3", cfg.Auth.DBPath)
+			// Share the auth manager's SQLite handle when there is one. Audit
+			// and auth are enabled independently (this block is gated on the
+			// license, not on cfg.Auth.Enabled), so authManager may be nil —
+			// sharedSQLiteHandle falls back to a dedicated handle we own.
+			auditDB, auditOwnsDB, err := sharedSQLiteHandle(authManager, cfg.Auth.DBPath)
 			if err != nil {
 				log.Error().Err(err).Msg("Failed to open audit database - feature disabled")
 			} else {
@@ -1866,10 +1890,18 @@ func main() {
 				})
 				if err != nil {
 					log.Error().Err(err).Msg("Failed to create audit logger - feature disabled")
+					if auditOwnsDB {
+						auditDB.Close()
+					}
 				} else {
 					auditLogger.Start()
 					shutdownCoordinator.RegisterHook("audit", func(ctx context.Context) error {
 						auditLogger.Stop()
+						// audit.Logger never closes its DB — it may be borrowed.
+						// Close it here only when this block opened it.
+						if auditOwnsDB {
+							return auditDB.Close()
+						}
 						return nil
 					}, shutdown.PriorityCompaction)
 
@@ -2463,8 +2495,12 @@ func main() {
 			log.Warn().Msg("License does not include tiered_storage feature - feature disabled")
 		} else {
 			// Open SQLite database for tiering metadata (shared with other features)
-			tieringDBPath := cfg.Auth.DBPath // Use shared SQLite database
-			tieringDB, err := sql.Open("sqlite3", tieringDBPath)
+			// Share the auth manager's SQLite handle when there is one. Tiering
+			// and auth are enabled independently (this block is gated on the
+			// license, not on cfg.Auth.Enabled), so authManager may be nil —
+			// sharedSQLiteHandle falls back to a dedicated handle we own.
+			tieringDBPath := cfg.Auth.DBPath // Shared SQLite database
+			tieringDB, tieringOwnsDB, err := sharedSQLiteHandle(authManager, tieringDBPath)
 			if err != nil {
 				log.Error().Err(err).Msg("Failed to open tiering database - feature disabled")
 			} else {
@@ -2518,13 +2554,28 @@ func main() {
 				})
 				if err != nil {
 					log.Error().Err(err).Msg("Failed to create tiering manager - feature disabled")
+					if tieringOwnsDB {
+						tieringDB.Close()
+					}
 				} else {
 					// Start tiering manager
 					if err := tieringManager.Start(); err != nil {
 						log.Error().Err(err).Msg("Failed to start tiering manager")
+						if tieringOwnsDB {
+							tieringDB.Close()
+						}
 					} else {
 						shutdownCoordinator.RegisterHook("tiering", func(ctx context.Context) error {
-							return tieringManager.Stop()
+							stopErr := tieringManager.Stop()
+							// tiering.Manager never closes its DB — it may be
+							// borrowed. Close it here only when this block
+							// opened it.
+							if tieringOwnsDB {
+								if closeErr := tieringDB.Close(); closeErr != nil && stopErr == nil {
+									stopErr = closeErr
+								}
+							}
+							return stopErr
 						}, shutdown.PriorityCompaction)
 
 						log.Info().
@@ -2719,6 +2770,63 @@ func main() {
 	}
 
 	log.Info().Msg("Arc shutdown complete")
+}
+
+// sharedSQLiteHandle returns the SQLite handle a feature should use for the
+// shared metadata database, preferring the auth manager's existing connection.
+//
+// Arc keeps auth, audit, tiering and MQTT metadata in one SQLite file
+// (cfg.Auth.DBPath). Each additional sql.Open on that file is a separate
+// connection pool competing for SQLite's single write lock, so features borrow
+// the auth manager's handle whenever there is one.
+//
+// authManager may legitimately be nil: auth, audit, tiering and MQTT are each
+// enabled independently, so a feature can be on while auth is off. In that case
+// the caller gets its own handle and owns it — the returned bool reports
+// ownership, and only an owner may Close.
+func sharedSQLiteHandle(authManager *auth.AuthManager, dbPath string) (db *sql.DB, owned bool, err error) {
+	if authManager != nil {
+		return authManager.GetDB(), false, nil
+	}
+
+	// No auth manager to borrow from, so open a dedicated handle. Everything
+	// below mirrors auth.NewAuthManager's setup: with auth disabled nothing
+	// else performs it, and this file holds audit logs and tiering metadata.
+
+	// Create the parent directory. sql.Open is lazy — it validates the DSN but
+	// does not touch the filesystem — so a missing directory would otherwise
+	// surface much later as a confusing "feature disabled" warning from the
+	// caller's first query rather than an error here.
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0700); err != nil {
+		return nil, false, fmt.Errorf("failed to create database directory: %w", err)
+	}
+
+	// Pre-create the file 0600. SQLite creates it with the process umask
+	// (typically 0644, world-readable) on first write, and the Chmod that
+	// normally tightens it lives inside the auth-enabled branch — which by
+	// definition has not run here.
+	f, err := os.OpenFile(dbPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create database file: %w", err)
+	}
+	f.Close()
+
+	db, err = sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Fail here rather than leaving a broken handle for the caller to discover
+	// on its first query, where the error reads as "feature disabled".
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, false, fmt.Errorf("failed to open database %s: %w", dbPath, err)
+	}
+
+	db.SetMaxOpenConns(1) // SQLite has a single writer
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(time.Hour)
+	return db, true, nil
 }
 
 // createWALRecoveryCallback creates a reusable WAL recovery callback function.

--- a/cmd/arc/shared_sqlite_test.go
+++ b/cmd/arc/shared_sqlite_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// With auth disabled there is no handle to borrow, so sharedSQLiteHandle opens
+// one itself. Nothing else in that configuration creates the parent directory
+// or tightens the file mode, so this helper has to do both — auth.NewAuthManager
+// does exactly this, and it is the code path that does not run here.
+func TestSharedSQLiteHandle_CreatesParentDirectory(t *testing.T) {
+	// Nested path that does not exist yet — a fresh install.
+	dbPath := filepath.Join(t.TempDir(), "nested", "data", "arc.db")
+
+	db, owned, err := sharedSQLiteHandle(nil, dbPath)
+	if err != nil {
+		t.Fatalf("sharedSQLiteHandle: %v", err)
+	}
+	defer db.Close()
+
+	if !owned {
+		t.Error("handle opened without an auth manager must be owned by the caller")
+	}
+
+	// sql.Open is lazy: it validates the DSN without touching the filesystem,
+	// so a missing directory only surfaces on first use. Verify the handle is
+	// actually usable rather than merely constructed.
+	if err := db.Ping(); err != nil {
+		t.Fatalf("handle is not usable: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("cannot write to the database: %v", err)
+	}
+}
+
+// The shared file holds audit logs and tiering metadata. SQLite creates it with
+// the process umask (typically 0644) on first write, and the chmod that would
+// normally tighten it lives inside the auth-enabled branch.
+func TestSharedSQLiteHandle_FileIsNotWorldReadable(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "arc.db")
+
+	db, _, err := sharedSQLiteHandle(nil, dbPath)
+	if err != nil {
+		t.Fatalf("sharedSQLiteHandle: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		t.Errorf("database file mode = %v, want owner-only (0600); it holds audit logs", mode)
+	}
+}
+
+// A path that cannot be opened must fail here, not leave a broken handle for
+// the caller to discover on its first query — where the error reads as
+// "feature disabled" rather than a startup failure.
+func TestSharedSQLiteHandle_ReportsUnusablePath(t *testing.T) {
+	// A directory where a file is expected: MkdirAll succeeds, the open fails.
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+	if err := os.MkdirAll(dbPath, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	db, _, err := sharedSQLiteHandle(nil, dbPath)
+	if err == nil {
+		if db != nil {
+			db.Close()
+		}
+		t.Fatal("expected an error for a path that cannot be opened as a database")
+	}
+}

--- a/internal/mqtt/manager_test.go
+++ b/internal/mqtt/manager_test.go
@@ -17,9 +17,9 @@ func TestSubscriptionManager_GetAllStats_NilSubscriber(t *testing.T) {
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "mqtt.db")
 
-	repo, err := NewRepository(dbPath, nil, zerolog.Nop())
+	repo, err := NewSQLiteRepository(dbPath, nil, zerolog.Nop())
 	if err != nil {
-		t.Fatalf("NewRepository: %v", err)
+		t.Fatalf("NewSQLiteRepository: %v", err)
 	}
 	t.Cleanup(func() { _ = repo.Close() })
 
@@ -72,9 +72,9 @@ func TestSubscriptionManager_GetAllStats_NilSubscriber(t *testing.T) {
 func newTestManager(t *testing.T) *SubscriptionManager {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "mqtt.db")
-	repo, err := NewRepository(dbPath, nil, zerolog.Nop())
+	repo, err := NewSQLiteRepository(dbPath, nil, zerolog.Nop())
 	if err != nil {
-		t.Fatalf("NewRepository: %v", err)
+		t.Fatalf("NewSQLiteRepository: %v", err)
 	}
 	t.Cleanup(func() { _ = repo.Close() })
 	encryptor, err := NewPasswordEncryptor(nil)

--- a/internal/mqtt/repository.go
+++ b/internal/mqtt/repository.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -19,42 +21,107 @@ type Repository struct {
 	db        *sql.DB
 	encryptor PasswordEncryptor
 	logger    zerolog.Logger
+
+	// ownsDB records whether this Repository opened db itself and is therefore
+	// responsible for closing it. When the handle is borrowed (the normal case
+	// — Arc shares one SQLite file across auth, audit, tiering and MQTT), Close
+	// must leave it alone: MQTT shuts down at PriorityIngest(20) but auth owns
+	// the handle until PriorityAuth(70), so closing a borrowed DB here would
+	// pull it out from under every other component still shutting down.
+	ownsDB bool
 }
 
-// NewRepository creates a new MQTT subscription repository
-func NewRepository(dbPath string, encryptor PasswordEncryptor, logger zerolog.Logger) (*Repository, error) {
-	return NewSQLiteRepository(dbPath, nil, logger)
-}
-
-// NewSQLiteRepository creates a new MQTT subscription repository with optional encryption key
-func NewSQLiteRepository(dbPath string, encryptionKey []byte, logger zerolog.Logger) (*Repository, error) {
+// NewRepository creates a subscription repository over an existing database
+// handle. The caller retains ownership of db: Close will not close it.
+//
+// db must be non-nil. Use OpenDB when there is no shared handle to borrow.
+func NewRepository(db *sql.DB, encryptionKey []byte, logger zerolog.Logger) (*Repository, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database handle is required")
+	}
 	encryptor, err := NewPasswordEncryptor(encryptionKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create encryptor: %w", err)
 	}
-	return newRepository(dbPath, encryptor, logger)
+	return newRepository(db, encryptor, false, logger)
 }
 
-// newRepository is the internal constructor
-func newRepository(dbPath string, encryptor PasswordEncryptor, logger zerolog.Logger) (*Repository, error) {
+// OpenDB opens a SQLite handle suitable for a Repository.
+//
+// It exists for deployments that run MQTT without auth, where there is no
+// shared handle to borrow.
+//
+// The DSN sets WAL and a busy timeout but, unlike the auth manager's, omits
+// _foreign_keys=ON. No MQTT table declares a foreign key and none references
+// mqtt_subscriptions, so the two handles behave identically today — but a
+// borrowed handle does run MQTT statements with foreign keys enabled. Any
+// future FK on an MQTT table must be checked against both settings.
+func OpenDB(dbPath string) (*sql.DB, error) {
+	// Create the parent directory. sql.Open is lazy — it validates the DSN but
+	// never touches the filesystem — so on a fresh install a missing directory
+	// would otherwise surface as a schema-init failure at startup.
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0700); err != nil {
+		return nil, fmt.Errorf("failed to create database directory: %w", err)
+	}
+
+	// Pre-create the file 0600. SQLite would otherwise create it with the
+	// process umask (typically 0644, world-readable), and this file holds
+	// broker credentials in the encrypted-password column.
+	f, err := os.OpenFile(dbPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create database file: %w", err)
+	}
+	f.Close()
+
 	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
-	// Limit connections for SQLite
+	// SQLite has a single writer; keep the pool at one connection.
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 
+	return db, nil
+}
+
+// NewSQLiteRepository opens dbPath and returns a Repository that owns the
+// resulting handle — Close will close it.
+//
+// Prefer NewRepository with a shared handle. This exists for the standalone
+// case (MQTT enabled, auth disabled) and for tests.
+func NewSQLiteRepository(dbPath string, encryptionKey []byte, logger zerolog.Logger) (*Repository, error) {
+	encryptor, err := NewPasswordEncryptor(encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create encryptor: %w", err)
+	}
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := newRepository(db, encryptor, true, logger)
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	return repo, nil
+}
+
+// newRepository is the internal constructor. ownsDB records whether the caller
+// handed over ownership of db.
+func newRepository(db *sql.DB, encryptor PasswordEncryptor, ownsDB bool, logger zerolog.Logger) (*Repository, error) {
 	repo := &Repository{
 		db:        db,
 		encryptor: encryptor,
 		logger:    logger.With().Str("component", "mqtt-repository").Logger(),
+		ownsDB:    ownsDB,
 	}
 
-	// Initialize schema
+	// Initialize schema. Safe on a borrowed handle: every statement is
+	// CREATE ... IF NOT EXISTS, and mqtt_subscriptions is created nowhere else.
 	if err := repo.initSchema(); err != nil {
-		db.Close()
 		return nil, fmt.Errorf("failed to initialize schema: %w", err)
 	}
 
@@ -140,8 +207,16 @@ func (r *Repository) runMigrations() error {
 	return nil
 }
 
-// Close closes the database connection
+// Close releases the database handle if this Repository owns it.
+//
+// When the handle was borrowed (NewRepository), Close is a no-op: the owner
+// closes it at its own point in the shutdown sequence. Closing it here would
+// be actively harmful — MQTT shuts down at PriorityIngest(20), well before the
+// auth manager that owns the shared handle closes it at PriorityAuth(70).
 func (r *Repository) Close() error {
+	if !r.ownsDB {
+		return nil
+	}
 	return r.db.Close()
 }
 

--- a/internal/mqtt/repository_test.go
+++ b/internal/mqtt/repository_test.go
@@ -1,0 +1,192 @@
+package mqtt
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// A borrowed handle must survive Repository.Close.
+//
+// Arc keeps auth, audit, tiering and MQTT metadata in one SQLite file. MQTT
+// shuts down at PriorityIngest(20) while the auth manager owns the handle
+// until PriorityAuth(70), so closing a borrowed DB here would pull it out from
+// under every component still shutting down (#329).
+func TestRepository_BorrowedDBSurvivesClose(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "shared.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db.Close()
+
+	repo, err := NewRepository(db, nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRepository: %v", err)
+	}
+
+	if err := repo.Close(); err != nil {
+		t.Fatalf("Close on a borrowed handle should be a no-op, got: %v", err)
+	}
+
+	// The owner must still be able to use the handle.
+	if err := db.Ping(); err != nil {
+		t.Fatalf("borrowed DB was closed by Repository.Close: %v", err)
+	}
+	if _, err := db.Exec("SELECT 1"); err != nil {
+		t.Fatalf("borrowed DB unusable after Repository.Close: %v", err)
+	}
+}
+
+// The owned case must keep its previous behavior: Close really closes.
+func TestRepository_OwnedDBIsClosed(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "own.db")
+
+	repo, err := NewSQLiteRepository(dbPath, nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewSQLiteRepository: %v", err)
+	}
+
+	if err := repo.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := repo.db.Ping(); err == nil {
+		t.Fatal("owned DB should be closed after Repository.Close")
+	}
+}
+
+// A nil handle is a programming error and must be rejected rather than
+// deferred to a nil-pointer panic on first query.
+func TestNewRepository_RejectsNilDB(t *testing.T) {
+	if _, err := NewRepository(nil, nil, zerolog.Nop()); err == nil {
+		t.Fatal("expected an error for a nil database handle")
+	}
+}
+
+// Schema init must be safe on a handle that already has the MQTT schema —
+// the borrowed-handle case runs it against a database another component may
+// have already initialized, and a restart runs it again.
+func TestRepository_InitSchemaIsIdempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "shared.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db.Close()
+
+	for i := 0; i < 3; i++ {
+		repo, err := NewRepository(db, nil, zerolog.Nop())
+		if err != nil {
+			t.Fatalf("NewRepository (iteration %d): %v", i, err)
+		}
+		if err := repo.Close(); err != nil {
+			t.Fatalf("Close (iteration %d): %v", i, err)
+		}
+	}
+}
+
+// Sharing one handle between MQTT and another component must not deadlock or
+// error: this is the configuration the fix introduces, where two components
+// issue writes through the same single-connection pool.
+func TestRepository_SharesHandleWithAnotherWriter(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "shared.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db.Close()
+
+	// Stand in for another component (auth/audit/tiering) using the same handle.
+	if _, err := db.Exec(`CREATE TABLE other_component (id INTEGER PRIMARY KEY, v TEXT)`); err != nil {
+		t.Fatalf("create other table: %v", err)
+	}
+
+	repo, err := NewRepository(db, nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRepository: %v", err)
+	}
+	defer repo.Close()
+
+	// Interleave writes from both "components" through the shared pool.
+	for i := 0; i < 20; i++ {
+		if _, err := db.Exec("INSERT INTO other_component (v) VALUES (?)", "x"); err != nil {
+			t.Fatalf("other component write %d failed: %v", i, err)
+		}
+		if _, err := repo.db.Exec(
+			`INSERT OR REPLACE INTO mqtt_subscriptions
+			 (id, name, broker, client_id, topics, database, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+			"id", "n", "tcp://localhost:1883", "c", "[]", "db",
+		); err != nil {
+			t.Fatalf("mqtt write %d failed: %v", i, err)
+		}
+	}
+
+	var n int
+	if err := db.QueryRow("SELECT count(*) FROM other_component").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 20 {
+		t.Errorf("other component rows = %d, want 20", n)
+	}
+}
+
+// A fresh install has no data directory yet. sql.Open is lazy, so a missing
+// parent directory does not fail at open — it fails at schema init, which
+// main.go treats as fatal. This is the MQTT-enabled/auth-disabled path.
+func TestNewSQLiteRepository_CreatesParentDirectory(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "nested", "data", "arc.db")
+
+	repo, err := NewSQLiteRepository(dbPath, nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewSQLiteRepository on a fresh install: %v", err)
+	}
+	defer repo.Close()
+
+	if _, err := repo.db.Exec("SELECT 1"); err != nil {
+		t.Fatalf("database unusable: %v", err)
+	}
+}
+
+// The MQTT database holds broker credentials in password_encrypted, so it must
+// not be world-readable. Nothing else tightens the mode when auth is disabled.
+func TestOpenDB_FileIsNotWorldReadable(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "mqtt.db")
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		t.Errorf("database file mode = %v, want owner-only (0600); it holds broker credentials", mode)
+	}
+}
+
+// OpenDB must produce a handle constrained to SQLite's single writer, matching
+// the auth manager's pool settings.
+func TestOpenDB_PoolIsSingleConnection(t *testing.T) {
+	db, err := OpenDB(filepath.Join(t.TempDir(), "pool.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db.Close()
+
+	if got := db.Stats().MaxOpenConnections; got != 1 {
+		t.Errorf("MaxOpenConnections = %d, want 1", got)
+	}
+	var _ *sql.DB = db
+}


### PR DESCRIPTION
Closes #329. Partially addresses #562.

## The problem

Arc keeps auth, audit, tiering and MQTT metadata in **one** SQLite file (`auth.db_path`, default `./data/arc.db`). Each feature called `sql.Open` on that file independently, so a default deployment ran several separate connection pools — each capped at one connection, because SQLite has a single writer — contending for the same write lock.

Six components do this. This change converts three; the rest are tracked in #562 (retention and CQ have their *own* config keys that merely default to the same file, so converting them is a deprecation decision, not a refactor).

Two of the converted handles were also **leaked** — nothing closed the audit or tiering connections on shutdown, on any path.

## Shape of the fix

**Audit and tiering** already accepted a borrowed `*sql.DB` correctly; only `main.go` was wrong. Those are main.go-only changes, plus closing the handle on every path when we do own it (including the failure branches that previously returned early).

**MQTT** needed a signature change: `NewRepository` now takes `*sql.DB`. The repository tracks whether it owns the handle, and `Close` closes only what it opened.

That ownership flag is load-bearing. MQTT shuts down at `PriorityIngest`(20) while auth owns the shared handle until `PriorityAuth`(70) — closing a borrowed handle there would take the database out from under auth, RBAC, audit, tiering, retention and CQ for the rest of shutdown. `TestRepository_BorrowedDBSurvivesClose` fails with exactly `sql: database is closed` if the guard is removed.

**MQTT initialization moved** from ~line 877 to after the auth manager (~line 1035), because `authManager` did not exist yet at the old location.

## Auth-disabled deployments

MQTT, audit and tiering are each enabled independently of auth, so `authManager` may be nil. In that case each opens and owns a handle exactly as before — no behavior change.

That path is now hardened to match `auth.NewAuthManager`: parent directory created, file pre-created **0600** instead of being left at the process umask (typically 0644, world-readable). The file holds audit logs, tiering metadata and encrypted MQTT broker credentials.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| MQTT/audit/tiering all off | No — every block gated off | n/a |
| **MQTT on + auth ON** | Yes — `NewRepository(authManager.GetDB(), …)` | `authManager` assigned above the moved block (main.go:933); `ownsDB=false` → `Close` no-ops |
| **MQTT on + auth OFF** | Yes — `NewSQLiteRepository`, owns handle | `ownsDB=true` → `Close` closes, as before. **Was a fatal startup crash — see below** |
| **Audit on + auth ON** | Yes — borrowed, `auditOwnsDB=false` | Hook skips `Close` |
| **Audit on + auth OFF** (license on, `auth.enabled=false`) | Yes — owns handle | Hook closes it — **fixes a pre-existing leak** |
| **Tiering on + auth ON / OFF** | Yes — same shape | 3 failure paths all close when owned |
| Shutdown ordering, borrowed handle | Yes | MQTT hook 20 → no-op; auth closes at 70 |

## What review and the binary run caught

The adversarial review found two blockers in the new `sharedSQLiteHandle`, both only reachable with **auth disabled** — the configuration the helper exists to serve:

1. **No `MkdirAll`.** `sql.Open` is lazy (verified: returns `nil` error with a missing parent dir), so the failure surfaced later as `NewLogger` failing → *"Failed to create audit logger - feature disabled"*. **Audit logging would silently disable itself on a licensed Enterprise deployment** — the worst failure mode for a compliance feature.
2. **File created 0644.** Verified empirically: `created file mode: -rw-r--r--`. The `chmod 0600` that normally tightens it lives inside `if cfg.Auth.Enabled`, which by definition has not run.

Then **running the binary caught a third instance that both the reviewer and I missed** — I had fixed `sharedSQLiteHandle` but not `mqtt.OpenDB`, which has the identical bug. A fresh install with MQTT enabled and auth disabled did not start at all:

```
{"level":"fatal","error":"failed to initialize schema: unable to open database file: no such file or directory"}
```

That is the CLAUDE.md thesis exactly — reviewers run on the diff, not on the running system.

## Test plan

- [x] `TestRepository_BorrowedDBSurvivesClose` — **verified it fails pre-fix** with `borrowed DB was closed by Repository.Close: sql: database is closed`
- [x] `TestRepository_OwnedDBIsClosed` — the owned direction still closes
- [x] `TestNewRepository_RejectsNilDB`, `TestRepository_InitSchemaIsIdempotent`, `TestRepository_SharesHandleWithAnotherWriter` (two writers interleaved through one pool)
- [x] `TestSharedSQLiteHandle_{CreatesParentDirectory,FileIsNotWorldReadable,ReportsUnusablePath}` — **all three verified to fail against the pre-fix helper**, with the diagnostics quoted above
- [x] `TestNewSQLiteRepository_CreatesParentDirectory`, `TestOpenDB_FileIsNotWorldReadable` — cover the third instance
- [x] `go build ./cmd/... ./internal/...`, `go vet`, `gofmt -l` clean; `go test -race ./internal/mqtt/ ./cmd/arc/` passes

**Binary run, both modes:**

| | auth ON | auth OFF (fresh data dir) |
|---|---|---|
| Startup | ready, `shared_db=true` | ready, `shared_db=false` (**was: fatal**) |
| DB file mode | unchanged (auth owns it) | `-rw-------` (**was: 0644**) |
| Shutdown | `MQTT … shutdown complete` → `Graceful shutdown complete` | same |
| `database is closed` errors | **0** | **0** |
| `level:error` lines | 0 | 0 |

## Note on scope

`sharedSQLiteHandle` sets `_journal_mode=WAL` where audit/tiering previously used a bare DSN. When auth is enabled this is a no-op (auth already set WAL — journal mode is persistent file state). When auth is disabled it converts the file to WAL on first open, creating `arc.db-wal`/`arc.db-shm` sidecars. Flagged for operators doing file-level backups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)