### PR TITLE
feat(compaction): make batch size configurable; remove dead TargetSizeMB

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -47,6 +47,21 @@ Env vars follow the usual pattern, e.g. `ARC_ICEBERG_ENABLED=true`.
 
 **Backups cover the catalog wherever it lives.** Backup copies the Iceberg warehouse metadata alongside the Parquet data, and now also the Iceberg SQL catalog itself when `iceberg.catalog_db_path` points somewhere other than the shared database. The catalog holds every table's schema and snapshot pointers, so a backup without it restores data whose tables no longer resolve. Restores of older backups that predate this are unaffected — a missing catalog copy is skipped, not an error.
 
+## New: tunable compaction batch size
+
+Compaction splits a large partition into batches, each becoming an independent job with its own output file. That batch size was a hardcoded constant (30 files); it is now configurable:
+
+```toml
+[compaction]
+max_files_per_batch = 30   # default; valid range [2, 500]
+```
+
+Env var: `ARC_COMPACTION_MAX_FILES_PER_BATCH`.
+
+This is a **file-count** bound, not a byte bound — compacted output size tracks input file size, which follows the ingest buffer settings. Lowering it yields smaller, independently-transferable compacted files, which matters when those files are shipped over a constrained or intermittent link (edge and field deployments). The cost is more compaction jobs per partition, and in cluster mode proportionally more Raft manifest entries — at `5`, a 600-file partition produces 120 manifest entries instead of 20.
+
+Out-of-range values fall back to the default with a startup warning rather than failing. **`1` is not usable** and is treated as out of range: compaction's adaptive retry rejects any batch below two files, so a batch size of one would fail every batch of every partition.
+
 ## Security hardening
 
 ### Strip client-controlled forwarding headers at the inter-node boundary (CVE-2026-45045 class)
@@ -174,7 +189,19 @@ Follow-up cleanup, no runtime behavior change: the channel governing the auth ma
 
 No current code path mutates a batch's `Files` in place, so this was latent rather than an active source of corruption — compaction jobs never produced wrong file lists because of it. But it left every future caller one in-place sort or append away from silently rewriting sibling batches, with no error or log signal.
 
