### PR TITLE
fix(startup): share the auth SQLite handle everywhere; drop audit's no-op vacuum (#562)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -57,15 +57,25 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
-### MQTT, audit and tiering share the auth manager's SQLite handle ([#329](https://github.com/Basekick-Labs/arc/issues/329))
+### Features share the auth manager's SQLite handle instead of opening their own ([#329](https://github.com/Basekick-Labs/arc/issues/329), [#562](https://github.com/Basekick-Labs/arc/issues/562))
 
-Arc keeps auth, audit, tiering and MQTT metadata in a single SQLite file (`auth.db_path`, default `./data/arc.db`). Each of those features opened its **own** connection to that file, so a default deployment ran several independent connection pools — each capped at one connection, since SQLite has a single writer — competing for the same write lock. MQTT, audit and tiering now borrow the auth manager's existing handle instead.
+Arc keeps auth, audit, tiering, governance, retention, continuous-query and MQTT metadata in a single SQLite file (`auth.db_path`, default `./data/arc.db`). Each of those features opened its **own** connection to that file, so a default deployment ran six independent connection pools — each capped at one connection, since SQLite has a single writer — competing for the same write lock. They now borrow the auth manager's existing handle instead.
 
-Two of those handles were also **leaked**: nothing closed the audit or tiering connections on shutdown. When these features now open their own handle (see below) it is closed on every path, including the failure paths that previously returned early.
+Three of those handles were also **leaked**: nothing closed the audit, tiering or governance connections on shutdown. When these features now open their own handle (see below) it is closed on every path, including the failure paths that previously returned early.
+
+**Retention and continuous queries keep their own config keys.** `retention.db_path` and `continuous_query.db_path` merely *default* to the auth database; an operator may point either at a different file and expects a genuinely separate database. Those features borrow the auth handle only when the configured path resolves to the same file — compared as a cleaned absolute path with symlinks resolved, so `./data/arc.db` and an absolute path to that file are correctly recognized as one database. Point them elsewhere and they open and own a separate handle exactly as before.
+
+One behavior change worth noting: the auth connection enables SQLite foreign-key enforcement, which retention's and CQ's own connections did not. Their schemas declare foreign keys (`retention_executions` → `retention_policies`, `continuous_query_executions` → `continuous_queries`) and both delete child rows before parents, so enforcement is satisfied — it now also rejects the orphan-creating order, which the code never used.
 
 MQTT initialization moved after auth initialization in startup so the handle exists to be borrowed. MQTT's repository tracks whether it owns its handle and closes it only if so — MQTT shuts down at ingest priority, well before the auth manager closes the shared handle, so closing a borrowed connection there would have taken the database out from under every component still shutting down.
 
