### PR TITLE
feat(sync): spoke-side ledger for edge-to-cloud replication (#569 PR 1/9)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -62,6 +62,16 @@ This is a **file-count** bound, not a byte bound — compacted output size track
 
 Out-of-range values fall back to the default with a startup warning rather than failing. **`1` is not usable** and is treated as out of range: compaction's adaptive retry rejects any batch below two files, so a batch size of one would fail every batch of every partition.
 
+## Groundwork: edge-to-cloud sync (not yet usable)
+
+Arc runs at the edge today — a standalone binary with local storage in a vehicle, a factory cell, or a forward deployment — with no first-class way to ship that data to a central Arc. Backup is a full DR snapshot rather than incremental sync, and Parquet import re-ingests rows through the write path, which breaks the end-to-end checksum and double-counts on retry.
+
+**Edge sync** ([#569](https://github.com/Basekick-Labs/arc/issues/569)) addresses this by shipping immutable Parquet *files* from a spoke (edge) to a hub (central Arc): the spoke initiates, the hub verifies each file's SHA256 before committing it, and re-delivery of an already-received file is a no-op. Connectivity is treated as the exception rather than the norm — discovery is a single batched round-trip regardless of backlog size, and transfers resume from a byte offset when a link drops mid-file.
+
+**Nothing is user-visible in this release, on disk or otherwise.** The work is landing as a sequence of reviewed changes, and this release contains only the first: the spoke-side ledger that tracks which files have reached which hub. No configuration key enables it, no endpoint exposes it, and no startup path constructs it — so its SQLite schema is not even created yet. It is recorded here so the release history matches the work, not because there is anything to use or configure.
+
+Manual export/import will be OSS when it ships; the automatic scheduled agent will be an Enterprise feature.
+
 ## Security hardening
 
 ### Strip client-controlled forwarding headers at the inter-node boundary (CVE-2026-45045 class)
@@ -343,6 +353,7 @@ The forwarding-header and loop-guard changes are cluster-only; the partition-pru
 2. **No API or on-disk format changes.** Reads, queries, and storage layout are untouched. Queries with a start date earlier than `1970-01-01` are pruned from the epoch forward; since Arc stores no pre-epoch data, results are unchanged.
 3. **Clustered operators:** if any external tooling deliberately sets `X-Arc-Forwarded-By`, `X-Real-IP`, or `X-Forwarded-*` headers on requests to Arc and expects them to survive an inter-node forward, note that these are now stripped on the forwarding hop and re-established by Arc. Client IP has never been derived from these headers, so log/audit attribution is unchanged.
 4. **Active licenses keep working.** No re-activation required.
+5. **Nothing changes on disk or in the database.** The edge-sync groundwork above defines two SQLite tables (`sync_ledger`, `sync_history`), but no startup path constructs the ledger, so the schema is never created and the tables do not appear in `auth.db_path`. They will be created by the release that first wires edge sync into the server.
 
 ## Dependencies
 

--- a/internal/sync/ledger.go
+++ b/internal/sync/ledger.go
@@ -1,0 +1,740 @@
+// Package sync implements edge-to-cloud replication: a spoke (an Arc instance
+// at the edge) ships its immutable Parquet files to a hub (a central Arc).
+//
+// The unit of sync is the FILE, not the row. Arc already produces immutable
+// content-addressed Parquet with a SHA256 in the manifest, so shipping files
+// gives end-to-end integrity for free, costs the hub no re-ingestion, and makes
+// idempotency trivial: (path, sha256) IS the file's identity.
+//
+// This file implements the spoke-side ledger — the durable record of what has
+// been sent to which hub, and how far. It is deliberately dumb: it tracks
+// state, and knows nothing about transports, HTTP, or hubs beyond their ID.
+//
+// See docs/progress/2026-06-04-edge-sync-architecture-converged.md.
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// SyncState is the lifecycle of one file's journey to one hub.
+type SyncState string
+
+const (
+	// StatePending — discovered locally, not yet sent. The starting state, and
+	// the state an interrupted transfer reverts to on restart.
+	StatePending SyncState = "pending"
+
+	// StateInFlight — a transfer is currently running. Any row left in this
+	// state after a crash is stale by definition (the transfer died with the
+	// process), which is why RecoverInFlight reverts them at startup.
+	StateInFlight SyncState = "in_flight"
+
+	// StateSynced — the hub acknowledged receipt. Terminal on the happy path.
+	// Only ever set from a 2xx/AlreadyPresent, never optimistically: the
+	// design's ack-then-advance rule means a lost ack costs one extra entry in
+	// the next reconcile, but never a silent gap.
+	StateSynced SyncState = "synced"
+
+	// StateFailed — exhausted retries. Terminal until an operator intervenes.
+	StateFailed SyncState = "failed"
+
+	// StateSkipped — deliberately excluded (e.g. a future filtering policy).
+	//
+	// TODO(#569): reserved, nothing sets it in phase 1. Stats deliberately
+	// does not count it, so a skipped row would be invisible to operators —
+	// whoever introduces the first writer must add it to Stats at the same
+	// time, or drop this constant.
+	StateSkipped SyncState = "skipped"
+)
+
+// DefaultHubID is the hub identifier used when multi-hub is not configured.
+//
+// The ledger is keyed (hub_id, path) from day one even though phase 1 syncs to
+// a single hub. Turning on multi-hub later is then configuration, not a
+// migration of a live edge database — which on a disconnected box in the field
+// is the difference between a config push and a site visit.
+const DefaultHubID = "default"
+
+// ErrNotFound is returned when a ledger lookup matches no row.
+var ErrNotFound = errors.New("sync: ledger entry not found")
+
+// ErrInvalidTransition is returned when a state change is attempted from a
+// state that does not permit it — e.g. marking a terminally failed entry
+// synced, or re-sending an entry the hub has already acknowledged.
+//
+// The ledger enforces these rather than trusting callers because §6.2's
+// exactly-once-effect property depends on `synced` being reached only via a
+// hub acknowledgment and never being silently walked back.
+var ErrInvalidTransition = errors.New("sync: invalid state transition")
+
+// LedgerEntry is one file's sync state with respect to one hub.
+type LedgerEntry struct {
+	ID            int64
+	HubID         string
+	Path          string // storage-relative path, as the spoke knows it
+	SHA256        string // from the manifest; the integrity anchor
+	SizeBytes     int64
+	Database      string
+	Measurement   string
+	PartitionTime time.Time
+	DiscoveredAt  time.Time
+	State         SyncState
+	Attempts      int
+	LastAttempt   *time.Time
+	SyncedAt      *time.Time
+
+	// BytesSent is the resume checkpoint: how many bytes of this file the hub
+	// has already accepted. A transfer that dies mid-file resumes from here
+	// rather than restarting, which is the difference between "eventually
+	// drains" and "never completes" on a link whose contact window is shorter
+	// than the file.
+	BytesSent int64
+
+	LastError string
+}
+
+// Ledger is the spoke-side record of sync progress, backed by the shared
+// SQLite database (cfg.Auth.DBPath).
+//
+// Concurrency: *sql.DB is already safe for concurrent use and this type holds
+// no in-memory state, so it takes no mutex of its own. Holding an application
+// lock across SQLite I/O would serialize readers behind writers for no benefit
+// (see the SQLite Review Checklist in CLAUDE.md).
+type Ledger struct {
+	db     *sql.DB
+	logger zerolog.Logger
+}
+
+// NewLedger creates the ledger and initializes its schema.
+func NewLedger(db *sql.DB, logger zerolog.Logger) (*Ledger, error) {
+	if db == nil {
+		return nil, errors.New("sync: ledger requires a non-nil database")
+	}
+
+	l := &Ledger{
+		db:     db,
+		logger: logger.With().Str("component", "sync-ledger").Logger(),
+	}
+
+	if err := l.initSchema(); err != nil {
+		return nil, fmt.Errorf("sync: initialize ledger schema: %w", err)
+	}
+
+	return l, nil
+}
+
+// initSchema creates the ledger tables if they do not exist.
+func (l *Ledger) initSchema() error {
+	const schema = `
+	-- One row per (hub, file). The UNIQUE key is what makes discovery
+	-- idempotent: re-discovering a file that is already tracked is a no-op
+	-- rather than a duplicate transfer.
+	CREATE TABLE IF NOT EXISTS sync_ledger (
+		id             INTEGER PRIMARY KEY AUTOINCREMENT,
+		hub_id         TEXT NOT NULL DEFAULT 'default',
+		path           TEXT NOT NULL,
+		sha256         TEXT NOT NULL,
+		size_bytes     INTEGER NOT NULL,
+		database       TEXT NOT NULL,
+		measurement    TEXT NOT NULL,
+		partition_time TIMESTAMP NOT NULL,
+		discovered_at  TIMESTAMP NOT NULL,
+		state          TEXT NOT NULL DEFAULT 'pending',
+		attempts       INTEGER NOT NULL DEFAULT 0,
+		last_attempt   TIMESTAMP,
+		synced_at      TIMESTAMP,
+		bytes_sent     INTEGER NOT NULL DEFAULT 0,
+		last_error     TEXT,
+		UNIQUE(hub_id, path)
+	);
+
+	-- Drives the hot query: "what is pending for this hub, newest first".
+	-- partition_time is in the index because the agent drains newest-first —
+	-- freshest telemetry reaches the hub before a contact window closes.
+	CREATE INDEX IF NOT EXISTS idx_sync_ledger_state
+		ON sync_ledger(hub_id, state, partition_time);
+
+	-- Serves two queries that idx_sync_ledger_state cannot, both verified with
+	-- EXPLAIN QUERY PLAN:
+	--   * PruneSynced's cutoff (state + synced_at, no hub_id — so the leading
+	--     hub_id column of the other index is unusable and it degrades to a
+	--     full scan on exactly the large table batching exists to protect).
+	--   * Stats' newest-synced lookup, which is walked in reverse for its
+	--     ORDER BY instead of sorting into a temp B-tree on every status call.
+	-- Column order is (state, synced_at, hub_id) and both queries must lead
+	-- with state to use it — hub_id trails because the prune is hub-agnostic.
+	CREATE INDEX IF NOT EXISTS idx_sync_ledger_synced
+		ON sync_ledger(state, synced_at, hub_id);
+
+	-- One row per contact session (connectivity acquired -> lost), which is
+	-- the unit an operator reasons about. A session may span many agent ticks.
+	--
+	-- TODO(#569): created here but not yet written. The session lifecycle
+	-- belongs to the sync agent (PR 8). Defined now so the schema lands in one
+	-- migration rather than altering a live edge database later — on a
+	-- disconnected box that is a site visit, not a config push. If PR 8 ships
+	-- without using it, delete the table rather than leaving it dead.
+	CREATE TABLE IF NOT EXISTS sync_history (
+		id           INTEGER PRIMARY KEY AUTOINCREMENT,
+		hub_id       TEXT NOT NULL,
+		started_at   TIMESTAMP NOT NULL,
+		completed_at TIMESTAMP,
+		files_synced INTEGER NOT NULL DEFAULT 0,
+		bytes_synced INTEGER NOT NULL DEFAULT 0,
+		transport    TEXT NOT NULL,
+		status       TEXT NOT NULL DEFAULT 'in_progress'
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_sync_history_started
+		ON sync_history(hub_id, started_at);
+	`
+
+	if _, err := l.db.Exec(schema); err != nil {
+		return fmt.Errorf("create sync tables: %w", err)
+	}
+
+	l.logger.Info().Msg("Sync ledger schema initialized")
+	return nil
+}
+
+// Track records a file as pending sync to a hub. It is idempotent: a file
+// already tracked for this hub is left untouched, whatever state it is in.
+//
+// This matters because discovery re-walks the manifest every tick. Without
+// DO NOTHING, a file already synced would be reset to pending and re-sent
+// forever.
+//
+// PRECONDITION — caller must guarantee path immutability. Because a conflict
+// does nothing, re-tracking a path whose content changed keeps the ORIGINAL
+// sha256 and size, and the ledger would then assert the hub holds content it
+// has never seen. Arc satisfies this: compaction and retention produce new
+// immutable paths rather than rewriting one in place (§13), so a given path's
+// bytes never change. If a future producer breaks that, this must become an
+// upsert that detects the divergence — §6.1 treats same-path-different-SHA as
+// a 409-class alarm, and silently discarding the evidence here would hide it.
+func (l *Ledger) Track(ctx context.Context, e *LedgerEntry) error {
+	hubID := e.HubID
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	// .UTC() on every timestamp: go-sqlite3 serializes a time.Time with its
+	// offset intact, so a caller passing a local-zone value would store
+	// "2026-08-06 14:00:00-06:00" while another stores the SAME INSTANT as
+	// "2026-08-06 20:00:00+00:00". Those are different strings, so SQL
+	// equality and ORDER BY both go wrong. Arc's convention is UTC everywhere.
+	discoveredAt := e.DiscoveredAt.UTC()
+	if e.DiscoveredAt.IsZero() {
+		discoveredAt = time.Now().UTC()
+	}
+
+	_, err := l.db.ExecContext(ctx, `
+		INSERT INTO sync_ledger
+			(hub_id, path, sha256, size_bytes, database, measurement,
+			 partition_time, discovered_at, state)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(hub_id, path) DO NOTHING`,
+		hubID, e.Path, e.SHA256, e.SizeBytes, e.Database, e.Measurement,
+		e.PartitionTime.UTC(), discoveredAt, string(StatePending))
+	if err != nil {
+		return fmt.Errorf("sync: track %q: %w", e.Path, err)
+	}
+	return nil
+}
+
+// TrackBatch records many files in one transaction.
+//
+// Discovery after a long disconnection can surface thousands of files at once;
+// inserting them individually would mean one implicit transaction (and one
+// fsync) each. A single transaction turns that into one fsync.
+func (l *Ledger) TrackBatch(ctx context.Context, entries []*LedgerEntry) (int, error) {
+	if len(entries) == 0 {
+		return 0, nil
+	}
+
+	tx, err := l.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("sync: begin track batch: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op after a successful Commit
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO sync_ledger
+			(hub_id, path, sha256, size_bytes, database, measurement,
+			 partition_time, discovered_at, state)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(hub_id, path) DO NOTHING`)
+	if err != nil {
+		return 0, fmt.Errorf("sync: prepare track batch: %w", err)
+	}
+	defer stmt.Close()
+
+	now := time.Now().UTC()
+	// Every error path returns 0, not the running count. The deferred
+	// Rollback discards all rows Exec'd so far, so reporting a partial count
+	// would tell the caller it tracked files that do not exist in the table —
+	// and a caller accumulating `total += n` across batches would drift.
+	var inserted int
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+
+		hubID := e.HubID
+		if hubID == "" {
+			hubID = DefaultHubID
+		}
+		discoveredAt := e.DiscoveredAt.UTC() // see Track: UTC-normalize every timestamp
+		if e.DiscoveredAt.IsZero() {
+			discoveredAt = now
+		}
+
+		res, err := stmt.ExecContext(ctx,
+			hubID, e.Path, e.SHA256, e.SizeBytes, e.Database, e.Measurement,
+			e.PartitionTime.UTC(), discoveredAt, string(StatePending))
+		if err != nil {
+			return 0, fmt.Errorf("sync: track %q in batch: %w", e.Path, err)
+		}
+		// RowsAffected is 0 for a conflict that hit DO NOTHING, so this counts
+		// genuinely new entries rather than rows considered.
+		if n, err := res.RowsAffected(); err == nil {
+			inserted += int(n)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("sync: commit track batch: %w", err)
+	}
+	return inserted, nil
+}
+
+// Pending returns entries awaiting transfer to a hub, newest partition first.
+//
+// Newest-first is a deliberate ordering, not an incidental one: when a contact
+// window closes mid-backlog, the freshest telemetry has already reached the
+// hub and backfill catches up on a later pass.
+//
+// A limit <= 0 returns all pending entries.
+func (l *Ledger) Pending(ctx context.Context, hubID string, limit int) ([]*LedgerEntry, error) {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+
+	query := `
+		SELECT id, hub_id, path, sha256, size_bytes, database, measurement,
+		       partition_time, discovered_at, state, attempts, last_attempt,
+		       synced_at, bytes_sent, COALESCE(last_error, '')
+		FROM sync_ledger
+		WHERE hub_id = ? AND state = ?
+		ORDER BY partition_time DESC, id ASC`
+	args := []any{hubID, string(StatePending)}
+
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := l.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sync: query pending: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*LedgerEntry
+	for rows.Next() {
+		e, err := scanEntry(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sync: iterate pending: %w", err)
+	}
+	return out, nil
+}
+
+// MarkInFlight moves an entry to in_flight and increments its attempt count.
+func (l *Ledger) MarkInFlight(ctx context.Context, hubID, path string) error {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	// Only a pending entry may start a transfer. Guarding this is what stops a
+	// synced entry from being re-sent while keeping its synced_at — a row that
+	// simultaneously claims "the hub has it" and "we are sending it", which
+	// would double-count in Stats and make LastSyncedAt point at a file
+	// currently in flight.
+	res, err := l.db.ExecContext(ctx, `
+		UPDATE sync_ledger
+		SET state = ?, attempts = attempts + 1, last_attempt = ?
+		WHERE hub_id = ? AND path = ? AND state = ?`,
+		string(StateInFlight), time.Now().UTC(), hubID, path, string(StatePending))
+	if err != nil {
+		return fmt.Errorf("sync: mark in-flight %q: %w", path, err)
+	}
+	return l.checkTransition(ctx, res, hubID, path, StatePending)
+}
+
+// RecordProgress updates the resume checkpoint for an in-flight transfer.
+//
+// bytesSent is the absolute offset the hub has accepted, not a delta, so a
+// retry that re-sends from an earlier offset cannot inflate it.
+func (l *Ledger) RecordProgress(ctx context.Context, hubID, path string, bytesSent int64) error {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	if bytesSent < 0 {
+		return fmt.Errorf("sync: negative progress %d for %q", bytesSent, path)
+	}
+
+	// Clamped to size_bytes in SQL. An offset larger than the file would make
+	// Stats.PendingBytes negative, and because that column is a SUM across the
+	// backlog, one bad offset silently cancels out other files' real pending
+	// bytes — understating exactly the number operators use to size a contact
+	// window. Only an in-flight transfer has progress to record.
+	res, err := l.db.ExecContext(ctx, `
+		UPDATE sync_ledger SET bytes_sent = MIN(?, size_bytes)
+		WHERE hub_id = ? AND path = ? AND state = ?`,
+		bytesSent, hubID, path, string(StateInFlight))
+	if err != nil {
+		return fmt.Errorf("sync: record progress %q: %w", path, err)
+	}
+	return l.checkTransition(ctx, res, hubID, path, StateInFlight)
+}
+
+// MarkSynced records that the hub has the file.
+//
+// Call this ONLY on a 2xx or AlreadyPresent from the hub — never optimistically
+// before the ack. The whole exactly-once-effect property rests on this rule:
+// advancing early converts a lost ack into permanent data loss, whereas
+// advancing late costs one redundant entry in the next reconcile.
+//
+// bytes_sent is set to size_bytes so a synced row reads consistently.
+func (l *Ledger) MarkSynced(ctx context.Context, hubID, path string) error {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	// Reachable only from pending or in_flight. Two exclusions matter:
+	//   - `synced` -> `synced` would move synced_at forward on a redundant ack,
+	//     making the acknowledgment timestamp unstable.
+	//   - `failed` -> `synced` would silently resurrect a terminally failed
+	//     entry, hiding the failure from operators.
+	// Pending is permitted because §5.1's reconcile advances entries the hub
+	// reports as `present` — the lost-ack recovery path — without a transfer.
+	res, err := l.db.ExecContext(ctx, `
+		UPDATE sync_ledger
+		SET state = ?, synced_at = ?, bytes_sent = size_bytes, last_error = NULL
+		WHERE hub_id = ? AND path = ? AND state IN (?, ?)`,
+		string(StateSynced), time.Now().UTC(), hubID, path,
+		string(StatePending), string(StateInFlight))
+	if err != nil {
+		return fmt.Errorf("sync: mark synced %q: %w", path, err)
+	}
+	return l.checkTransition(ctx, res, hubID, path, StatePending, StateInFlight)
+}
+
+// MarkFailed records a transfer failure. If the entry has reached maxAttempts
+// it becomes terminally failed; otherwise it returns to pending for retry.
+//
+// bytes_sent is deliberately preserved on the retry path — a failure is
+// usually a dropped link, and the bytes the hub already accepted are still
+// valid. Discarding the checkpoint would restart a large file from zero on
+// exactly the link least able to afford it.
+func (l *Ledger) MarkFailed(ctx context.Context, hubID, path, errMsg string, maxAttempts int) error {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	if maxAttempts <= 0 {
+		return fmt.Errorf("sync: mark failed %q: maxAttempts must be >= 1, got %d", path, maxAttempts)
+	}
+
+	// The cap decision is made INSIDE the UPDATE rather than by reading
+	// attempts first and deciding in Go. A read-then-write pair is a
+	// lost-update race: between the SELECT and the UPDATE another worker can
+	// bump attempts past the cap, and this call would then write back
+	// 'pending' — resurrecting an entry that should be terminally failed, so
+	// it retries forever. §8.2 configures max_concurrent_files (default 2), so
+	// concurrent workers are the designed steady state, not a hypothetical.
+	res, err := l.db.ExecContext(ctx, `
+		UPDATE sync_ledger
+		SET state = CASE WHEN attempts >= ? THEN ? ELSE ? END,
+		    last_error = ?
+		WHERE hub_id = ? AND path = ? AND state = ?`,
+		maxAttempts, string(StateFailed), string(StatePending),
+		errMsg, hubID, path, string(StateInFlight))
+	if err != nil {
+		return fmt.Errorf("sync: mark failed %q: %w", path, err)
+	}
+	return l.checkTransition(ctx, res, hubID, path, StateInFlight)
+}
+
+// RecoverInFlight reverts in_flight entries to pending. Call once at startup.
+//
+// An in_flight row can only have been written by a transfer that is no longer
+// running — the process that owned it is gone. Reverting makes those files
+// eligible for the next reconcile, where the hub reports any that actually
+// landed as `present` and the spoke advances them without re-sending a byte.
+func (l *Ledger) RecoverInFlight(ctx context.Context) (int64, error) {
+	res, err := l.db.ExecContext(ctx,
+		`UPDATE sync_ledger SET state = ? WHERE state = ?`,
+		string(StatePending), string(StateInFlight))
+	if err != nil {
+		return 0, fmt.Errorf("sync: recover in-flight entries: %w", err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("sync: count recovered entries: %w", err)
+	}
+	if n > 0 {
+		l.logger.Info().
+			Int64("entries", n).
+			Msg("Reverted interrupted transfers to pending")
+	}
+	return n, nil
+}
+
+// Stats summarizes ledger state for one hub.
+type Stats struct {
+	HubID        string
+	Pending      int64
+	InFlight     int64
+	Synced       int64
+	Failed       int64
+	PendingBytes int64
+	LastSyncedAt *time.Time
+}
+
+// Stats returns a summary for a hub, for the status endpoint and operators.
+func (l *Ledger) Stats(ctx context.Context, hubID string) (*Stats, error) {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+
+	s := &Stats{HubID: hubID}
+
+	err := l.db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(SUM(state = 'pending'), 0),
+			COALESCE(SUM(state = 'in_flight'), 0),
+			COALESCE(SUM(state = 'synced'), 0),
+			COALESCE(SUM(state = 'failed'), 0),
+			COALESCE(SUM(CASE WHEN state IN ('pending','in_flight')
+			                  THEN size_bytes - bytes_sent ELSE 0 END), 0)
+		FROM sync_ledger WHERE hub_id = ?`, hubID).
+		Scan(&s.Pending, &s.InFlight, &s.Synced, &s.Failed, &s.PendingBytes)
+	if err != nil {
+		return nil, fmt.Errorf("sync: ledger stats: %w", err)
+	}
+
+	// The newest synced_at is fetched by ORDER BY ... LIMIT 1 rather than
+	// MAX(synced_at) in the aggregate above. go-sqlite3 maps a column to
+	// time.Time from its declared TIMESTAMP type, and that association is lost
+	// through an aggregate function — MAX() returns a bare string that
+	// sql.NullTime cannot scan. Selecting the column directly keeps the
+	// declared type, and the ORDER BY is index-eligible.
+	// The predicate leads with state so idx_sync_ledger_synced(state,
+	// synced_at, hub_id) can be walked in reverse for the ORDER BY instead of
+	// sorting into a temp B-tree. Filtering on hub_id first (its natural
+	// phrasing) picks idx_sync_ledger_state, whose columns cannot serve an
+	// ORDER BY on synced_at — verified with EXPLAIN QUERY PLAN.
+	var lastSynced sql.NullTime
+	err = l.db.QueryRowContext(ctx, `
+		SELECT synced_at FROM sync_ledger
+		WHERE state = ? AND synced_at IS NOT NULL AND hub_id = ?
+		ORDER BY synced_at DESC LIMIT 1`, string(StateSynced), hubID).Scan(&lastSynced)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("sync: ledger last-synced: %w", err)
+	}
+	if lastSynced.Valid {
+		t := lastSynced.Time.UTC()
+		s.LastSyncedAt = &t
+	}
+	return s, nil
+}
+
+// Get returns a single entry, or ErrNotFound.
+func (l *Ledger) Get(ctx context.Context, hubID, path string) (*LedgerEntry, error) {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	row := l.db.QueryRowContext(ctx, `
+		SELECT id, hub_id, path, sha256, size_bytes, database, measurement,
+		       partition_time, discovered_at, state, attempts, last_attempt,
+		       synced_at, bytes_sent, COALESCE(last_error, '')
+		FROM sync_ledger WHERE hub_id = ? AND path = ?`, hubID, path)
+
+	e, err := scanEntry(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return e, err
+}
+
+// PruneSynced deletes synced entries older than retentionDays, across ALL
+// hubs. Unlike every other method here it is deliberately not hub-scoped:
+// retention is a local disk-space concern, not a per-hub policy. When
+// multi-hub becomes real and per-hub retention is wanted, this needs a hubID
+// parameter — the signature is the place that will have to change.
+//
+// Batched at 1000 rows with an ORDER BY on the primary key: a single unbounded
+// DELETE on a table with millions of rows holds the SQLite write lock for the
+// duration, blocking ingest file registration and auth token updates. The
+// context is checked between batches so shutdown is not delayed.
+//
+// No incremental_vacuum: the freed pages are reused by subsequent inserts, and
+// vacuuming a continuously-written table just causes write amplification.
+func (l *Ledger) PruneSynced(ctx context.Context, retentionDays int) (int64, error) {
+	if retentionDays <= 0 {
+		return 0, nil
+	}
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
+
+	// Resolve the predicate once to a primary-key bound, so the batch loop
+	// deletes by rowid instead of re-evaluating the date predicate per batch.
+	//
+	// Time domain: go-sqlite3 serializes a time.Time as
+	// "2006-01-02 15:04:05.999999999-07:00" — space-separated WITH an offset
+	// suffix. That is neither RFC3339 nor SQLite's datetime() output (which is
+	// space-separated with NO offset). Comparing these strings against a
+	// datetime()-produced value is therefore unsafe even though both use a
+	// space: a whole-second UTC time serializes as "…00:00:00+00:00" while
+	// datetime() gives "…00:00:00", and the longer string sorts AFTER the
+	// shorter one at the same instant. So: values written as Go time.Time are
+	// compared ONLY against Go time.Time parameters, as here. Never mix.
+	var maxID int64
+	err := l.db.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(id), 0) FROM sync_ledger
+		WHERE state = ? AND synced_at IS NOT NULL AND synced_at < ?`,
+		string(StateSynced), cutoff).Scan(&maxID)
+	if err != nil {
+		return 0, fmt.Errorf("sync: find prune cutoff: %w", err)
+	}
+	if maxID == 0 {
+		return 0, nil
+	}
+
+	const batchSize = 1000
+	var total int64
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+
+		// The state/synced_at predicate is repeated here even though maxID
+		// already bounds the set: id <= maxID alone would also match rows
+		// interleaved below the cutoff that are pending or failed. Either
+		// filter alone is sufficient (removing one and keeping the other
+		// still protects unsynced work) — they are deliberate belt-and-braces
+		// on a DELETE, where the cost of being wrong is unrecoverable.
+		// ORDER BY id is on the primary key, so each batch is deterministic.
+		res, err := l.db.ExecContext(ctx, `
+			DELETE FROM sync_ledger WHERE id IN (
+				SELECT id FROM sync_ledger
+				WHERE id <= ? AND state = ? AND synced_at IS NOT NULL AND synced_at < ?
+				ORDER BY id ASC LIMIT ?
+			)`, maxID, string(StateSynced), cutoff, batchSize)
+		if err != nil {
+			return total, fmt.Errorf("sync: prune synced entries: %w", err)
+		}
+
+		deleted, err := res.RowsAffected()
+		if err != nil {
+			return total, fmt.Errorf("sync: count pruned entries: %w", err)
+		}
+		total += deleted
+
+		if deleted < batchSize {
+			break
+		}
+	}
+	return total, nil
+}
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanEntry(s rowScanner) (*LedgerEntry, error) {
+	var (
+		e           LedgerEntry
+		lastAttempt sql.NullTime
+		syncedAt    sql.NullTime
+		state       string
+	)
+
+	err := s.Scan(
+		&e.ID, &e.HubID, &e.Path, &e.SHA256, &e.SizeBytes, &e.Database,
+		&e.Measurement, &e.PartitionTime, &e.DiscoveredAt, &state,
+		&e.Attempts, &lastAttempt, &syncedAt, &e.BytesSent, &e.LastError,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, err // caller maps to ErrNotFound
+		}
+		return nil, fmt.Errorf("sync: scan ledger entry: %w", err)
+	}
+
+	e.State = SyncState(state)
+	e.PartitionTime = e.PartitionTime.UTC()
+	e.DiscoveredAt = e.DiscoveredAt.UTC()
+	if lastAttempt.Valid {
+		t := lastAttempt.Time.UTC()
+		e.LastAttempt = &t
+	}
+	if syncedAt.Valid {
+		t := syncedAt.Time.UTC()
+		e.SyncedAt = &t
+	}
+	return &e, nil
+}
+
+// checkAffected turns a zero-row UPDATE into ErrNotFound. Without this a state
+// transition against a path that isn't tracked would silently succeed, and the
+// agent would believe it had advanced an entry that does not exist.
+func checkAffected(res sql.Result, path string) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("sync: rows affected for %q: %w", path, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("sync: %q: %w", path, ErrNotFound)
+	}
+	return nil
+}
+
+// checkTransition reports the outcome of a guarded state transition. A guarded
+// UPDATE carries `AND state = ?`, so zero rows affected is ambiguous: either
+// the path is untracked, or it is tracked but in the wrong state. The two are
+// different bugs — an untracked path means discovery is broken, a wrong state
+// means the agent's state machine is — so they get different errors.
+func (l *Ledger) checkTransition(ctx context.Context, res sql.Result, hubID, path string, from ...SyncState) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("sync: rows affected for %q: %w", path, err)
+	}
+	if n > 0 {
+		return nil
+	}
+
+	var current string
+	err = l.db.QueryRowContext(ctx,
+		`SELECT state FROM sync_ledger WHERE hub_id = ? AND path = ?`, hubID, path).Scan(&current)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("sync: %q: %w", path, ErrNotFound)
+	}
+	if err != nil {
+		return fmt.Errorf("sync: read state for %q: %w", path, err)
+	}
+	return fmt.Errorf("sync: %q: %w: state is %q, expected one of %v",
+		path, ErrInvalidTransition, current, from)
+}

--- a/internal/sync/ledger_test.go
+++ b/internal/sync/ledger_test.go
@@ -1,0 +1,844 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	stdsync "sync"
+	"testing"
+	"time"
+
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+)
+
+func setupTestLedger(t *testing.T) *Ledger {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp("", "sync_ledger_test_*.db")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	db, err := sql.Open("sqlite3", tmpFile.Name())
+	if err != nil {
+		os.Remove(tmpFile.Name())
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	// Bulk-insert tests write hundreds of rows; without this each insert
+	// fsyncs in its own implicit transaction and the suite crawls.
+	if _, err := db.Exec("PRAGMA synchronous = OFF"); err != nil {
+		t.Fatalf("set synchronous: %v", err)
+	}
+
+	l, err := NewLedger(db, zerolog.Nop())
+	if err != nil {
+		db.Close()
+		os.Remove(tmpFile.Name())
+		t.Fatalf("new ledger: %v", err)
+	}
+
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(tmpFile.Name())
+	})
+
+	return l
+}
+
+func testEntry(path string) *LedgerEntry {
+	return &LedgerEntry{
+		HubID:         DefaultHubID,
+		Path:          path,
+		SHA256:        "abc123",
+		SizeBytes:     1024,
+		Database:      "default",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2026, 8, 6, 14, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestLedger_TrackIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	e := testEntry("db/cpu/2026/08/06/14/a.parquet")
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("first track: %v", err)
+	}
+
+	// Discovery re-walks the manifest every tick. Re-tracking must not reset
+	// state, or a synced file would be re-sent forever.
+	if err := l.MarkSynced(ctx, DefaultHubID, e.Path); err != nil {
+		t.Fatalf("mark synced: %v", err)
+	}
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("re-track: %v", err)
+	}
+
+	got, err := l.Get(ctx, DefaultHubID, e.Path)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.State != StateSynced {
+		t.Errorf("state = %q after re-track, want %q — re-discovery reset a synced entry",
+			got.State, StateSynced)
+	}
+
+	stats, err := l.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Synced != 1 || stats.Pending != 0 {
+		t.Errorf("synced=%d pending=%d, want 1/0 — re-track created a duplicate row",
+			stats.Synced, stats.Pending)
+	}
+}
+
+func TestLedger_TrackBatchCountsOnlyNewEntries(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	entries := []*LedgerEntry{
+		testEntry("db/cpu/2026/08/06/14/a.parquet"),
+		testEntry("db/cpu/2026/08/06/14/b.parquet"),
+	}
+	n, err := l.TrackBatch(ctx, entries)
+	if err != nil {
+		t.Fatalf("track batch: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("inserted = %d, want 2", n)
+	}
+
+	// Re-running with one overlap must report only the genuinely new row.
+	entries = append(entries, testEntry("db/cpu/2026/08/06/14/c.parquet"))
+	n, err = l.TrackBatch(ctx, entries)
+	if err != nil {
+		t.Fatalf("second track batch: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("inserted = %d on re-run, want 1 (only the new path)", n)
+	}
+}
+
+func TestLedger_PendingIsNewestFirst(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// Newest-first ordering is a design guarantee: when a contact window
+	// closes mid-backlog the freshest telemetry must already have landed.
+	times := []time.Time{
+		time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 8, 6, 14, 0, 0, 0, time.UTC),
+		time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC),
+	}
+	for i, pt := range times {
+		e := testEntry(fmt.Sprintf("db/cpu/f%d.parquet", i))
+		e.PartitionTime = pt
+		if err := l.Track(ctx, e); err != nil {
+			t.Fatalf("track %d: %v", i, err)
+		}
+	}
+
+	pending, err := l.Pending(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(pending) != 3 {
+		t.Fatalf("got %d pending, want 3", len(pending))
+	}
+
+	for i := 1; i < len(pending); i++ {
+		if pending[i].PartitionTime.After(pending[i-1].PartitionTime) {
+			t.Errorf("entry %d (%s) is newer than %d (%s) — not newest-first",
+				i, pending[i].PartitionTime, i-1, pending[i-1].PartitionTime)
+		}
+	}
+	if !pending[0].PartitionTime.Equal(times[1]) {
+		t.Errorf("first entry partition = %s, want the newest %s",
+			pending[0].PartitionTime, times[1])
+	}
+}
+
+func TestLedger_RecoverInFlight(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	paths := []string{"db/cpu/a.parquet", "db/cpu/b.parquet", "db/cpu/c.parquet"}
+	for _, p := range paths {
+		if err := l.Track(ctx, testEntry(p)); err != nil {
+			t.Fatalf("track %s: %v", p, err)
+		}
+	}
+
+	// Two transfers were running when the process died; one had completed.
+	if err := l.MarkInFlight(ctx, DefaultHubID, paths[0]); err != nil {
+		t.Fatalf("mark in-flight: %v", err)
+	}
+	if err := l.MarkInFlight(ctx, DefaultHubID, paths[1]); err != nil {
+		t.Fatalf("mark in-flight: %v", err)
+	}
+	if err := l.MarkSynced(ctx, DefaultHubID, paths[2]); err != nil {
+		t.Fatalf("mark synced: %v", err)
+	}
+
+	n, err := l.RecoverInFlight(ctx)
+	if err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("recovered = %d, want 2", n)
+	}
+
+	stats, err := l.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.InFlight != 0 {
+		t.Errorf("in_flight = %d after recovery, want 0 — a dead transfer stayed in_flight forever",
+			stats.InFlight)
+	}
+	if stats.Pending != 2 {
+		t.Errorf("pending = %d, want 2", stats.Pending)
+	}
+	if stats.Synced != 1 {
+		t.Errorf("synced = %d, want 1 — recovery must not touch synced entries", stats.Synced)
+	}
+}
+
+func TestLedger_ResumeCheckpointSurvivesFailure(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	e := testEntry("db/cpu/big.parquet")
+	e.SizeBytes = 500 << 20 // 500 MB
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+
+	if err := l.MarkInFlight(ctx, DefaultHubID, e.Path); err != nil {
+		t.Fatalf("mark in-flight: %v", err)
+	}
+	const sent = 200 << 20
+	if err := l.RecordProgress(ctx, DefaultHubID, e.Path, sent); err != nil {
+		t.Fatalf("record progress: %v", err)
+	}
+
+	// The link drops. The bytes the hub accepted are still valid — discarding
+	// the checkpoint would restart a 500MB file from zero on exactly the link
+	// least able to afford it.
+	if err := l.MarkFailed(ctx, DefaultHubID, e.Path, "connection reset", 3); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+
+	got, err := l.Get(ctx, DefaultHubID, e.Path)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.BytesSent != sent {
+		t.Errorf("bytes_sent = %d after failure, want %d — resume checkpoint lost",
+			got.BytesSent, sent)
+	}
+	if got.State != StatePending {
+		t.Errorf("state = %q, want %q (retries remain)", got.State, StatePending)
+	}
+	if got.Attempts != 1 {
+		t.Errorf("attempts = %d, want 1", got.Attempts)
+	}
+}
+
+func TestLedger_MarkFailedTerminalAtMaxAttempts(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	e := testEntry("db/cpu/doomed.parquet")
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+
+	const maxAttempts = 3
+	for i := 1; i <= maxAttempts; i++ {
+		if err := l.MarkInFlight(ctx, DefaultHubID, e.Path); err != nil {
+			t.Fatalf("attempt %d in-flight: %v", i, err)
+		}
+		if err := l.MarkFailed(ctx, DefaultHubID, e.Path, "nope", maxAttempts); err != nil {
+			t.Fatalf("attempt %d failed: %v", i, err)
+		}
+
+		got, err := l.Get(ctx, DefaultHubID, e.Path)
+		if err != nil {
+			t.Fatalf("get after attempt %d: %v", i, err)
+		}
+		want := StatePending
+		if i >= maxAttempts {
+			want = StateFailed
+		}
+		if got.State != want {
+			t.Errorf("after attempt %d/%d: state = %q, want %q", i, maxAttempts, got.State, want)
+		}
+	}
+}
+
+func TestLedger_MarkSyncedClearsErrorAndCompletesBytes(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	e := testEntry("db/cpu/a.parquet")
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkInFlight(ctx, DefaultHubID, e.Path); err != nil {
+		t.Fatalf("in-flight: %v", err)
+	}
+	if err := l.MarkFailed(ctx, DefaultHubID, e.Path, "transient blip", 5); err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if err := l.MarkSynced(ctx, DefaultHubID, e.Path); err != nil {
+		t.Fatalf("synced: %v", err)
+	}
+
+	got, err := l.Get(ctx, DefaultHubID, e.Path)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.LastError != "" {
+		t.Errorf("last_error = %q after sync, want empty — a stale error would mislead operators",
+			got.LastError)
+	}
+	if got.BytesSent != e.SizeBytes {
+		t.Errorf("bytes_sent = %d, want %d (full size)", got.BytesSent, e.SizeBytes)
+	}
+	if got.SyncedAt == nil {
+		t.Error("synced_at is nil after MarkSynced")
+	}
+}
+
+func TestLedger_UnknownPathIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// A state transition against an untracked path must fail loudly. A silent
+	// no-op would let the agent believe it advanced an entry that doesn't exist.
+	for name, fn := range map[string]func() error{
+		"MarkInFlight":   func() error { return l.MarkInFlight(ctx, DefaultHubID, "nope.parquet") },
+		"MarkSynced":     func() error { return l.MarkSynced(ctx, DefaultHubID, "nope.parquet") },
+		"RecordProgress": func() error { return l.RecordProgress(ctx, DefaultHubID, "nope.parquet", 1) },
+		"MarkFailed":     func() error { return l.MarkFailed(ctx, DefaultHubID, "nope.parquet", "x", 3) },
+	} {
+		if err := fn(); !errors.Is(err, ErrNotFound) {
+			t.Errorf("%s on unknown path: err = %v, want ErrNotFound", name, err)
+		}
+	}
+
+	if _, err := l.Get(ctx, DefaultHubID, "nope.parquet"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get on unknown path: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestLedger_HubIsolation(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// The (hub_id, path) key exists so the same file can be tracked
+	// independently per hub — multi-hub is config later, not a field migration.
+	const path = "db/cpu/shared.parquet"
+	for _, hub := range []string{"cloud", "factory"} {
+		e := testEntry(path)
+		e.HubID = hub
+		if err := l.Track(ctx, e); err != nil {
+			t.Fatalf("track for %s: %v", hub, err)
+		}
+	}
+
+	if err := l.MarkSynced(ctx, "cloud", path); err != nil {
+		t.Fatalf("mark synced on cloud: %v", err)
+	}
+
+	cloud, err := l.Stats(ctx, "cloud")
+	if err != nil {
+		t.Fatalf("cloud stats: %v", err)
+	}
+	factory, err := l.Stats(ctx, "factory")
+	if err != nil {
+		t.Fatalf("factory stats: %v", err)
+	}
+
+	if cloud.Synced != 1 {
+		t.Errorf("cloud synced = %d, want 1", cloud.Synced)
+	}
+	if factory.Synced != 0 || factory.Pending != 1 {
+		t.Errorf("factory synced=%d pending=%d, want 0/1 — hubs are not isolated",
+			factory.Synced, factory.Pending)
+	}
+}
+
+func TestLedger_StatsPendingBytesExcludesSentPrefix(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	e := testEntry("db/cpu/partial.parquet")
+	e.SizeBytes = 1000
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkInFlight(ctx, DefaultHubID, e.Path); err != nil {
+		t.Fatalf("in-flight: %v", err)
+	}
+	if err := l.RecordProgress(ctx, DefaultHubID, e.Path, 400); err != nil {
+		t.Fatalf("progress: %v", err)
+	}
+
+	stats, err := l.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	// Operators use this to estimate how much link time a drain needs; counting
+	// already-transferred bytes would overstate it.
+	if stats.PendingBytes != 600 {
+		t.Errorf("pending_bytes = %d, want 600 (1000 total - 400 sent)", stats.PendingBytes)
+	}
+}
+
+func TestLedger_PruneSyncedBatchesAndSpares(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// Created first so it holds id=1, below the prune's maxID bound — that is
+	// what makes the DELETE's state filter load-bearing rather than incidental.
+	if err := l.Track(ctx, testEntry("db/cpu/still_pending.parquet")); err != nil {
+		t.Fatalf("track pending: %v", err)
+	}
+
+	// Just above the 1000-row batch limit, to exercise the loop's second pass.
+	const total = 1050
+	entries := make([]*LedgerEntry, 0, total)
+	for i := 0; i < total; i++ {
+		entries = append(entries, testEntry(fmt.Sprintf("db/cpu/old_%d.parquet", i)))
+	}
+	if _, err := l.TrackBatch(ctx, entries); err != nil {
+		t.Fatalf("track batch: %v", err)
+	}
+	for i := 0; i < total; i++ {
+		if err := l.MarkSynced(ctx, DefaultHubID, fmt.Sprintf("db/cpu/old_%d.parquet", i)); err != nil {
+			t.Fatalf("mark synced %d: %v", i, err)
+		}
+	}
+
+	// Backdate every synced row past the retention horizon.
+	cutoff := time.Now().UTC().AddDate(0, 0, -30)
+	if _, err := l.db.ExecContext(ctx,
+		`UPDATE sync_ledger SET synced_at = ? WHERE state = ?`, cutoff, string(StateSynced)); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	if err := l.Track(ctx, testEntry("db/cpu/fresh.parquet")); err != nil {
+		t.Fatalf("track fresh: %v", err)
+	}
+	if err := l.MarkSynced(ctx, DefaultHubID, "db/cpu/fresh.parquet"); err != nil {
+		t.Fatalf("mark fresh synced: %v", err)
+	}
+
+	// A failed entry that was synced once and later re-sent carries an old
+	// synced_at. Only the state filter keeps it out of the prune —
+	// `synced_at IS NOT NULL` does not discriminate here — so this is what
+	// makes that clause load-bearing rather than redundant.
+	resurrect := testEntry("db/cpu/failed_but_synced_before.parquet")
+	if err := l.Track(ctx, resurrect); err != nil {
+		t.Fatalf("track resurrect: %v", err)
+	}
+	if _, err := l.db.ExecContext(ctx,
+		`UPDATE sync_ledger SET state = ?, synced_at = ? WHERE path = ?`,
+		string(StateFailed), cutoff, resurrect.Path); err != nil {
+		t.Fatalf("stage failed-with-old-synced_at: %v", err)
+	}
+
+	deleted, err := l.PruneSynced(ctx, 7)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if deleted != total {
+		t.Errorf("deleted = %d, want %d", deleted, total)
+	}
+
+	stats, err := l.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Pending != 1 {
+		t.Errorf("pending = %d after prune, want 1 — prune must never touch unsynced work",
+			stats.Pending)
+	}
+	if stats.Synced != 1 {
+		t.Errorf("synced = %d after prune, want 1 (the fresh entry)", stats.Synced)
+	}
+	if stats.Failed != 1 {
+		t.Errorf("failed = %d after prune, want 1 — prune deleted a failed entry because it had an old synced_at", stats.Failed)
+	}
+}
+
+func TestLedger_PruneSyncedNoOpForNonPositiveRetention(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	if err := l.Track(ctx, testEntry("db/cpu/a.parquet")); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkSynced(ctx, DefaultHubID, "db/cpu/a.parquet"); err != nil {
+		t.Fatalf("synced: %v", err)
+	}
+
+	for _, days := range []int{0, -1} {
+		deleted, err := l.PruneSynced(ctx, days)
+		if err != nil {
+			t.Fatalf("prune(%d): %v", days, err)
+		}
+		if deleted != 0 {
+			t.Errorf("prune(%d) deleted %d rows, want 0 — retention disabled must not delete", days, deleted)
+		}
+	}
+}
+
+func TestLedger_TimestampsRoundTripAsUTC(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// Arc's convention is UTC everywhere. Writing a non-UTC time must not
+	// change the instant that comes back.
+	loc := time.FixedZone("UTC-6", -6*60*60)
+	e := testEntry("db/cpu/tz.parquet")
+	e.PartitionTime = time.Date(2026, 8, 6, 14, 0, 0, 0, loc)
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+
+	got, err := l.Get(ctx, DefaultHubID, e.Path)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !got.PartitionTime.Equal(e.PartitionTime) {
+		t.Errorf("partition_time = %s, want the same instant as %s",
+			got.PartitionTime, e.PartitionTime)
+	}
+	if got.PartitionTime.Location() != time.UTC {
+		t.Errorf("partition_time location = %s, want UTC", got.PartitionTime.Location())
+	}
+}
+
+func TestNewLedger_RejectsNilDB(t *testing.T) {
+	if _, err := NewLedger(nil, zerolog.Nop()); err == nil {
+		t.Error("NewLedger(nil) succeeded, want an error")
+	}
+}
+
+func TestLedger_IllegalTransitionsRejected(t *testing.T) {
+	ctx := context.Background()
+
+	// Each case sets an entry up in some state, then attempts a transition
+	// that must be refused. Before state guards existed every one of these
+	// silently succeeded — leaving rows that claimed both "the hub has it"
+	// and "we are sending it", or resurrecting terminally failed entries.
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, l *Ledger, path string)
+		act   func(l *Ledger, path string) error
+	}{
+		{
+			name: "MarkInFlight on synced",
+			setup: func(t *testing.T, l *Ledger, p string) {
+				mustSync(t, l, p)
+			},
+			act: func(l *Ledger, p string) error { return l.MarkInFlight(ctx, DefaultHubID, p) },
+		},
+		{
+			name: "MarkSynced on failed",
+			setup: func(t *testing.T, l *Ledger, p string) {
+				mustFail(t, l, p, 1)
+			},
+			act: func(l *Ledger, p string) error { return l.MarkSynced(ctx, DefaultHubID, p) },
+		},
+		{
+			name: "MarkSynced twice",
+			setup: func(t *testing.T, l *Ledger, p string) {
+				mustSync(t, l, p)
+			},
+			act: func(l *Ledger, p string) error { return l.MarkSynced(ctx, DefaultHubID, p) },
+		},
+		{
+			name: "RecordProgress on synced",
+			setup: func(t *testing.T, l *Ledger, p string) {
+				mustSync(t, l, p)
+			},
+			act: func(l *Ledger, p string) error { return l.RecordProgress(ctx, DefaultHubID, p, 10) },
+		},
+		{
+			name:  "MarkFailed on pending (never started)",
+			setup: func(t *testing.T, l *Ledger, p string) {},
+			act:   func(l *Ledger, p string) error { return l.MarkFailed(ctx, DefaultHubID, p, "x", 3) },
+		},
+		{
+			name: "MarkInFlight on already in-flight",
+			setup: func(t *testing.T, l *Ledger, p string) {
+				if err := l.MarkInFlight(ctx, DefaultHubID, p); err != nil {
+					t.Fatalf("setup in-flight: %v", err)
+				}
+			},
+			act: func(l *Ledger, p string) error { return l.MarkInFlight(ctx, DefaultHubID, p) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := setupTestLedger(t)
+			const path = "db/cpu/x.parquet"
+			if err := l.Track(ctx, testEntry(path)); err != nil {
+				t.Fatalf("track: %v", err)
+			}
+			tt.setup(t, l, path)
+
+			err := tt.act(l, path)
+			if !errors.Is(err, ErrInvalidTransition) {
+				t.Fatalf("err = %v, want ErrInvalidTransition", err)
+			}
+			// A refused transition must be distinguishable from a missing
+			// entry — they are different bugs for the caller to react to.
+			if errors.Is(err, ErrNotFound) {
+				t.Error("illegal transition reported as ErrNotFound; caller cannot tell the two apart")
+			}
+		})
+	}
+}
+
+func mustSync(t *testing.T, l *Ledger, path string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := l.MarkInFlight(ctx, DefaultHubID, path); err != nil {
+		t.Fatalf("setup in-flight: %v", err)
+	}
+	if err := l.MarkSynced(ctx, DefaultHubID, path); err != nil {
+		t.Fatalf("setup synced: %v", err)
+	}
+}
+
+func mustFail(t *testing.T, l *Ledger, path string, maxAttempts int) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < maxAttempts; i++ {
+		if err := l.MarkInFlight(ctx, DefaultHubID, path); err != nil {
+			t.Fatalf("setup in-flight %d: %v", i, err)
+		}
+		if err := l.MarkFailed(ctx, DefaultHubID, path, "boom", maxAttempts); err != nil {
+			t.Fatalf("setup failed %d: %v", i, err)
+		}
+	}
+}
+
+func TestLedger_MarkFailedCapHoldsUnderConcurrency(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// The cap decision must be made inside the UPDATE. A read-then-write pair
+	// lets a concurrent worker bump attempts past the cap between the two
+	// statements, and the losing writer then resurrects the entry to pending —
+	// so it retries forever. §8.2 makes concurrent workers the default.
+	const path = "db/cpu/contended.parquet"
+	const maxAttempts = 2
+	if err := l.Track(ctx, testEntry(path)); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+
+	for round := 0; round < 20; round++ {
+		got, err := l.Get(ctx, DefaultHubID, path)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if got.State == StateFailed {
+			break
+		}
+		if err := l.MarkInFlight(ctx, DefaultHubID, path); err != nil {
+			t.Fatalf("round %d in-flight: %v", round, err)
+		}
+
+		var wg stdsync.WaitGroup
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// Only one racer wins the in_flight guard; the rest get
+				// ErrInvalidTransition, which is the correct outcome.
+				_ = l.MarkFailed(ctx, DefaultHubID, path, "boom", maxAttempts)
+			}()
+		}
+		wg.Wait()
+	}
+
+	got, err := l.Get(ctx, DefaultHubID, path)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.State != StateFailed {
+		t.Errorf("state = %q with attempts=%d and max=%d — cap not enforced, entry retries forever",
+			got.State, got.Attempts, maxAttempts)
+	}
+}
+
+func TestLedger_ProgressClampedToFileSize(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	e := testEntry("db/cpu/small.parquet")
+	e.SizeBytes = 100
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkInFlight(ctx, DefaultHubID, e.Path); err != nil {
+		t.Fatalf("in-flight: %v", err)
+	}
+	if err := l.RecordProgress(ctx, DefaultHubID, e.Path, 5000); err != nil {
+		t.Fatalf("progress: %v", err)
+	}
+
+	got, err := l.Get(ctx, DefaultHubID, e.Path)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.BytesSent != e.SizeBytes {
+		t.Errorf("bytes_sent = %d, want clamped to %d", got.BytesSent, e.SizeBytes)
+	}
+
+	// PendingBytes is a SUM across the backlog, so one unclamped offset would
+	// go negative and cancel out other files' real pending bytes — understating
+	// exactly the figure operators use to size a contact window.
+	stats, err := l.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.PendingBytes < 0 {
+		t.Errorf("pending_bytes = %d, must never be negative", stats.PendingBytes)
+	}
+}
+
+func TestLedger_DiscoveredAtNormalizedToUTC(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// go-sqlite3 stores a time.Time with its offset intact, so the same
+	// instant in two zones yields two different strings — breaking SQL
+	// equality and ORDER BY. Both Track and TrackBatch must normalize.
+	loc := time.FixedZone("UTC-6", -6*60*60)
+	instant := time.Date(2026, 8, 6, 20, 0, 0, 0, time.UTC)
+
+	a := testEntry("db/cpu/utc.parquet")
+	a.DiscoveredAt = instant
+	if err := l.Track(ctx, a); err != nil {
+		t.Fatalf("track a: %v", err)
+	}
+
+	b := testEntry("db/cpu/local.parquet")
+	b.DiscoveredAt = instant.In(loc)
+	if _, err := l.TrackBatch(ctx, []*LedgerEntry{b}); err != nil {
+		t.Fatalf("track batch b: %v", err)
+	}
+
+	var equal int
+	err := l.db.QueryRowContext(ctx, `
+		SELECT (SELECT discovered_at FROM sync_ledger WHERE path = ?)
+		     = (SELECT discovered_at FROM sync_ledger WHERE path = ?)`,
+		a.Path, b.Path).Scan(&equal)
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if equal != 1 {
+		t.Error("the same instant stored via Track and TrackBatch is not string-equal in SQLite; discovered_at is not UTC-normalized")
+	}
+}
+
+func TestLedger_TrackBatchReportsZeroOnRollback(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// A CHECK constraint gives the batch a deterministic mid-loop failure.
+	// Empty strings satisfy NOT NULL, so forcing a real violation needs an
+	// explicit predicate — without one this test would pass vacuously with
+	// both rows inserted and nothing rolled back.
+	if _, err := l.db.ExecContext(ctx,
+		`CREATE TRIGGER reject_bad BEFORE INSERT ON sync_ledger
+		 WHEN NEW.path = 'db/cpu/reject.parquet'
+		 BEGIN SELECT RAISE(ABORT, 'rejected'); END`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	good := testEntry("db/cpu/good.parquet")
+	bad := testEntry("db/cpu/reject.parquet")
+
+	n, err := l.TrackBatch(ctx, []*LedgerEntry{good, bad})
+	if err == nil {
+		t.Fatal("TrackBatch succeeded; the trigger should have aborted the second insert")
+	}
+
+	var rows int
+	if qerr := l.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sync_ledger`).Scan(&rows); qerr != nil {
+		t.Fatalf("count: %v", qerr)
+	}
+	if rows != 0 {
+		t.Errorf("%d rows persisted after a failed batch, want 0 — the transaction did not roll back", rows)
+	}
+	// The first insert reported RowsAffected=1 before the abort, but rollback
+	// discarded it. Reporting that count would tell the caller it tracked a
+	// file that does not exist.
+	if n != 0 {
+		t.Errorf("TrackBatch reported %d inserted but rollback discarded every row", n)
+	}
+}
+
+func TestLedger_PendingToSyncedIsReconcilePath(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	// §5.1: batch reconcile returns files the hub already holds under
+	// `present` — typically because a previous ack was lost. The spoke then
+	// advances them to synced WITHOUT a transfer, re-sending zero bytes.
+	// That makes pending -> synced a legitimate transition, not a bypass of
+	// the in_flight step, and it is the whole reason a lost ack costs one
+	// redundant reconcile entry rather than a duplicate upload.
+	e := testEntry("db/cpu/hub_already_has_it.parquet")
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+
+	before, err := l.Get(ctx, DefaultHubID, e.Path)
+	if err != nil {
+		t.Fatalf("get before: %v", err)
+	}
+	if before.State != StatePending {
+		t.Fatalf("setup: state = %q, want pending", before.State)
+	}
+
+	if err := l.MarkSynced(ctx, DefaultHubID, e.Path); err != nil {
+		t.Fatalf("pending -> synced must be permitted (lost-ack recovery): %v", err)
+	}
+
+	got, err := l.Get(ctx, DefaultHubID, e.Path)
+	if err != nil {
+		t.Fatalf("get after: %v", err)
+	}
+	if got.State != StateSynced {
+		t.Errorf("state = %q, want %q", got.State, StateSynced)
+	}
+	if got.SyncedAt == nil {
+		t.Error("synced_at not set on the reconcile path")
+	}
+	// No transfer ran, so the attempt counter must not have moved — otherwise
+	// repeated lost acks would burn through the retry budget.
+	if got.Attempts != 0 {
+		t.Errorf("attempts = %d, want 0 — reconcile advanced an entry without a transfer", got.Attempts)
+	}
+	if got.BytesSent != e.SizeBytes {
+		t.Errorf("bytes_sent = %d, want %d (a synced row reads as fully sent)", got.BytesSent, e.SizeBytes)
+	}
+}


### PR DESCRIPTION
First of nine PRs for edge sync — see [#569](https://github.com/Basekick-Labs/arc/issues/569) for the phase-1 breakdown and [`docs/progress/2026-06-04-edge-sync-architecture-converged.md`](docs/progress/2026-06-04-edge-sync-architecture-converged.md) for the design.

## Summary

Adds `internal/sync` with the **spoke-side ledger**: the durable record of which Parquet files have reached which hub, and how far a partial transfer got.

- `sync_ledger` keyed `UNIQUE(hub_id, path)` from day one — multi-hub becomes config later, not a schema migration on a disconnected box.
- State transitions enforced **in SQL**, not by trusting callers.
- `MarkFailed`'s retry cap decided **inside a single UPDATE** — no read-then-write race.
- `bytes_sent` as the resume checkpoint, preserved across failure, clamped to `size_bytes`.
- `PruneSynced` batched at 1000 rows, PK-ordered, `ctx.Err()` between batches, no vacuum.
- UTC normalization on write and read.

**No production callers.** Nothing constructs the ledger, so its schema is never created. Wiring lands with `/sync/run` (PR 8).

## Design decision recorded on the issue

Granularity is **whole-file, not row-group** — [decision comment](https://github.com/Basekick-Labs/arc/issues/569#issuecomment-5209574245). `raft.FileEntry` carries `SHA256`/`SizeBytes` per *file* with no row-group data, which is what makes §5.1's reconcile answerable from the manifest with no I/O on parquet bytes. Row-group sync would force the spoke to open every pending file's footer, need a second integrity chain with no authority to verify against, and turn §6.1's three-case receive into a range-merge problem. Revisit later is cheap: a row-group range is an additive column.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, any config | **No** — `grep NewLedger` outside the package returns nothing | n/a; no live derefs |
| Cluster mode, any config | **No** — no wiring in `cmd/arc/main.go` | n/a |
| Tests only | Yes — `ledger_test.go` is the sole caller | test DB via `sql.Open`, `t.Cleanup` closes |

Every row is "no", which inverts the usual risk profile: no config reaches this code, so no nil-deref or subsystem-interaction bug is possible. Risk sits entirely in SQL correctness and the state machine, which is where review was pointed.

**Config keys introduced:** none. **Deref check:** `NewLedger` rejects a nil `*sql.DB`; no other pointer is dereferenced internally.

## Review

Two adversarial passes. The first found **3 blockers + 6 high**, all fixed; I verified each empirically with probes before fixing rather than taking them on faith:

- **Lost-update race in `MarkFailed`** — read-then-write let a concurrent worker push `attempts` past the cap between statements; the losing writer resurrected the entry to `pending`, retrying **forever**. Now one atomic `UPDATE` with the `CASE` inside.
- **A factually wrong time-domain comment** — probed the real stored format: `"2026-08-06 22:40:43.006808+00:00"`, space-separated *with an offset*, neither RFC3339 nor `datetime()` output. The comment pointed a future maintainer the wrong way.
- **`discovered_at` not UTC-normalized** — probed: the same instant stored two ways gave SQL equality `0`.
- **Every illegal transition permitted** — `MarkInFlight` on a synced row succeeded *with `synced_at` still set*, double-counting in `Stats`.
- **`PendingBytes` went negative** (−4900 with an over-large offset), and since it is a `SUM`, one bad offset silently cancelled other files' real pending bytes.
- **Full scan + temp B-tree** on the prune cutoff and status query — fixed with a second index, both re-verified with `EXPLAIN QUERY PLAN`.

Two reviewer claims I checked and **declined**: the prune's state filter is redundant-by-construction rather than untested (removing either filter alone still protects unsynced rows — deliberate belt-and-braces on a DELETE), and `database` as a column name doesn't actually need quoting (probed unquoted in `WHERE`/`SELECT`/`GROUP BY`/`ORDER BY`; four existing Arc tables already do this).

The second pass found no bugs. It suggested an explicit `pending → synced` reconcile-path test, which is added.

I also found one of my own tests was **vacuous** — the `TrackBatch` rollback test never triggered a rollback because empty strings satisfy `NOT NULL`. Replaced with a trigger-based abort and verified it fails pre-fix (`reported 1 inserted but rollback discarded every row`).

## Test plan

- [x] `go build ./cmd/... ./internal/...`
- [x] `go test ./internal/sync/` — 23 tests
- [x] `go test -race ./internal/sync/`
- [x] `go vet` / `gofmt -l` clean
- [x] Query plans verified with `EXPLAIN QUERY PLAN` (no full scans, no temp B-trees)
- [x] New regression tests verified to fail pre-fix
- [ ] **Binary run — N/A.** No startup path reaches this code; there is nothing to exercise. The usual run-the-binary gate applies to PR 8, which first gives the ledger a caller.

## Notes

- **Docs:** no `docs.basekick.net` change — nothing here is configurable or observable. Docs land with PR 8's endpoints.
- **Package name:** `internal/sync` shadows stdlib `sync`; importers needing `sync.Mutex` must alias. Renaming to `edgesync` is cheap now and progressively more annoying as PRs 2–9 stack. Happy to do it before PR 2.
- **Deferred to PR 8:** `RecoverInFlight` has no age guard and `Pending` has no claim/lease, so two workers could hand out the same row. Both are real but belong with the agent, where concurrency actually exists — building a lease with no consumer now would be speculative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)