### PR TITLE
feat(edgesync): SyncTransport interface + in-process implementation (#569 PR 2/9)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -68,7 +68,7 @@ Arc runs at the edge today — a standalone binary with local storage in a vehic
 
 **Edge sync** ([#569](https://github.com/Basekick-Labs/arc/issues/569)) addresses this by shipping immutable Parquet *files* from a spoke (edge) to a hub (central Arc): the spoke initiates, the hub verifies each file's SHA256 before committing it, and re-delivery of an already-received file is a no-op. Connectivity is treated as the exception rather than the norm — discovery is a single batched round-trip regardless of backlog size, and transfers resume from a byte offset when a link drops mid-file.
 
-**Nothing is user-visible in this release, on disk or otherwise.** The work is landing as a sequence of reviewed changes, and this release contains only the first: the spoke-side ledger that tracks which files have reached which hub. No configuration key enables it, no endpoint exposes it, and no startup path constructs it — so its SQLite schema is not even created yet. It is recorded here so the release history matches the work, not because there is anything to use or configure.
+**Nothing is user-visible in this release, on disk or otherwise.** The work is landing as a sequence of reviewed changes; so far that is the spoke-side ledger (which files have reached which hub, and how far a partial transfer got) and the `SyncTransport` interface the agent will talk to, with an in-process implementation for tests. No configuration key enables it, no endpoint exposes it, and no startup path constructs it — so its SQLite schema is not even created yet. It is recorded here so the release history matches the work, not because there is anything to use or configure.
 
 Manual export/import will be OSS when it ships; the automatic scheduled agent will be an Enterprise feature.
 

--- a/internal/edgesync/ledger.go
+++ b/internal/edgesync/ledger.go
@@ -6,9 +6,14 @@
 // gives end-to-end integrity for free, costs the hub no re-ingestion, and makes
 // idempotency trivial: (path, sha256) IS the file's identity.
 //
-// This file implements the spoke-side ledger — the durable record of what has
-// been sent to which hub, and how far. It is deliberately dumb: it tracks
-// state, and knows nothing about transports, HTTP, or hubs beyond their ID.
+// The package is layered so each piece can be tested on its own:
+//
+//   - ledger.go — the durable record of what has been sent to which hub, and
+//     how far. Deliberately dumb: it tracks state and knows nothing about
+//     transports, HTTP, or hubs beyond their ID.
+//   - transport.go — the SyncTransport interface the agent talks to, so the
+//     wire format (HTTPS, S3 relay, sneakernet bundle) stays swappable.
+//   - transport_memory.go — an in-process transport for tests.
 //
 // See docs/progress/2026-06-04-edge-sync-architecture-converged.md.
 package edgesync

--- a/internal/edgesync/transport.go
+++ b/internal/edgesync/transport.go
@@ -1,0 +1,313 @@
+package edgesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// SyncTransport moves reconcile requests and file bytes from a spoke to a hub.
+//
+// It exists so the sync agent is written once against an abstract hub and the
+// wire format stays swappable. Phase 1 ships HTTPS; an S3/Azure relay (where
+// spoke and hub never connect directly, exchanging objects through a shared
+// bucket) and a sneakernet bundle (a signed directory carried on physical
+// media) are planned, and both reuse the reconcile/identity/idempotency logic
+// unchanged because none of it is HTTP-specific.
+//
+// Implementations must be safe for concurrent use: the agent transfers several
+// files at once (§8.2, sync.max_concurrent_files defaults to 2).
+type SyncTransport interface {
+	// Reconcile asks the hub which of the spoke's pending files it already
+	// holds. This is ONE round-trip for the whole backlog regardless of size —
+	// the property that makes a long disconnection survivable, since 5,000
+	// pending files cost one request rather than 5,000.
+	//
+	// The signature materializes both lists, which is fine at phase-1 scale
+	// and keeps the interface simple. The WIRE format is where streaming
+	// matters: a spoke returning from a months-long outage can present
+	// hundreds of thousands of entries (~20MB compressed), so the HTTPS
+	// implementation must stream the request and response bodies rather than
+	// buffering them, even though the values it produces are materialized.
+	// If a deployment ever outgrows an in-memory pending slice, this becomes
+	// an iterator — a breaking change deliberately deferred until real.
+	Reconcile(ctx context.Context, hubID string, pending []*LedgerEntry) (*ReconcileResult, error)
+
+	// PutFile streams one file's bytes to the hub, resuming from offset.
+	//
+	// body must yield the file's content starting at that offset; the caller
+	// owns opening, seeking, and closing it. offset is absolute within the
+	// file, so a resumed transfer sends only the remaining tail.
+	//
+	// Implementations must read ONLY the content-describing fields of entry —
+	// Path, SHA256, SizeBytes, Database, Measurement, PartitionTime. The rest
+	// (State, Attempts, BytesSent, SyncedAt, LastError, ID) is spoke-private
+	// bookkeeping that no hub has any business seeing, and a transport that
+	// branched on it would be reading state a sneakernet bundle or S3 relay
+	// cannot meaningfully carry. The whole entry is passed rather than a
+	// narrower descriptor to avoid a lossy conversion at every call site.
+	//
+	// A non-nil error means the transfer did not complete. A nil error with a
+	// result whose Outcome is not OutcomeCommitted or OutcomeAlreadyPresent
+	// means the hub answered deliberately (partial, conflict, backpressure)
+	// and the caller must act on the Outcome rather than assume success.
+	PutFile(ctx context.Context, hubID string, entry *LedgerEntry, body io.Reader, offset int64) (*PutResult, error)
+}
+
+// ReconcileResult is the hub's answer to a reconcile request: a partition of
+// the spoke's pending set into what must be sent, what is already there, and
+// what disagrees.
+type ReconcileResult struct {
+	// Missing lists storage-relative paths the hub does not have. These are
+	// what the agent streams, newest-first.
+	Missing []string
+
+	// Present lists paths the hub already holds with a matching SHA256. The
+	// agent advances these straight to synced without sending a byte.
+	//
+	// This is the lost-ack recovery path: a transfer that completed but whose
+	// acknowledgment never arrived leaves the spoke believing the file is
+	// pending. Reconcile discovers the truth in bulk, which is why a lost ack
+	// costs one redundant entry in the next batch rather than a re-upload.
+	Present []string
+
+	// Conflicts lists paths the hub holds with a DIFFERENT SHA256.
+	//
+	// This is an alarm, not a retry: it means either two spokes are writing
+	// the same namespaced path (a spoke_id collision) or one side's bytes are
+	// corrupt. The agent must not resend — overwriting would destroy whichever
+	// copy is correct. Surfacing conflicts here catches the whole backlog at
+	// once, rather than discovering them one 409 at a time during transfer.
+	Conflicts []Conflict
+}
+
+// Conflict is one same-path-different-content disagreement between spoke and
+// hub.
+type Conflict struct {
+	Path string // storage-relative path, as the spoke knows it
+	// TheirSHA256 is the digest the hub holds. The spoke's own digest is in
+	// its ledger entry for the same path; the pair is what an operator needs
+	// to work out which side is wrong.
+	TheirSHA256 string
+}
+
+// PutOutcome is the machine-readable result of a PutFile call.
+//
+// It is a distinct type rather than an HTTP status because the caller's
+// response differs per outcome and must not depend on parsing an error
+// string — and because a non-HTTP transport (S3 relay, sneakernet bundle) has
+// to express the same set without inventing status codes.
+type PutOutcome string
+
+const (
+	// OutcomeCommitted — the hub verified the checksum and durably stored the
+	// file. Advance the ledger to synced.
+	OutcomeCommitted PutOutcome = "committed"
+
+	// OutcomeAlreadyPresent — the hub already had this exact content at this
+	// path, so the write was a no-op. Treated identically to committed: this
+	// is what makes redelivery harmless and turns at-least-once delivery into
+	// exactly-once effect.
+	OutcomeAlreadyPresent PutOutcome = "already_present"
+
+	// OutcomePartial — the hub accepted a prefix but not the whole file,
+	// typically because the link dropped mid-stream. PutResult.BytesAccepted
+	// is the new resume checkpoint; the file stays pending.
+	OutcomePartial PutOutcome = "partial"
+
+	// OutcomeConflict — same path, different content. The hub refused to
+	// overwrite. Do NOT retry: this needs an operator, not a backoff.
+	OutcomeConflict PutOutcome = "conflict"
+
+	// OutcomeChecksumMismatch — the bytes arrived corrupted and the hub
+	// discarded them without committing. Retrying is correct and worthwhile:
+	// the corruption may be in flight, or in the spoke's own storage (edge
+	// hardware in the field is exactly where bit-rot shows up).
+	OutcomeChecksumMismatch PutOutcome = "checksum_mismatch"
+
+	// OutcomeBackpressure — the hub is overloaded and asked the spoke to slow
+	// down. PutResult.RetryAfter carries how long to wait. Not a failure: at
+	// fan-in scale with many spokes, this is the hub's normal flow control.
+	OutcomeBackpressure PutOutcome = "backpressure"
+)
+
+// Retryable reports whether re-attempting the transfer unchanged could
+// succeed.
+//
+// Conflict is the one outcome that is emphatically not retryable — resending
+// cannot resolve a content disagreement and would risk overwriting good data.
+// Committed and AlreadyPresent are "not retryable" only because there is
+// nothing left to do.
+func (o PutOutcome) Retryable() bool {
+	switch o {
+	case OutcomePartial, OutcomeChecksumMismatch, OutcomeBackpressure:
+		return true
+	default:
+		return false
+	}
+}
+
+// Done reports whether the hub now holds the file, so the ledger entry can
+// advance to synced.
+func (o PutOutcome) Done() bool {
+	return o == OutcomeCommitted || o == OutcomeAlreadyPresent
+}
+
+// PutResult is the outcome of one PutFile call.
+type PutResult struct {
+	Outcome PutOutcome
+
+	// BytesAccepted is the absolute offset the hub has durably accepted, and
+	// becomes the ledger's resume checkpoint. Meaningful for OutcomePartial;
+	// equals the file size for a committed transfer.
+	BytesAccepted int64
+
+	// RetryAfter is how long the hub asked the spoke to wait. Only set for
+	// OutcomeBackpressure.
+	RetryAfter time.Duration
+
+	// TheirSHA256 is the hub's digest for the path. Only set for
+	// OutcomeConflict, where it is the evidence an operator needs.
+	TheirSHA256 string
+}
+
+// ErrTransportClosed is returned by a transport that has been shut down.
+var ErrTransportClosed = errors.New("edgesync: transport closed")
+
+// Validate reports whether the result is internally consistent for its
+// outcome.
+//
+// A transport is remote code as far as the agent is concerned — a buggy or
+// hostile hub could answer OutcomePartial with a negative offset, or claim
+// backpressure with no delay, and the agent would write nonsense into the
+// ledger. Implementations should call this before returning, and the agent
+// should call it on anything it receives.
+func (r *PutResult) Validate(entry *LedgerEntry) error {
+	if r == nil {
+		return errors.New("edgesync: nil put result")
+	}
+
+	switch r.Outcome {
+	case OutcomeCommitted, OutcomeAlreadyPresent, OutcomePartial,
+		OutcomeConflict, OutcomeChecksumMismatch, OutcomeBackpressure:
+	default:
+		return fmt.Errorf("edgesync: unknown put outcome %q", r.Outcome)
+	}
+
+	if r.BytesAccepted < 0 {
+		return fmt.Errorf("edgesync: negative bytes accepted (%d)", r.BytesAccepted)
+	}
+	if entry != nil && r.BytesAccepted > entry.SizeBytes {
+		return fmt.Errorf("edgesync: hub accepted %d bytes, more than the file's %d",
+			r.BytesAccepted, entry.SizeBytes)
+	}
+
+	// Fields that belong to exactly one outcome. A hub setting them elsewhere
+	// is confused about its own answer, and the caller would act on a delay
+	// or a digest that means nothing.
+	if r.RetryAfter != 0 && r.Outcome != OutcomeBackpressure {
+		return fmt.Errorf("edgesync: retry delay set on a %q outcome", r.Outcome)
+	}
+	if r.TheirSHA256 != "" && r.Outcome != OutcomeConflict {
+		return fmt.Errorf("edgesync: hub sha256 set on a %q outcome", r.Outcome)
+	}
+
+	switch r.Outcome {
+	case OutcomeCommitted, OutcomeAlreadyPresent:
+		// A terminal success must account for the whole file. The agent
+		// advances the ledger to synced on Done(), writing BytesAccepted as
+		// the final byte count — and because synced is terminal, an
+		// under-report is never corrected and silently poisons lag reporting.
+		if entry != nil && r.BytesAccepted != entry.SizeBytes {
+			return fmt.Errorf("edgesync: %q outcome accepted %d of %d bytes",
+				r.Outcome, r.BytesAccepted, entry.SizeBytes)
+		}
+	case OutcomePartial:
+		// A "partial" that accepted everything is a contradiction, and one
+		// that accepted nothing gives the caller no progress to record —
+		// both would leave the agent looping without advancing.
+		if entry != nil && r.BytesAccepted >= entry.SizeBytes {
+			return fmt.Errorf("edgesync: partial outcome accepted the whole file (%d of %d)",
+				r.BytesAccepted, entry.SizeBytes)
+		}
+	case OutcomeConflict:
+		// Without the hub's digest a conflict is unactionable: an operator
+		// cannot tell a spoke_id collision from corruption.
+		if r.TheirSHA256 == "" {
+			return errors.New("edgesync: conflict outcome without the hub's sha256")
+		}
+		if entry != nil && r.TheirSHA256 == entry.SHA256 {
+			return fmt.Errorf("edgesync: conflict outcome but sha256 matches (%s) — not a conflict",
+				r.TheirSHA256)
+		}
+	case OutcomeBackpressure:
+		// Zero would busy-loop against an overloaded hub, which is the
+		// opposite of what backpressure is for.
+		if r.RetryAfter <= 0 {
+			return errors.New("edgesync: backpressure outcome without a retry delay")
+		}
+		// The hub declined to take the file; claiming progress would advance
+		// a checkpoint past bytes it never accepted.
+		if r.BytesAccepted != 0 {
+			return fmt.Errorf("edgesync: backpressure outcome accepted %d bytes", r.BytesAccepted)
+		}
+	case OutcomeChecksumMismatch:
+		// The bytes were discarded, so nothing was accepted. A non-zero count
+		// would move the resume checkpoint forward over content the hub threw
+		// away, and the retry would skip it.
+		if r.BytesAccepted != 0 {
+			return fmt.Errorf("edgesync: checksum-mismatch outcome accepted %d bytes", r.BytesAccepted)
+		}
+	}
+
+	return nil
+}
+
+// Validate reports whether the reconcile result is internally consistent.
+//
+// The agent drives ledger state directly from these lists, so a hub that
+// reports the same path as both missing and present would produce
+// contradictory transitions. Checking here keeps that from reaching the
+// ledger.
+func (r *ReconcileResult) Validate() error {
+	if r == nil {
+		return errors.New("edgesync: nil reconcile result")
+	}
+
+	seen := make(map[string]string, len(r.Missing)+len(r.Present)+len(r.Conflicts))
+
+	for _, list := range []struct {
+		name  string
+		paths []string
+	}{
+		{"missing", r.Missing},
+		{"present", r.Present},
+	} {
+		for _, p := range list.paths {
+			if p == "" {
+				return fmt.Errorf("edgesync: empty path in %s", list.name)
+			}
+			if prev, dup := seen[p]; dup {
+				return fmt.Errorf("edgesync: path %q reported as both %s and %s", p, prev, list.name)
+			}
+			seen[p] = list.name
+		}
+	}
+
+	for _, c := range r.Conflicts {
+		if c.Path == "" {
+			return errors.New("edgesync: empty path in conflicts")
+		}
+		if c.TheirSHA256 == "" {
+			return fmt.Errorf("edgesync: conflict for %q without the hub's sha256", c.Path)
+		}
+		if prev, dup := seen[c.Path]; dup {
+			return fmt.Errorf("edgesync: path %q reported as both %s and conflicts", c.Path, prev)
+		}
+		seen[c.Path] = "conflicts"
+	}
+
+	return nil
+}

--- a/internal/edgesync/transport_memory.go
+++ b/internal/edgesync/transport_memory.go
@@ -1,0 +1,368 @@
+package edgesync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// MemoryTransport is an in-process SyncTransport backed by a map.
+//
+// It exists for two reasons. First, it keeps SyncTransport honest: an
+// interface with no implementation is a guess, and writing this one is what
+// surfaced the fact that PutFile needs a result type rather than a bare error.
+// Second, the agent (PR 8) needs a hub it can drive deterministically —
+// exercising lost acks, conflicts, mid-stream drops, and backpressure against
+// a real HTTP server means either a fragile fake server or no test at all.
+//
+// It implements the same identity rule as a real hub (§6.1): a path is
+// absent (write), present with the same digest (no-op), or present with a
+// different digest (conflict, never overwrite). It is NOT a hub — it does no
+// authentication, no namespacing, and keeps bytes in memory.
+type MemoryTransport struct {
+	mu sync.Mutex
+
+	// files is the hub's contents, keyed by hub ID then path.
+	files map[string]map[string]*memFile
+
+	// staging holds partially-received files, keyed by hub ID then path.
+	//
+	// A SEPARATE map, not a reserved key inside files: sharing the namespace
+	// meant a crafted hubID could address the staging bucket as a real hub,
+	// and a staged file (which has no digest until it commits) then surfaced
+	// as a phantom conflict with an empty SHA256 — an operator-escalating
+	// alarm on a file that was merely mid-transfer.
+	staging map[string]map[string]*memFile
+
+	// failures queues scripted outcomes per path so a test can make the next
+	// PutFile answer partial/backpressure/mismatch without needing a real
+	// failing link.
+	failures map[string][]*PutResult
+
+	closed bool
+}
+
+type memFile struct {
+	sha256 string
+	size   int64
+	bytes  []byte
+}
+
+// NewMemoryTransport returns an empty in-memory hub.
+func NewMemoryTransport() *MemoryTransport {
+	return &MemoryTransport{
+		files:    make(map[string]map[string]*memFile),
+		staging:  make(map[string]map[string]*memFile),
+		failures: make(map[string][]*PutResult),
+	}
+}
+
+// Seed pre-populates the hub with a file, as though a previous sync had
+// delivered it. Used to set up the lost-ack and conflict paths.
+func (m *MemoryTransport) Seed(hubID, path, sha256Hex string, size int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hubLocked(hubID)[path] = &memFile{sha256: sha256Hex, size: size}
+}
+
+// ScriptPut queues results for the next PutFile calls on (hubID, path),
+// letting a test drive the partial/backpressure/mismatch branches
+// deterministically. Queued results are consumed in order; once empty,
+// PutFile behaves normally.
+//
+// Keyed by hub as well as path: with a path-only key, a script intended for
+// one hub would be consumed by a transfer to another, so a "hub A throttles,
+// hub B does not" test would silently assert the opposite.
+func (m *MemoryTransport) ScriptPut(hubID, path string, results ...*PutResult) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := scriptKey(hubID, path)
+	m.failures[key] = append(m.failures[key], results...)
+}
+
+// scriptKey namespaces a scripted result by hub and path. The NUL separator
+// keeps a hubID containing the delimiter from addressing another hub's queue.
+func scriptKey(hubID, path string) string {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	return hubID + "\x00" + path
+}
+
+// Has reports whether the hub holds a path, and its digest.
+func (m *MemoryTransport) Has(hubID, path string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	f, ok := m.hubLocked(hubID)[path]
+	if !ok {
+		return "", false
+	}
+	return f.sha256, true
+}
+
+// Close makes every subsequent call return ErrTransportClosed.
+func (m *MemoryTransport) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+// hubLocked returns the hub's committed-file map, creating it if needed.
+// Caller holds mu.
+func (m *MemoryTransport) hubLocked(hubID string) map[string]*memFile {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	h, ok := m.files[hubID]
+	if !ok {
+		h = make(map[string]*memFile)
+		m.files[hubID] = h
+	}
+	return h
+}
+
+// stagingLocked returns the hub's partial-file map, creating it if needed.
+// Caller holds mu.
+func (m *MemoryTransport) stagingLocked(hubID string) map[string]*memFile {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	h, ok := m.staging[hubID]
+	if !ok {
+		h = make(map[string]*memFile)
+		m.staging[hubID] = h
+	}
+	return h
+}
+
+// Reconcile partitions the pending set exactly as a hub would: matching digest
+// is present, differing digest is a conflict, unknown path is missing.
+func (m *MemoryTransport) Reconcile(ctx context.Context, hubID string, pending []*LedgerEntry) (*ReconcileResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil, ErrTransportClosed
+	}
+
+	hub := m.hubLocked(hubID)
+	res := &ReconcileResult{}
+
+	for _, e := range pending {
+		if e == nil {
+			return nil, errors.New("edgesync: nil entry in reconcile batch")
+		}
+		// An empty path is a valid map key, so without this check it would
+		// silently classify against hub[""] and land in one of the result
+		// lists — where ReconcileResult.Validate would then reject the whole
+		// batch with a confusing error about the result rather than the input.
+		if e.Path == "" {
+			return nil, errors.New("edgesync: entry with an empty path in reconcile batch")
+		}
+		switch f, ok := hub[e.Path]; {
+		case !ok:
+			res.Missing = append(res.Missing, e.Path)
+		case f.sha256 == e.SHA256:
+			res.Present = append(res.Present, e.Path)
+		default:
+			res.Conflicts = append(res.Conflicts, Conflict{
+				Path:        e.Path,
+				TheirSHA256: f.sha256,
+			})
+		}
+	}
+
+	return res, nil
+}
+
+// PutFile stores the streamed bytes, applying the §6.1 identity rule and
+// verifying the digest before committing — the same verify-before-commit
+// ordering a real hub uses, so a mismatch never lands as stored content.
+func (m *MemoryTransport) PutFile(ctx context.Context, hubID string, entry *LedgerEntry, body io.Reader, offset int64) (*PutResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, errors.New("edgesync: PutFile requires an entry")
+	}
+	if entry.Path == "" {
+		return nil, errors.New("edgesync: PutFile requires a path")
+	}
+	// The digest is the integrity anchor — without it there is nothing to
+	// verify against, and committing anyway would defeat the whole
+	// verify-before-commit ordering.
+	if entry.SHA256 == "" {
+		return nil, fmt.Errorf("edgesync: PutFile for %q requires a sha256", entry.Path)
+	}
+	if offset < 0 || offset > entry.SizeBytes {
+		return nil, fmt.Errorf("edgesync: offset %d out of range for %q (size %d)",
+			offset, entry.Path, entry.SizeBytes)
+	}
+
+	// Phase 1 — decide under the lock whether this transfer should read a body
+	// at all, and grab the staged prefix if resuming.
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return nil, ErrTransportClosed
+	}
+	// A scripted result short-circuits before the body is touched, so a test
+	// can simulate a hub that rejects without reading.
+	if key := scriptKey(hubID, entry.Path); len(m.failures[key]) > 0 {
+		res := m.failures[key][0]
+		m.failures[key] = m.failures[key][1:]
+		m.mu.Unlock()
+		if res == nil {
+			return nil, fmt.Errorf("edgesync: scripted nil result for %q", entry.Path)
+		}
+		if err := res.Validate(entry); err != nil {
+			return nil, fmt.Errorf("edgesync: scripted result for %q is invalid: %w", entry.Path, err)
+		}
+		return res, nil
+	}
+
+	// §6.1: identical content at the same path is an idempotent no-op, and a
+	// differing digest is refused rather than overwritten. Decided before
+	// reading the body — a duplicate costs no transfer, and a conflict must
+	// not consume bytes it will discard.
+	if existing, exists := m.hubLocked(hubID)[entry.Path]; exists {
+		m.mu.Unlock()
+		if existing.sha256 == entry.SHA256 {
+			return &PutResult{
+				Outcome:       OutcomeAlreadyPresent,
+				BytesAccepted: existing.size,
+			}, nil
+		}
+		return &PutResult{
+			Outcome:     OutcomeConflict,
+			TheirSHA256: existing.sha256,
+		}, nil
+	}
+
+	// A resumed transfer carries only the tail, so the prefix must already be
+	// staged from an earlier partial attempt.
+	var prefix []byte
+	if offset > 0 {
+		staged, ok := m.stagingLocked(hubID)[entry.Path]
+		if !ok || int64(len(staged.bytes)) < offset {
+			m.mu.Unlock()
+			return nil, fmt.Errorf("edgesync: resume from %d for %q but no staged prefix",
+				offset, entry.Path)
+		}
+		// Copy: the staged buffer may be replaced by a concurrent attempt
+		// while this one is reading its body outside the lock.
+		prefix = append([]byte(nil), staged.bytes[:offset]...)
+	}
+	m.mu.Unlock()
+
+	// Phase 2 — read the body WITHOUT the lock. A real hub streams bytes to
+	// storage here; holding a mutex across that I/O would serialize every
+	// concurrent transfer.
+	// io.ReadAll is acceptable ONLY because this transport is test-only and
+	// its files are small. It is NOT a model for the HTTPS transport, which
+	// must tee the stream into a SHA-256 hasher and write to a temp path as
+	// bytes arrive (§5.2) — buffering a multi-hundred-MB parquet file in
+	// memory on a hub receiving from many spokes is how the receive path
+	// falls over.
+	tail, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: read body for %q: %w", entry.Path, err)
+	}
+
+	full := make([]byte, 0, len(prefix)+len(tail))
+	full = append(full, prefix...)
+	full = append(full, tail...)
+
+	// Verify before taking the lock: a mismatch never reaches the commit path
+	// at all, so corrupt bytes cannot become stored content.
+	var got string
+	if int64(len(full)) >= entry.SizeBytes {
+		sum := sha256.Sum256(full)
+		got = hex.EncodeToString(sum[:])
+		if got != entry.SHA256 {
+			return &PutResult{Outcome: OutcomeChecksumMismatch}, nil
+		}
+	}
+
+	// Phase 3 — commit under the lock, RE-CHECKING the identity rule.
+	//
+	// The re-check is the whole point: between the phase-1 decision and here,
+	// another transfer for the same path may have committed. Without it, two
+	// concurrent PutFile calls both observe "absent", both read their bodies,
+	// and the second silently overwrites the first with DIFFERENT content —
+	// the exact never-overwrite violation §6.1 calls an alarm. That race is
+	// invisible to -race (every map access is locked; the bug is in the
+	// interleaving, not the memory access), so it has to be reasoned about
+	// rather than detected.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil, ErrTransportClosed
+	}
+
+	if existing, exists := m.hubLocked(hubID)[entry.Path]; exists {
+		if existing.sha256 == entry.SHA256 {
+			return &PutResult{
+				Outcome:       OutcomeAlreadyPresent,
+				BytesAccepted: existing.size,
+			}, nil
+		}
+		return &PutResult{
+			Outcome:     OutcomeConflict,
+			TheirSHA256: existing.sha256,
+		}, nil
+	}
+
+	// Short of the declared size means the stream ended early — stage what
+	// arrived so the next attempt resumes rather than restarting.
+	if int64(len(full)) < entry.SizeBytes {
+		staged := m.stagingLocked(hubID)
+		// Keep the LONGEST prefix. A shorter later attempt must not move the
+		// checkpoint backward: a spoke holding the older, longer offset would
+		// then resume past what the hub has and get a hard error with no
+		// defined recovery.
+		if prev, ok := staged[entry.Path]; !ok || len(full) > len(prev.bytes) {
+			staged[entry.Path] = &memFile{bytes: full, size: int64(len(full))}
+		} else {
+			full = prev.bytes
+		}
+		return &PutResult{
+			Outcome:       OutcomePartial,
+			BytesAccepted: int64(len(full)),
+		}, nil
+	}
+
+	m.hubLocked(hubID)[entry.Path] = &memFile{
+		sha256: got,
+		size:   int64(len(full)),
+		bytes:  full,
+	}
+	delete(m.stagingLocked(hubID), entry.Path)
+
+	return &PutResult{
+		Outcome:       OutcomeCommitted,
+		BytesAccepted: int64(len(full)),
+	}, nil
+}
+
+// BackpressureResult builds the result a hub returns when it wants the spoke
+// to slow down. Provided so tests and future transports produce a valid one
+// (a zero delay would busy-loop).
+func BackpressureResult(d time.Duration) *PutResult {
+	if d <= 0 {
+		d = time.Second
+	}
+	return &PutResult{Outcome: OutcomeBackpressure, RetryAfter: d}
+}
+
+// Compile-time check that MemoryTransport satisfies the interface.
+var _ SyncTransport = (*MemoryTransport)(nil)