-**Auth-disabled deployments are unaffected in behavior:** MQTT, audit and tiering are each enabled independently of auth, so when auth is off they open and own a handle exactly as before. That path is now hardened to match what the auth manager does: the parent directory is created, and the database file is pre-created with owner-only (0600) permissions rather than being left at the process umask (typically 0644, world-readable). The file holds audit logs, tiering metadata and encrypted MQTT broker credentials. Previously, an MQTT-enabled deployment with auth disabled and no existing data directory **failed to start**.
+**Auth-disabled deployments are unaffected in behavior:** these features are each enabled independently of auth, so when auth is off they open and own a handle exactly as before. That path is now hardened to match what the auth manager does: the parent directory is created, and the database file is pre-created with owner-only (0600) permissions rather than being left at the process umask (typically 0644, world-readable). The file holds audit logs, tiering metadata and encrypted MQTT broker credentials. Previously, an MQTT-enabled deployment with auth disabled and no existing data directory **failed to start**.
+
+### Audit log disk reclamation no longer runs a no-op vacuum
+
+Audit set `PRAGMA auto_vacuum = INCREMENTAL` during schema init, then ran `PRAGMA incremental_vacuum` after each retention cleanup. Because audit shares the auth database, whose tables already exist by then, the pragma was rejected — `auto_vacuum` can only be changed on an empty database — and SQLite reports no error for the rejection, so the setting silently stayed at NONE and every subsequent vacuum was a no-op.
+
+Both statements are removed rather than repaired. `audit_logs` is written on every request, and vacuuming a continuously-written table causes write amplification: the vacuum shrinks the file and the next insert re-grows it. Pages freed by the retention `DELETE` are reused by later inserts, which is what actually bounds file growth. No operational change — the vacuum was already doing nothing.
 
 ### Compaction subprocesses no longer drop the S3 prefix ([#560](https://github.com/Basekick-Labs/arc/issues/560))
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2046,11 +2046,16 @@ func main() {
 		} else if !licenseClient.CanUseQueryGovernance() {
 			log.Warn().Msg("License does not include query_governance feature - feature disabled")
 		} else {
+			// Share the auth manager's SQLite handle when there is one.
+			// Governance and auth are enabled independently (this block is
+			// gated on the license, not on cfg.Auth.Enabled), so authManager
+			// may be nil — sharedSQLiteHandle falls back to a dedicated handle
+			// we own.
 			governanceDBPath := cfg.Auth.DBPath
 			if governanceDBPath == "" {
 				governanceDBPath = "./data/arc.db"
 			}
-			governanceDB, err := sql.Open("sqlite3", governanceDBPath)
+			governanceDB, governanceOwnsDB, err := sharedSQLiteHandle(authManager, governanceDBPath)
 			if err != nil {
 				log.Error().Err(err).Msg("Failed to open governance database - feature disabled")
 			} else {
@@ -2061,10 +2066,21 @@ func main() {
 				})
 				if err != nil {
 					log.Error().Err(err).Msg("Failed to create governance manager - feature disabled")
+					if governanceOwnsDB {
+						governanceDB.Close()
+					}
 				} else {
 					governanceManager.Start()
 					shutdownCoordinator.RegisterHook("governance", func(ctx context.Context) error {
-						return governanceManager.Stop()
+						stopErr := governanceManager.Stop()
+						// governance.Manager never closes its DB — it may be
+						// borrowed. Close it here only when this block opened it.
+						if governanceOwnsDB {
+							if closeErr := governanceDB.Close(); closeErr != nil && stopErr == nil {
+								stopErr = closeErr
+							}
+						}
+						return stopErr
 					}, shutdown.PriorityCompaction)
 
 					// Wire governance to query handler

--- a/internal/api/continuous_query.go
+++ b/internal/api/continuous_query.go
@@ -47,6 +47,10 @@ type ContinuousQueryHandler struct {
 	arrowBuffer *ingest.ArrowBuffer
 	config      *config.ContinuousQueryConfig
 	sqliteDB    *sql.DB
+	// ownsDB records whether this handler opened sqliteDB itself. When CQ
+	// shares the auth database (the default), the handle is borrowed and Close
+	// must leave it to its owner.
+	ownsDB      bool
 	authManager *auth.AuthManager
 	scheduler   CQSchedulerReloader
 	coordinator CQCoordinator
@@ -147,16 +151,31 @@ type CQExecution struct {
 
 // NewContinuousQueryHandler creates a new continuous query handler
 func NewContinuousQueryHandler(db *database.DuckDB, storage storage.Backend, arrowBuffer *ingest.ArrowBuffer, cfg *config.ContinuousQueryConfig, authManager *auth.AuthManager, logger zerolog.Logger) (*ContinuousQueryHandler, error) {
-	// Ensure directory exists
-	dir := filepath.Dir(cfg.DBPath)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create directory for CQ DB: %w", err)
-	}
+	// continuous_query.db_path defaults to the auth database. When it resolves
+	// to the same file, borrow the auth manager's handle rather than opening a
+	// second connection pool against it — SQLite has a single writer, so
+	// independent pools on one file only contend for the same lock. An operator
+	// who points continuous_query.db_path elsewhere still gets a genuinely
+	// separate database.
+	var (
+		sqliteDB *sql.DB
+		ownsDB   bool
+	)
+	if authManager.SharesDBPath(cfg.DBPath) {
+		sqliteDB = authManager.GetDB()
+	} else {
+		// Ensure directory exists
+		dir := filepath.Dir(cfg.DBPath)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return nil, fmt.Errorf("failed to create directory for CQ DB: %w", err)
+		}
 
-	// Open SQLite database
-	sqliteDB, err := sql.Open("sqlite3", cfg.DBPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open CQ database: %w", err)
+		// Open SQLite database
+		opened, err := sql.Open("sqlite3", cfg.DBPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open CQ database: %w", err)
+		}
+		sqliteDB, ownsDB = opened, true
 	}
 
 	h := &ContinuousQueryHandler{
@@ -165,13 +184,16 @@ func NewContinuousQueryHandler(db *database.DuckDB, storage storage.Backend, arr
 		arrowBuffer: arrowBuffer,
 		config:      cfg,
 		sqliteDB:    sqliteDB,
+		ownsDB:      ownsDB,
 		authManager: authManager,
 		logger:      logger.With().Str("component", "cq-handler").Logger(),
 	}
 
 	// Initialize tables
 	if err := h.initTables(); err != nil {
-		sqliteDB.Close()
+		if ownsDB {
+			sqliteDB.Close()
+		}
 		return nil, fmt.Errorf("failed to initialize CQ tables: %w", err)
 	}
 
@@ -240,6 +262,9 @@ func (h *ContinuousQueryHandler) initTables() error {
 
 // Close closes the database connection
 func (h *ContinuousQueryHandler) Close() error {
+	if !h.ownsDB {
+		return nil
+	}
 	return h.sqliteDB.Close()
 }
 

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -36,9 +36,13 @@ type RetentionCoordinator interface {
 
 // RetentionHandler handles retention policy operations
 type RetentionHandler struct {
-	storage       storage.Backend
-	config        *config.RetentionConfig
-	db            *sql.DB              // SQLite for policy metadata
+	storage storage.Backend
+	config  *config.RetentionConfig
+	db      *sql.DB // SQLite for policy metadata
+	// ownsDB records whether this handler opened db itself. When retention
+	// shares the auth database (the default), the handle is borrowed and Close
+	// must leave it to its owner.
+	ownsDB        bool
 	duckdb        *database.DuckDB     // Shared DuckDB for parquet queries
 	coordinator   RetentionCoordinator // nil in standalone mode
 	licenseClient *license.Client      // nil when auth/licensing is disabled
@@ -104,22 +108,37 @@ type RetentionExecution struct {
 
 // NewRetentionHandler creates a new retention handler
 func NewRetentionHandler(storage storage.Backend, duckdb *database.DuckDB, cfg *config.RetentionConfig, licenseClient *license.Client, authManager *auth.AuthManager, logger zerolog.Logger) (*RetentionHandler, error) {
-	// Ensure directory exists
-	dir := filepath.Dir(cfg.DBPath)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create directory for retention DB: %w", err)
-	}
+	// retention.db_path defaults to the auth database. When it resolves to the
+	// same file, borrow the auth manager's handle rather than opening a second
+	// connection pool against it — SQLite has a single writer, so independent
+	// pools on one file only contend for the same lock. An operator who points
+	// retention.db_path elsewhere still gets a genuinely separate database.
+	var (
+		db     *sql.DB
+		ownsDB bool
+	)
+	if authManager.SharesDBPath(cfg.DBPath) {
+		db = authManager.GetDB()
+	} else {
+		// Ensure directory exists
+		dir := filepath.Dir(cfg.DBPath)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return nil, fmt.Errorf("failed to create directory for retention DB: %w", err)
+		}
 
-	// Open SQLite database for policy metadata
-	db, err := sql.Open("sqlite3", cfg.DBPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open retention database: %w", err)
+		// Open SQLite database for policy metadata
+		opened, err := sql.Open("sqlite3", cfg.DBPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open retention database: %w", err)
+		}
+		db, ownsDB = opened, true
 	}
 
 	h := &RetentionHandler{
 		storage:       storage,
 		config:        cfg,
 		db:            db,
+		ownsDB:        ownsDB,
 		duckdb:        duckdb,
 		licenseClient: licenseClient,
 		authManager:   authManager,
@@ -128,7 +147,9 @@ func NewRetentionHandler(storage storage.Backend, duckdb *database.DuckDB, cfg *
 
 	// Initialize tables
 	if err := h.initTables(); err != nil {
-		db.Close()
+		if ownsDB {
+			db.Close()
+		}
 		return nil, fmt.Errorf("failed to initialize retention tables: %w", err)
 	}
 
@@ -183,8 +204,14 @@ func (h *RetentionHandler) initTables() error {
 	return nil
 }
 
-// Close closes the database connection
+// Close releases the database handle if this handler owns it.
+//
+// When retention shares the auth database (the default), the handle is
+// borrowed and its owner closes it later in the shutdown sequence.
 func (h *RetentionHandler) Close() error {
+	if !h.ownsDB {
+		return nil
+	}
 	return h.db.Close()
 }
 
@@ -838,7 +865,7 @@ func (h *RetentionHandler) deleteOldFiles(ctx context.Context, database, measure
 		// into ops. The storage delete loop uses this subset so a marshal failure
 		// never causes a file to be deleted from storage without a manifest entry.
 		var ops []raft.BatchFileOp
-		subPaths := chunk          // default: all chunk paths (no coordinator)
+		subPaths := chunk // default: all chunk paths (no coordinator)
 		subRows := eligibleRows[i:end]
 		if h.coordinator != nil {
 			ops = make([]raft.BatchFileOp, 0, len(chunk))

--- a/internal/api/shared_db_test.go
+++ b/internal/api/shared_db_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/rs/zerolog"
+)
+
+// Retention and CQ have their own *_db_path keys that default to the auth
+// database. When they resolve to the same file the handle is borrowed, and
+// Close must not close it: these handlers shut down before the auth manager
+// that owns it, so closing here would take the database out from under
+// everything still shutting down.
+func TestRetentionHandler_BorrowsAndDoesNotCloseSharedDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+
+	am, err := auth.NewAuthManager(dbPath, time.Minute, 10, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	defer am.Close()
+
+	h, err := NewRetentionHandler(nil, nil, &config.RetentionConfig{DBPath: dbPath}, nil, am, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRetentionHandler: %v", err)
+	}
+
+	if h.ownsDB {
+		t.Error("handler must borrow the auth handle when the paths match")
+	}
+	if h.db != am.GetDB() {
+		t.Error("handler must use the auth manager's handle, not a new one")
+	}
+
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close on a borrowed handle should be a no-op: %v", err)
+	}
+	if err := am.GetDB().Ping(); err != nil {
+		t.Fatalf("borrowed handle was closed by the handler: %v", err)
+	}
+}
+
+// An operator who points retention.db_path at a different file expects a
+// genuinely separate database — borrowing there would silently ignore the key.
+func TestRetentionHandler_OwnsSeparateDB(t *testing.T) {
+	dir := t.TempDir()
+	authPath := filepath.Join(dir, "arc.db")
+	retentionPath := filepath.Join(dir, "retention.db")
+
+	am, err := auth.NewAuthManager(authPath, time.Minute, 10, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	defer am.Close()
+
+	h, err := NewRetentionHandler(nil, nil, &config.RetentionConfig{DBPath: retentionPath}, nil, am, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRetentionHandler: %v", err)
+	}
+
+	if !h.ownsDB {
+		t.Fatal("a separate db_path must produce a handle the handler owns")
+	}
+	if h.db == am.GetDB() {
+		t.Error("a separate db_path must not reuse the auth handle")
+	}
+
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := h.db.Ping(); err == nil {
+		t.Error("an owned handle must actually be closed")
+	}
+	// The auth database must be untouched.
+	if err := am.GetDB().Ping(); err != nil {
+		t.Errorf("closing the retention handle affected the auth database: %v", err)
+	}
+}
+
+// With auth disabled there is no handle to borrow; the handler opens its own,
+// exactly as before.
+func TestRetentionHandler_NilAuthManagerOpensOwnDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "retention.db")
+
+	h, err := NewRetentionHandler(nil, nil, &config.RetentionConfig{DBPath: dbPath}, nil, nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRetentionHandler with a nil auth manager: %v", err)
+	}
+	defer h.Close()
+
+	if !h.ownsDB {
+		t.Error("with no auth manager the handler must own its handle")
+	}
+	if _, err := h.db.Exec("SELECT 1"); err != nil {
+		t.Fatalf("database unusable: %v", err)
+	}
+}
+
+func TestContinuousQueryHandler_BorrowsAndDoesNotCloseSharedDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+
+	am, err := auth.NewAuthManager(dbPath, time.Minute, 10, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	defer am.Close()
+
+	h, err := NewContinuousQueryHandler(nil, nil, nil, &config.ContinuousQueryConfig{DBPath: dbPath}, am, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewContinuousQueryHandler: %v", err)
+	}
+
+	if h.ownsDB {
+		t.Error("handler must borrow the auth handle when the paths match")
+	}
+	if h.sqliteDB != am.GetDB() {
+		t.Error("handler must use the auth manager's handle, not a new one")
+	}
+
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close on a borrowed handle should be a no-op: %v", err)
+	}
+	if err := am.GetDB().Ping(); err != nil {
+		t.Fatalf("borrowed handle was closed by the handler: %v", err)
+	}
+}
+
+func TestContinuousQueryHandler_OwnsSeparateDB(t *testing.T) {
+	dir := t.TempDir()
+	am, err := auth.NewAuthManager(filepath.Join(dir, "arc.db"), time.Minute, 10, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	defer am.Close()
+
+	h, err := NewContinuousQueryHandler(nil, nil, nil,
+		&config.ContinuousQueryConfig{DBPath: filepath.Join(dir, "cq.db")}, am, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewContinuousQueryHandler: %v", err)
+	}
+
+	if !h.ownsDB {
+		t.Fatal("a separate db_path must produce a handle the handler owns")
+	}
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := am.GetDB().Ping(); err != nil {
+		t.Errorf("closing the CQ handle affected the auth database: %v", err)
+	}
+}
+
+// Retention's schema declares a foreign key from retention_executions to
+// retention_policies. The auth DSN enables foreign key enforcement while
+// retention's own DSN did not, so borrowing changes enforcement — verify the
+// handler's actual delete order still works under it.
+func TestRetentionHandler_DeleteOrderWorksWithForeignKeysEnabled(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+
+	am, err := auth.NewAuthManager(dbPath, time.Minute, 10, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	defer am.Close()
+
+	h, err := NewRetentionHandler(nil, nil, &config.RetentionConfig{DBPath: dbPath}, nil, am, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRetentionHandler: %v", err)
+	}
+	defer h.Close()
+
+	res, err := h.db.Exec(
+		`INSERT INTO retention_policies (name, database, retention_days) VALUES ('p', 'db', 30)`)
+	if err != nil {
+		t.Fatalf("insert policy: %v", err)
+	}
+	policyID, _ := res.LastInsertId()
+
+	if _, err := h.db.Exec(
+		`INSERT INTO retention_executions (policy_id, status) VALUES (?, 'ok')`, policyID); err != nil {
+		t.Fatalf("insert execution: %v", err)
+	}
+
+	// Children first, then the parent — the order deletePolicy uses.
+	if _, err := h.db.Exec("DELETE FROM retention_executions WHERE policy_id = ?", policyID); err != nil {
+		t.Fatalf("delete executions: %v", err)
+	}
+	if _, err := h.db.Exec("DELETE FROM retention_policies WHERE id = ?", policyID); err != nil {
+		t.Fatalf("delete policy with foreign keys enabled: %v", err)
+	}
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -100,11 +100,19 @@ func NewLogger(cfg *LoggerConfig) (*Logger, error) {
 }
 
 func (l *Logger) initSchema() error {
-	// Enable incremental auto-vacuum to reclaim disk space after retention cleanup.
-	// Must be set before creating tables (only takes effect on new databases).
-	if _, err := l.db.Exec("PRAGMA auto_vacuum = INCREMENTAL"); err != nil {
-		l.logger.Warn().Err(err).Msg("Failed to set auto_vacuum pragma")
-	}
+	// No auto_vacuum pragma here, deliberately.
+	//
+	// auto_vacuum can only be changed on an empty database (or via a full
+	// VACUUM), and audit shares the auth database, whose tables already exist
+	// by the time this runs. SQLite reports no error for the rejected pragma,
+	// so the setting silently stayed at NONE and the incremental_vacuum that
+	// followed each retention cleanup was a no-op.
+	//
+	// Restoring it would be the wrong fix: audit_logs is written on every
+	// request, and vacuuming a continuously-written table causes write
+	// amplification — the vacuum shrinks the file, the next insert re-grows it.
+	// Pages freed by the retention DELETE are reused by subsequent inserts,
+	// which is what actually bounds file growth.
 
 	schema := `
 	CREATE TABLE IF NOT EXISTS audit_logs (
@@ -304,11 +312,8 @@ func (l *Logger) cleanupOldEntries() {
 
 	if rows, _ := result.RowsAffected(); rows > 0 {
 		l.logger.Info().Int64("deleted", rows).Int("retention_days", l.config.RetentionDays).Msg("Cleaned up old audit entries")
-
-		// Reclaim disk space freed by deleted rows
-		if _, err := l.db.Exec("PRAGMA incremental_vacuum"); err != nil {
-			l.logger.Warn().Err(err).Msg("Failed to run incremental vacuum")
-		}
+		// No incremental_vacuum: see initSchema. Pages freed here are reused by
+		// subsequent inserts, so the DELETE alone bounds file growth.
 	}
 }
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1523,3 +1523,43 @@ func (am *AuthManager) Close() error {
 func (am *AuthManager) GetDB() *sql.DB {
 	return am.db
 }
+
+// SharesDBPath reports whether dbPath refers to the same file this manager has
+// open, so a caller can borrow GetDB instead of opening a second connection.
+//
+// Features such as retention and continuous queries have their own *_db_path
+// config keys that merely default to the auth database. An operator who points
+// one at a different file expects a genuinely separate database, so borrowing
+// must be conditional on the paths actually matching rather than assumed.
+//
+// Comparison is on the cleaned absolute path, with symlinks resolved when the
+// file exists: "./data/arc.db" and an absolute path to the same file are the
+// same database, and answering otherwise would silently open a redundant
+// connection. Returns false for a nil receiver or an in-memory database, where
+// there is nothing meaningful to share.
+func (am *AuthManager) SharesDBPath(dbPath string) bool {
+	if am == nil || dbPath == "" {
+		return false
+	}
+	// In-memory databases are private to the connection that opened them, so
+	// two handles naming ":memory:" are not the same database.
+	if strings.HasPrefix(am.dbPath, ":memory:") || strings.HasPrefix(dbPath, ":memory:") ||
+		strings.HasPrefix(am.dbPath, "file::memory:") || strings.HasPrefix(dbPath, "file::memory:") {
+		return false
+	}
+
+	resolve := func(p string) string {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return filepath.Clean(p)
+		}
+		// EvalSymlinks fails when the file does not exist yet; the cleaned
+		// absolute path is the best available answer in that case.
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			return resolved
+		}
+		return abs
+	}
+
+	return resolve(am.dbPath) == resolve(dbPath)
+}

--- a/internal/auth/shares_dbpath_test.go
+++ b/internal/auth/shares_dbpath_test.go
@@ -1,0 +1,115 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// SharesDBPath decides whether a feature with its own *_db_path config key can
+// borrow the auth handle. A false negative opens a redundant connection pool on
+// the same file; a false positive silently ignores an operator's explicit
+// choice to use a separate database.
+func TestSharesDBPath(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+
+	am, err := NewAuthManager(dbPath, time.Minute, 10, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	defer am.Close()
+
+	t.Run("identical path", func(t *testing.T) {
+		if !am.SharesDBPath(dbPath) {
+			t.Error("the same path must be reported as shared")
+		}
+	})
+
+	t.Run("relative form of the same file", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Skip("cannot determine working directory")
+		}
+		rel, err := filepath.Rel(cwd, dbPath)
+		if err != nil {
+			t.Skip("paths are not relatable on this filesystem")
+		}
+		if !am.SharesDBPath(rel) {
+			t.Errorf("relative path %q refers to the same file and must be reported as shared", rel)
+		}
+	})
+
+	t.Run("path with redundant separators", func(t *testing.T) {
+		noisy := filepath.Join(dir, ".", "arc.db")
+		if !am.SharesDBPath(noisy) {
+			t.Errorf("%q refers to the same file and must be reported as shared", noisy)
+		}
+	})
+
+	t.Run("different file", func(t *testing.T) {
+		if am.SharesDBPath(filepath.Join(dir, "retention.db")) {
+			t.Error("a different file must not be reported as shared — the operator asked for a separate database")
+		}
+	})
+
+	t.Run("same basename in another directory", func(t *testing.T) {
+		if am.SharesDBPath(filepath.Join(t.TempDir(), "arc.db")) {
+			t.Error("matching basenames in different directories are different databases")
+		}
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		if am.SharesDBPath("") {
+			t.Error("an empty path must not be reported as shared")
+		}
+	})
+}
+
+// A symlinked path is the same database, and answering otherwise opens a second
+// pool against one file.
+func TestSharesDBPath_ResolvesSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+
+	am, err := NewAuthManager(dbPath, time.Minute, 10, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	defer am.Close()
+
+	link := filepath.Join(dir, "linked.db")
+	if err := os.Symlink(dbPath, link); err != nil {
+		t.Skipf("cannot create symlinks here: %v", err)
+	}
+
+	if !am.SharesDBPath(link) {
+		t.Error("a symlink to the auth database is the same database")
+	}
+}
+
+// The nil receiver is reachable: features gated on a license rather than on
+// cfg.Auth.Enabled can run with auth disabled, and must not panic.
+func TestSharesDBPath_NilReceiver(t *testing.T) {
+	var am *AuthManager
+	if am.SharesDBPath("./data/arc.db") {
+		t.Error("a nil auth manager has no database to share")
+	}
+}
+
+// In-memory databases are private to the connection that opened them, so two
+// handles naming ":memory:" are not the same database.
+func TestSharesDBPath_InMemoryIsNeverShared(t *testing.T) {
+	am, err := NewAuthManager(":memory:", time.Minute, 10, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewAuthManager: %v", err)
+	}
+	defer am.Close()
+
+	if am.SharesDBPath(":memory:") {
+		t.Error("in-memory databases are per-connection and must never be reported as shared")
+	}
+}


### PR DESCRIPTION
Closes #562. Completes the work started in #329, plus a finding from that PR's adversarial review.

## The remaining three handles

Arc keeps auth, audit, tiering, governance, retention, continuous-query and MQTT metadata in **one** SQLite file. Each feature opened its own connection — six independent pools, each capped at one connection because SQLite has a single writer, contending for the same write lock. #329 converted three; this converts the rest.

**Governance** follows the audit/tiering shape exactly: it already accepted a borrowed `*sql.DB`, so only `main.go` changed. Its handle was also **leaked** — nothing closed it on any path, including the constructor failure branch.

**Retention and CQ needed more care.** Both have their own `db_path` config keys that merely *default* to the auth database. Borrowing unconditionally would silently ignore an operator who pointed one at a separate file — the key would stop meaning anything.

They now borrow **only when the configured path resolves to the same file**, via a new `AuthManager.SharesDBPath`:

- Compares **cleaned absolute paths with symlinks resolved** — `./data/arc.db` and an absolute path to that file are one database, and answering otherwise opens a redundant pool
- **In-memory databases are never shared** — they're private to the connection that opened them
- **Nil receiver safe** — these features are license-gated, not `cfg.Auth.Enabled`-gated, so they can run with auth disabled

## Foreign-key enforcement change

The auth connection sets `_foreign_keys=ON`; retention's and CQ's own connections did not. Both schemas declare FKs (`retention_executions` → `retention_policies`, `continuous_query_executions` → `continuous_queries`).

I verified against real SQLite rather than assuming:

```
FK OFF (old retention)   child-then-parent: e1=<nil> e2=<nil>
FK OFF (old retention)   parent-with-child:  e3=<nil>
FK ON  (borrowed auth)   child-then-parent: e1=<nil> e2=<nil>
FK ON  (borrowed auth)   parent-with-child:  e3=FOREIGN KEY constraint failed
```

Both handlers delete children before parents, so enforcement is satisfied. FK-ON only rejects the orphan-creating order, which the code never uses — strictly more correct.

## Audit's no-op vacuum (adversarial-review finding from #563)

Audit set `PRAGMA auto_vacuum = INCREMENTAL` at schema init, then ran `PRAGMA incremental_vacuum` after each retention cleanup. Verified empirically:

```
A: pragma BEFORE any table              auto_vacuum=2
B: pragma error returned? <nil>
B: pragma AFTER auth created tables     auto_vacuum=0
B: incremental_vacuum error? <nil>
```

`auto_vacuum` can only be changed on an **empty** database. Audit shares the auth database, whose tables already exist by then, so the pragma was rejected — and **SQLite returns no error for the rejection**, so the warn-log never fired and the setting silently stayed at NONE. Every subsequent vacuum was a no-op.

Removed rather than repaired, per CLAUDE.md's SQLite checklist item 4: `audit_logs` is written on every request, and vacuuming a continuously-written table causes write amplification — the vacuum shrinks the file, the next insert re-grows it. Pages freed by the retention `DELETE` are reused by later inserts, which is what actually bounds growth. **No operational change — it was already doing nothing.**

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| All features off | No | n/a |
| **Retention/CQ at default path + auth ON** | Yes — `SharesDBPath` true → borrow | `ownsDB=false` → `Close` no-ops; auth closes at priority 70 |
| **Retention/CQ at SEPARATE path + auth ON (NON-DEFAULT)** | Yes — `SharesDBPath` false → own | `ownsDB=true` → `Close` closes; auth DB untouched |
| **Retention/CQ + auth OFF** | Yes — nil receiver → own | `SharesDBPath` returns false for nil, no panic |
| **Governance on + auth ON** | Yes — borrowed | Hook skips `Close` |
| **Governance on + auth OFF** (license on, auth off) | Yes — owns handle | Hook closes it — **fixes a leak** |
| Symlinked / relative db_path | Yes | Resolved to the same file → borrow |
| Audit schema init on shared DB | Yes | Vacuum statements removed entirely |

## Test plan

- [x] `TestSharesDBPath` — identical, relative, redundant-separator, different file, same basename elsewhere, empty
- [x] `TestSharesDBPath_ResolvesSymlinks`, `_NilReceiver`, `_InMemoryIsNeverShared`
- [x] `TestRetentionHandler_{BorrowsAndDoesNotCloseSharedDB,OwnsSeparateDB,NilAuthManagerOpensOwnDB}`
- [x] `TestContinuousQueryHandler_{BorrowsAndDoesNotCloseSharedDB,OwnsSeparateDB}`
- [x] `TestRetentionHandler_DeleteOrderWorksWithForeignKeysEnabled` — pins the FK behavior change
- [x] **Verified the borrow tests fail pre-fix**: `handler must borrow the auth handle when the paths match` / `handler must use the auth manager's handle, not a new one`
- [x] `go test` passes for `internal/api`, `internal/audit`, `internal/auth`, `internal/mqtt`, `cmd/arc`; build/vet/gofmt clean

**Binary run, both configurations:**

| | all paths default | retention/CQ at separate paths |
|---|---|---|
| Startup | healthy | healthy |
| SQLite files created | **only `arc.db`** | **3 distinct dbs** |
| Table placement | all in `arc.db` | `retention_*` in `retention-separate.db`, `continuous_quer*` in `cq-separate.db`, **neither in `arc.db`** |
| Shutdown | `Graceful shutdown complete` | same |
| `database is closed` errors | **0** | **0** |

The second column is the case that would have broken had I borrowed unconditionally — the config key would have silently stopped working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)