### PR TITLE
test(wal): wait for async writes instead of racing the writer goroutine

### DIFF
--- a/internal/wal/wal_purge_inactive_test.go
+++ b/internal/wal/wal_purge_inactive_test.go
@@ -12,6 +12,37 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// waitForEntries blocks until the writer has durably recorded at least want
+// entries, or fails the test after a generous timeout.
+//
+// Append is asynchronous: it enqueues onto entryChan and returns, while a
+// background writer goroutine performs the file write and only then increments
+// TotalEntries. Reading that counter straight after Append therefore races the
+// writer, and a fixed sleep only sets how often the race is lost — on a loaded
+// or heavily-scheduled machine (CI, a container) the writer may not have run at
+// all. Polling makes the test wait for the condition it actually depends on.
+func waitForEntries(t *testing.T, w *Writer, want int64) {
+	t.Helper()
+
+	const (
+		timeout = 5 * time.Second
+		step    = 2 * time.Millisecond
+	)
+
+	deadline := time.Now().Add(timeout)
+	for {
+		got := atomic.LoadInt64(&w.TotalEntries)
+		if got >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %v waiting for %d entries; TotalEntries=%d dropped=%d",
+				timeout, want, got, atomic.LoadInt64(&w.DroppedEntries))
+		}
+		time.Sleep(step)
+	}
+}
+
 // ==========================================================================
 // Duplication proof: old periodic recovery replays already-flushed data
 // ==========================================================================
@@ -408,7 +439,7 @@ func TestPurgeInactive_PreservesActiveFileDuringWrites(t *testing.T) {
 	defer writer.Close()
 
 	writer.Append([]map[string]interface{}{{"measurement": "cpu", "value": 42.0}})
-	time.Sleep(50 * time.Millisecond)
+	waitForEntries(t, writer, 1)
 
 	os.WriteFile(filepath.Join(tmpDir, "arc-20240101_000000.wal"), []byte("old"), 0600)
 
@@ -428,11 +459,7 @@ func TestPurgeInactive_PreservesActiveFileDuringWrites(t *testing.T) {
 	if err != nil {
 		t.Errorf("should be able to write after PurgeInactive: %v", err)
 	}
-	time.Sleep(50 * time.Millisecond)
-
-	if atomic.LoadInt64(&writer.TotalEntries) < 2 {
-		t.Errorf("expected at least 2 entries, got %d", atomic.LoadInt64(&writer.TotalEntries))
-	}
+	waitForEntries(t, writer, 2)
 }
 
 // TestPurgeInactive_DoesNotDeleteNonWALFiles verifies only .wal files are deleted.
@@ -511,10 +538,10 @@ func TestPurgeInactive_ConcurrentWithWrite(t *testing.T) {
 		t.Errorf("expected 5 deleted, got %d", deleted)
 	}
 
+	// <-done only means the 100 Appends were enqueued; the background writer
+	// may not have written any of them yet. Wait for the writes themselves.
 	<-done
-	if atomic.LoadInt64(&writer.TotalEntries) == 0 {
-		t.Error("expected some entries to be written")
-	}
+	waitForEntries(t, writer, 1)
 }
 
 // TestPurgeAll_VsPurgeInactive verifies the behavioral difference between


### PR DESCRIPTION
Follow-up to #565, where I flagged `TestPurgeInactive_ConcurrentWithWrite` failing under Linux containers.

## It is a test bug, not a product bug — and not flaky

I measured it rather than assuming:

| Platform | Result |
|---|---|
| Linux (container), 20 runs | **19 failures** |
| macOS, 20 runs | **0 failures** |

Nearly deterministic on Linux. "Flaky" was the wrong label — the test relies on a race the writer goroutine has no particular reason to win, and macOS's scheduler simply happens to let it.

## Root cause

`Append` is asynchronous. It enqueues onto `entryChan` and returns (wal.go:444-453); a background writer goroutine performs the file write and only *then* increments `TotalEntries` (wal.go:300).

The test closed its producer channel once the 100 `Append` calls had been **enqueued**, then immediately asserted `TotalEntries != 0`. `<-done` says nothing about whether the writer ran.

I instrumented the actual values to confirm rather than infer:

```
TotalEntries immediately after <-done: 0
DroppedEntries:                        0
TotalEntries after 300ms settle:       100
```

**Nothing was dropped and every entry was written.** The WAL behaved correctly throughout; the test just looked too early.

## Fix

Added `waitForEntries`, which polls until the writer has durably recorded the entries, or fails after 5s with a diagnostic (`TotalEntries=… dropped=…`) so a future failure says *why*.

Also replaced two fixed `time.Sleep(50 * time.Millisecond)` calls in `TestPurgeInactive_ActiveFileNotDeleted`. Those have the identical fragility with a larger margin — a fixed sleep only sets how often the race is lost, and on a loaded CI box or a slow container it can be lost too.

## Verification

| | before | after |
|---|---|---|
| `TestPurgeInactive_ConcurrentWithWrite`, Linux ×20 | 19 FAIL | **0 FAIL** |
| Full WAL suite, Linux container | FAIL | **PASS** (first time) |
| Full WAL suite, darwin | PASS | PASS |
| darwin `-race` ×10 | PASS | PASS |

Test-only change — one file, no product code touched, so no release-notes entry.

Note the cross-compiled `-race` binary can't be built here (needs a Linux C toolchain), so the container runs are non-race builds. Darwin `-race` covers the detector side.