--- a/internal/edgesync/transport_test.go
+++ b/internal/edgesync/transport_test.go
@@ -1,0 +1,855 @@
+package edgesync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// entryFor builds a ledger entry describing the given content.
+func entryFor(path string, content []byte) *LedgerEntry {
+	return &LedgerEntry{
+		HubID:       DefaultHubID,
+		Path:        path,
+		SHA256:      sha256Hex(content),
+		SizeBytes:   int64(len(content)),
+		Database:    "default",
+		Measurement: "cpu",
+	}
+}
+
+func TestPutOutcome_RetryableAndDone(t *testing.T) {
+	// The two classification helpers drive the agent's control flow, so their
+	// disagreements matter more than their agreements. Conflict is the case
+	// worth pinning: it is neither done nor retryable, because resending
+	// cannot resolve a content disagreement and would risk overwriting good
+	// data.
+	tests := []struct {
+		outcome       PutOutcome
+		wantRetryable bool
+		wantDone      bool
+	}{
+		{OutcomeCommitted, false, true},
+		{OutcomeAlreadyPresent, false, true},
+		{OutcomePartial, true, false},
+		{OutcomeChecksumMismatch, true, false},
+		{OutcomeBackpressure, true, false},
+		{OutcomeConflict, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.outcome), func(t *testing.T) {
+			if got := tt.outcome.Retryable(); got != tt.wantRetryable {
+				t.Errorf("Retryable() = %v, want %v", got, tt.wantRetryable)
+			}
+			if got := tt.outcome.Done(); got != tt.wantDone {
+				t.Errorf("Done() = %v, want %v", got, tt.wantDone)
+			}
+		})
+	}
+}
+
+func TestPutResult_Validate(t *testing.T) {
+	entry := entryFor("db/cpu/a.parquet", []byte("hello world"))
+
+	tests := []struct {
+		name    string
+		result  *PutResult
+		wantErr string // substring; empty means the result must validate
+	}{
+		{
+			name:   "committed full size",
+			result: &PutResult{Outcome: OutcomeCommitted, BytesAccepted: entry.SizeBytes},
+		},
+		{
+			name:   "partial short of the file",
+			result: &PutResult{Outcome: OutcomePartial, BytesAccepted: 4},
+		},
+		{
+			name:   "conflict with the hub digest",
+			result: &PutResult{Outcome: OutcomeConflict, TheirSHA256: sha256Hex([]byte("other"))},
+		},
+		{
+			name:   "backpressure with a delay",
+			result: &PutResult{Outcome: OutcomeBackpressure, RetryAfter: 2 * time.Second},
+		},
+		{
+			name:    "unknown outcome",
+			result:  &PutResult{Outcome: PutOutcome("teapot")},
+			wantErr: "unknown put outcome",
+		},
+		{
+			name:    "negative bytes",
+			result:  &PutResult{Outcome: OutcomeCommitted, BytesAccepted: -1},
+			wantErr: "negative bytes accepted",
+		},
+		{
+			name:    "accepted more than the file holds",
+			result:  &PutResult{Outcome: OutcomeCommitted, BytesAccepted: entry.SizeBytes + 1},
+			wantErr: "more than the file's",
+		},
+		{
+			name: "partial that accepted everything",
+			// A contradiction: the caller would leave the entry pending
+			// forever with nothing left to send.
+			result:  &PutResult{Outcome: OutcomePartial, BytesAccepted: entry.SizeBytes},
+			wantErr: "accepted the whole file",
+		},
+		{
+			name:    "conflict without a digest",
+			result:  &PutResult{Outcome: OutcomeConflict},
+			wantErr: "without the hub's sha256",
+		},
+		{
+			name: "conflict whose digest matches",
+			// Not a conflict at all — the hub holds identical content, so
+			// this should have been AlreadyPresent.
+			result:  &PutResult{Outcome: OutcomeConflict, TheirSHA256: entry.SHA256},
+			wantErr: "not a conflict",
+		},
+		{
+			name: "backpressure without a delay",
+			// Zero would busy-loop against an already-overloaded hub.
+			result:  &PutResult{Outcome: OutcomeBackpressure},
+			wantErr: "without a retry delay",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.result.Validate(entry)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Validate() = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+
+	t.Run("nil result", func(t *testing.T) {
+		var r *PutResult
+		if err := r.Validate(entry); err == nil {
+			t.Error("Validate() on nil = nil, want an error")
+		}
+	})
+}
+
+func TestReconcileResult_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *ReconcileResult
+		wantErr string
+	}{
+		{
+			name: "disjoint lists",
+			result: &ReconcileResult{
+				Missing:   []string{"a.parquet", "b.parquet"},
+				Present:   []string{"c.parquet"},
+				Conflicts: []Conflict{{Path: "d.parquet", TheirSHA256: "deadbeef"}},
+			},
+		},
+		{
+			name:   "empty result",
+			result: &ReconcileResult{},
+		},
+		{
+			name: "same path missing and present",
+			// The agent would try to both send and skip this file.
+			result: &ReconcileResult{
+				Missing: []string{"a.parquet"},
+				Present: []string{"a.parquet"},
+			},
+			wantErr: "both missing and present",
+		},
+		{
+			name: "same path present and conflicted",
+			result: &ReconcileResult{
+				Present:   []string{"a.parquet"},
+				Conflicts: []Conflict{{Path: "a.parquet", TheirSHA256: "deadbeef"}},
+			},
+			wantErr: "both present and conflicts",
+		},
+		{
+			name:    "empty path in missing",
+			result:  &ReconcileResult{Missing: []string{""}},
+			wantErr: "empty path in missing",
+		},
+		{
+			name:    "conflict without a digest",
+			result:  &ReconcileResult{Conflicts: []Conflict{{Path: "a.parquet"}}},
+			wantErr: "without the hub's sha256",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.result.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Validate() = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMemoryTransport_ReconcilePartitionsPendingSet(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	missing := entryFor("db/cpu/missing.parquet", []byte("not on the hub"))
+	present := entryFor("db/cpu/present.parquet", []byte("already delivered"))
+	conflict := entryFor("db/cpu/conflict.parquet", []byte("spoke version"))
+
+	tr.Seed(DefaultHubID, present.Path, present.SHA256, present.SizeBytes)
+	// Same path, different content — a spoke_id collision or corruption.
+	tr.Seed(DefaultHubID, conflict.Path, sha256Hex([]byte("hub version")), 11)
+
+	res, err := tr.Reconcile(ctx, DefaultHubID, []*LedgerEntry{missing, present, conflict})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if err := res.Validate(); err != nil {
+		t.Fatalf("reconcile result failed validation: %v", err)
+	}
+
+	if len(res.Missing) != 1 || res.Missing[0] != missing.Path {
+		t.Errorf("missing = %v, want [%s]", res.Missing, missing.Path)
+	}
+	if len(res.Present) != 1 || res.Present[0] != present.Path {
+		t.Errorf("present = %v, want [%s]", res.Present, present.Path)
+	}
+	if len(res.Conflicts) != 1 || res.Conflicts[0].Path != conflict.Path {
+		t.Fatalf("conflicts = %v, want one for %s", res.Conflicts, conflict.Path)
+	}
+	// The hub's digest is the evidence an operator needs to tell a collision
+	// from corruption; a conflict without it is unactionable.
+	if res.Conflicts[0].TheirSHA256 == conflict.SHA256 {
+		t.Error("conflict reports the spoke's own digest; it must report the hub's")
+	}
+}
+
+func TestMemoryTransport_PutCommitsAndVerifies(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	content := []byte("parquet bytes")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	res, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := res.Validate(e); err != nil {
+		t.Fatalf("result failed validation: %v", err)
+	}
+	if res.Outcome != OutcomeCommitted {
+		t.Errorf("outcome = %q, want %q", res.Outcome, OutcomeCommitted)
+	}
+	if res.BytesAccepted != e.SizeBytes {
+		t.Errorf("bytes accepted = %d, want %d", res.BytesAccepted, e.SizeBytes)
+	}
+
+	if got, ok := tr.Has(DefaultHubID, e.Path); !ok || got != e.SHA256 {
+		t.Errorf("hub holds (%q, %v), want (%q, true)", got, ok, e.SHA256)
+	}
+}
+
+func TestMemoryTransport_RedeliveryIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	content := []byte("parquet bytes")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	if _, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0); err != nil {
+		t.Fatalf("first put: %v", err)
+	}
+
+	// The lost-ack case: the spoke never saw the acknowledgment and resends.
+	// This must be a no-op, not a duplicate — it is what turns at-least-once
+	// delivery into exactly-once effect.
+	res, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0)
+	if err != nil {
+		t.Fatalf("redelivery: %v", err)
+	}
+	if res.Outcome != OutcomeAlreadyPresent {
+		t.Errorf("outcome = %q, want %q", res.Outcome, OutcomeAlreadyPresent)
+	}
+	if !res.Outcome.Done() {
+		t.Error("already-present must count as done, or the agent would resend forever")
+	}
+}
+
+func TestMemoryTransport_ConflictRefusesOverwrite(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	hubContent := []byte("the hub's version")
+	spokeContent := []byte("the spoke's version")
+	e := entryFor("db/cpu/contested.parquet", spokeContent)
+	tr.Seed(DefaultHubID, e.Path, sha256Hex(hubContent), int64(len(hubContent)))
+
+	res, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(spokeContent), 0)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if res.Outcome != OutcomeConflict {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeConflict)
+	}
+	if res.Outcome.Retryable() {
+		t.Error("conflict must not be retryable — resending cannot resolve it")
+	}
+
+	// The hub's bytes must be untouched: overwriting would destroy whichever
+	// copy is the correct one.
+	if got, _ := tr.Has(DefaultHubID, e.Path); got != sha256Hex(hubContent) {
+		t.Error("conflict overwrote the hub's content")
+	}
+}
+
+func TestMemoryTransport_ChecksumMismatchDiscards(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	// The entry claims one digest; the body carries different bytes — bit-rot
+	// in flight, or in the edge's own storage.
+	e := entryFor("db/cpu/corrupt.parquet", []byte("original content"))
+	corrupted := []byte("corrupted conten") // same length, different bytes
+
+	res, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(corrupted), 0)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if res.Outcome != OutcomeChecksumMismatch {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeChecksumMismatch)
+	}
+	if !res.Outcome.Retryable() {
+		t.Error("checksum mismatch must be retryable — the spoke can resend from its own copy")
+	}
+
+	// Verify-before-commit: corrupt bytes must never become stored content.
+	if _, ok := tr.Has(DefaultHubID, e.Path); ok {
+		t.Error("hub stored content that failed checksum verification")
+	}
+}
+
+func TestMemoryTransport_PartialThenResume(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	content := []byte("the full parquet payload")
+	e := entryFor("db/cpu/big.parquet", content)
+
+	// A contact window closes mid-file: only a prefix arrives.
+	const prefixLen = 10
+	res, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content[:prefixLen]), 0)
+	if err != nil {
+		t.Fatalf("partial put: %v", err)
+	}
+	if err := res.Validate(e); err != nil {
+		t.Fatalf("partial result failed validation: %v", err)
+	}
+	if res.Outcome != OutcomePartial {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomePartial)
+	}
+	if res.BytesAccepted != prefixLen {
+		t.Fatalf("bytes accepted = %d, want %d", res.BytesAccepted, prefixLen)
+	}
+	if _, ok := tr.Has(DefaultHubID, e.Path); ok {
+		t.Error("a partially-received file must not be visible as committed content")
+	}
+
+	// The next window resumes from the checkpoint, sending only the tail —
+	// the property that lets a large file cross a link whose windows are
+	// shorter than the transfer.
+	res2, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content[res.BytesAccepted:]), res.BytesAccepted)
+	if err != nil {
+		t.Fatalf("resume put: %v", err)
+	}
+	if res2.Outcome != OutcomeCommitted {
+		t.Fatalf("resumed outcome = %q, want %q", res2.Outcome, OutcomeCommitted)
+	}
+
+	// The reassembled file must hash to the original — a resume that spliced
+	// the tail at the wrong offset would corrupt silently.
+	if got, ok := tr.Has(DefaultHubID, e.Path); !ok || got != e.SHA256 {
+		t.Errorf("reassembled digest = %q, want %q", got, e.SHA256)
+	}
+}
+
+func TestMemoryTransport_ResumeWithoutStagedPrefixFails(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	content := []byte("the full parquet payload")
+	e := entryFor("db/cpu/big.parquet", content)
+
+	// Resuming against a hub that has no prefix (it restarted, or the spoke's
+	// checkpoint is stale) must fail loudly rather than commit a file built
+	// from a tail alone.
+	_, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content[10:]), 10)
+	if err == nil {
+		t.Fatal("resume without a staged prefix succeeded; it must fail")
+	}
+	if !strings.Contains(err.Error(), "no staged prefix") {
+		t.Errorf("err = %q, want it to mention the missing prefix", err)
+	}
+}
+
+func TestMemoryTransport_ScriptedBackpressure(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	content := []byte("payload")
+	e := entryFor("db/cpu/a.parquet", content)
+	tr.ScriptPut(DefaultHubID, e.Path, BackpressureResult(3*time.Second))
+
+	res, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := res.Validate(e); err != nil {
+		t.Fatalf("backpressure result failed validation: %v", err)
+	}
+	if res.Outcome != OutcomeBackpressure {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeBackpressure)
+	}
+	if res.RetryAfter != 3*time.Second {
+		t.Errorf("retry after = %v, want 3s", res.RetryAfter)
+	}
+	// The hub deliberately did not read the body, so nothing is stored.
+	if _, ok := tr.Has(DefaultHubID, e.Path); ok {
+		t.Error("hub stored a file it answered with backpressure")
+	}
+
+	// Once the script is exhausted the transport behaves normally, so a test
+	// can drive "throttled, then accepted".
+	res2, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0)
+	if err != nil {
+		t.Fatalf("retry after backpressure: %v", err)
+	}
+	if res2.Outcome != OutcomeCommitted {
+		t.Errorf("outcome after backpressure = %q, want %q", res2.Outcome, OutcomeCommitted)
+	}
+}
+
+func TestBackpressureResult_NeverZeroDelay(t *testing.T) {
+	// A zero delay would busy-loop against an already-overloaded hub, so the
+	// constructor floors it rather than trusting the caller.
+	for _, d := range []time.Duration{0, -time.Second} {
+		got := BackpressureResult(d)
+		if got.RetryAfter <= 0 {
+			t.Errorf("BackpressureResult(%v).RetryAfter = %v, want > 0", d, got.RetryAfter)
+		}
+		if err := got.Validate(nil); err != nil {
+			t.Errorf("BackpressureResult(%v) failed validation: %v", d, err)
+		}
+	}
+}
+
+func TestMemoryTransport_HubIsolation(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	content := []byte("payload")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	if _, err := tr.PutFile(ctx, "cloud", e, bytes.NewReader(content), 0); err != nil {
+		t.Fatalf("put to cloud: %v", err)
+	}
+
+	// Delivering to one hub must not mark it delivered to another — the same
+	// isolation the ledger's (hub_id, path) key provides on the spoke side.
+	res, err := tr.Reconcile(ctx, "factory", []*LedgerEntry{e})
+	if err != nil {
+		t.Fatalf("reconcile factory: %v", err)
+	}
+	if len(res.Missing) != 1 {
+		t.Errorf("factory missing = %v, want the file to still be missing there", res.Missing)
+	}
+	if len(res.Present) != 0 {
+		t.Errorf("factory present = %v, want empty — hubs are not isolated", res.Present)
+	}
+}
+
+func TestMemoryTransport_ClosedRejectsCalls(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+	content := []byte("payload")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := tr.Reconcile(ctx, DefaultHubID, []*LedgerEntry{e}); !errors.Is(err, ErrTransportClosed) {
+		t.Errorf("Reconcile after close = %v, want ErrTransportClosed", err)
+	}
+	if _, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0); !errors.Is(err, ErrTransportClosed) {
+		t.Errorf("PutFile after close = %v, want ErrTransportClosed", err)
+	}
+}
+
+func TestMemoryTransport_HonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tr := NewMemoryTransport()
+	content := []byte("payload")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	// A contact window that closes must abort in-progress work rather than
+	// finishing against a link that is already gone.
+	if _, err := tr.Reconcile(ctx, DefaultHubID, []*LedgerEntry{e}); !errors.Is(err, context.Canceled) {
+		t.Errorf("Reconcile with cancelled ctx = %v, want context.Canceled", err)
+	}
+	if _, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0); !errors.Is(err, context.Canceled) {
+		t.Errorf("PutFile with cancelled ctx = %v, want context.Canceled", err)
+	}
+}
+
+func TestMemoryTransport_RejectsBadOffset(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+	content := []byte("payload")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	for _, offset := range []int64{-1, e.SizeBytes + 1} {
+		if _, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), offset); err == nil {
+			t.Errorf("PutFile with offset %d succeeded, want an error", offset)
+		}
+	}
+}
+
+func TestMemoryTransport_ConcurrentPutsAreSafe(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	// §8.2 runs several transfers at once, so the transport must tolerate it.
+	// Run under -race for this to mean anything.
+	const files = 16
+	errs := make(chan error, files)
+	for i := 0; i < files; i++ {
+		go func(i int) {
+			content := []byte(strings.Repeat("x", i+1))
+			e := entryFor("db/cpu/f"+string(rune('a'+i))+".parquet", content)
+			_, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0)
+			errs <- err
+		}(i)
+	}
+	for i := 0; i < files; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent put: %v", err)
+		}
+	}
+}
+
+func TestMemoryTransport_SamePathConcurrencyNeverOverwrites(t *testing.T) {
+	ctx := context.Background()
+
+	// §6.1's never-overwrite rule under concurrency. Two transfers race to
+	// write DIFFERENT content to the same path: exactly one may commit, and
+	// the other must see a conflict or already-present — never a second
+	// commit that silently replaces the first.
+	//
+	// This is a LOGIC race, not a data race: every map access is mutex-guarded,
+	// so -race cannot see it. It only appears as a wrong outcome, which is why
+	// it needs its own test rather than relying on the detector. Repeated
+	// because the losing interleaving is probabilistic.
+	for trial := 0; trial < 200; trial++ {
+		tr := NewMemoryTransport()
+		contentA := []byte("aaaaaaaaaaaa")
+		contentB := []byte("bbbbbbbbbbbb")
+		const path = "db/cpu/contested.parquet"
+		entryA := entryFor(path, contentA)
+		entryB := entryFor(path, contentB)
+
+		var wg sync.WaitGroup
+		results := make([]*PutResult, 2)
+		errs := make([]error, 2)
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			results[0], errs[0] = tr.PutFile(ctx, DefaultHubID, entryA, bytes.NewReader(contentA), 0)
+		}()
+		go func() {
+			defer wg.Done()
+			results[1], errs[1] = tr.PutFile(ctx, DefaultHubID, entryB, bytes.NewReader(contentB), 0)
+		}()
+		wg.Wait()
+
+		committed := 0
+		for i, r := range results {
+			if errs[i] != nil {
+				t.Fatalf("trial %d: put %d: %v", trial, i, errs[i])
+			}
+			if r.Outcome == OutcomeCommitted {
+				committed++
+			}
+		}
+		if committed != 1 {
+			t.Fatalf("trial %d: %d of 2 concurrent puts committed different content to %q; exactly 1 may win",
+				trial, committed, path)
+		}
+
+		// Whichever won, the stored digest must match one of the two inputs
+		// exactly — not a splice of both.
+		got, ok := tr.Has(DefaultHubID, path)
+		if !ok {
+			t.Fatalf("trial %d: nothing stored after a committed put", trial)
+		}
+		if got != entryA.SHA256 && got != entryB.SHA256 {
+			t.Fatalf("trial %d: stored digest %q matches neither input — content was spliced", trial, got)
+		}
+	}
+}
+
+func TestMemoryTransport_PerPathHubIsolation(t *testing.T) {
+	ctx := context.Background()
+
+	// The previous isolation test wrote to one hub and reconciled another, so
+	// it only failed if EVERY path lost hubID at once. Real bugs live in one
+	// path, so each is checked independently against a hub that holds the file
+	// and one that does not.
+	content := []byte("payload")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	tr := NewMemoryTransport()
+	if _, err := tr.PutFile(ctx, "cloud", e, bytes.NewReader(content), 0); err != nil {
+		t.Fatalf("put to cloud: %v", err)
+	}
+
+	t.Run("Has", func(t *testing.T) {
+		if _, ok := tr.Has("cloud", e.Path); !ok {
+			t.Error("cloud should hold the file")
+		}
+		if _, ok := tr.Has("factory", e.Path); ok {
+			t.Error("factory reports a file only cloud received — Has ignores hubID")
+		}
+	})
+
+	t.Run("Reconcile", func(t *testing.T) {
+		cloudRes, err := tr.Reconcile(ctx, "cloud", []*LedgerEntry{e})
+		if err != nil {
+			t.Fatalf("reconcile cloud: %v", err)
+		}
+		if len(cloudRes.Present) != 1 {
+			t.Errorf("cloud present = %v, want the file", cloudRes.Present)
+		}
+
+		factoryRes, err := tr.Reconcile(ctx, "factory", []*LedgerEntry{e})
+		if err != nil {
+			t.Fatalf("reconcile factory: %v", err)
+		}
+		if len(factoryRes.Present) != 0 {
+			t.Errorf("factory present = %v, want empty — Reconcile ignores hubID", factoryRes.Present)
+		}
+	})
+
+	t.Run("PutFile writes to the named hub", func(t *testing.T) {
+		// A second hub must accept the same file independently rather than
+		// short-circuiting on the first hub's copy.
+		res, err := tr.PutFile(ctx, "factory", e, bytes.NewReader(content), 0)
+		if err != nil {
+			t.Fatalf("put to factory: %v", err)
+		}
+		if res.Outcome != OutcomeCommitted {
+			t.Errorf("outcome = %q, want %q — PutFile ignores hubID", res.Outcome, OutcomeCommitted)
+		}
+	})
+}
+
+func TestMemoryTransport_ScriptIsHubScoped(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	content := []byte("payload")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	// Only "cloud" is throttled. A path-keyed script would be consumed by the
+	// factory transfer, inverting the test's meaning.
+	tr.ScriptPut("cloud", e.Path, BackpressureResult(time.Second))
+
+	factoryRes, err := tr.PutFile(ctx, "factory", e, bytes.NewReader(content), 0)
+	if err != nil {
+		t.Fatalf("put to factory: %v", err)
+	}
+	if factoryRes.Outcome != OutcomeCommitted {
+		t.Errorf("factory outcome = %q, want %q — it consumed cloud's script",
+			factoryRes.Outcome, OutcomeCommitted)
+	}
+
+	cloudRes, err := tr.PutFile(ctx, "cloud", e, bytes.NewReader(content), 0)
+	if err != nil {
+		t.Fatalf("put to cloud: %v", err)
+	}
+	if cloudRes.Outcome != OutcomeBackpressure {
+		t.Errorf("cloud outcome = %q, want %q — its script was consumed elsewhere",
+			cloudRes.Outcome, OutcomeBackpressure)
+	}
+}
+
+func TestMemoryTransport_ConflictReportsHubDigestNotSpokes(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	hubContent := []byte("the hub's version")
+	spokeContent := []byte("the spoke's version")
+	e := entryFor("db/cpu/contested.parquet", spokeContent)
+	hubSHA := sha256Hex(hubContent)
+	tr.Seed(DefaultHubID, e.Path, hubSHA, int64(len(hubContent)))
+
+	res, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(spokeContent), 0)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	// §6.1 calls the hub's digest the operator's only evidence for telling a
+	// spoke_id collision from corruption. Echoing the spoke's own digest back
+	// would make the conflict unactionable.
+	if res.TheirSHA256 != hubSHA {
+		t.Errorf("TheirSHA256 = %q, want the hub's %q", res.TheirSHA256, hubSHA)
+	}
+	if res.TheirSHA256 == e.SHA256 {
+		t.Error("conflict echoed the spoke's own digest")
+	}
+}
+
+func TestMemoryTransport_StagedCheckpointNeverMovesBackward(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+
+	content := []byte("the full parquet payload here")
+	e := entryFor("db/cpu/big.parquet", content)
+
+	// A long partial, then a shorter one (a retry that died earlier). If the
+	// hub replaced its staged prefix with the shorter attempt, a spoke holding
+	// the longer checkpoint would resume past what the hub has and get a hard
+	// error with no defined recovery — the file would strand permanently.
+	first, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content[:20]), 0)
+	if err != nil {
+		t.Fatalf("first partial: %v", err)
+	}
+	if first.BytesAccepted != 20 {
+		t.Fatalf("first accepted = %d, want 20", first.BytesAccepted)
+	}
+
+	second, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content[:5]), 0)
+	if err != nil {
+		t.Fatalf("second partial: %v", err)
+	}
+	if second.BytesAccepted < first.BytesAccepted {
+		t.Fatalf("checkpoint moved backward: %d then %d", first.BytesAccepted, second.BytesAccepted)
+	}
+
+	// Resuming from the original, longer checkpoint must still work.
+	final, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content[first.BytesAccepted:]), first.BytesAccepted)
+	if err != nil {
+		t.Fatalf("resume from %d: %v", first.BytesAccepted, err)
+	}
+	if final.Outcome != OutcomeCommitted {
+		t.Fatalf("outcome = %q, want %q", final.Outcome, OutcomeCommitted)
+	}
+	if got, _ := tr.Has(DefaultHubID, e.Path); got != e.SHA256 {
+		t.Errorf("reassembled digest = %q, want %q", got, e.SHA256)
+	}
+}
+
+func TestMemoryTransport_RejectsIncompleteEntry(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+	content := []byte("payload")
+
+	t.Run("empty sha256", func(t *testing.T) {
+		// Without a digest there is nothing to verify against; committing
+		// anyway would defeat verify-before-commit entirely.
+		e := entryFor("db/cpu/a.parquet", content)
+		e.SHA256 = ""
+		if _, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0); err == nil {
+			t.Error("PutFile with an empty sha256 succeeded; it must be rejected")
+		}
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		e := entryFor("", content)
+		if _, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0); err == nil {
+			t.Error("PutFile with an empty path succeeded; it must be rejected")
+		}
+	})
+}
+
+func TestMemoryTransport_RejectsInvalidScriptedResult(t *testing.T) {
+	ctx := context.Background()
+	content := []byte("payload")
+	e := entryFor("db/cpu/a.parquet", content)
+
+	t.Run("nil", func(t *testing.T) {
+		tr := NewMemoryTransport()
+		tr.ScriptPut(DefaultHubID, e.Path, nil)
+		// (nil, nil) would violate the interface contract and panic every
+		// caller that reads res.Outcome.
+		res, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0)
+		if err == nil {
+			t.Errorf("scripted nil returned (%v, nil); want an error", res)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		tr := NewMemoryTransport()
+		// A conflict with no digest is exactly what Validate exists to reject;
+		// scripting must not be a way to bypass it.
+		tr.ScriptPut(DefaultHubID, e.Path, &PutResult{Outcome: OutcomeConflict})
+		if _, err := tr.PutFile(ctx, DefaultHubID, e, bytes.NewReader(content), 0); err == nil {
+			t.Error("an invalid scripted result was returned without error")
+		}
+	})
+}
+
+func TestMemoryTransport_ReconcileRejectsMalformedEntries(t *testing.T) {
+	ctx := context.Background()
+	tr := NewMemoryTransport()
+	good := entryFor("db/cpu/a.parquet", []byte("payload"))
+
+	t.Run("nil entry", func(t *testing.T) {
+		if _, err := tr.Reconcile(ctx, DefaultHubID, []*LedgerEntry{good, nil}); err == nil {
+			t.Error("Reconcile with a nil entry succeeded; it must be rejected")
+		}
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		// An empty path is a valid map key, so without an explicit guard it
+		// would classify against hub[""] and land in a result list — which
+		// ReconcileResult.Validate then rejects, blaming the result instead
+		// of the input that caused it.
+		bad := entryFor("", []byte("payload"))
+		if _, err := tr.Reconcile(ctx, DefaultHubID, []*LedgerEntry{good, bad}); err == nil {
+			t.Error("Reconcile with an empty path succeeded; it must be rejected")
+		}
+	})
+}