-Both sites now copy into independent backing arrays, including the single-batch (`len(Files) <= MaxFilesPerBatch`) path that previously returned the caller's slice unchanged. Batch isolation no longer depends on file count: mutating any returned batch cannot affect another batch or the original candidate.
+Both sites now copy into independent backing arrays, including the single-batch (`len(Files) <= DefaultMaxFilesPerBatch`) path that previously returned the caller's slice unchanged. Batch isolation no longer depends on file count: mutating any returned batch cannot affect another batch or the original candidate.
+
+### Compaction batch splitting no longer strands a sub-minimum remainder
+
+Splitting a partition into batches could leave a trailing batch of one file — 31 files at the default batch size of 30 produced batches of 30 and 1. `compactFilesAdaptively` rejects any batch below two files on its first attempt (`compaction failed: batch size 1 below minimum 2`), so that remainder failed every cycle and its file never compacted. The partition's tail stayed permanently uncompacted, with the only symptom a per-batch failure log.
+
+A trailing remainder smaller than the two-file floor is now folded into the final batch, which overshoots the configured size by at most one file. Every emitted batch is now large enough to actually compact.
+
+### `compaction.target_size_mb` removed (it never did anything)
+
+The compaction tiers carried a `TargetSizeMB` field, defaulted to 512 (hourly) and 2048 (daily), plumbed through five structs and the parent↔subprocess IPC, and reported as `target_size_mb` on `GET /api/v1/compaction/stats`. Nothing ever read it: the file-selection path has no size information (`Candidate` carries no file sizes), and the compaction `COPY` never emitted a `FILE_SIZE_BYTES` clause. Compacted file size was, and is, governed by the batch file count.
+
+There was no config key for it, so no deployment could have set it — the removal cannot change anyone's behavior. **The `target_size_mb` field is gone from the `tiers[]` entries of `GET /api/v1/compaction/stats`**; the tier-initialization log lines no longer include it either.
 
 ### Backup no longer loads entire files into memory ([#322](https://github.com/Basekick-Labs/arc/issues/322))
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1136,11 +1136,12 @@ func main() {
 		// Create compaction manager (discovers all databases dynamically)
 		// Compaction jobs run in subprocesses for memory isolation
 		compactionManager = compaction.NewManager(&compaction.ManagerConfig{
-			StorageBackend: storageBackend,
-			LockManager:    lockManager,
-			MaxConcurrent:  cfg.Compaction.MaxConcurrent,
-			MemoryLimit:    cfg.Database.MemoryLimit, // Use same limit as main DuckDB
-			CompletionDir:  completionDir,            // Phase 4: empty in OSS, set in cluster mode
+			StorageBackend:   storageBackend,
+			LockManager:      lockManager,
+			MaxConcurrent:    cfg.Compaction.MaxConcurrent,
+			MaxFilesPerBatch: cfg.Compaction.MaxFilesPerBatch,
+			MemoryLimit:      cfg.Database.MemoryLimit, // Use same limit as main DuckDB
+			CompletionDir:    completionDir,            // Phase 4: empty in OSS, set in cluster mode
 			// Pass the SAME absolute-resolved value the DB-layer sandbox
 			// allowlist references — dbConfig.CompactionTempDirectory has
 			// already been through resolveAbsPath. Using the raw

--- a/internal/compaction/daily.go
+++ b/internal/compaction/daily.go
@@ -24,7 +24,6 @@ type DailyTierConfig struct {
 	MinAgeHours          int  // Don't compact days younger than this (default: 24)
 	MinFiles             int  // Only compact days with at least this many files (default: 12)
 	SkipFileAgeCheckDays int  // Skip file creation time check for partitions older than this (default: 7)
-	TargetSizeMB         int  // Target size for compacted files (default: 2048)
 	Enabled              bool // Enable daily compaction (default: true)
 	Logger               zerolog.Logger
 }
@@ -46,18 +45,11 @@ func NewDailyTier(cfg *DailyTierConfig) *DailyTier {
 		// backfill is assumed complete.
 		cfg.SkipFileAgeCheckDays = 7
 	}
-	if cfg.TargetSizeMB == 0 {
-		// 2048 MB (2 GB): daily files should be large for efficient cold-tier reads.
-		// Larger than hourly (512 MB) because daily data is read less frequently.
-		cfg.TargetSizeMB = 2048
-	}
-
 	tier := &DailyTier{
 		BaseTier: NewBaseTier(&BaseTierConfig{
 			StorageBackend: cfg.StorageBackend,
 			MinAgeHours:    cfg.MinAgeHours,
 			MinFiles:       cfg.MinFiles,
-			TargetSizeMB:   cfg.TargetSizeMB,
 			Enabled:        cfg.Enabled,
 			Logger:         cfg.Logger.With().Str("tier", "daily").Logger(),
 		}),
@@ -68,7 +60,6 @@ func NewDailyTier(cfg *DailyTierConfig) *DailyTier {
 		Int("min_age_hours", cfg.MinAgeHours).
 		Int("min_files", cfg.MinFiles).
 		Int("skip_file_age_check_days", cfg.SkipFileAgeCheckDays).
-		Int("target_size_mb", cfg.TargetSizeMB).
 		Bool("enabled", cfg.Enabled).
 		Msg("Daily compaction tier initialized")
 

--- a/internal/compaction/hourly.go
+++ b/internal/compaction/hourly.go
@@ -22,7 +22,6 @@ type HourlyTierConfig struct {
 	StorageBackend storage.Backend
 	MinAgeHours    int  // Don't compact partitions younger than this (default: 1)
 	MinFiles       int  // Only compact partitions with at least this many files (default: 10)
-	TargetSizeMB   int  // Target size for compacted files (default: 512)
 	Enabled        bool // Enable hourly compaction (default: true)
 	Logger         zerolog.Logger
 }
@@ -41,18 +40,11 @@ func NewHourlyTier(cfg *HourlyTierConfig) *HourlyTier {
 		// Below this threshold compaction overhead outweighs the read-time savings.
 		cfg.MinFiles = 10
 	}
-	if cfg.TargetSizeMB == 0 {
-		// 512 MB: balances DuckDB read performance (prefers fewer, larger files)
-		// with memory usage during compaction.
-		cfg.TargetSizeMB = 512
-	}
-
 	tier := &HourlyTier{
 		BaseTier: NewBaseTier(&BaseTierConfig{
 			StorageBackend: cfg.StorageBackend,
 			MinAgeHours:    cfg.MinAgeHours,
 			MinFiles:       cfg.MinFiles,
-			TargetSizeMB:   cfg.TargetSizeMB,
 			Enabled:        cfg.Enabled,
 			Logger:         cfg.Logger.With().Str("tier", "hourly").Logger(),
 		}),
@@ -67,7 +59,6 @@ func NewHourlyTier(cfg *HourlyTierConfig) *HourlyTier {
 	tier.Logger.Info().
 		Int("min_age_hours", cfg.MinAgeHours).
 		Int("min_files", cfg.MinFiles).
-		Int("target_size_mb", cfg.TargetSizeMB).
 		Bool("enabled", cfg.Enabled).
 		Msg("Hourly compaction tier initialized")
 

--- a/internal/compaction/job.go
+++ b/internal/compaction/job.go
@@ -113,10 +113,13 @@ type Job struct {
 	Files          []string // Original files to be compacted
 	StorageBackend storage.Backend
 	Database       string
-	TargetSizeMB   int
 	Tier           string
-	TempDirectory  string   // Base temp directory for compaction files
-	SortKeys       []string // Sort keys for this measurement (for ORDER BY in compaction)
+	// BatchNumber is the 1-based index of this batch within its partition
+	// (0 when the job was not produced by SplitCandidateIntoBatches). It is
+	// part of the output filename so sibling batches cannot collide.
+	BatchNumber   int
+	TempDirectory string   // Base temp directory for compaction files
+	SortKeys      []string // Sort keys for this measurement (for ORDER BY in compaction)
 
 	// Job metadata
 	JobID       string
@@ -161,8 +164,8 @@ type JobConfig struct {
 	Files           []string
 	StorageBackend  storage.Backend
 	Database        string
-	TargetSizeMB    int
 	Tier            string
+	BatchNumber     int      // 1-based batch index within the partition (0 = not batched)
 	TempDirectory   string   // Base temp directory for compaction files (default: ./data/compaction)
 	SortKeys        []string // Sort keys for this measurement (for ORDER BY in compaction)
 	Logger          zerolog.Logger
@@ -219,8 +222,8 @@ func NewJob(cfg *JobConfig) *Job {
 		Files:           cfg.Files,
 		StorageBackend:  cfg.StorageBackend,
 		Database:        cfg.Database,
-		TargetSizeMB:    cfg.TargetSizeMB,
 		Tier:            cfg.Tier,
+		BatchNumber:     cfg.BatchNumber,
 		TempDirectory:   tempDir,
 		SortKeys:        sortKeys,
 		JobID:           jobID,
@@ -582,18 +585,28 @@ func (j *Job) downloadSingleFile(ctx context.Context, tempDir string, index int,
 // successfully compacted files' storage keys in j.compactedFiles.
 func (j *Job) compactFiles(ctx context.Context, files []downloadedFile, tempDir string) (string, error) {
 	// Generate output filename with tier-specific suffix.
-	// Format: {measurement}_{YYYYMMDD}_{HHMMSS}_{nanos}_{suffix}.parquet
+	// Format: {measurement}_{YYYYMMDD}_{HHMMSS}_{nanos}_b{batch}_{suffix}.parquet
 	// The nanos field guarantees uniqueness when multiple batches run
 	// sequentially for the same partition (SplitCandidateIntoBatches).
 	// Without it, batches within the same second produce identical filenames
 	// and each overwrites the previous, destroying data.
+	//
+	// The batch segment is belt-and-braces on top of nanos: wall-clock
+	// resolution is coarser than 1ns on some platforms (macOS in particular),
+	// and lowering compaction.max_files_per_batch multiplies the number of
+	// sibling batches competing for a distinct timestamp. BatchNumber is
+	// exactly the field that distinguishes them, so use it rather than relying
+	// on the clock alone. The uploaded storage key derives from this basename
+	// (see Job.Run), so a collision here would silently overwrite a sibling
+	// batch's compacted output.
 	now := time.Now().UTC()
 	timestamp := now.Format("20060102_150405")
 	suffix := "compacted"
 	if j.Tier != "hourly" {
 		suffix = j.Tier
 	}
-	outputFile := filepath.Join(tempDir, fmt.Sprintf("%s_%s_%d_%s.parquet", j.Measurement, timestamp, now.UnixNano(), suffix))
+	outputFile := filepath.Join(tempDir, fmt.Sprintf("%s_%s_%d_b%d_%s.parquet",
+		j.Measurement, timestamp, now.UnixNano(), j.BatchNumber, suffix))
 
 	// Use the shared DuckDB connection instead of creating a new one
 	// This prevents memory retention from DuckDB's jemalloc not releasing memory on Close()

--- a/internal/compaction/manager.go
+++ b/internal/compaction/manager.go
@@ -25,12 +25,15 @@ type Manager struct {
 	ManifestManager *ManifestManager
 
 	// Configuration
-	MinAgeHours   int
-	MinFiles      int
-	TargetSizeMB  int
-	MaxConcurrent int
-	TempDirectory string // Temp directory for compaction files
-	MemoryLimit   string // DuckDB memory limit for subprocess (e.g., "8GB")
+	MinAgeHours int
+	MinFiles    int
+	// MaxFilesPerBatch bounds how many files one compaction job feeds to a
+	// single DuckDB read_parquet() call. Already clamped to the supported
+	// range by NewManager.
+	MaxFilesPerBatch int
+	MaxConcurrent    int
+	TempDirectory    string // Temp directory for compaction files
+	MemoryLimit      string // DuckDB memory limit for subprocess (e.g., "8GB")
 	// Phase 4: local-disk directory where compaction subprocesses write
 	// completion manifests for the parent-side CompletionWatcher to pick
 	// up. Empty means "OSS mode, no completion-manifest handoff". Set by
@@ -69,19 +72,22 @@ type Manager struct {
 
 // ManagerConfig holds configuration for creating a compaction manager
 type ManagerConfig struct {
-	StorageBackend  storage.Backend
-	LockManager     *LockManager
-	MinAgeHours     int
-	MinFiles        int
-	TargetSizeMB    int
-	MaxConcurrent   int
-	TempDirectory   string              // Temp directory for compaction files
-	MemoryLimit     string              // DuckDB memory limit for subprocess (e.g., "8GB")
-	CompletionDir   string              // Phase 4: local-disk completion-manifest dir (empty = OSS mode)
-	SortKeysConfig  map[string][]string // Per-measurement sort keys from ingest config
-	DefaultSortKeys []string            // Default sort keys from ingest config
-	Tiers           []Tier
-	Logger          zerolog.Logger
+	StorageBackend storage.Backend
+	LockManager    *LockManager
+	MinAgeHours    int
+	MinFiles       int
+	// MaxFilesPerBatch bounds files per compaction job. Out-of-range values
+	// (including 0 from an unset field) are clamped by NewManager — see
+	// clampFilesPerBatch.
+	MaxFilesPerBatch int
+	MaxConcurrent    int
+	TempDirectory    string              // Temp directory for compaction files
+	MemoryLimit      string              // DuckDB memory limit for subprocess (e.g., "8GB")
+	CompletionDir    string              // Phase 4: local-disk completion-manifest dir (empty = OSS mode)
+	SortKeysConfig   map[string][]string // Per-measurement sort keys from ingest config
+	DefaultSortKeys  []string            // Default sort keys from ingest config
+	Tiers            []Tier
+	Logger           zerolog.Logger
 }
 
 // NewManager creates a new compaction manager
@@ -93,12 +99,13 @@ func NewManager(cfg *ManagerConfig) *Manager {
 	if cfg.MinFiles == 0 {
 		cfg.MinFiles = 10
 	}
-	if cfg.TargetSizeMB == 0 {
-		cfg.TargetSizeMB = 512
-	}
 	if cfg.MaxConcurrent == 0 {
 		cfg.MaxConcurrent = 2
 	}
+	// Clamp the batch size once here rather than per-partition, so an
+	// out-of-range configured value produces exactly one warning at startup.
+	// SplitCandidateIntoBatches clamps again defensively.
+	maxFilesPerBatch, batchSizeAdjusted := clampFilesPerBatch(cfg.MaxFilesPerBatch)
 	if cfg.TempDirectory == "" {
 		cfg.TempDirectory = "./data/compaction"
 	}
@@ -117,21 +124,30 @@ func NewManager(cfg *ManagerConfig) *Manager {
 	logger := cfg.Logger.With().Str("component", "compaction-manager").Logger()
 
 	m := &Manager{
-		StorageBackend:  cfg.StorageBackend,
-		LockManager:     cfg.LockManager,
-		ManifestManager: NewManifestManager(cfg.StorageBackend, logger),
-		MinAgeHours:     cfg.MinAgeHours,
-		MinFiles:        cfg.MinFiles,
-		TargetSizeMB:    cfg.TargetSizeMB,
-		MaxConcurrent:   cfg.MaxConcurrent,
-		TempDirectory:   cfg.TempDirectory,
-		MemoryLimit:     cfg.MemoryLimit,
-		CompletionDir:   cfg.CompletionDir,
-		SortKeysConfig:  sortKeysConfig,
-		DefaultSortKeys: defaultSortKeys,
-		Tiers:           cfg.Tiers,
-		jobHistory:      make([]map[string]interface{}, 0),
-		logger:          logger,
+		StorageBackend:   cfg.StorageBackend,
+		LockManager:      cfg.LockManager,
+		ManifestManager:  NewManifestManager(cfg.StorageBackend, logger),
+		MinAgeHours:      cfg.MinAgeHours,
+		MinFiles:         cfg.MinFiles,
+		MaxFilesPerBatch: maxFilesPerBatch,
+		MaxConcurrent:    cfg.MaxConcurrent,
+		TempDirectory:    cfg.TempDirectory,
+		MemoryLimit:      cfg.MemoryLimit,
+		CompletionDir:    cfg.CompletionDir,
+		SortKeysConfig:   sortKeysConfig,
+		DefaultSortKeys:  defaultSortKeys,
+		Tiers:            cfg.Tiers,
+		jobHistory:       make([]map[string]interface{}, 0),
+		logger:           logger,
+	}
+
+	if batchSizeAdjusted {
+		m.logger.Warn().
+			Int("configured", cfg.MaxFilesPerBatch).
+			Int("effective", maxFilesPerBatch).
+			Int("min", MinFilesPerBatch).
+			Int("max", MaxAllowedFilesPerBatch).
+			Msg("compaction.max_files_per_batch out of range; using adjusted value")
 	}
 
 	// Log tier information
@@ -229,11 +245,30 @@ func (m *Manager) CompactPartition(ctx context.Context, candidate Candidate) err
 	// Build subprocess config. JobID is generated here (not inside NewJob)
 	// so the parent and subprocess agree on the completion-manifest filename.
 	// The format matches NewJob's default to stay consistent with the
-	// existing temp-dir naming scheme used by CleanupOrphanedTempDirs.
-	jobID := fmt.Sprintf("%s_%s_%d",
+	// existing temp-dir naming scheme used by CleanupOrphanedTempDirs (which
+	// removes non-reserved subdirectories wholesale and does not parse this).
+	//
+	// BatchNumber is included because sibling batches of one partition differ
+	// in nothing else: same database, same partition path, and a wall-clock
+	// nanosecond that is not guaranteed distinct (macOS returns a coarse
+	// clock). A JobID collision would make two batches share a
+	// completion-manifest filename (completion.go writes {JobID}.json), so one
+	// batch's manifest would overwrite the other's and its output would never
+	// be registered in the Raft manifest. Batches run sequentially today, which
+	// makes this remote — BatchNumber makes it impossible.
+	//
+	// This assumes the candidate came from SplitCandidateIntoBatches, which
+	// always sets a 1-based BatchNumber (1 of 1 for an unsplit partition).
+	// Today that holds: the only caller is compactFilesAdaptively, which is
+	// only ever reached from runCycleInternal via the split. A candidate
+	// constructed directly would carry BatchNumber 0 and yield a "_b0" suffix
+	// — still unique against real batches, but a signal the invariant was
+	// bypassed.
+	jobID := fmt.Sprintf("%s_%s_%d_b%d",
 		candidate.Database,
 		strings.ReplaceAll(candidate.PartitionPath, "/", "_"),
 		time.Now().UnixNano(),
+		candidate.BatchNumber,
 	)
 	config := &SubprocessJobConfig{
 		Database:      candidate.Database,
@@ -241,7 +276,7 @@ func (m *Manager) CompactPartition(ctx context.Context, candidate Candidate) err
 		PartitionPath: candidate.PartitionPath,
 		Files:         candidate.Files,
 		Tier:          candidate.Tier,
-		TargetSizeMB:  m.TargetSizeMB,
+		BatchNumber:   candidate.BatchNumber,
 		TempDirectory: m.TempDirectory,
 		MemoryLimit:   m.MemoryLimit,
 		SortKeys:      m.GetSortKeys(candidate.Measurement),
@@ -378,8 +413,16 @@ func (m *Manager) CompactPartition(ctx context.Context, candidate Candidate) err
 //     - Recursively compact each half
 //  3. If batch size <= minBatchSize and still failing, give up
 func (m *Manager) compactFilesAdaptively(ctx context.Context, candidate Candidate, files []string, depth int, stderr string) error {
-	const maxDepth = 4     // Maximum split depth: 30 → 15 → 7 → 3 → minimum
-	const minBatchSize = 2 // Don't split below 2 files
+	// Maximum split depth. Each level halves the batch, so the ladder starts at
+	// whatever compaction.max_files_per_batch produced and bottoms out at
+	// MinFilesPerBatch — e.g. at the default 30: 30 → 15 → 7 → 3 → stop.
+	// A larger configured batch size does not get proportionally more retries,
+	// which is part of why MaxAllowedFilesPerBatch caps it.
+	const maxDepth = 4
+	// Don't split below MinFilesPerBatch files. This is the same floor
+	// SplitCandidateIntoBatches clamps to, so a configured batch size can never
+	// land below it and fail here on the first attempt.
+	const minBatchSize = MinFilesPerBatch
 
 	// Check context cancellation
 	if ctx.Err() != nil {
@@ -657,7 +700,7 @@ func (m *Manager) runCycleInternal(ctx context.Context, filterDatabases []string
 
 					// Split large candidates into batches to prevent DuckDB segfaults
 					// when processing too many files in a single read_parquet() call
-					batches := SplitCandidateIntoBatches(filteredCandidate)
+					batches := SplitCandidateIntoBatches(filteredCandidate, m.MaxFilesPerBatch)
 					if len(batches) > 1 {
 						m.logger.Info().
 							Str("partition", filteredCandidate.PartitionPath).

--- a/internal/compaction/manager_test.go
+++ b/internal/compaction/manager_test.go
@@ -30,14 +30,14 @@ func setupTestManager(t *testing.T) (*Manager, storage.Backend, func()) {
 	lockManager := NewLockManager()
 
 	cfg := &ManagerConfig{
-		StorageBackend: backend,
-		LockManager:    lockManager,
-		MinAgeHours:    1,
-		MinFiles:       5,
-		TargetSizeMB:   256,
-		MaxConcurrent:  2,
-		TempDirectory:  tmpDir + "/temp",
-		Logger:         logger,
+		StorageBackend:   backend,
+		LockManager:      lockManager,
+		MinAgeHours:      1,
+		MinFiles:         5,
+		MaxFilesPerBatch: 10,
+		MaxConcurrent:    2,
+		TempDirectory:    tmpDir + "/temp",
+		Logger:           logger,
 	}
 
 	manager := NewManager(cfg)
@@ -75,8 +75,11 @@ func TestNewManager(t *testing.T) {
 		if manager.MinFiles != 10 {
 			t.Errorf("MinFiles = %d, want 10", manager.MinFiles)
 		}
-		if manager.TargetSizeMB != 512 {
-			t.Errorf("TargetSizeMB = %d, want 512", manager.TargetSizeMB)
+		// An unset MaxFilesPerBatch (0) is out of range and must clamp to the
+		// default rather than reaching SplitCandidateIntoBatches as a zero
+		// divisor.
+		if manager.MaxFilesPerBatch != DefaultMaxFilesPerBatch {
+			t.Errorf("MaxFilesPerBatch = %d, want %d", manager.MaxFilesPerBatch, DefaultMaxFilesPerBatch)
 		}
 		if manager.MaxConcurrent != 2 {
 			t.Errorf("MaxConcurrent = %d, want 2", manager.MaxConcurrent)
@@ -92,14 +95,14 @@ func TestNewManager(t *testing.T) {
 		defer backend.Close()
 
 		cfg := &ManagerConfig{
-			StorageBackend: backend,
-			LockManager:    NewLockManager(),
-			MinAgeHours:    24,
-			MinFiles:       20,
-			TargetSizeMB:   1024,
-			MaxConcurrent:  4,
-			TempDirectory:  "/custom/temp",
-			Logger:         logger,
+			StorageBackend:   backend,
+			LockManager:      NewLockManager(),
+			MinAgeHours:      24,
+			MinFiles:         20,
+			MaxFilesPerBatch: 12,
+			MaxConcurrent:    4,
+			TempDirectory:    "/custom/temp",
+			Logger:           logger,
 		}
 
 		manager := NewManager(cfg)
@@ -110,8 +113,9 @@ func TestNewManager(t *testing.T) {
 		if manager.MinFiles != 20 {
 			t.Errorf("MinFiles = %d, want 20", manager.MinFiles)
 		}
-		if manager.TargetSizeMB != 1024 {
-			t.Errorf("TargetSizeMB = %d, want 1024", manager.TargetSizeMB)
+		// An in-range value is honored verbatim.
+		if manager.MaxFilesPerBatch != 12 {
+			t.Errorf("MaxFilesPerBatch = %d, want 12", manager.MaxFilesPerBatch)
 		}
 		if manager.MaxConcurrent != 4 {
 			t.Errorf("MaxConcurrent = %d, want 4", manager.MaxConcurrent)

--- a/internal/compaction/subprocess.go
+++ b/internal/compaction/subprocess.go
@@ -30,10 +30,14 @@ type SubprocessJobConfig struct {
 	PartitionPath string   `json:"partition_path"`
 	Files         []string `json:"files"`
 	Tier          string   `json:"tier"`
-	TargetSizeMB  int      `json:"target_size_mb"`
 	TempDirectory string   `json:"temp_directory"`
-	SortKeys      []string `json:"sort_keys"`    // Sort keys for ORDER BY in compaction
-	MemoryLimit   string   `json:"memory_limit"` // DuckDB memory limit (e.g., "8GB")
+	// BatchNumber is the 1-based index of this batch within its partition.
+	// Carried through so the subprocess can disambiguate the output filename
+	// between sibling batches (see Job.compactFiles). Zero means the job was
+	// not produced by SplitCandidateIntoBatches.
+	BatchNumber int      `json:"batch_number,omitempty"`
+	SortKeys    []string `json:"sort_keys"`    // Sort keys for ORDER BY in compaction
+	MemoryLimit string   `json:"memory_limit"` // DuckDB memory limit (e.g., "8GB")
 
 	// Storage configuration
 	StorageType   string `json:"storage_type"`   // "local" or "s3"
@@ -124,8 +128,8 @@ func RunSubprocessJob(config *SubprocessJobConfig) (*SubprocessJobResult, error)
 		PartitionPath:   config.PartitionPath,
 		Files:           config.Files,
 		StorageBackend:  backend,
-		TargetSizeMB:    config.TargetSizeMB,
 		Tier:            config.Tier,
+		BatchNumber:     config.BatchNumber,
 		TempDirectory:   config.TempDirectory,
 		SortKeys:        config.SortKeys,
 		Logger:          logger,

--- a/internal/compaction/tier.go
+++ b/internal/compaction/tier.go
@@ -9,11 +9,51 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// MaxFilesPerBatch is the maximum number of files to process in a single compaction job.
-// DuckDB can segfault/abort when processing too many files in a single read_parquet() call.
-// This limit prevents OOM and crashes on partitions with many large files.
-// With 1M buffer size, files are ~10-14MB each, so 30 files ≈ 300-420MB per batch.
-const MaxFilesPerBatch = 30
+// Batch-size bounds for a single compaction job.
+//
+// DuckDB can segfault/abort when a single read_parquet() call spans too many
+// files, so compaction splits large partitions into batches. Each batch becomes
+// an independent job with its own output file, upload, and manifest entry.
+//
+// Output size scales with INPUT file size, which in turn tracks the ingest
+// buffer settings — this is a file-count bound, not a byte bound, so the size
+// of a compacted file is not directly controlled here. Deployments on
+// constrained or intermittent links (edge/field) may lower
+// compaction.max_files_per_batch to get smaller, independently-transferable
+// outputs, at the cost of more compaction jobs per partition.
+const (
+	// DefaultMaxFilesPerBatch is the default and the fallback used when the
+	// configured value is out of range.
+	DefaultMaxFilesPerBatch = 30
+
+	// MinFilesPerBatch is the smallest usable batch size. It matches the
+	// minBatchSize floor in compactFilesAdaptively: a batch below this size is
+	// rejected there outright, so allowing it here would fail every batch of
+	// every partition rather than merely producing small outputs.
+	MinFilesPerBatch = 2
+
+	// MaxAllowedFilesPerBatch caps the configured value. The whole point of
+	// batching is to keep read_parquet() below DuckDB's crash threshold, and
+	// the adaptive retry in compactFilesAdaptively only halves four times —
+	// not enough to rescue an arbitrarily large value.
+	MaxAllowedFilesPerBatch = 500
+)
+
+// clampFilesPerBatch coerces a configured batch size into the supported range.
+// Out-of-range low values (including 0 and the fatal 1) fall back to the
+// default; excessive values are capped. Returns the effective size and whether
+// the input was adjusted, so callers can log the correction once at startup
+// rather than on every partition.
+func clampFilesPerBatch(n int) (int, bool) {
+	switch {
+	case n < MinFilesPerBatch:
+		return DefaultMaxFilesPerBatch, true
+	case n > MaxAllowedFilesPerBatch:
+		return MaxAllowedFilesPerBatch, true
+	default:
+		return n, false
+	}
+}
 
 // Candidate represents a partition candidate for compaction
 type Candidate struct {
@@ -24,32 +64,68 @@ type Candidate struct {
 	FileCount     int
 	Tier          string
 	PartitionTime time.Time
-	BatchNumber   int // Batch number when candidate is split (0 = not batched or first batch)
-	TotalBatches  int // Total number of batches for this partition (0 = not batched)
+	// BatchNumber and TotalBatches are 1-based and always set by
+	// SplitCandidateIntoBatches, including for a partition that fits in a
+	// single batch (1 of 1). Job and output-file identifiers incorporate
+	// BatchNumber to keep sibling batches of one partition distinct, so a zero
+	// value here would collide with batch 1. A Candidate constructed directly
+	// (not via SplitCandidateIntoBatches) leaves these at 0.
+	BatchNumber  int // 1-based batch index within the partition
+	TotalBatches int // Total number of batches for this partition
 }
 
 // SplitCandidateIntoBatches splits a candidate with many files into multiple candidates,
-// each with at most MaxFilesPerBatch files. This prevents DuckDB segfaults when processing
+// each with at most maxFilesPerBatch files. This prevents DuckDB segfaults when processing
 // thousands of files in a single read_parquet() call.
+//
+// maxFilesPerBatch is clamped to [MinFilesPerBatch, MaxAllowedFilesPerBatch];
+// out-of-range values fall back to DefaultMaxFilesPerBatch (see
+// clampFilesPerBatch). Clamping happens here as well as at startup so a caller
+// that bypasses the configured manager value cannot produce a zero divisor or a
+// batch size that compactFilesAdaptively would reject outright.
 //
 // Every returned batch owns an independent Files backing array, including the
 // single-batch case. Callers may mutate a batch's Files without affecting the
 // input candidate or any sibling batch.
-func SplitCandidateIntoBatches(c Candidate) []Candidate {
-	if len(c.Files) <= MaxFilesPerBatch {
+func SplitCandidateIntoBatches(c Candidate, maxFilesPerBatch int) []Candidate {
+	maxFilesPerBatch, _ = clampFilesPerBatch(maxFilesPerBatch)
+
+	if len(c.Files) <= maxFilesPerBatch {
 		single := c
 		single.Files = append([]string(nil), c.Files...)
+		// A partition that fits in one batch is still batch 1 of 1 — callers
+		// derive job and output identifiers from these fields, so leaving them
+		// zero here would make the single-batch case indistinguishable from an
+		// unbatched candidate.
+		single.BatchNumber = 1
+		single.TotalBatches = 1
 		return []Candidate{single}
 	}
 
 	// Calculate number of batches needed
-	numBatches := (len(c.Files) + MaxFilesPerBatch - 1) / MaxFilesPerBatch
+	numBatches := (len(c.Files) + maxFilesPerBatch - 1) / maxFilesPerBatch
+
+	// A trailing remainder smaller than MinFilesPerBatch cannot be compacted:
+	// compactFilesAdaptively rejects any batch below that floor on its first
+	// attempt, so the remainder would fail every cycle and its files would
+	// never compact. Drop the last batch and let the loop's end-clamp fold
+	// those files into the (now final) batch instead, which overshoots
+	// maxFilesPerBatch by at most MinFilesPerBatch-1 files — far safer than
+	// leaving a partition permanently un-compacted at the tail.
+	if rem := len(c.Files) % maxFilesPerBatch; rem != 0 && rem < MinFilesPerBatch && numBatches > 1 {
+		numBatches--
+	}
 
 	batches := make([]Candidate, 0, numBatches)
 	for i := 0; i < numBatches; i++ {
-		start := i * MaxFilesPerBatch
-		end := start + MaxFilesPerBatch
-		if end > len(c.Files) {
+		start := i * maxFilesPerBatch
+		end := start + maxFilesPerBatch
+		// The final batch absorbs every remaining file, so it spans its nominal
+		// maxFilesPerBatch plus any remainder left by the adjustment above. A
+		// non-final batch always ends within bounds — numBatches is derived
+		// from len(Files), so only the last iteration can reach past it — which
+		// is why this clamp keys off the index rather than comparing to length.
+		if i == numBatches-1 {
 			end = len(c.Files)
 		}
 
@@ -102,7 +178,6 @@ type BaseTier struct {
 	StorageBackend storage.Backend
 	MinAgeHours    int
 	MinFiles       int
-	TargetSizeMB   int
 	Enabled        bool
 
 	// Metrics
@@ -119,7 +194,6 @@ type BaseTierConfig struct {
 	StorageBackend storage.Backend
 	MinAgeHours    int
 	MinFiles       int
-	TargetSizeMB   int
 	Enabled        bool
 	Logger         zerolog.Logger
 }
@@ -130,7 +204,6 @@ func NewBaseTier(cfg *BaseTierConfig) *BaseTier {
 		StorageBackend: cfg.StorageBackend,
 		MinAgeHours:    cfg.MinAgeHours,
 		MinFiles:       cfg.MinFiles,
-		TargetSizeMB:   cfg.TargetSizeMB,
 		Enabled:        cfg.Enabled,
 		Logger:         cfg.Logger,
 	}
@@ -151,7 +224,6 @@ func (t *BaseTier) GetBaseStats(tierName string) map[string]interface{} {
 		"enabled":               t.Enabled,
 		"min_age_hours":         t.MinAgeHours,
 		"min_files":             t.MinFiles,
-		"target_size_mb":        t.TargetSizeMB,
 		"total_compactions":     t.totalCompactions,
 		"total_files_compacted": t.totalFilesCompacted,
 		"total_bytes_saved":     t.totalBytesSaved,

--- a/internal/compaction/tier_test.go
+++ b/internal/compaction/tier_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSplitCandidateIntoBatches_NoAlias(t *testing.T) {
-	files := make([]string, MaxFilesPerBatch*3+5)
+	files := make([]string, DefaultMaxFilesPerBatch*3+5)
 	for i := range files {
 		files[i] = fmt.Sprintf("file_%d.parquet", i)
 	}
@@ -22,7 +22,7 @@ func TestSplitCandidateIntoBatches_NoAlias(t *testing.T) {
 		PartitionTime: time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC),
 	}
 
-	batches := SplitCandidateIntoBatches(c)
+	batches := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
 
 	// Mutate every batch's Files slice.
 	for i := range batches {
@@ -40,7 +40,7 @@ func TestSplitCandidateIntoBatches_NoAlias(t *testing.T) {
 
 	// Verify: batches must not alias each other.
 	// Reset and mutate only batch 0.
-	batches2 := SplitCandidateIntoBatches(c)
+	batches2 := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
 	if len(batches2) < 2 {
 		t.Fatal("expected at least 2 batches")
 	}
@@ -57,7 +57,7 @@ func TestSplitCandidateIntoBatches_NoAlias(t *testing.T) {
 }
 
 func TestSplitCandidateIntoBatches_SingleBatchNoAlias(t *testing.T) {
-	// The <= MaxFilesPerBatch early-return path must copy too, so batch
+	// The <= DefaultMaxFilesPerBatch early-return path must copy too, so batch
 	// isolation does not silently depend on file count.
 	files := []string{"a.parquet", "b.parquet", "c.parquet"}
 	c := Candidate{
@@ -67,7 +67,7 @@ func TestSplitCandidateIntoBatches_SingleBatchNoAlias(t *testing.T) {
 		FileCount:   len(files),
 	}
 
-	batches := SplitCandidateIntoBatches(c)
+	batches := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
 	if len(batches) != 1 {
 		t.Fatalf("expected 1 batch, got %d", len(batches))
 	}
@@ -89,7 +89,7 @@ func TestSplitCandidateIntoBatches_EmptyFiles(t *testing.T) {
 		FileCount:   0,
 	}
 
-	batches := SplitCandidateIntoBatches(c)
+	batches := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
 	if len(batches) != 1 {
 		t.Fatalf("expected 1 batch for empty files, got %d", len(batches))
 	}
@@ -99,8 +99,11 @@ func TestSplitCandidateIntoBatches_EmptyFiles(t *testing.T) {
 }
 
 func TestSplitCandidateIntoBatches_MinimalSplit(t *testing.T) {
-	// MaxFilesPerBatch+1 is the minimum case that exercises the multi-batch path.
-	files := make([]string, MaxFilesPerBatch+1)
+	// DefaultMaxFilesPerBatch+1 files leaves a 1-file remainder. A 1-file batch
+	// is unusable — compactFilesAdaptively rejects anything below
+	// MinFilesPerBatch on its first attempt — so the remainder is folded into
+	// the final batch rather than emitted as its own.
+	files := make([]string, DefaultMaxFilesPerBatch+1)
 	for i := range files {
 		files[i] = fmt.Sprintf("file_%d.parquet", i)
 	}
@@ -111,20 +114,34 @@ func TestSplitCandidateIntoBatches_MinimalSplit(t *testing.T) {
 		FileCount:   len(files),
 	}
 
-	batches := SplitCandidateIntoBatches(c)
-	if len(batches) != 2 {
-		t.Fatalf("expected 2 batches, got %d", len(batches))
+	batches := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
+	if len(batches) != 1 {
+		t.Fatalf("expected 1 batch (remainder absorbed), got %d", len(batches))
 	}
-	if len(batches[0].Files) != MaxFilesPerBatch {
-		t.Fatalf("batch 0: expected %d files, got %d", MaxFilesPerBatch, len(batches[0].Files))
+	if len(batches[0].Files) != DefaultMaxFilesPerBatch+1 {
+		t.Fatalf("batch 0: expected %d files, got %d", DefaultMaxFilesPerBatch+1, len(batches[0].Files))
 	}
-	if len(batches[1].Files) != 1 {
-		t.Fatalf("batch 1: expected 1 file, got %d", len(batches[1].Files))
+
+	// Two files over the limit must still split into two usable batches.
+	files2 := make([]string, DefaultMaxFilesPerBatch+MinFilesPerBatch)
+	for i := range files2 {
+		files2[i] = fmt.Sprintf("file_%d.parquet", i)
+	}
+	c2 := c
+	c2.Files = files2
+	c2.FileCount = len(files2)
+
+	batches2 := SplitCandidateIntoBatches(c2, DefaultMaxFilesPerBatch)
+	if len(batches2) != 2 {
+		t.Fatalf("expected 2 batches, got %d", len(batches2))
+	}
+	if len(batches2[1].Files) != MinFilesPerBatch {
+		t.Fatalf("batch 1: expected %d files, got %d", MinFilesPerBatch, len(batches2[1].Files))
 	}
 
 	// Verify no aliasing between the two batches.
-	batches[0].Files[0] = "CHANGED"
-	if batches[1].Files[0] == "CHANGED" {
+	batches2[0].Files[0] = "CHANGED"
+	if batches2[1].Files[0] == "CHANGED" {
 		t.Fatal("batch[1].Files[0] aliased with batch[0].Files[0]")
 	}
 }
@@ -137,7 +154,7 @@ func TestSplitCandidateIntoBatches_UnderLimit(t *testing.T) {
 		FileCount:   2,
 	}
 
-	batches := SplitCandidateIntoBatches(c)
+	batches := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
 	if len(batches) != 1 {
 		t.Fatalf("expected 1 batch, got %d", len(batches))
 	}
@@ -147,7 +164,7 @@ func TestSplitCandidateIntoBatches_UnderLimit(t *testing.T) {
 }
 
 func TestSplitCandidateIntoBatches_ExactLimit(t *testing.T) {
-	files := make([]string, MaxFilesPerBatch)
+	files := make([]string, DefaultMaxFilesPerBatch)
 	for i := range files {
 		files[i] = fmt.Sprintf("f_%d.parquet", i)
 	}
@@ -155,17 +172,17 @@ func TestSplitCandidateIntoBatches_ExactLimit(t *testing.T) {
 		Database:    "db",
 		Measurement: "cpu",
 		Files:       files,
-		FileCount:   MaxFilesPerBatch,
+		FileCount:   DefaultMaxFilesPerBatch,
 	}
 
-	batches := SplitCandidateIntoBatches(c)
+	batches := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
 	if len(batches) != 1 {
-		t.Fatalf("expected 1 batch for exactly MaxFilesPerBatch files, got %d", len(batches))
+		t.Fatalf("expected 1 batch for exactly DefaultMaxFilesPerBatch files, got %d", len(batches))
 	}
 }
 
 func TestSplitCandidateIntoBatches_CorrectPartitioning(t *testing.T) {
-	n := MaxFilesPerBatch*2 + 3
+	n := DefaultMaxFilesPerBatch*2 + 3
 	files := make([]string, n)
 	for i := range files {
 		files[i] = fmt.Sprintf("file_%d.parquet", i)
@@ -179,7 +196,7 @@ func TestSplitCandidateIntoBatches_CorrectPartitioning(t *testing.T) {
 		Tier:          "daily",
 	}
 
-	batches := SplitCandidateIntoBatches(c)
+	batches := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
 
 	expectedBatches := 3
 	if len(batches) != expectedBatches {
@@ -187,12 +204,12 @@ func TestSplitCandidateIntoBatches_CorrectPartitioning(t *testing.T) {
 	}
 
 	// First batch: full.
-	if len(batches[0].Files) != MaxFilesPerBatch {
-		t.Fatalf("batch 0: expected %d files, got %d", MaxFilesPerBatch, len(batches[0].Files))
+	if len(batches[0].Files) != DefaultMaxFilesPerBatch {
+		t.Fatalf("batch 0: expected %d files, got %d", DefaultMaxFilesPerBatch, len(batches[0].Files))
 	}
 	// Second batch: full.
-	if len(batches[1].Files) != MaxFilesPerBatch {
-		t.Fatalf("batch 1: expected %d files, got %d", MaxFilesPerBatch, len(batches[1].Files))
+	if len(batches[1].Files) != DefaultMaxFilesPerBatch {
+		t.Fatalf("batch 1: expected %d files, got %d", DefaultMaxFilesPerBatch, len(batches[1].Files))
 	}
 	// Last batch: remainder.
 	if len(batches[2].Files) != 3 {
@@ -218,6 +235,246 @@ func TestSplitCandidateIntoBatches_CorrectPartitioning(t *testing.T) {
 				t.Errorf("file mismatch at index %d: got %q, want %q", want, f, expected)
 			}
 			want++
+		}
+	}
+}
+
+// newTestCandidate builds a candidate with n synthetic files.
+func newTestCandidate(n int) Candidate {
+	files := make([]string, n)
+	for i := range files {
+		files[i] = fmt.Sprintf("file_%d.parquet", i)
+	}
+	return Candidate{
+		Database:      "db",
+		Measurement:   "cpu",
+		PartitionPath: "2026/08/06",
+		Files:         files,
+		FileCount:     n,
+		Tier:          "hourly",
+		PartitionTime: time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestSplitCandidateIntoBatches_HonorsConfiguredSize is the core behavioral
+// test for making the batch size configurable: the SAME input must split
+// differently depending on the argument. Before this was configurable, batching
+// was fixed at the package const and no argument could change it.
+func TestSplitCandidateIntoBatches_HonorsConfiguredSize(t *testing.T) {
+	c := newTestCandidate(12)
+
+	// At the default (30), 12 files fit in a single batch.
+	atDefault := SplitCandidateIntoBatches(c, DefaultMaxFilesPerBatch)
+	if len(atDefault) != 1 {
+		t.Fatalf("at default: expected 1 batch for 12 files, got %d", len(atDefault))
+	}
+
+	// At 5, the same 12 files must split 5/5/2.
+	atFive := SplitCandidateIntoBatches(c, 5)
+	if len(atFive) != 3 {
+		t.Fatalf("at 5: expected 3 batches for 12 files, got %d", len(atFive))
+	}
+	wantSizes := []int{5, 5, 2}
+	for i, want := range wantSizes {
+		if got := len(atFive[i].Files); got != want {
+			t.Errorf("at 5: batch %d has %d files, want %d", i, got, want)
+		}
+		if atFive[i].FileCount != want {
+			t.Errorf("at 5: batch %d FileCount = %d, want %d", i, atFive[i].FileCount, want)
+		}
+	}
+
+	// Every file must appear exactly once across batches — a smaller batch size
+	// must not drop or duplicate work.
+	seen := make(map[string]int, 12)
+	for _, b := range atFive {
+		for _, f := range b.Files {
+			seen[f]++
+		}
+	}
+	if len(seen) != 12 {
+		t.Errorf("at 5: expected 12 distinct files across batches, got %d", len(seen))
+	}
+	for f, n := range seen {
+		if n != 1 {
+			t.Errorf("at 5: file %s appeared %d times, want 1", f, n)
+		}
+	}
+}
+
+// TestSplitCandidateIntoBatches_ClampsOutOfRange covers the config-value domain.
+// The value 1 is the important case: compactFilesAdaptively rejects any batch
+// below MinFilesPerBatch outright, so a batch size of 1 would fail every batch
+// of every partition rather than merely producing small outputs.
+func TestSplitCandidateIntoBatches_ClampsOutOfRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		wantSize int
+	}{
+		{"negative falls back to default", -1, DefaultMaxFilesPerBatch},
+		{"zero falls back to default", 0, DefaultMaxFilesPerBatch},
+		{"one falls back to default (below adaptive-retry floor)", 1, DefaultMaxFilesPerBatch},
+		{"minimum is honored", MinFilesPerBatch, MinFilesPerBatch},
+		{"excessive value is capped", 10000, MaxAllowedFilesPerBatch},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := clampFilesPerBatch(tt.input); got != tt.wantSize {
+				t.Errorf("clampFilesPerBatch(%d) = %d, want %d", tt.input, got, tt.wantSize)
+			}
+
+			// The clamp must also hold through the split itself, not only in
+			// the helper — a zero divisor here would panic.
+			c := newTestCandidate(DefaultMaxFilesPerBatch + 1)
+			batches := SplitCandidateIntoBatches(c, tt.input)
+			for i, b := range batches {
+				// The final batch may absorb a sub-minimum remainder, so it can
+				// overshoot by up to MinFilesPerBatch-1.
+				if limit := tt.wantSize + MinFilesPerBatch - 1; len(b.Files) > limit {
+					t.Errorf("batch %d has %d files, exceeds effective max %d (+remainder slack)",
+						i, len(b.Files), limit)
+				}
+				// No batch may fall below the floor compactFilesAdaptively
+				// rejects — that batch could never compact.
+				if len(b.Files) < MinFilesPerBatch {
+					t.Errorf("batch %d has %d files, below the adaptive-retry floor %d",
+						i, len(b.Files), MinFilesPerBatch)
+				}
+			}
+		})
+	}
+}
+
+// TestSplitCandidateIntoBatches_ClampReportsAdjustment verifies the second
+// return value, which drives the one-shot startup warning in NewManager.
+func TestSplitCandidateIntoBatches_ClampReportsAdjustment(t *testing.T) {
+	for _, in := range []int{-1, 0, 1, 10000} {
+		if _, adjusted := clampFilesPerBatch(in); !adjusted {
+			t.Errorf("clampFilesPerBatch(%d): expected adjusted=true", in)
+		}
+	}
+	for _, in := range []int{MinFilesPerBatch, DefaultMaxFilesPerBatch, MaxAllowedFilesPerBatch} {
+		if _, adjusted := clampFilesPerBatch(in); adjusted {
+			t.Errorf("clampFilesPerBatch(%d): expected adjusted=false", in)
+		}
+	}
+}
+
+// TestSplitCandidateIntoBatches_BatchNumberAtCustomSize guards the identifiers
+// that job and output filenames derive from. BatchNumber must be 1-based and
+// distinct across siblings, including in the single-batch case — a zero there
+// would collide with batch 1.
+func TestSplitCandidateIntoBatches_BatchNumberAtCustomSize(t *testing.T) {
+	t.Run("multi-batch", func(t *testing.T) {
+		batches := SplitCandidateIntoBatches(newTestCandidate(12), 5)
+		if len(batches) != 3 {
+			t.Fatalf("expected 3 batches, got %d", len(batches))
+		}
+		seen := make(map[int]bool, len(batches))
+		for i, b := range batches {
+			if b.BatchNumber != i+1 {
+				t.Errorf("batch %d: BatchNumber = %d, want %d", i, b.BatchNumber, i+1)
+			}
+			if b.TotalBatches != 3 {
+				t.Errorf("batch %d: TotalBatches = %d, want 3", i, b.TotalBatches)
+			}
+			if seen[b.BatchNumber] {
+				t.Errorf("duplicate BatchNumber %d — job IDs and output filenames would collide", b.BatchNumber)
+			}
+			seen[b.BatchNumber] = true
+		}
+	})
+
+	t.Run("single batch is 1 of 1", func(t *testing.T) {
+		batches := SplitCandidateIntoBatches(newTestCandidate(3), 5)
+		if len(batches) != 1 {
+			t.Fatalf("expected 1 batch, got %d", len(batches))
+		}
+		if batches[0].BatchNumber != 1 {
+			t.Errorf("BatchNumber = %d, want 1 (0 would collide with batch 1 in derived identifiers)",
+				batches[0].BatchNumber)
+		}
+		if batches[0].TotalBatches != 1 {
+			t.Errorf("TotalBatches = %d, want 1", batches[0].TotalBatches)
+		}
+	})
+}
+
+// TestSplitCandidateIntoBatches_AtMinimumSize exercises the remainder logic at
+// the smallest legal batch size, where it is tightest: with maxFilesPerBatch=2,
+// every odd file count leaves a 1-file remainder that must be absorbed rather
+// than emitted. Exact batch sizes are asserted because this is the arithmetic
+// that decides whether a batch is compactable at all.
+func TestSplitCandidateIntoBatches_AtMinimumSize(t *testing.T) {
+	tests := []struct {
+		files     int
+		wantSizes []int
+	}{
+		{3, []int{3}},       // odd: remainder absorbed, single batch
+		{4, []int{2, 2}},    // even: clean division
+		{5, []int{2, 3}},    // odd: last batch absorbs the remainder
+		{6, []int{2, 2, 2}}, // even
+		{7, []int{2, 2, 3}}, // odd
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d_files", tt.files), func(t *testing.T) {
+			batches := SplitCandidateIntoBatches(newTestCandidate(tt.files), MinFilesPerBatch)
+
+			if len(batches) != len(tt.wantSizes) {
+				t.Fatalf("got %d batches, want %d", len(batches), len(tt.wantSizes))
+			}
+
+			total := 0
+			for i, want := range tt.wantSizes {
+				got := len(batches[i].Files)
+				if got != want {
+					t.Errorf("batch %d: %d files, want %d", i, got, want)
+				}
+				if got < MinFilesPerBatch {
+					t.Errorf("batch %d: %d files is below the adaptive-retry floor %d — this batch could never compact",
+						i, got, MinFilesPerBatch)
+				}
+				total += got
+			}
+
+			// No file may be dropped or duplicated by the remainder handling.
+			if total != tt.files {
+				t.Errorf("batches account for %d files, want %d", total, tt.files)
+			}
+		})
+	}
+}
+
+// TestSplitCandidateIntoBatches_EveryBatchIsCompactable is the integration-level
+// guard between the two independent batch-sizing mechanisms: whatever
+// SplitCandidateIntoBatches emits must survive compactFilesAdaptively's floor
+// check, or the batch fails on its first attempt and its files never compact.
+// Swept across batch sizes and file counts because the failure only appears at
+// specific remainders.
+func TestSplitCandidateIntoBatches_EveryBatchIsCompactable(t *testing.T) {
+	for _, size := range []int{MinFilesPerBatch, 3, 5, 7, DefaultMaxFilesPerBatch} {
+		for files := 1; files <= size*3+1; files++ {
+			batches := SplitCandidateIntoBatches(newTestCandidate(files), size)
+
+			total := 0
+			for i, b := range batches {
+				total += len(b.Files)
+				// A single batch holding the whole (possibly tiny) partition is
+				// fine — compactFilesAdaptively's floor only rejects a batch
+				// that is small because it was split badly, and a partition
+				// with fewer than MinFilesPerBatch files would not reach
+				// compaction anyway (tier MinFiles is far higher).
+				if len(batches) > 1 && len(b.Files) < MinFilesPerBatch {
+					t.Errorf("size=%d files=%d: batch %d has %d files, below compactFilesAdaptively's floor %d",
+						size, files, i, len(b.Files), MinFilesPerBatch)
+				}
+			}
+			if total != files {
+				t.Errorf("size=%d files=%d: batches account for %d files", size, files, total)
+			}
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,23 @@ type CompactionConfig struct {
 	MaxConcurrent             int    // Max concurrent compaction jobs (default: 2)
 	TempDirectory             string // Temporary directory for compaction files (default: ./data/compaction)
 
+	// MaxFilesPerBatch bounds how many files a single compaction job feeds to
+	// one DuckDB read_parquet() call; larger partitions are split into that
+	// many batches, each producing its own output file. DuckDB can segfault
+	// when a single call spans too many files, which is why this bound exists.
+	//
+	// This is a file-count bound, not a byte bound — compacted output size
+	// tracks input file size, which follows the ingest buffer settings.
+	// Deployments syncing compacted files over constrained or intermittent
+	// links may lower it to get smaller, independently-transferable outputs,
+	// at the cost of more compaction jobs (and, in cluster mode,
+	// proportionally more Raft manifest entries) per partition.
+	//
+	// Valid range is [2, 500]; out-of-range values fall back to the default
+	// with a startup warning. 1 is explicitly not usable — the adaptive retry
+	// in compaction rejects batches below 2 files. (default: 30)
+	MaxFilesPerBatch int
+
 	// Phase 4: completion-manifest watcher tunables. The watcher polls
 	// {temp_directory}/.completion/pending on a 1s default interval
 	// looking for compaction jobs that finished and need their outputs
@@ -605,6 +622,7 @@ func Load() (*Config, error) {
 			DailyMinFiles:               v.GetInt("compaction.daily_min_files"),
 			DailySkipFileAgeCheckDays:   v.GetInt("compaction.daily_skip_file_age_check_days"),
 			MaxConcurrent:               v.GetInt("compaction.max_concurrent"),
+			MaxFilesPerBatch:            v.GetInt("compaction.max_files_per_batch"),
 			TempDirectory:               v.GetString("compaction.temp_directory"),
 			CompletionWatcherIntervalMS: v.GetInt("compaction.completion_watcher_interval_ms"),
 			CompletionDir:               v.GetString("compaction.completion_dir"),
@@ -1006,6 +1024,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("compaction.daily_min_files", 12)                 // 12 files minimum
 	v.SetDefault("compaction.daily_skip_file_age_check_days", 7)   // Skip file age check for partitions older than 7 days
 	v.SetDefault("compaction.max_concurrent", 2)                   // 2 concurrent jobs
+	v.SetDefault("compaction.max_files_per_batch", 30)             // 30 files per DuckDB read_parquet() call; valid range [2, 500]
 	v.SetDefault("compaction.temp_directory", "./data/compaction") // Temp directory for compaction files
 	// Phase 4: completion-manifest watcher tunables
 	v.SetDefault("compaction.completion_watcher_interval_ms", 1000) // 1s poll rate

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1034,3 +1034,52 @@ func TestLoad_StorageValuesTrimmed(t *testing.T) {
 		t.Errorf("Cold.S3Bucket = %q, want trimmed %q (pointer mutation must persist)", cfg.TieredStorage.Cold.S3Bucket, "cold-bucket")
 	}
 }
+
+func TestLoad_CompactionMaxFilesPerBatch(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "arc-config-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		oldWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(oldWd)
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+
+		if cfg.Compaction.MaxFilesPerBatch != 30 {
+			t.Errorf("Compaction.MaxFilesPerBatch = %d, want 30 (default)", cfg.Compaction.MaxFilesPerBatch)
+		}
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "arc-config-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		oldWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(oldWd)
+
+		// The edge/constrained-link case: smaller batches produce smaller,
+		// independently-transferable compacted outputs.
+		os.Setenv("ARC_COMPACTION_MAX_FILES_PER_BATCH", "5")
+		defer os.Unsetenv("ARC_COMPACTION_MAX_FILES_PER_BATCH")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+
+		if cfg.Compaction.MaxFilesPerBatch != 5 {
+			t.Errorf("Compaction.MaxFilesPerBatch = %d, want 5 (from env)", cfg.Compaction.MaxFilesPerBatch)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **`compaction.max_files_per_batch` is now configurable** (default 30, range [2, 500], env `ARC_COMPACTION_MAX_FILES_PER_BATCH`). Compaction splits a large partition into batches, each becoming an independent job with its own output file, upload, and manifest entry — that size was a hardcoded const.
- **Removed `TargetSizeMB`**, which was plumbed through 7 files and reported on a public API but never read by anything.
- **Fixed a pre-existing bug** found while testing: a sub-minimum trailing remainder was emitted as its own batch and could never compact.
- **Plumbed `BatchNumber` into job IDs and output filenames** to remove a latent collision.

### Why make it configurable

It's a **file-count** bound, not a byte bound — compacted output size tracks input file size, which follows the ingest buffer settings. Lowering it yields smaller, independently-transferable compacted files, which matters when those files are shipped over a constrained or intermittent link (edge/field deployments). The cost is more compaction jobs per partition, and in cluster mode proportionally more Raft manifest entries — at `5`, a 600-file partition produces 120 manifest entries instead of 20.

### Guards on both ends

`1` is rejected and falls back to the default with a startup warning. `compactFilesAdaptively` rejects any batch below 2 files at depth 0 (`manager.go:393`), so `max_files_per_batch=1` — plausibly the first thing an edge operator tries — would have failed **every batch of every partition**, with no symptom beyond a per-batch error log.

`500` caps the top end. The const exists because DuckDB can abort when one `read_parquet()` call spans too many files, and the adaptive retry only halves four times (10000 → 625 still crashes). It's a conservative bound, not empirically derived.

### Pre-existing bug: stranded remainder

31 files at batch size 30 split into 30 and **1**. That 1-file batch hit the same `minBatchSize` floor and failed every cycle, so the partition's tail file never compacted — silently. Confirmed pre-existing by stashing the diff and re-running. Sub-minimum remainders now fold into the final batch, which overshoots by at most one file.

### `TargetSizeMB` removal

Defaulted to 512 (hourly) / 2048 (daily), copied through five structs and the parent↔subprocess IPC, and reported as `target_size_mb` on `GET /api/v1/compaction/stats`. Nothing read it: `Candidate` carries no file sizes, and the compaction `COPY` emits no `FILE_SIZE_BYTES`. There was no config key, so no deployment could have set it — removal cannot change anyone's behavior.

⚠️ **API shape change:** `target_size_mb` is gone from the `tiers[]` entries of `GET /api/v1/compaction/stats`.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS, compaction disabled | No — `manager.go:663` unreached | n/a |
| OSS, key at **default (30)** | Yes — batching identical to today | `m.MaxFilesPerBatch` set at manager construction |
| OSS, key at **NON-DEFAULT (5)** | Yes — 6× more jobs/outputs on large partitions | Each batch is an independent job → independent upload + manifest |
| OSS, key = **1** | Guard forces default | Without it, every batch fails at `manager.go:393` |
| OSS, key = **0 / negative** | Guard forces default | Guard precedes all arithmetic; else div-by-zero |
| OSS, key = **10000** | Clamped to 500 + Warn | Adaptive retry can't rescue it (10000→625) |
| Cluster, key at default | Yes — unchanged | `CompletionDir != ""`; untouched by this diff |
| Cluster, key at **NON-DEFAULT (5)** | Yes — 6× more Raft entries | Watcher has no fixed buffer (`watcher.go:282-299`); batches ops per-manifest via `BatchFileOps` (`watcher.go:371`), so no per-file Raft proposals |
| Hourly + daily both on, key at 5 | Yes — compounding | More hourly outputs → more daily inputs, re-split by the same key |
| Any mode reading `/api/v1/compaction/stats` | Yes — `target_size_mb` disappears | No non-Go consumer repo-wide |

**Deref check:** no new pointer dereferences. `m.MaxFilesPerBatch` is an int on an already-constructed manager.

**Invariant preserved:** `CompactPartition` takes a non-blocking, skip-on-contention per-partition lock (`manager.go:222-229`). Batches are safe only because they run sequentially in one goroutine — if they were ever parallelized, batches 2..N would be silently dropped and reported as success. Do not parallelize batches.

## Test plan

- [x] `go build ./cmd/... ./internal/...`
- [x] `go test ./internal/compaction/... ./internal/config/...`
- [x] `go test -race ./internal/compaction/...`
- [x] `gofmt -l` clean on all changed files
- [x] `go vet` clean for affected packages
- [x] **Binary run at NON-DEFAULT (`max_files_per_batch=5`)** — drove 13 real files through compaction: 3 batches of 5/5/3, `succeeded: 3, failed: 0`, distinct `_b2`/`_b3` job IDs and output filenames
- [x] **Binary run at `1`** — clamp warning fired: `configured=1 effective=30 min=2 max=500`
- [x] **Binary run at default** — no warning, no errors, clean startup
- [x] Verified `target_size_mb` absent from the live `/api/v1/compaction/stats` response
- [x] **New tests verified to FAIL pre-fix** — reverted the remainder fix, confirmed the odd-file-count cases fail, restored

### New test coverage

- `HonorsConfiguredSize` — same input, different param, different result (12 files → 1 batch at 30, 3 batches at 5)
- `ClampsOutOfRange` — table-driven over `{-1, 0, 1, 2, 10000}`
- `AtMinimumSize` — exact batch sizes at `maxFilesPerBatch=2` across file counts 3–7
- `EveryBatchIsCompactable` — sweeps batch sizes × file counts, asserting every emitted batch clears `compactFilesAdaptively`'s floor
- `BatchNumberAtCustomSize` — 1-based and distinct, including single-batch-is-1-of-1
- `TestLoad_CompactionMaxFilesPerBatch` — default resolves to 30; env var lands correctly

## Review

Internal deep review found two blockers, both fixed here: the `minBatchSize=1` hard-fail, and a collision mitigation that cited a batch suffix which didn't exist. A second pass verified the remainder arithmetic (exhaustive sweep over ~15,600 `(batch size, file count)` combinations: zero file loss, zero sub-minimum batches) and identified an unreachable disjunct in the split loop, now removed.

## Docs

`docs.basekick.net` updated in [b5f4c00](https://github.com/Basekick-Labs/docs.basekick.net/commit/b5f4c00), gated behind a v2026.09.1+ admonition.