### PR DESCRIPTION
Second of nine PRs for edge sync — see [#569](https://github.com/Basekick-Labs/arc/issues/569). Follows #570 (ledger) and #571 (package rename).

## Summary

Adds the `SyncTransport` interface the sync agent talks to, plus `MemoryTransport`, an in-process implementation for tests.

- **`Reconcile`** — one round-trip partitioning the pending set into `missing` / `present` / `conflicts` (§5.1).
- **`PutFile`** — streams one file, resuming from a byte offset (§5.2).
- **`PutOutcome`** — a typed result covering all five documented hub responses, with `Retryable()` and `Done()` so the agent branches on meaning rather than wire details.
- **`Validate`** on both result types — rejects internally inconsistent answers from a buggy or hostile hub before they reach the ledger.

No production callers. The agent wires this up in PR 8.

## Two deliberate deviations from §10

**`PutFile` returns `(*PutResult, error)`, not a bare `error`.** §5.2 defines five distinct outcomes and the caller's action differs for each; collapsing them into an error forces string-matching. `PutOutcome` follows the `AckErrorCode` precedent in `internal/cluster/protocol`.

**It takes `*LedgerEntry`, not a new `FileRef`.** Matches `filereplication.Fetcher` taking `*raft.FileEntry` — a narrower type means a lossy conversion at every call site. Review correctly noted the precedent is inexact (`raft.FileEntry` is a pure content descriptor; `LedgerEntry` has the state machine attached), so the doc comment now states explicitly which fields implementations may read.

## The bug review caught

`MemoryTransport.PutFile` released its lock between "does this path exist?" and the write. **Two concurrent transfers to the same path both saw absent and both committed different content** — a direct §6.1 never-overwrite violation, measured at **60 of 500 trials**.

`-race` cannot see it: every map access *is* locked, so it is a logic race, not a data race. My original concurrency test used 16 distinct paths and never exercised the same-path case.

This matters beyond a test helper: `MemoryTransport` is the only hub PR 8's agent will test against, so the agent's conflict-handling tests would have passed against a hub violating the invariant they exist to check.

Fixed with three-phase commit — decide under lock, read the body outside it (a real hub streams; holding a mutex across I/O would serialize every transfer), then **re-check the identity rule under lock** before committing. Verified: removing the re-check fails the new 200-trial test at trial 7.

### Other blockers, all verified empirically before fixing

- **Staging forgery** — partials lived under a reserved key in the *same* map as real hubs, so a crafted `hubID` addressed them, and any staged file surfaced as a phantom conflict with an empty digest, producing a `ReconcileResult` that **failed its own `Validate`**. Now a separate map.
- **`ScriptPut(path, nil)` returned `(nil, nil)`** — violating the interface contract and panicking every caller.
- **Under-reported byte counts validated clean** — `committed` with 0 of 11 bytes passed. `Done()` makes the entry terminal, so the wrong count would never be corrected.
- **Empty `SHA256` committed unverified**, defeating verify-before-commit.
- **Staged checkpoint could move backward** — a shorter later partial replaced a longer one, stranding the file permanently.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, any config | **No** — nothing constructs a transport | n/a |
| Cluster mode, any config | **No** — no `cmd/arc/main.go` wiring | n/a |
| Tests only | Yes — `transport_test.go` is the sole caller | in-process, no I/O, no DB |

Zero production callers, so no config-interaction or nil-deref surface. Risk sits in protocol semantics and in `MemoryTransport`'s fidelity to §6.1 — which is where review was pointed, and where it found the concurrency bug.

**Config keys:** none. **Deref check:** `Validate` guards nil receiver and nil entry; `PutFile` rejects nil/empty entry, empty SHA256, and out-of-range offsets.

## Test plan

- [x] `go build ./cmd/... ./internal/...`
- [x] `go test ./internal/edgesync/` — 45 tests
- [x] `go test -race ./internal/edgesync/` (×3 on the concurrency test)
- [x] `go vet` / `gofmt -l` clean
- [x] **Mutation-tested.** Review found 7 survivors; 4 mattered. Fixed and added tests, then re-ran each to confirm it now fails: `Has`/`Reconcile` ignoring `hubID`, conflict reporting the spoke's digest instead of the hub's, and the staged checkpoint moving backward.
- [x] Every new regression test verified to fail against the pre-fix code.
- [ ] **Binary run — N/A.** No startup path reaches this code. That gate applies at PR 8.

## Review

Two adversarial passes. The first found 3 blockers + 6 high (above), all fixed. The second found no bugs and suggested a defensive `Reconcile` guard against empty paths, which is added and verified load-bearing.

One correction: the second review's verification table reports 24 tests. The actual count is 45 top-level (81 including subtests). It doesn't change any finding, but the table isn't reliable on counts.

## Notes

- **Docs:** no `docs.basekick.net` change — nothing configurable or observable yet. Docs land with PR 8's endpoints.
- Release notes updated to mention the transport alongside the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)