### PR TITLE
feat(edgesync): hub receive endpoint with verify-before-commit (#569 PR 4/9)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -68,7 +68,22 @@ Arc runs at the edge today — a standalone binary with local storage in a vehic
 
 **Edge sync** ([#569](https://github.com/Basekick-Labs/arc/issues/569)) addresses this by shipping immutable Parquet *files* from a spoke (edge) to a hub (central Arc): the spoke initiates, the hub verifies each file's SHA256 before committing it, and re-delivery of an already-received file is a no-op. Connectivity is treated as the exception rather than the norm — discovery is a single batched round-trip regardless of backlog size, and transfers resume from a byte offset when a link drops mid-file.
 
-**Nothing is user-visible in this release, on disk or otherwise.** The work is landing as a sequence of reviewed changes; so far that is the spoke-side ledger (which files have reached which hub, and how far a partial transfer got), the `SyncTransport` interface the agent will talk to with an in-process implementation for tests, and the HMAC scheme that authenticates a spoke to a hub. No configuration key enables it, no endpoint exposes it, and no startup path constructs it — so its SQLite schema is not even created yet. It is recorded here so the release history matches the work, not because there is anything to use or configure.
+The hub receive endpoint is the first piece an operator can turn on:
+
+```toml
+[edge_sync]
+enabled = true                     # default false
+hub_id = "ground-station"          # required when enabled; bound into every request's HMAC
+max_file_bytes = 536870912         # 512MiB default; must not exceed server.max_payload_size
+```
+
+With it enabled, `POST /api/v1/sync/file` accepts an authenticated file push from a registered spoke. Every upload is streamed to a staging area, hashed on the way in, and **verified before it is promoted** to its final location — a checksum mismatch is discarded and never appears where a reader would find it. Redelivering a file the hub already holds is a no-op; the same path arriving with *different* content is refused with `409` rather than overwritten, because one of the two copies is wrong and silently replacing either destroys the evidence.
+
+Two independent authentication layers apply: Arc's API token middleware, and a per-spoke HMAC binding the spoke, the hub, the path, and the content digest. **There is no way to register a spoke yet** (that lands with the spoke registry), so an enabled hub currently rejects every request and logs a warning saying so — visible and safe, rather than silently accepting unauthenticated writes.
+
+Resume is supported on local storage. On S3 and Azure a dropped transfer restarts from zero, because block objects cannot be appended to; this is a throughput cost on intermittent links, not a correctness problem.
+
+The rest of the work is still internal: the spoke-side ledger, the `SyncTransport` interface, and the HMAC scheme. Manual export/import will be OSS when it ships; the automatic scheduled agent will be an Enterprise feature.
 
 Manual export/import will be OSS when it ships; the automatic scheduled agent will be an Enterprise feature.
 
@@ -353,7 +368,7 @@ The forwarding-header and loop-guard changes are cluster-only; the partition-pru
 2. **No API or on-disk format changes.** Reads, queries, and storage layout are untouched. Queries with a start date earlier than `1970-01-01` are pruned from the epoch forward; since Arc stores no pre-epoch data, results are unchanged.
 3. **Clustered operators:** if any external tooling deliberately sets `X-Arc-Forwarded-By`, `X-Real-IP`, or `X-Forwarded-*` headers on requests to Arc and expects them to survive an inter-node forward, note that these are now stripped on the forwarding hop and re-established by Arc. Client IP has never been derived from these headers, so log/audit attribution is unchanged.
 4. **Active licenses keep working.** No re-activation required.
-5. **Nothing changes on disk or in the database.** The edge-sync groundwork above defines two SQLite tables (`sync_ledger`, `sync_history`), but no startup path constructs the ledger, so the schema is never created and the tables do not appear in `auth.db_path`. They will be created by the release that first wires edge sync into the server.
+5. **Edge sync is off by default and nothing changes unless you enable it.** With `edge_sync.enabled=false` (the default) no routes are mounted and `/api/v1/sync/file` returns 404. The `sync_ledger` and `sync_history` tables are still not created — the spoke side is not yet wired into startup.
 
 ## Dependencies
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/basekick-labs/arc/internal/compaction"
 	"github.com/basekick-labs/arc/internal/config"
 	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/edgesync"
 	"github.com/basekick-labs/arc/internal/fips"
 	"github.com/basekick-labs/arc/internal/governance"
 	"github.com/basekick-labs/arc/internal/iceberg"
@@ -1932,6 +1933,73 @@ func main() {
 		lineProtocolHandler.SetAuthAndRBAC(authManager, rbacManager)
 	}
 	lineProtocolHandler.RegisterRoutes(server.GetApp())
+
+	// Register the edge-sync hub receive endpoint (#569).
+	//
+	// Opt-in: an Arc that is not a hub must not expose a remotely-writable
+	// surface. When enabled, two independent auth layers apply — Arc's API
+	// token middleware on the route group, and a per-spoke HMAC inside the
+	// handler that binds spoke, hub, path, and content digest.
+	//
+	// storageBackend is always non-nil here (main exits earlier if it fails to
+	// construct), but clusterCoordinator may be nil: OSS standalone runs a hub
+	// with no Raft manifest, where the backend's own listing is the manifest.
+	// RegisterFile is therefore nil in that mode rather than assumed present.
+	if cfg.EdgeSync.Enabled {
+		var registerFile func(context.Context, *edgesync.ReceivedFile) error
+		if clusterCoordinator != nil {
+			coord := clusterCoordinator
+			registerFile = func(_ context.Context, f *edgesync.ReceivedFile) error {
+				return coord.RegisterFileInManifest(clusterraft.FileEntry{
+					Path:        f.Path,
+					SHA256:      f.SHA256,
+					SizeBytes:   f.SizeBytes,
+					Database:    f.Database(),
+					Measurement: f.Measurement(),
+					// PartitionTime drives hot/cold routing and tiering age
+					// checks; leaving it zero would make a synced file look
+					// infinitely old to the migrator and exclude it from
+					// time-ranged queries.
+					PartitionTime: f.PartitionTime(),
+					OriginNodeID:  f.SpokeID,
+					Tier:          "hot",
+					CreatedAt:     time.Now().UTC(),
+				})
+			}
+		}
+
+		receiver, err := edgesync.NewReceiver(edgesync.ReceiverConfig{
+			Backend:      storageBackend,
+			Logger:       logger.Get("edgesync"),
+			RegisterFile: registerFile,
+		})
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create edge sync receiver; refusing to start")
+		}
+
+		// TODO(#569 PR 7): spoke secrets come from the SQLite registry. Until
+		// that lands there is no way to register a spoke, so the hub starts
+		// with an empty set and rejects every request — visible and safe,
+		// rather than silently accepting unauthenticated writes.
+		syncHandler, err := api.NewEdgeSyncHandler(api.EdgeSyncHandlerConfig{
+			Receiver:     receiver,
+			SpokeSecrets: api.StaticSpokeSecrets(nil),
+			Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
+			HubID:        cfg.EdgeSync.HubID,
+			MaxFileBytes: cfg.EdgeSync.MaxFileBytes,
+			AuthManager:  authManager,
+			Logger:       logger.Get("edgesync"),
+		})
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create edge sync handler; refusing to start")
+		}
+		syncHandler.RegisterRoutes(server.GetApp())
+
+		syncLogger := logger.Get("edgesync")
+		syncLogger.Warn().
+			Str("hub_id", cfg.EdgeSync.HubID).
+			Msg("Edge sync hub enabled with no registered spokes; every request will be rejected until the spoke registry lands (#569 PR 7)")
+	}
 
 	// Register TLE handler (streaming TLE ingestion)
 	tleHandler := api.NewTLEHandler(arrowBuffer, logger.Get("tle"))

--- a/internal/api/edgesync.go
+++ b/internal/api/edgesync.go
@@ -1,0 +1,379 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/edgesync"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// Sync request headers. The spoke sends its native path; the hub namespaces it.
+const (
+	headerSpokeID = "X-Arc-Spoke-ID"
+	headerHubID   = "X-Arc-Sync-HubID"
+	headerPath    = "X-Arc-Sync-Path"
+	headerSHA256  = "X-Arc-Sync-SHA256"
+	headerSize    = "X-Arc-Sync-Size"
+	headerOffset  = "X-Arc-Sync-Offset"
+	headerNonce   = "X-Arc-Sync-Nonce"
+	headerTS      = "X-Arc-Sync-Timestamp"
+	headerMAC     = "X-Arc-Sync-MAC"
+)
+
+// receiveTimeout bounds a single file transfer. Generous because a large
+// Parquet file over a constrained link is the expected case, not an anomaly.
+const receiveTimeout = 30 * time.Minute
+
+// SpokeSecretLookup returns the shared secret registered for a spoke.
+//
+// Per-spoke secrets are the point: revoking one edge must not re-key the
+// fleet. Returning ok=false rejects the request without disclosing whether the
+// spoke is unknown or merely disabled.
+type SpokeSecretLookup func(ctx context.Context, spokeID string) (secret string, ok bool)
+
+// EdgeSyncHandler serves the hub side of edge-to-cloud sync.
+type EdgeSyncHandler struct {
+	receiver     *edgesync.Receiver
+	lookup       SpokeSecretLookup
+	replay       security.ReplayGuard
+	authManager  *auth.AuthManager
+	hubID        string
+	maxFileBytes int64
+	logger       zerolog.Logger
+}
+
+// EdgeSyncHandlerConfig configures the handler.
+type EdgeSyncHandlerConfig struct {
+	Receiver *edgesync.Receiver
+
+	// SpokeSecrets resolves a spoke's shared secret. Required — without it
+	// every request would be unauthenticated.
+	SpokeSecrets SpokeSecretLookup
+
+	// Replay consumes nonces so a captured request cannot be replayed inside
+	// the freshness window. Required.
+	Replay security.ReplayGuard
+
+	// HubID identifies this hub. It is bound into the request MAC, so a
+	// request minted for another hub sharing the spoke's secret is rejected.
+	HubID string
+
+	// MaxFileBytes caps a single upload. Required and must be > 0.
+	MaxFileBytes int64
+
+	AuthManager *auth.AuthManager
+	Logger      zerolog.Logger
+}
+
+// NewEdgeSyncHandler validates configuration and returns a ready handler.
+//
+// Every dependency that carries a security property is required rather than
+// optional: a nil secret lookup or replay guard would silently downgrade
+// authentication, and a handler that half-works is worse than one that refuses
+// to start.
+func NewEdgeSyncHandler(cfg EdgeSyncHandlerConfig) (*EdgeSyncHandler, error) {
+	if cfg.Receiver == nil {
+		return nil, errors.New("edgesync handler: receiver is required")
+	}
+	if cfg.SpokeSecrets == nil {
+		return nil, errors.New("edgesync handler: spoke secret lookup is required")
+	}
+	if cfg.Replay == nil {
+		return nil, errors.New("edgesync handler: replay guard is required")
+	}
+	if cfg.HubID == "" {
+		return nil, errors.New("edgesync handler: hub ID is required")
+	}
+	if cfg.MaxFileBytes <= 0 {
+		return nil, errors.New("edgesync handler: max file bytes must be > 0")
+	}
+	return &EdgeSyncHandler{
+		receiver:     cfg.Receiver,
+		lookup:       cfg.SpokeSecrets,
+		replay:       cfg.Replay,
+		authManager:  cfg.AuthManager,
+		hubID:        cfg.HubID,
+		maxFileBytes: cfg.MaxFileBytes,
+		// logger.Get already sets component; adding it again duplicates the key.
+		logger: cfg.Logger,
+	}, nil
+}
+
+// RegisterRoutes mounts the hub receive endpoints.
+//
+// Two independent authentication layers, both mandatory:
+//
+//   - Arc's API token auth, so the endpoint is not reachable by an anonymous
+//     caller even before sync-specific checks run.
+//   - Per-spoke HMAC inside the handler, which is what actually binds the
+//     request to a spoke identity and its content.
+//
+// The token layer alone is insufficient (it proves a caller has *an* Arc
+// token, not that it is a given spoke), and the HMAC alone would leave the
+// endpoint reachable by anyone who can guess a spoke ID. Both, always.
+func (h *EdgeSyncHandler) RegisterRoutes(app fiber.Router) {
+	group := app.Group("/api/v1/sync")
+
+	if h.authManager != nil {
+		group.Use(auth.RequireAdmin(h.authManager))
+	}
+
+	group.Post("/file", h.receiveFile)
+
+	h.logger.Info().
+		Str("hub_id", h.hubID).
+		Bool("resume_supported", h.receiver.SupportsResume()).
+		Msg("Edge sync receive routes registered")
+}
+
+// receiveFile handles POST /api/v1/sync/file.
+func (h *EdgeSyncHandler) receiveFile(c *fiber.Ctx) error {
+	// Size check FIRST, before anything else touches the request.
+	//
+	// The Fiber app runs with StreamRequestBody=false, so fasthttp has already
+	// buffered the body by the time this handler is entered — but rejecting
+	// here still bounds what an attacker can make the hub hold, because the
+	// route-level limit is what an operator can tune down from the global
+	// server.max_payload_size (1GB by default). Without it, any party who can
+	// reach the port could pin up to 1GB per connection with no token and no
+	// spoke secret.
+	if cl := c.Request().Header.ContentLength(); cl > 0 && int64(cl) > h.maxFileBytes {
+		h.logger.Warn().
+			Int("content_length", cl).
+			Int64("limit", h.maxFileBytes).
+			Msg("Sync upload rejected: exceeds edge_sync.max_file_bytes")
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+			"error": "upload exceeds edge_sync.max_file_bytes",
+			"limit": h.maxFileBytes,
+		})
+	}
+
+	// Fiber's header values alias a reusable buffer, so anything retained past
+	// this handler must be copied. These are all consumed synchronously, but
+	// copying keeps that from becoming a latent bug if the receive path ever
+	// goes async.
+	spokeID := string(append([]byte(nil), c.Request().Header.Peek(headerSpokeID)...))
+	hubID := string(append([]byte(nil), c.Request().Header.Peek(headerHubID)...))
+	filePath := string(append([]byte(nil), c.Request().Header.Peek(headerPath)...))
+	sha := string(append([]byte(nil), c.Request().Header.Peek(headerSHA256)...))
+	nonce := string(append([]byte(nil), c.Request().Header.Peek(headerNonce)...))
+	mac := string(append([]byte(nil), c.Request().Header.Peek(headerMAC)...))
+
+	if spokeID == "" || filePath == "" || sha == "" || nonce == "" || mac == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "missing required sync headers",
+		})
+	}
+
+	// The hub ID must match this hub. A MAC minted for a different hub that
+	// shares the spoke's secret is not valid here.
+	if hubID != h.hubID {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "hub ID mismatch",
+		})
+	}
+
+	size, err := strconv.ParseInt(c.Get(headerSize), 10, 64)
+	if err != nil || size < 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid or missing " + headerSize,
+		})
+	}
+	// A declared size above the cap is refused even when Content-Length is
+	// absent or understated — the declared size is what the receiver uses to
+	// bound its reads and to size the staging write.
+	if size > h.maxFileBytes {
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+			"error": "declared size exceeds edge_sync.max_file_bytes",
+			"limit": h.maxFileBytes,
+		})
+	}
+
+	var offset int64
+	if raw := c.Get(headerOffset); raw != "" {
+		offset, err = strconv.ParseInt(raw, 10, 64)
+		if err != nil || offset < 0 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "invalid " + headerOffset,
+			})
+		}
+	}
+
+	ts, err := strconv.ParseInt(c.Get(headerTS), 10, 64)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid or missing " + headerTS,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), receiveTimeout)
+	defer cancel()
+
+	secret, ok := h.lookup(ctx, spokeID)
+	if !ok {
+		// Deliberately identical to a MAC failure: distinguishing "unknown
+		// spoke" from "bad signature" would let an attacker enumerate
+		// registered spoke IDs.
+		h.logger.Warn().Str("spoke_id", spokeID).Msg("Sync rejected: unknown or disabled spoke")
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication failed"})
+	}
+
+	// Validates the MAC and consumes the nonce, in that order — a forged
+	// request must not burn a nonce slot and lock out the legitimate one.
+	if err := security.ValidateSyncFileHMACWithReplay(
+		h.replay, secret, nonce, spokeID, hubID, filePath, sha, ts, mac,
+		security.HMACTimestampTolerance,
+	); err != nil {
+		return h.authFailure(c, spokeID, err)
+	}
+
+	// The body is fully buffered, not streamed: the Fiber app is constructed
+	// with StreamRequestBody=false (api/server.go) so the gzip-compressed
+	// ingest path can handle bodies itself, and RequestBodyStream() returns
+	// nothing usable under that setting. A sync upload is therefore bounded by
+	// the server's BodyLimit (server.max_payload_size), which an operator
+	// running a hub must size above their largest compacted Parquet file.
+	//
+	// This is a real deviation from §5.2's "stream the body". Flipping
+	// StreamRequestBody globally would change behavior for every existing
+	// endpoint, so it is deliberately out of scope here; the receiver itself
+	// takes an io.Reader and streams to storage, so only this seam buffers.
+	res, err := h.receiver.Receive(ctx, spokeID, filePath, sha, size, offset, bytes.NewReader(c.Body()))
+	if err != nil {
+		if errors.Is(err, storage.ErrResumeNotSupported) {
+			// Not a failure the spoke can fix by retrying the same request:
+			// it must restart from zero. 409 with an explicit reason so the
+			// agent branches without parsing prose.
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"error":  "resume not supported by this hub's storage backend",
+				"reason": "resume_unsupported",
+				"resume": false,
+			})
+		}
+		// A hub-side failure — storage I/O, or a manifest write during a Raft
+		// election — is transient and the spoke SHOULD retry. Telling it 400
+		// would say its request was malformed, so it would either give up or
+		// retry a request it believes is broken. 503 is the honest answer, and
+		// the error text is withheld because it describes hub internals.
+		if errors.Is(err, edgesync.ErrReceiveInternal) {
+			h.logger.Error().Err(err).
+				Str("spoke_id", spokeID).
+				Str("path", filePath).
+				Msg("Sync receive failed for a hub-side reason")
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"error":  "hub temporarily unable to accept this file",
+				"reason": "hub_unavailable",
+			})
+		}
+
+		// Everything else is the spoke's fault — a bad path, a malformed
+		// digest, an out-of-range offset — and the message tells it what to fix.
+		h.logger.Warn().Err(err).
+			Str("spoke_id", spokeID).
+			Str("path", filePath).
+			Msg("Sync receive rejected an invalid request")
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return h.writeOutcome(c, res)
+}
+
+// authFailure reports an authentication problem without leaking which check
+// failed, beyond the skew/forgery distinction an operator genuinely needs.
+func (h *EdgeSyncHandler) authFailure(c *fiber.Ctx, spokeID string, err error) error {
+	log := h.logger.Warn().Str("spoke_id", spokeID)
+
+	switch {
+	case errors.Is(err, security.ErrSyncAuthExpired):
+		// Worth distinguishing: an operator seeing this fixes NTP on the edge
+		// box, whereas a MAC failure means investigating a forgery.
+		log.Msg("Sync rejected: timestamp outside the freshness window")
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error":  "authentication failed",
+			"reason": "timestamp_expired",
+		})
+	case errors.Is(err, security.ErrSyncAuthReplay):
+		log.Msg("Sync rejected: nonce already used")
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error":  "authentication failed",
+			"reason": "replay",
+		})
+	default:
+		log.Msg("Sync rejected: HMAC validation failed")
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication failed"})
+	}
+}
+
+// writeOutcome maps a receive outcome to the status codes §5.2 defines.
+func (h *EdgeSyncHandler) writeOutcome(c *fiber.Ctx, res *edgesync.PutResult) error {
+	switch res.Outcome {
+	case edgesync.OutcomeCommitted, edgesync.OutcomeAlreadyPresent:
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{
+			"outcome":        string(res.Outcome),
+			"bytes_accepted": res.BytesAccepted,
+		})
+
+	case edgesync.OutcomePartial:
+		// 206 carries the hub's true offset, which may differ from what the
+		// spoke sent — that is how a diverged checkpoint gets corrected.
+		return c.Status(fiber.StatusPartialContent).JSON(fiber.Map{
+			"outcome":        string(res.Outcome),
+			"bytes_accepted": res.BytesAccepted,
+		})
+
+	case edgesync.OutcomeConflict:
+		// The hub's digest is the evidence an operator needs to tell a
+		// spoke-ID collision from corruption.
+		return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+			"outcome":      string(res.Outcome),
+			"their_sha256": res.TheirSHA256,
+		})
+
+	case edgesync.OutcomeChecksumMismatch:
+		return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
+			"outcome": string(res.Outcome),
+			"error":   "checksum mismatch; the upload was discarded",
+		})
+
+	case edgesync.OutcomeBackpressure:
+		c.Set("Retry-After", strconv.Itoa(int(res.RetryAfter.Seconds())))
+		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+			"outcome": string(res.Outcome),
+		})
+
+	default:
+		h.logger.Error().Str("outcome", string(res.Outcome)).Msg("Unhandled sync outcome")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "unhandled sync outcome",
+		})
+	}
+}
+
+// StaticSpokeSecrets builds a lookup over an in-memory map.
+//
+// A stand-in until the spoke registry lands (#569 PR 7), which will store
+// per-spoke secrets in SQLite. Exported so the hub can be wired and exercised
+// end to end before that PR.
+func StaticSpokeSecrets(secrets map[string]string) SpokeSecretLookup {
+	// Copy so a later mutation of the caller's map cannot silently change
+	// which spokes authenticate.
+	own := make(map[string]string, len(secrets))
+	for k, v := range secrets {
+		own[k] = v
+	}
+	return func(_ context.Context, spokeID string) (string, bool) {
+		s, ok := own[spokeID]
+		if !ok || s == "" {
+			return "", false
+		}
+		return s, true
+	}
+}

--- a/internal/api/edgesync_test.go
+++ b/internal/api/edgesync_test.go
@@ -1,0 +1,691 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/edgesync"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+const (
+	testHubID   = "ground-station"
+	testSpokeID = "rocket-01"
+	testSecret  = "per-spoke-shared-secret"
+	testSyncPth = "metrics/cpu/2026/08/07/14/cpu_123.parquet"
+)
+
+func testDigest(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// syncTestRig is a hub with the receive endpoint mounted and no API-token auth
+// (authManager nil), so tests exercise the sync-specific HMAC layer directly.
+type syncTestRig struct {
+	app     *fiber.App
+	backend storage.Backend
+}
+
+func newSyncTestRig(t *testing.T) *syncTestRig {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "api-sync-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	recv, err := edgesync.NewReceiver(edgesync.ReceiverConfig{Backend: backend, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+
+	h, err := NewEdgeSyncHandler(EdgeSyncHandlerConfig{
+		Receiver:     recv,
+		SpokeSecrets: StaticSpokeSecrets(map[string]string{testSpokeID: testSecret}),
+		Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
+		HubID:        testHubID,
+		MaxFileBytes: 8 << 20,
+		Logger:       zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	// A generous global limit so tests exercise the HANDLER's per-upload cap
+	// rather than fasthttp's default 4MB, which would mask it.
+	app := fiber.New(fiber.Config{DisableStartupMessage: true, BodyLimit: 32 << 20})
+	h.RegisterRoutes(app)
+
+	return &syncTestRig{app: app, backend: backend}
+}
+
+// req builds a signed upload request. Fields are overridable so a test can
+// tamper with exactly one thing.
+type syncReq struct {
+	spokeID, hubID, path, sha string
+	size                      int64
+	offset                    int64
+	nonce                     string
+	ts                        int64
+	body                      []byte
+	macOverride               string
+	secret                    string
+}
+
+func defaultReq(body []byte) syncReq {
+	nonce, _ := security.GenerateNonce()
+	return syncReq{
+		spokeID: testSpokeID,
+		hubID:   testHubID,
+		path:    testSyncPth,
+		sha:     testDigest(body),
+		size:    int64(len(body)),
+		nonce:   nonce,
+		ts:      time.Now().Unix(),
+		body:    body,
+		secret:  testSecret,
+	}
+}
+
+func (r syncReq) do(t *testing.T, rig *syncTestRig) *http.Response {
+	t.Helper()
+
+	mac := r.macOverride
+	if mac == "" {
+		var err error
+		mac, err = security.ComputeSyncFileHMAC(r.secret, r.nonce, r.spokeID, r.hubID, r.path, r.sha, r.ts)
+		if err != nil {
+			t.Fatalf("compute MAC: %v", err)
+		}
+	}
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/sync/file", bytes.NewReader(r.body))
+	httpReq.Header.Set(headerSpokeID, r.spokeID)
+	httpReq.Header.Set(headerHubID, r.hubID)
+	httpReq.Header.Set(headerPath, r.path)
+	httpReq.Header.Set(headerSHA256, r.sha)
+	httpReq.Header.Set(headerSize, strconv.FormatInt(r.size, 10))
+	httpReq.Header.Set(headerNonce, r.nonce)
+	httpReq.Header.Set(headerTS, strconv.FormatInt(r.ts, 10))
+	httpReq.Header.Set(headerMAC, mac)
+	if r.offset > 0 {
+		httpReq.Header.Set(headerOffset, strconv.FormatInt(r.offset, 10))
+	}
+
+	resp, err := rig.app.Test(httpReq, 10_000)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	return resp
+}
+
+func decodeBody(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var out map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("decode %q: %v", raw, err)
+		}
+	}
+	return out
+}
+
+func TestEdgeSyncHandler_CommitsAuthenticatedUpload(t *testing.T) {
+	rig := newSyncTestRig(t)
+	body := []byte("parquet payload bytes")
+
+	resp := defaultReq(body).do(t, rig)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%v", resp.StatusCode, decodeBody(t, resp))
+	}
+	got := decodeBody(t, resp)
+	if got["outcome"] != string(edgesync.OutcomeCommitted) {
+		t.Errorf("outcome = %v, want %q", got["outcome"], edgesync.OutcomeCommitted)
+	}
+
+	stored, err := rig.backend.Read(context.Background(), edgesync.NamespacedPath(testSpokeID, testSyncPth))
+	if err != nil {
+		t.Fatalf("read stored file: %v", err)
+	}
+	if !bytes.Equal(stored, body) {
+		t.Error("stored content differs from the upload")
+	}
+}
+
+func TestEdgeSyncHandler_RejectsUnauthenticated(t *testing.T) {
+	rig := newSyncTestRig(t)
+	body := []byte("payload")
+
+	// Each case is a distinct way of failing authentication. All must be
+	// refused — an endpoint that accepts any of these is remotely writable.
+	tests := []struct {
+		name   string
+		mutate func(*syncReq)
+	}{
+		{"wrong secret", func(r *syncReq) { r.secret = "not-the-spokes-secret" }},
+		{"unknown spoke", func(r *syncReq) {
+			// The MAC is computed with a secret this spoke does not have
+			// registered, so ONLY the registry lookup can reject it — if the
+			// lookup were skipped, the request would still be well-formed and
+			// internally consistent.
+			r.spokeID = "rocket-99"
+			r.secret = "rocket-99-own-secret"
+		}},
+		{"forged MAC", func(r *syncReq) { r.macOverride = hex.EncodeToString(bytes.Repeat([]byte{0}, 32)) }},
+		{"tampered path after signing", func(r *syncReq) {
+			mac, _ := security.ComputeSyncFileHMAC(r.secret, r.nonce, r.spokeID, r.hubID, r.path, r.sha, r.ts)
+			r.macOverride = mac
+			r.path = "metrics/cpu/2026/08/07/14/other.parquet"
+		}},
+		{"tampered digest after signing", func(r *syncReq) {
+			mac, _ := security.ComputeSyncFileHMAC(r.secret, r.nonce, r.spokeID, r.hubID, r.path, r.sha, r.ts)
+			r.macOverride = mac
+			r.sha = testDigest([]byte("different"))
+		}},
+		{"expired timestamp", func(r *syncReq) {
+			r.ts = time.Now().Add(-2 * security.HMACTimestampTolerance).Unix()
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := defaultReq(body)
+			tt.mutate(&r)
+			resp := r.do(t, rig)
+			if resp.StatusCode != fiber.StatusUnauthorized {
+				t.Errorf("status = %d, want 401", resp.StatusCode)
+			}
+			// Nothing may be written for a request that failed auth.
+			exists, _ := rig.backend.Exists(context.Background(), edgesync.NamespacedPath(r.spokeID, r.path))
+			if exists {
+				t.Error("an unauthenticated upload was written to storage")
+			}
+		})
+	}
+}
+
+func TestEdgeSyncHandler_RejectsReplay(t *testing.T) {
+	rig := newSyncTestRig(t)
+	body := []byte("payload")
+	r := defaultReq(body)
+
+	if resp := r.do(t, rig); resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("first delivery: status = %d", resp.StatusCode)
+	}
+
+	// Replaying the identical signed request must be refused. The MAC still
+	// verifies — every bound field is unchanged — so only the nonce cache
+	// stops it.
+	resp := r.do(t, rig)
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("replay: status = %d, want 401", resp.StatusCode)
+	}
+	if got := decodeBody(t, resp); got["reason"] != "replay" {
+		t.Errorf("reason = %v, want %q", got["reason"], "replay")
+	}
+}
+
+func TestEdgeSyncHandler_RejectsWrongHub(t *testing.T) {
+	rig := newSyncTestRig(t)
+	r := defaultReq([]byte("payload"))
+	r.hubID = "a-different-hub"
+
+	// A request minted for another hub — even correctly signed with this
+	// spoke's secret — must not be accepted here.
+	resp := r.do(t, rig)
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestEdgeSyncHandler_MapsOutcomesToStatusCodes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("already present is 200", func(t *testing.T) {
+		rig := newSyncTestRig(t)
+		body := []byte("payload")
+		if resp := defaultReq(body).do(t, rig); resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("seed: status = %d", resp.StatusCode)
+		}
+		// Fresh nonce, same content — the lost-ack case.
+		resp := defaultReq(body).do(t, rig)
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		if got := decodeBody(t, resp); got["outcome"] != string(edgesync.OutcomeAlreadyPresent) {
+			t.Errorf("outcome = %v, want %q", got["outcome"], edgesync.OutcomeAlreadyPresent)
+		}
+	})
+
+	t.Run("conflict is 409 with the hub digest", func(t *testing.T) {
+		rig := newSyncTestRig(t)
+		original := []byte("the hub's content")
+		if resp := defaultReq(original).do(t, rig); resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("seed: status = %d", resp.StatusCode)
+		}
+
+		resp := defaultReq([]byte("different content")).do(t, rig)
+		if resp.StatusCode != fiber.StatusConflict {
+			t.Fatalf("status = %d, want 409", resp.StatusCode)
+		}
+		got := decodeBody(t, resp)
+		if got["their_sha256"] != testDigest(original) {
+			t.Errorf("their_sha256 = %v, want the hub's digest", got["their_sha256"])
+		}
+
+		// The original must survive — a conflict never overwrites.
+		stored, err := rig.backend.Read(ctx, edgesync.NamespacedPath(testSpokeID, testSyncPth))
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if !bytes.Equal(stored, original) {
+			t.Error("a conflicting upload overwrote the hub's content")
+		}
+	})
+
+	t.Run("checksum mismatch is 422 and stores nothing", func(t *testing.T) {
+		rig := newSyncTestRig(t)
+		declared := []byte("the declared content")
+		r := defaultReq(declared)
+		r.body = []byte("the actual content!!") // same length, different bytes
+
+		resp := r.do(t, rig)
+		if resp.StatusCode != fiber.StatusUnprocessableEntity {
+			t.Fatalf("status = %d, want 422", resp.StatusCode)
+		}
+		if exists, _ := rig.backend.Exists(ctx, edgesync.NamespacedPath(testSpokeID, testSyncPth)); exists {
+			t.Error("content that failed verification was stored")
+		}
+	})
+
+	t.Run("partial is 206 with the accepted offset", func(t *testing.T) {
+		rig := newSyncTestRig(t)
+		full := []byte("the complete parquet payload for this file")
+		r := defaultReq(full)
+		r.body = full[:12] // link dropped mid-stream
+
+		resp := r.do(t, rig)
+		if resp.StatusCode != fiber.StatusPartialContent {
+			t.Fatalf("status = %d, want 206", resp.StatusCode)
+		}
+		got := decodeBody(t, resp)
+		if got["bytes_accepted"] != float64(12) {
+			t.Errorf("bytes_accepted = %v, want 12", got["bytes_accepted"])
+		}
+	})
+}
+
+func TestEdgeSyncHandler_ResumesFromOffset(t *testing.T) {
+	rig := newSyncTestRig(t)
+	full := []byte("the complete parquet payload for this file")
+
+	first := defaultReq(full)
+	first.body = full[:12]
+	resp := first.do(t, rig)
+	if resp.StatusCode != fiber.StatusPartialContent {
+		t.Fatalf("partial: status = %d, want 206", resp.StatusCode)
+	}
+
+	// The spoke resumes, sending only the tail.
+	second := defaultReq(full)
+	second.body = full[12:]
+	second.offset = 12
+	resp2 := second.do(t, rig)
+	if resp2.StatusCode != fiber.StatusOK {
+		t.Fatalf("resume: status = %d, want 200; body=%v", resp2.StatusCode, decodeBody(t, resp2))
+	}
+
+	stored, err := rig.backend.Read(context.Background(), edgesync.NamespacedPath(testSpokeID, testSyncPth))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(stored, full) {
+		t.Error("the resumed file does not match the original")
+	}
+}
+
+func TestEdgeSyncHandler_RejectsMalformedRequests(t *testing.T) {
+	rig := newSyncTestRig(t)
+	body := []byte("payload")
+
+	tests := []struct {
+		name   string
+		mutate func(*http.Request)
+	}{
+		{"no spoke ID", func(r *http.Request) { r.Header.Del(headerSpokeID) }},
+		{"no path", func(r *http.Request) { r.Header.Del(headerPath) }},
+		{"no digest", func(r *http.Request) { r.Header.Del(headerSHA256) }},
+		{"no nonce", func(r *http.Request) { r.Header.Del(headerNonce) }},
+		{"no MAC", func(r *http.Request) { r.Header.Del(headerMAC) }},
+		{"no size", func(r *http.Request) { r.Header.Del(headerSize) }},
+		{"non-numeric size", func(r *http.Request) { r.Header.Set(headerSize, "big") }},
+		{"negative size", func(r *http.Request) { r.Header.Set(headerSize, "-1") }},
+		{"non-numeric offset", func(r *http.Request) { r.Header.Set(headerOffset, "start") }},
+		{"no timestamp", func(r *http.Request) { r.Header.Del(headerTS) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := defaultReq(body)
+			mac, _ := security.ComputeSyncFileHMAC(r.secret, r.nonce, r.spokeID, r.hubID, r.path, r.sha, r.ts)
+
+			httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/sync/file", bytes.NewReader(body))
+			httpReq.Header.Set(headerSpokeID, r.spokeID)
+			httpReq.Header.Set(headerHubID, r.hubID)
+			httpReq.Header.Set(headerPath, r.path)
+			httpReq.Header.Set(headerSHA256, r.sha)
+			httpReq.Header.Set(headerSize, strconv.FormatInt(r.size, 10))
+			httpReq.Header.Set(headerNonce, r.nonce)
+			httpReq.Header.Set(headerTS, strconv.FormatInt(r.ts, 10))
+			httpReq.Header.Set(headerMAC, mac)
+			tt.mutate(httpReq)
+
+			resp, err := rig.app.Test(httpReq, 10_000)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			if resp.StatusCode == fiber.StatusOK {
+				t.Errorf("a malformed request was accepted (status 200)")
+			}
+		})
+	}
+}
+
+func TestEdgeSyncHandler_RejectsPathTraversal(t *testing.T) {
+	rig := newSyncTestRig(t)
+	body := []byte("payload")
+
+	// The path is signed, so this models a COMPROMISED spoke — one holding a
+	// valid secret and deliberately trying to write outside its namespace.
+	// The HMAC proves who is asking, not where they may write.
+	for _, p := range []string{
+		"../../../etc/passwd.parquet",
+		"metrics/../../escape.parquet",
+		"/absolute/path.parquet",
+		".sync-staging/rocket-02/steal.parquet",
+	} {
+		t.Run(p, func(t *testing.T) {
+			r := defaultReq(body)
+			r.path = p
+			resp := r.do(t, rig)
+			if resp.StatusCode == fiber.StatusOK {
+				t.Errorf("path %q was accepted", p)
+			}
+		})
+	}
+}
+
+func TestNewEdgeSyncHandler_RequiresSecurityDependencies(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "api-sync-*")
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	backend, _ := storage.NewLocalBackend(dir, zerolog.Nop())
+	t.Cleanup(func() { backend.Close() })
+	recv, _ := edgesync.NewReceiver(edgesync.ReceiverConfig{Backend: backend, Logger: zerolog.Nop()})
+
+	base := EdgeSyncHandlerConfig{
+		Receiver:     recv,
+		SpokeSecrets: StaticSpokeSecrets(map[string]string{testSpokeID: testSecret}),
+		Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
+		HubID:        testHubID,
+		MaxFileBytes: 8 << 20,
+		Logger:       zerolog.Nop(),
+	}
+
+	// A missing security dependency must be a hard startup error. Defaulting
+	// any of these to a no-op would silently disable authentication.
+	tests := []struct {
+		name   string
+		mutate func(*EdgeSyncHandlerConfig)
+	}{
+		{"no receiver", func(c *EdgeSyncHandlerConfig) { c.Receiver = nil }},
+		{"no spoke secrets", func(c *EdgeSyncHandlerConfig) { c.SpokeSecrets = nil }},
+		{"no replay guard", func(c *EdgeSyncHandlerConfig) { c.Replay = nil }},
+		{"no hub ID", func(c *EdgeSyncHandlerConfig) { c.HubID = "" }},
+		{"no upload cap", func(c *EdgeSyncHandlerConfig) { c.MaxFileBytes = 0 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			tt.mutate(&cfg)
+			if _, err := NewEdgeSyncHandler(cfg); err == nil {
+				t.Error("handler was constructed without a required dependency")
+			}
+		})
+	}
+}
+
+func TestStaticSpokeSecrets(t *testing.T) {
+	ctx := context.Background()
+	source := map[string]string{"rocket-01": "secret-one", "rocket-02": ""}
+	lookup := StaticSpokeSecrets(source)
+
+	if s, ok := lookup(ctx, "rocket-01"); !ok || s != "secret-one" {
+		t.Errorf("known spoke: (%q, %v), want (secret-one, true)", s, ok)
+	}
+	if _, ok := lookup(ctx, "rocket-99"); ok {
+		t.Error("an unregistered spoke resolved to a secret")
+	}
+	// An empty secret must not authenticate — it would make an unconfigured
+	// spoke interoperable with anyone computing a MAC over an empty key.
+	if _, ok := lookup(ctx, "rocket-02"); ok {
+		t.Error("a spoke with an empty secret was accepted")
+	}
+
+	// Mutating the caller's map must not change which spokes authenticate.
+	source["rocket-99"] = "injected"
+	if _, ok := lookup(ctx, "rocket-99"); ok {
+		t.Error("mutating the source map added a spoke after construction")
+	}
+}
+
+func TestEdgeSyncHandler_ConcurrentUploadsAreIsolated(t *testing.T) {
+	rig := newSyncTestRig(t)
+
+	// Distinct spokes and files, uploaded concurrently — the hub must keep
+	// them apart. Run under -race for this to mean anything.
+	const n = 8
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			body := []byte(fmt.Sprintf("payload for file %d", i))
+			r := defaultReq(body)
+			r.path = fmt.Sprintf("metrics/cpu/2026/08/07/14/cpu_%d.parquet", i)
+			mac, err := security.ComputeSyncFileHMAC(r.secret, r.nonce, r.spokeID, r.hubID, r.path, r.sha, r.ts)
+			if err != nil {
+				errs <- err
+				return
+			}
+			r.macOverride = mac
+
+			httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/sync/file", bytes.NewReader(r.body))
+			httpReq.Header.Set(headerSpokeID, r.spokeID)
+			httpReq.Header.Set(headerHubID, r.hubID)
+			httpReq.Header.Set(headerPath, r.path)
+			httpReq.Header.Set(headerSHA256, r.sha)
+			httpReq.Header.Set(headerSize, strconv.FormatInt(r.size, 10))
+			httpReq.Header.Set(headerNonce, r.nonce)
+			httpReq.Header.Set(headerTS, strconv.FormatInt(r.ts, 10))
+			httpReq.Header.Set(headerMAC, mac)
+
+			resp, err := rig.app.Test(httpReq, 10_000)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if resp.StatusCode != fiber.StatusOK {
+				errs <- fmt.Errorf("file %d: status %d", i, resp.StatusCode)
+				return
+			}
+			errs <- nil
+		}(i)
+	}
+	for i := 0; i < n; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent upload: %v", err)
+		}
+	}
+
+	for i := 0; i < n; i++ {
+		p := edgesync.NamespacedPath(testSpokeID, fmt.Sprintf("metrics/cpu/2026/08/07/14/cpu_%d.parquet", i))
+		got, err := rig.backend.Read(context.Background(), p)
+		if err != nil {
+			t.Errorf("read file %d: %v", i, err)
+			continue
+		}
+		if want := fmt.Sprintf("payload for file %d", i); string(got) != want {
+			t.Errorf("file %d holds %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestEdgeSyncHandler_UnregisteredSpokeIsRejectedByTheRegistry(t *testing.T) {
+	rig := newSyncTestRig(t)
+	body := []byte("payload")
+
+	// Isolates the registry lookup from the MAC check. An unregistered spoke
+	// signing with the EMPTY secret produces a MAC that would verify if the
+	// handler fell back to an empty secret when the lookup fails — so only a
+	// genuine registry rejection stops this request.
+	r := defaultReq(body)
+	r.spokeID = "rocket-99"
+	r.secret = ""
+
+	resp := r.do(t, rig)
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 — an unregistered spoke authenticated", resp.StatusCode)
+	}
+
+	// The rejection must not disclose whether the spoke is unknown versus
+	// merely mis-signed; either would let an attacker enumerate spoke IDs.
+	if got := decodeBody(t, resp); got["reason"] != nil {
+		t.Errorf("reason = %v, want none — an unknown spoke must be indistinguishable from a bad MAC", got["reason"])
+	}
+
+	if exists, _ := rig.backend.Exists(context.Background(), edgesync.NamespacedPath(r.spokeID, r.path)); exists {
+		t.Error("an unregistered spoke wrote to storage")
+	}
+}
+
+func TestEdgeSyncHandler_RejectsOversizedUploads(t *testing.T) {
+	rig := newSyncTestRig(t)
+
+	// The rig caps uploads at 8MiB. Because StreamRequestBody=false buffers the
+	// whole body before routing, an unbounded cap would let anyone who can
+	// reach the port pin memory without holding a token or a spoke secret.
+	big := bytes.Repeat([]byte("x"), 9<<20) // above the 8MiB handler cap, below the 32MiB app limit
+	r := defaultReq(big)
+
+	resp := r.do(t, rig)
+	if resp.StatusCode != fiber.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+	if exists, _ := rig.backend.Exists(context.Background(), edgesync.NamespacedPath(testSpokeID, testSyncPth)); exists {
+		t.Error("an oversized upload was written to storage")
+	}
+}
+
+func TestEdgeSyncHandler_RejectsOversizedDeclaredSize(t *testing.T) {
+	rig := newSyncTestRig(t)
+
+	// A small body with a huge declared size must also be refused: the
+	// declared size is what the receiver uses to bound its reads and to size
+	// the staging write, so an unbounded value is a resource claim regardless
+	// of how many bytes actually arrive.
+	small := []byte("tiny")
+	r := defaultReq(small)
+	r.size = 100 << 20
+
+	resp := r.do(t, rig)
+	if resp.StatusCode != fiber.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", resp.StatusCode)
+	}
+}
+
+// failingRegistrarBackend is fine; the manifest write is what fails.
+func TestEdgeSyncHandler_HubSideFailureIs503NotBadRequest(t *testing.T) {
+	dir, err := os.MkdirTemp("", "api-sync-503-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	// Models a Raft election or quorum loss: registration fails transiently.
+	recv, err := edgesync.NewReceiver(edgesync.ReceiverConfig{
+		Backend: backend,
+		Logger:  zerolog.Nop(),
+		RegisterFile: func(context.Context, *edgesync.ReceivedFile) error {
+			return errors.New("raft: leadership lost")
+		},
+	})
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+
+	h, err := NewEdgeSyncHandler(EdgeSyncHandlerConfig{
+		Receiver:     recv,
+		SpokeSecrets: StaticSpokeSecrets(map[string]string{testSpokeID: testSecret}),
+		Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
+		HubID:        testHubID,
+		MaxFileBytes: 8 << 20,
+		Logger:       zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	app := fiber.New(fiber.Config{DisableStartupMessage: true, BodyLimit: 32 << 20})
+	h.RegisterRoutes(app)
+	rig := &syncTestRig{app: app, backend: backend}
+
+	resp := defaultReq([]byte("payload")).do(t, rig)
+
+	// 400 would tell the spoke its request was malformed, so it would either
+	// give up or keep retrying something it believes is broken. A transient
+	// hub-side failure is exactly what it SHOULD retry.
+	if resp.StatusCode != fiber.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+	got := decodeBody(t, resp)
+	if got["reason"] != "hub_unavailable" {
+		t.Errorf("reason = %v, want %q", got["reason"], "hub_unavailable")
+	}
+	// The message must not leak hub internals to a spoke.
+	if msg, _ := got["error"].(string); strings.Contains(msg, "raft") {
+		t.Errorf("error message leaks hub internals: %q", msg)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Log             LogConfig
 	Auth            AuthConfig
 	Compaction      CompactionConfig
+	EdgeSync        EdgeSyncConfig
 	WAL             WALConfig
 	Telemetry       TelemetryConfig
 	Delete          DeleteConfig
@@ -171,6 +172,38 @@ type CompactionConfig struct {
 	CompletionWatcherIntervalMS int    // Watcher poll interval in milliseconds (default: 1000)
 	CompletionDir               string // Override the watcher directory (default: "" = {temp_directory}/.completion/pending)
 	CompletionOrphanTimeoutMS   int    // Sweep "writing_output" manifests older than this on startup (default: 600000 = 10min)
+}
+
+// EdgeSyncConfig configures the hub side of edge-to-cloud sync (#569).
+//
+// A "hub" is a central Arc that receives immutable Parquet files pushed by
+// "spokes" — edge Arc instances in vehicles, factories, or forward
+// deployments. Only the receive side is configured here; a spoke needs no
+// server-side configuration at all.
+type EdgeSyncConfig struct {
+	// Enabled mounts the hub receive endpoints. Off by default: an Arc that
+	// is not acting as a hub must not expose a remotely-writable surface.
+	Enabled bool
+
+	// HubID names this hub. It is bound into every request's HMAC, so a
+	// request minted for a different hub — even by a spoke that legitimately
+	// syncs to both — is rejected here. Required when Enabled.
+	HubID string
+
+	// MaxFileBytes caps a single upload.
+	//
+	// This is a DoS control, not a tuning knob. The Fiber app runs with
+	// StreamRequestBody=false (see api/server.go), so fasthttp buffers the
+	// WHOLE body in memory before routing — which means before any
+	// authentication runs. Under the global server.max_payload_size default
+	// of 1GB, anyone who can merely reach the port could pin 1GB of hub
+	// memory per connection without holding a token or a spoke secret.
+	//
+	// The handler rejects on Content-Length before the body is consumed, so
+	// this bound is enforced ahead of that buffering rather than after it.
+	// Default 512MiB, comfortably above a compacted Parquet file
+	// (compaction.max_files_per_batch keeps those well below it).
+	MaxFileBytes int64
 }
 
 type WALConfig struct {
@@ -610,6 +643,11 @@ func Load() (*Config, error) {
 			BootstrapToken: v.GetString("auth.bootstrap_token"),
 			ForceBootstrap: v.GetBool("auth.force_bootstrap"),
 		},
+		EdgeSync: EdgeSyncConfig{
+			Enabled:      v.GetBool("edge_sync.enabled"),
+			HubID:        v.GetString("edge_sync.hub_id"),
+			MaxFileBytes: int64(v.GetInt64("edge_sync.max_file_bytes")),
+		},
 		Compaction: CompactionConfig{
 			Enabled:                     v.GetBool("compaction.enabled"),
 			HourlySchedule:              v.GetString("compaction.hourly_schedule"),
@@ -941,6 +979,43 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// A hub without an ID cannot authenticate anything: hub_id is bound into
+	// every request MAC, so an empty value would mean every spoke signs for
+	// the same anonymous hub and a request captured at one could be replayed
+	// at another. Refuse at load rather than start an unsafe listener.
+	if cfg.EdgeSync.Enabled {
+		if cfg.EdgeSync.HubID == "" {
+			return nil, fmt.Errorf("edge_sync.enabled=true requires edge_sync.hub_id to be set: " +
+				"it is bound into every spoke request's HMAC, so an empty value would let a request " +
+				"captured at one hub be replayed at another")
+		}
+		if strings.ContainsAny(cfg.EdgeSync.HubID, "\x00/\\") {
+			return nil, fmt.Errorf("edge_sync.hub_id %q may not contain a path separator or NUL byte", cfg.EdgeSync.HubID)
+		}
+		// Control characters would land in logs and error messages verbatim.
+		// No forgery consequence (hub_id is length-prefixed into the MAC and
+		// never used as a path) — this is log-injection hygiene.
+		for _, r := range cfg.EdgeSync.HubID {
+			if r < 0x20 || r == 0x7f {
+				return nil, fmt.Errorf("edge_sync.hub_id may not contain control characters")
+			}
+		}
+		if len(cfg.EdgeSync.HubID) > 128 {
+			return nil, fmt.Errorf("edge_sync.hub_id is %d bytes; the maximum is 128", len(cfg.EdgeSync.HubID))
+		}
+		if cfg.EdgeSync.MaxFileBytes <= 0 {
+			return nil, fmt.Errorf("edge_sync.max_file_bytes must be > 0 (got %d)", cfg.EdgeSync.MaxFileBytes)
+		}
+		// The global body limit is enforced by fasthttp BEFORE the handler
+		// runs, so a per-upload cap above it could never take effect and the
+		// operator would silently get the smaller bound.
+		if cfg.EdgeSync.MaxFileBytes > cfg.Server.MaxPayloadSize {
+			return nil, fmt.Errorf("edge_sync.max_file_bytes (%d) exceeds server.max_payload_size (%d); "+
+				"the server limit is enforced first, so the larger value would never apply",
+				cfg.EdgeSync.MaxFileBytes, cfg.Server.MaxPayloadSize)
+		}
+	}
+
 	return cfg, nil
 }
 
@@ -1013,6 +1088,14 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("auth.max_cache_size", 1000)     // Max cached tokens
 
 	// Compaction defaults
+	// Edge sync: the hub receive side is OFF by default. Enabling it exposes
+	// an endpoint that accepts file writes from registered spokes, so it must
+	// be a deliberate operator decision rather than something that appears on
+	// upgrade.
+	v.SetDefault("edge_sync.enabled", false)
+	v.SetDefault("edge_sync.hub_id", "")
+	v.SetDefault("edge_sync.max_file_bytes", 512*1024*1024) // 512MiB per upload
+
 	v.SetDefault("compaction.enabled", true)
 	v.SetDefault("compaction.hourly_schedule", "5 * * * *")        // Every hour at :05
 	v.SetDefault("compaction.daily_schedule", "0 3 * * *")         // 3 AM daily

--- a/internal/edgesync/receive.go
+++ b/internal/edgesync/receive.go
@@ -1,0 +1,683 @@
+package edgesync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// StagingPrefix is where partially-received and unverified files live.
+//
+// It sits outside every database's namespace so a staged file can never be
+// mistaken for queryable data: Arc's storage layout is
+// {database}/{measurement}/{y}/{m}/{d}/{h}/file.parquet, and a leading dot
+// cannot be a database name (validateSyncPath rejects it).
+const StagingPrefix = ".sync-staging"
+
+// ErrReceiveInternal wraps a failure that is the HUB's fault rather than the
+// spoke's — storage I/O, a manifest write during a Raft election, a promote
+// that could not complete.
+//
+// The distinction is not cosmetic: a spoke told "bad request" has no reason to
+// retry, while a transient hub-side failure is exactly what it should retry.
+// Handlers map this to 503 rather than 400.
+var ErrReceiveInternal = errors.New("edgesync: receive failed for a hub-side reason")
+
+// Receiver implements the hub side of a file transfer: it accepts bytes from a
+// spoke, verifies them, and only then makes them visible.
+//
+// The ordering is the point. Bytes stream into a staging path while a SHA-256
+// runs over them; the digest is compared against what the spoke declared; and
+// only on a match is the file promoted into its final namespaced location.
+// A mismatch never produces a byte at the path a reader would look at.
+type Receiver struct {
+	backend storage.Backend
+	logger  zerolog.Logger
+
+	// registerFile publishes a committed file so readers can see it. In
+	// cluster mode this proposes to the Raft manifest; standalone it is nil,
+	// because a local backend's directory listing IS the manifest.
+	//
+	// Nil is a supported configuration, not an error — the hub must work in
+	// OSS standalone, where no coordinator exists.
+	registerFile func(ctx context.Context, f *ReceivedFile) error
+}
+
+// ReceivedFile describes a file that has been verified and promoted.
+type ReceivedFile struct {
+	// SpokeID is the sender. The hub namespaces by it, so this is what keeps
+	// two edges writing the same measurement from colliding.
+	SpokeID string
+
+	// Path is the final storage-relative path, already namespaced.
+	Path string
+
+	// SourcePath is the path as the spoke knows it, before namespacing —
+	// carried so logs and manifests can be correlated with the spoke's ledger.
+	SourcePath string
+
+	SHA256    string
+	SizeBytes int64
+}
+
+// Database and Measurement extract the Arc namespace a received file belongs
+// to, from the spoke's own path.
+//
+// Arc's layout is {database}/{measurement}/{y}/{m}/{d}/{h}/file.parquet, and
+// SourcePath is the spoke's path BEFORE hub namespacing — so the database and
+// measurement are its first two segments. Deriving them from SourcePath rather
+// than the namespaced Path is deliberate: the hub prepends the spoke ID, which
+// would otherwise be read as the database name.
+//
+// Both return "" for a path too short to carry them. validateSyncPath has
+// already rejected traversal and absolute paths by the time these are called.
+func (f *ReceivedFile) Database() string {
+	if db, _, ok := splitFirstTwo(f.SourcePath); ok {
+		return db
+	}
+	return ""
+}
+
+func (f *ReceivedFile) Measurement() string {
+	if _, m, ok := splitFirstTwo(f.SourcePath); ok {
+		return m
+	}
+	return ""
+}
+
+// PartitionTime is the hour partition the file belongs to, parsed from the
+// spoke's path.
+//
+// This is not cosmetic metadata. raft.FileEntry.PartitionTime drives hot/cold
+// routing: tiering/router.go filters files by it when a query carries a time
+// range, and tiering/migrator.go computes file age from it to decide what to
+// migrate. A zero value would make every synced file look infinitely old to
+// the migrator and drop it from time-ranged queries entirely.
+//
+// Returns the zero time when the path does not carry a parseable partition —
+// callers should treat that as "unknown" rather than "epoch".
+func (f *ReceivedFile) PartitionTime() time.Time {
+	// {database}/{measurement}/{YYYY}/{MM}/{DD}/{HH}/file.parquet
+	parts := strings.Split(f.SourcePath, "/")
+	if len(parts) < 7 {
+		return time.Time{}
+	}
+	year, month, day, hour := parts[2], parts[3], parts[4], parts[5]
+	t, err := time.Parse("2006/01/02/15", year+"/"+month+"/"+day+"/"+hour)
+	if err != nil {
+		return time.Time{}
+	}
+	return t.UTC()
+}
+
+func splitFirstTwo(p string) (first, second string, ok bool) {
+	parts := strings.SplitN(p, "/", 3)
+	if len(parts) < 3 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// ReceiverConfig configures a Receiver.
+type ReceiverConfig struct {
+	Backend storage.Backend
+	Logger  zerolog.Logger
+
+	// RegisterFile is called after a file is verified and promoted. Leave nil
+	// in standalone mode.
+	RegisterFile func(ctx context.Context, f *ReceivedFile) error
+}
+
+// NewReceiver validates configuration and returns a ready Receiver.
+func NewReceiver(cfg ReceiverConfig) (*Receiver, error) {
+	if cfg.Backend == nil {
+		return nil, errors.New("edgesync: receiver requires a storage backend")
+	}
+	return &Receiver{
+		backend: cfg.Backend,
+		// No .Str("component", ...) here: logger.Get already sets it, and a
+		// second one emits a duplicate JSON key that strict parsers and log
+		// aggregators mishandle.
+		logger:       cfg.Logger,
+		registerFile: cfg.RegisterFile,
+	}, nil
+}
+
+// SupportsResume reports whether this hub can accept a partial transfer and
+// continue it later.
+//
+// Only backends implementing storage.AppendingBackend can — S3 and Azure
+// cannot append to a block object. On those, a dropped transfer restarts from
+// zero rather than resuming, which is a throughput cost on intermittent links,
+// not a correctness problem. Handlers surface this so a spoke does not send an
+// offset the hub cannot honor.
+func (r *Receiver) SupportsResume() bool {
+	_, ok := r.backend.(storage.AppendingBackend)
+	return ok
+}
+
+// Receive streams one file from a spoke, verifies it, and promotes it.
+//
+// offset resumes a previous partial transfer: body must carry only the bytes
+// from offset onward. declaredSHA256 is the digest of the WHOLE file, so a
+// resumed transfer is still verified end to end — the staged prefix is hashed
+// before the tail is appended.
+//
+// The returned PutResult mirrors what the spoke's transport expects, so an
+// HTTP handler maps it to a status code without re-deriving the semantics.
+func (r *Receiver) Receive(ctx context.Context, spokeID, sourcePath, declaredSHA256 string, declaredSize, offset int64, body io.Reader) (*PutResult, error) {
+	if err := validateSpokeID(spokeID); err != nil {
+		return nil, err
+	}
+	if err := validateSyncPath(sourcePath); err != nil {
+		return nil, err
+	}
+	if declaredSize < 0 {
+		return nil, fmt.Errorf("edgesync: negative declared size %d", declaredSize)
+	}
+	if offset < 0 || offset > declaredSize {
+		return nil, fmt.Errorf("edgesync: offset %d out of range for a %d-byte file", offset, declaredSize)
+	}
+	if !isHexSHA256(declaredSHA256) {
+		return nil, fmt.Errorf("edgesync: declared sha256 %q is not a 64-character hex digest", declaredSHA256)
+	}
+
+	finalPath := NamespacedPath(spokeID, sourcePath)
+	stagingPath := stagingPathFor(spokeID, sourcePath)
+
+	// §6.1 identity check, before reading a single byte of the body. A
+	// duplicate costs no transfer, and a conflict must not consume bytes it
+	// will discard.
+	//
+	// Exists, not StatFile. LocalBackend.StatFile deliberately falls back to
+	// the "{path}.part" staging file when the final file is absent, which is
+	// right for the peer-fetch puller (it wants to know how much of a partial
+	// it already holds) and wrong here: a stale .part left by an interrupted
+	// promote would be read as "the file exists", and the resolveExisting
+	// branch would then fail forever because ReadTo is NOT .part-aware. That
+	// wedges the path permanently — no retry could ever clear it. Exists()
+	// checks only the real file.
+	exists, err := r.backend.Exists(ctx, finalPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: stat %q: %w", ErrReceiveInternal, finalPath, err)
+	}
+	if exists {
+		size, err := r.backend.StatFile(ctx, finalPath)
+		if err != nil {
+			return nil, fmt.Errorf("%w: stat %q: %w", ErrReceiveInternal, finalPath, err)
+		}
+		return r.resolveExisting(ctx, spokeID, sourcePath, finalPath, declaredSHA256, size)
+	}
+
+	// Hash any already-staged prefix so the final digest covers the whole
+	// file, not just the tail this request carries.
+	hasher := sha256.New()
+	if offset > 0 {
+		if !r.SupportsResume() {
+			// Discard the stale staging object: this backend cannot append,
+			// so the spoke must restart from zero and a leftover prefix would
+			// only mislead the next attempt.
+			_ = r.backend.Delete(ctx, stagingPath)
+			return nil, storage.ErrResumeNotSupported
+		}
+		staged, err := r.stagedSize(ctx, stagingPath)
+		if err != nil {
+			return nil, fmt.Errorf("%w: stat staging %q: %w", ErrReceiveInternal, stagingPath, err)
+		}
+		if staged != offset {
+			// The spoke's checkpoint disagrees with what the hub holds.
+			// Answering with the truth lets it resume correctly instead of
+			// appending at the wrong place and corrupting the file.
+			if staged < 0 {
+				staged = 0
+			}
+			// A staged prefix at least as long as the newly-declared size
+			// means the two sides disagree about the FILE, not just the
+			// offset — the spoke has re-declared the same path at a smaller
+			// size, so the staged bytes belong to a different version. Report
+			// no progress and discard them: reporting `staged` here would
+			// return BytesAccepted > SizeBytes, which PutResult.Validate
+			// rejects, so the spoke would hard-error on the hub's own reply.
+			if staged >= declaredSize {
+				_ = r.backend.Delete(ctx, stagingPath)
+				_ = r.backend.Delete(ctx, partSuffix(stagingPath))
+				return &PutResult{Outcome: OutcomePartial, BytesAccepted: 0}, nil
+			}
+			return &PutResult{Outcome: OutcomePartial, BytesAccepted: staged}, nil
+		}
+		if err := r.backend.ReadTo(ctx, partSuffix(stagingPath), hasherWriter{hasher}); err != nil {
+			return nil, fmt.Errorf("%w: rehash staged prefix %q: %w", ErrReceiveInternal, stagingPath, err)
+		}
+	}
+
+	written, err := r.stage(ctx, stagingPath, body, hasher, offset, declaredSize)
+	if err != nil {
+		return nil, err
+	}
+
+	// A short body means the link dropped mid-stream. Keep what arrived —
+	// that prefix is the spoke's resume checkpoint — but only where the
+	// backend can actually append to it later.
+	if total := offset + written; total < declaredSize {
+		if !r.SupportsResume() {
+			_ = r.backend.Delete(ctx, stagingPath)
+			return &PutResult{Outcome: OutcomePartial, BytesAccepted: 0}, nil
+		}
+		return &PutResult{Outcome: OutcomePartial, BytesAccepted: total}, nil
+	}
+
+	// Verify BEFORE promoting. This is the whole reason for a staging path:
+	// a mismatch is discarded here, so corrupt bytes never appear at the
+	// path a reader or a later reconcile would consult.
+	if got := hex.EncodeToString(hasher.Sum(nil)); got != declaredSHA256 {
+		r.logger.Warn().
+			Str("spoke_id", spokeID).
+			Str("path", sourcePath).
+			Str("declared", declaredSHA256).
+			Str("computed", got).
+			Msg("Discarding sync upload: checksum mismatch")
+		_ = r.backend.Delete(ctx, stagingPath)
+		return &PutResult{Outcome: OutcomeChecksumMismatch}, nil
+	}
+
+	if err := r.promote(ctx, stagingPath, finalPath, declaredSize); err != nil {
+		return nil, err
+	}
+
+	if r.registerFile != nil {
+		if err := r.register(ctx, spokeID, sourcePath, finalPath, declaredSHA256, declaredSize); err != nil {
+			// The bytes are committed but invisible to readers. Reporting an
+			// error is right: deleting a verified transfer over a transient
+			// manifest failure would be worse. The spoke retries, and
+			// resolveExisting re-attempts registration on that retry — see
+			// the note there.
+			return nil, err
+		}
+	}
+
+	return &PutResult{Outcome: OutcomeCommitted, BytesAccepted: declaredSize}, nil
+}
+
+// register publishes a committed file to the manifest.
+func (r *Receiver) register(ctx context.Context, spokeID, sourcePath, finalPath, sha string, size int64) error {
+	f := &ReceivedFile{
+		SpokeID:    spokeID,
+		Path:       finalPath,
+		SourcePath: sourcePath,
+		SHA256:     sha,
+		SizeBytes:  size,
+	}
+	if err := r.registerFile(ctx, f); err != nil {
+		return fmt.Errorf("%w: register %q: %w", ErrReceiveInternal, finalPath, err)
+	}
+	return nil
+}
+
+// resolveExisting applies §6.1 to a path the hub already holds.
+func (r *Receiver) resolveExisting(ctx context.Context, spokeID, sourcePath, finalPath, declaredSHA256 string, size int64) (*PutResult, error) {
+	existingSHA, err := r.hashStored(ctx, finalPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: hash existing %q: %w", ErrReceiveInternal, finalPath, err)
+	}
+
+	if existingSHA == declaredSHA256 {
+		// Redelivery of identical content — the lost-ack case. The bytes are a
+		// no-op, which is what turns at-least-once delivery into exactly-once
+		// effect.
+		//
+		// Registration is NOT a no-op, though. If a previous attempt committed
+		// the bytes but failed its manifest write (a Raft election, a quorum
+		// blip), the file is on disk and invisible to every reader. Returning
+		// AlreadyPresent without retrying would make that permanent: the spoke
+		// marks the file synced and never sends it again, so nothing would
+		// ever register it. Re-attempting is idempotent — registering a file
+		// the manifest already has is a no-op — so the only cost is one extra
+		// proposal on a path that is already rare.
+		if r.registerFile != nil {
+			if err := r.register(ctx, spokeID, sourcePath, finalPath, declaredSHA256, size); err != nil {
+				return nil, err
+			}
+		}
+		return &PutResult{Outcome: OutcomeAlreadyPresent, BytesAccepted: size}, nil
+	}
+
+	// Same path, different content. Never overwrite: one of the two copies is
+	// wrong and silently replacing either destroys evidence. This is an
+	// operator alarm, not a retry.
+	return &PutResult{Outcome: OutcomeConflict, TheirSHA256: existingSHA}, nil
+}
+
+// stage writes the incoming bytes to the staging path, tee'd through hasher.
+//
+// A short body must leave a RESUMABLE partial rather than a promoted short
+// file, and that constrains how the backend is called. LocalBackend writes
+// through a "{path}.part" staging file and renames it to the final name when
+// the call returns cleanly — so handing WriteReader a short reader would
+// promote a truncated file. Returning an error from the reader instead leaves
+// the .part in place, which is exactly the state AppendReader later extends.
+// This mirrors how the peer-fetch puller resumes (filereplication/puller.go).
+func (r *Receiver) stage(ctx context.Context, stagingPath string, body io.Reader, hasher hash.Hash, offset, declaredSize int64) (int64, error) {
+	// Cap the reader at what the spoke declared. Without this a spoke could
+	// stream unbounded bytes into hub storage under a small declared size.
+	expected := declaredSize - offset
+	counted := &countingReader{r: io.TeeReader(io.LimitReader(body, expected), hasher)}
+	guarded := &shortBodyGuard{r: counted, expected: expected}
+
+	if offset > 0 {
+		ab, ok := r.backend.(storage.AppendingBackend)
+		if !ok {
+			return 0, storage.ErrResumeNotSupported
+		}
+		err := ab.AppendReader(ctx, stagingPath, guarded, expected)
+		if errors.Is(err, errShortBody) {
+			return counted.n, nil
+		}
+		if err != nil {
+			return counted.n, fmt.Errorf("%w: append staging %q: %w", ErrReceiveInternal, stagingPath, err)
+		}
+		return counted.n, nil
+	}
+
+	err := r.backend.WriteReader(ctx, stagingPath, guarded, expected)
+	if errors.Is(err, errShortBody) {
+		// Deliberate: the .part survives for a later resume.
+		return counted.n, nil
+	}
+	if err != nil {
+		return counted.n, fmt.Errorf("%w: write staging %q: %w", ErrReceiveInternal, stagingPath, err)
+	}
+	return counted.n, nil
+}
+
+// stagedSize reports how many bytes of a staged file the hub holds, whether it
+// sits in the backend's partial (".part") state or was fully written.
+func (r *Receiver) stagedSize(ctx context.Context, stagingPath string) (int64, error) {
+	if n, err := r.backend.StatFile(ctx, partSuffix(stagingPath)); err != nil {
+		return -1, err
+	} else if n >= 0 {
+		return n, nil
+	}
+	return r.backend.StatFile(ctx, stagingPath)
+}
+
+// partSuffix names the backend's in-progress staging file. LocalBackend writes
+// through "{path}.part" and renames on completion; sizing that file is how the
+// hub learns where a dropped transfer stopped.
+func partSuffix(p string) string { return p + ".part" }
+
+// errShortBody signals that the spoke sent fewer bytes than it declared. It is
+// returned from the reader so the backend abandons its write with the partial
+// staging file intact, instead of promoting a truncated file.
+var errShortBody = errors.New("edgesync: body ended before the declared size")
+
+type shortBodyGuard struct {
+	r        io.Reader
+	expected int64
+	read     int64
+}
+
+func (g *shortBodyGuard) Read(p []byte) (int, error) {
+	n, err := g.r.Read(p)
+	g.read += int64(n)
+	if errors.Is(err, io.EOF) && g.read < g.expected {
+		return n, errShortBody
+	}
+	return n, err
+}
+
+// promote moves a verified file from staging to its final path.
+//
+// A copy, not a rename: storage.Backend has no move operation, and inventing
+// one would mean touching every backend. Streaming staging -> final uses the
+// same pipe pattern as the tiering migrator, so it works identically on local
+// disk and object storage.
+//
+// The staging object is deleted only after the final write succeeds. A crash
+// between them leaves a staging orphan, which is harmless — the next transfer
+// of the same file overwrites it, and the final path already holds verified
+// content. The reverse order could lose the file entirely.
+//
+// BACKEND REQUIREMENT: the write to finalPath must be atomic — a reader must
+// see either the whole file or none of it. Every backend in the tree satisfies
+// this (LocalBackend writes to "{path}.part" and renames; S3 and Azure PUTs
+// are atomic), but storage.Backend does not state it as a contract. A backend
+// that could expose a partial write would break the guarantee this whole
+// function exists to provide: the next attempt would find a truncated file,
+// hash it, and return a conflict against content the hub itself produced —
+// wedging that path the same way a stale ".part" once did.
+func (r *Receiver) promote(ctx context.Context, stagingPath, finalPath string, size int64) error {
+	// Clear any stale staging file at the DESTINATION before writing. A
+	// previous promote that died between WriteReader's staging write and its
+	// rename leaves "{finalPath}.part" behind; left in place it makes
+	// StatFile report the final file as present (see the note in Receive) and
+	// would defeat the Exists() guard for any code that still uses StatFile.
+	if err := r.backend.Delete(ctx, partSuffix(finalPath)); err != nil {
+		r.logger.Debug().Err(err).Str("path", finalPath).Msg("No stale promote staging file to clear")
+	}
+
+	pr, pw := io.Pipe()
+	errCh := make(chan error, 2)
+
+	go func() {
+		err := r.backend.ReadTo(ctx, stagingPath, pw)
+		_ = pw.CloseWithError(err)
+		errCh <- err
+	}()
+	go func() {
+		err := r.backend.WriteReader(ctx, finalPath, pr, size)
+		_ = pr.CloseWithError(err)
+		errCh <- err
+	}()
+
+	var firstErr error
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr != nil {
+		return fmt.Errorf("%w: promote %q -> %q: %w", ErrReceiveInternal, stagingPath, finalPath, firstErr)
+	}
+
+	if err := r.backend.Delete(ctx, stagingPath); err != nil {
+		// Non-fatal: the file is committed and visible. A leftover staging
+		// object costs disk, not correctness.
+		r.logger.Warn().Err(err).Str("staging", stagingPath).Msg("Failed to remove staging object after promote")
+	}
+	return nil
+}
+
+// hashStored computes the SHA-256 of a file already in storage, streaming so a
+// large file does not have to be buffered.
+func (r *Receiver) hashStored(ctx context.Context, p string) (string, error) {
+	h := sha256.New()
+	if err := r.backend.ReadTo(ctx, p, hasherWriter{h}); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// NamespacedPath rewrites a spoke's path into the hub's namespace.
+//
+// This is a HUB-SIDE rewrite by design: the spoke sends its own native paths
+// and stays unaware of namespacing, so the same spoke can sync to several hubs
+// unmodified. Because spoke_id is bound into the request HMAC, a spoke cannot
+// claim another's namespace.
+func NamespacedPath(spokeID, sourcePath string) string {
+	return path.Join(spokeID, sourcePath)
+}
+
+func stagingPathFor(spokeID, sourcePath string) string {
+	return path.Join(StagingPrefix, spokeID, sourcePath)
+}
+
+// validateSpokeID rejects identifiers that could escape their namespace.
+//
+// The spoke ID becomes the first path segment of everything that spoke writes,
+// so a value containing a separator or a traversal element would let it write
+// outside its own namespace — defeating §6.3 even though the ID is
+// HMAC-bound, because the binding proves WHO is asking, not WHERE they may
+// write.
+func validateSpokeID(spokeID string) error {
+	if spokeID == "" {
+		return errors.New("edgesync: spoke ID is required")
+	}
+	if strings.ContainsAny(spokeID, "/\\") {
+		return fmt.Errorf("edgesync: spoke ID %q contains a path separator", spokeID)
+	}
+	if spokeID == "." || spokeID == ".." || strings.HasPrefix(spokeID, ".") {
+		return fmt.Errorf("edgesync: spoke ID %q may not start with a dot", spokeID)
+	}
+	if strings.ContainsRune(spokeID, 0) {
+		return fmt.Errorf("edgesync: spoke ID contains a NUL byte")
+	}
+	return nil
+}
+
+// validateSyncPath rejects paths that would escape the spoke's namespace or
+// collide with the staging area.
+//
+// A spoke is a remote, semi-trusted party — it may be a compromised edge box —
+// so its declared path is untrusted input that becomes a filesystem location.
+func validateSyncPath(p string) error {
+	if p == "" {
+		return errors.New("edgesync: path is required")
+	}
+	if strings.ContainsRune(p, 0) {
+		return errors.New("edgesync: path contains a NUL byte")
+	}
+	if strings.HasPrefix(p, "/") {
+		return fmt.Errorf("edgesync: path %q must be relative", p)
+	}
+	if strings.Contains(p, "\\") {
+		return fmt.Errorf("edgesync: path %q contains a backslash", p)
+	}
+	// Reject ".." ANYWHERE, not only as a whole segment. LocalBackend
+	// sanitizes by replacing every ".." substring with "_" (storage/local.go),
+	// which is many-to-one: "a..b.parquet" and "a_b.parquet" both land on
+	// "a_b.parquet". A spoke sending the former would then collide with an
+	// unrelated file, get an unresolvable 409 naming a digest it never
+	// uploaded, and leave that path permanently unsyncable.
+	//
+	// Checked before cleaning: path.Clean would resolve "a/../../b" into
+	// "../b", and checking only the cleaned form invites the reader to assume
+	// the raw form was safe.
+	if strings.Contains(p, "..") {
+		return fmt.Errorf("edgesync: path %q contains a parent-directory sequence", p)
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == "" {
+			return fmt.Errorf("edgesync: path %q contains an empty segment", p)
+		}
+	}
+	if strings.HasPrefix(p, ".") {
+		return fmt.Errorf("edgesync: path %q may not start with a dot", p)
+	}
+	if !strings.HasSuffix(p, ".parquet") {
+		// The sync unit is an immutable Parquet file. Anything else is either
+		// a mistake or an attempt to write something the query layer would
+		// never read but an operator might execute.
+		return fmt.Errorf("edgesync: path %q is not a .parquet file", p)
+	}
+	return nil
+}
+
+// isHexSHA256 reports whether s is a 64-character lowercase hex digest.
+func isHexSHA256(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// hasherWriter adapts a hash.Hash to io.Writer without exposing Sum.
+type hasherWriter struct{ h hash.Hash }
+
+func (w hasherWriter) Write(p []byte) (int, error) { return w.h.Write(p) }
+
+// countingReader records how many bytes were actually read, so a short body is
+// distinguishable from a complete one.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+// SweepStaging deletes abandoned staging files older than maxAge and reports
+// how many it removed.
+//
+// Without this the staging area grows without bound: a spoke that declares a
+// large file, sends a few bytes, and never returns leaves a partial behind,
+// and nothing else in the system reclaims it. A compromised or merely buggy
+// spoke can repeat that with fresh paths until the hub's disk is full.
+//
+// maxAge must be comfortably longer than a plausible contact gap, because a
+// staged prefix IS a legitimate resume checkpoint — sweeping too eagerly turns
+// a recoverable transfer into a restart from zero on exactly the link least
+// able to afford it.
+//
+// Cluster note: this deletes from storage only. Staged files are never in the
+// manifest (they are unverified by definition), so there is no manifest-before-
+// storage ordering to preserve and no Raft proposal to batch.
+func (r *Receiver) SweepStaging(ctx context.Context, maxAge time.Duration, now time.Time) (int, error) {
+	lister, ok := r.backend.(storage.ObjectLister)
+	if !ok {
+		// Without modification times there is no safe way to tell an
+		// abandoned partial from one mid-transfer, and deleting the latter
+		// would destroy a live resume checkpoint.
+		return 0, fmt.Errorf("%w: backend does not support listing object metadata", ErrReceiveInternal)
+	}
+
+	objects, err := lister.ListObjects(ctx, StagingPrefix+"/")
+	if err != nil {
+		return 0, fmt.Errorf("%w: list staging: %w", ErrReceiveInternal, err)
+	}
+
+	cutoff := now.Add(-maxAge)
+	var removed int
+	for _, obj := range objects {
+		if err := ctx.Err(); err != nil {
+			return removed, err
+		}
+		if !obj.LastModified.Before(cutoff) {
+			continue
+		}
+		if err := r.backend.Delete(ctx, obj.Path); err != nil {
+			// Keep going: one undeletable orphan must not stop the sweep from
+			// reclaiming the rest.
+			r.logger.Warn().Err(err).Str("path", obj.Path).Msg("Failed to delete abandoned sync staging file")
+			continue
+		}
+		removed++
+	}
+
+	if removed > 0 {
+		r.logger.Info().
+			Int("removed", removed).
+			Dur("max_age", maxAge).
+			Msg("Swept abandoned sync staging files")
+	}
+	return removed, nil
+}

--- a/internal/edgesync/receive_test.go
+++ b/internal/edgesync/receive_test.go
@@ -1,0 +1,846 @@
+package edgesync
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+func newTestReceiver(t *testing.T) (*Receiver, storage.Backend) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "sync-receive-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("local backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	r, err := NewReceiver(ReceiverConfig{Backend: backend, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("new receiver: %v", err)
+	}
+	return r, backend
+}
+
+const testPath = "metrics/cpu/2026/08/07/14/cpu_123.parquet"
+
+func TestReceiver_CommitsVerifiedFile(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	content := []byte("parquet payload bytes")
+	digest := sha256Hex(content)
+
+	res, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	if res.Outcome != OutcomeCommitted {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeCommitted)
+	}
+
+	// The file must land under the spoke's namespace, not at its native path.
+	final := NamespacedPath("rocket-01", testPath)
+	got, err := backend.Read(ctx, final)
+	if err != nil {
+		t.Fatalf("read committed file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Error("committed content differs from what was sent")
+	}
+
+	// Staging must be cleaned up, or every transfer doubles hub disk use.
+	if exists, _ := backend.Exists(ctx, stagingPathFor("rocket-01", testPath)); exists {
+		t.Error("staging object survived a successful promote")
+	}
+}
+
+func TestReceiver_ChecksumMismatchNeverReachesFinalPath(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	content := []byte("the real payload")
+	corrupted := []byte("the fake payload") // same length, different bytes
+
+	res, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(content), int64(len(content)), 0, bytes.NewReader(corrupted))
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	if res.Outcome != OutcomeChecksumMismatch {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeChecksumMismatch)
+	}
+
+	// This is the property the whole staging design exists for: corrupt bytes
+	// must never appear where a reader — or a later reconcile — would find them.
+	if exists, _ := backend.Exists(ctx, NamespacedPath("rocket-01", testPath)); exists {
+		t.Error("corrupt content was committed to the final path")
+	}
+	if exists, _ := backend.Exists(ctx, stagingPathFor("rocket-01", testPath)); exists {
+		t.Error("corrupt staging object was left behind")
+	}
+}
+
+func TestReceiver_RedeliveryIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	r, _ := newTestReceiver(t)
+
+	content := []byte("parquet payload")
+	digest := sha256Hex(content)
+
+	if _, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content)); err != nil {
+		t.Fatalf("first delivery: %v", err)
+	}
+
+	// The lost-ack case: the spoke never saw the acknowledgment and resends.
+	res, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("redelivery: %v", err)
+	}
+	if res.Outcome != OutcomeAlreadyPresent {
+		t.Errorf("outcome = %q, want %q", res.Outcome, OutcomeAlreadyPresent)
+	}
+	if !res.Outcome.Done() {
+		t.Error("already-present must be terminal, or the spoke resends forever")
+	}
+}
+
+func TestReceiver_ConflictRefusesOverwrite(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	original := []byte("the hub's content")
+	if _, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(original), int64(len(original)), 0, bytes.NewReader(original)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Same path, different content — a spoke_id collision or corruption.
+	replacement := []byte("a different content")
+	res, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(replacement), int64(len(replacement)), 0, bytes.NewReader(replacement))
+	if err != nil {
+		t.Fatalf("conflicting delivery: %v", err)
+	}
+	if res.Outcome != OutcomeConflict {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeConflict)
+	}
+	if res.TheirSHA256 != sha256Hex(original) {
+		t.Errorf("TheirSHA256 = %q, want the hub's %q", res.TheirSHA256, sha256Hex(original))
+	}
+
+	// The original bytes must be untouched — overwriting destroys whichever
+	// copy is the correct one.
+	stored, err := backend.Read(ctx, NamespacedPath("rocket-01", testPath))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(stored, original) {
+		t.Error("a conflicting upload overwrote the hub's content")
+	}
+}
+
+func TestReceiver_SpokeNamespacingIsolatesEdges(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	// Two rockets legitimately produce the SAME native path — identical
+	// measurement, identical hour. Without namespacing the second would
+	// conflict with (or overwrite) the first.
+	a := []byte("rocket one telemetry")
+	b := []byte("rocket two telemetry")
+
+	if _, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(a), int64(len(a)), 0, bytes.NewReader(a)); err != nil {
+		t.Fatalf("rocket-01: %v", err)
+	}
+	res, err := r.Receive(ctx, "rocket-02", testPath, sha256Hex(b), int64(len(b)), 0, bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("rocket-02: %v", err)
+	}
+	if res.Outcome != OutcomeCommitted {
+		t.Fatalf("second spoke got %q, want %q — namespacing failed", res.Outcome, OutcomeCommitted)
+	}
+
+	for spoke, want := range map[string][]byte{"rocket-01": a, "rocket-02": b} {
+		got, err := backend.Read(ctx, NamespacedPath(spoke, testPath))
+		if err != nil {
+			t.Fatalf("read %s: %v", spoke, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s holds the wrong content", spoke)
+		}
+	}
+}
+
+func TestReceiver_PartialThenResume(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	if !r.SupportsResume() {
+		t.Skip("local backend should support resume")
+	}
+
+	content := []byte("the complete parquet payload for this file")
+	digest := sha256Hex(content)
+	const prefixLen = 15
+
+	// A contact window closes mid-file.
+	res, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content[:prefixLen]))
+	if err != nil {
+		t.Fatalf("partial: %v", err)
+	}
+	if res.Outcome != OutcomePartial {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomePartial)
+	}
+	if res.BytesAccepted != prefixLen {
+		t.Fatalf("accepted %d bytes, want %d", res.BytesAccepted, prefixLen)
+	}
+	// A partial file must not be visible as committed data.
+	if exists, _ := backend.Exists(ctx, NamespacedPath("rocket-01", testPath)); exists {
+		t.Error("a partially-received file appeared at the final path")
+	}
+
+	// The next window sends only the tail.
+	res2, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), res.BytesAccepted, bytes.NewReader(content[res.BytesAccepted:]))
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if res2.Outcome != OutcomeCommitted {
+		t.Fatalf("resumed outcome = %q, want %q", res2.Outcome, OutcomeCommitted)
+	}
+
+	// The reassembled file must be byte-identical — a resume that mis-splices
+	// the tail corrupts silently, which is exactly what the whole-file digest
+	// is there to catch.
+	stored, err := backend.Read(ctx, NamespacedPath("rocket-01", testPath))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(stored, content) {
+		t.Error("the resumed file does not match the original")
+	}
+}
+
+func TestReceiver_ResumeWithWrongOffsetReportsTruth(t *testing.T) {
+	ctx := context.Background()
+	r, _ := newTestReceiver(t)
+
+	content := []byte("the complete parquet payload for this file")
+	digest := sha256Hex(content)
+
+	if _, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content[:10])); err != nil {
+		t.Fatalf("partial: %v", err)
+	}
+
+	// The spoke thinks the hub has 30 bytes; it actually has 10. Appending at
+	// the wrong place would corrupt the file, so the hub must answer with what
+	// it really holds instead.
+	res, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 30, bytes.NewReader(content[30:]))
+	if err != nil {
+		t.Fatalf("bad-offset resume: %v", err)
+	}
+	if res.Outcome != OutcomePartial {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomePartial)
+	}
+	if res.BytesAccepted != 10 {
+		t.Errorf("accepted = %d, want the 10 bytes the hub actually holds", res.BytesAccepted)
+	}
+}
+
+func TestReceiver_RejectsOversizedBody(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	// The spoke declares a small file but streams more. Without a cap this
+	// writes unbounded bytes into hub storage under an honest-looking header.
+	declared := []byte("small")
+	oversized := append(declared, bytes.Repeat([]byte("x"), 10_000)...)
+
+	res, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(declared), int64(len(declared)), 0, bytes.NewReader(oversized))
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	// Only the declared prefix is read, so it verifies and commits at the
+	// declared size — the excess is simply never consumed.
+	if res.Outcome != OutcomeCommitted {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeCommitted)
+	}
+	stored, err := backend.Read(ctx, NamespacedPath("rocket-01", testPath))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(stored) != len(declared) {
+		t.Errorf("stored %d bytes, want %d — the declared size did not cap the body", len(stored), len(declared))
+	}
+}
+
+func TestReceiver_RejectsMaliciousPaths(t *testing.T) {
+	ctx := context.Background()
+	r, _ := newTestReceiver(t)
+	content := []byte("payload")
+
+	// A spoke is semi-trusted — it may be a compromised edge box — so its
+	// declared path is untrusted input that becomes a filesystem location.
+	paths := []struct {
+		name, path string
+	}{
+		{"parent traversal", "../../../etc/passwd.parquet"},
+		{"embedded traversal", "metrics/../../escape.parquet"},
+		{"absolute", "/etc/passwd.parquet"},
+		{"backslash", "metrics\\cpu\\f.parquet"},
+		{"empty", ""},
+		{"NUL byte", "metrics/cpu\x00/f.parquet"},
+		{"dot prefix", ".sync-staging/rocket-02/f.parquet"},
+		{"empty segment", "metrics//f.parquet"},
+		{"not parquet", "metrics/cpu/evil.sh"},
+	}
+
+	for _, tt := range paths {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := r.Receive(ctx, "rocket-01", tt.path, sha256Hex(content), int64(len(content)), 0, bytes.NewReader(content)); err == nil {
+				t.Errorf("path %q was accepted", tt.path)
+			}
+		})
+	}
+}
+
+func TestReceiver_RejectsMaliciousSpokeIDs(t *testing.T) {
+	ctx := context.Background()
+	r, _ := newTestReceiver(t)
+	content := []byte("payload")
+
+	// The spoke ID is the first path segment of everything that spoke writes.
+	// The HMAC proves WHO is asking, not WHERE they may write — so the ID
+	// still has to be validated as a path component.
+	ids := []struct{ name, id string }{
+		{"empty", ""},
+		{"traversal", ".."},
+		{"separator", "rocket/../other"},
+		{"backslash", "rocket\\other"},
+		{"dot prefix", ".sync-staging"},
+		{"NUL byte", "rocket\x00-01"},
+	}
+
+	for _, tt := range ids {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := r.Receive(ctx, tt.id, testPath, sha256Hex(content), int64(len(content)), 0, bytes.NewReader(content)); err == nil {
+				t.Errorf("spoke ID %q was accepted", tt.id)
+			}
+		})
+	}
+}
+
+func TestReceiver_RejectsMalformedDigestAndSize(t *testing.T) {
+	ctx := context.Background()
+	r, _ := newTestReceiver(t)
+	content := []byte("payload")
+	good := sha256Hex(content)
+
+	t.Run("digest not hex", func(t *testing.T) {
+		if _, err := r.Receive(ctx, "rocket-01", testPath, strings.Repeat("z", 64), int64(len(content)), 0, bytes.NewReader(content)); err == nil {
+			t.Error("a non-hex digest was accepted")
+		}
+	})
+	t.Run("digest wrong length", func(t *testing.T) {
+		if _, err := r.Receive(ctx, "rocket-01", testPath, "abc123", int64(len(content)), 0, bytes.NewReader(content)); err == nil {
+			t.Error("a short digest was accepted")
+		}
+	})
+	t.Run("negative size", func(t *testing.T) {
+		if _, err := r.Receive(ctx, "rocket-01", testPath, good, -1, 0, bytes.NewReader(content)); err == nil {
+			t.Error("a negative size was accepted")
+		}
+	})
+	t.Run("offset beyond size", func(t *testing.T) {
+		if _, err := r.Receive(ctx, "rocket-01", testPath, good, int64(len(content)), int64(len(content))+1, bytes.NewReader(nil)); err == nil {
+			t.Error("an offset past the file size was accepted")
+		}
+	})
+	t.Run("negative offset", func(t *testing.T) {
+		if _, err := r.Receive(ctx, "rocket-01", testPath, good, int64(len(content)), -1, bytes.NewReader(content)); err == nil {
+			t.Error("a negative offset was accepted")
+		}
+	})
+}
+
+func TestReceiver_RegistersCommittedFiles(t *testing.T) {
+	ctx := context.Background()
+	dir, err := os.MkdirTemp("", "sync-receive-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	var registered []*ReceivedFile
+	r, err := NewReceiver(ReceiverConfig{
+		Backend: backend,
+		Logger:  zerolog.Nop(),
+		RegisterFile: func(_ context.Context, f *ReceivedFile) error {
+			registered = append(registered, f)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new receiver: %v", err)
+	}
+
+	content := []byte("payload")
+	if _, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(content), int64(len(content)), 0, bytes.NewReader(content)); err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+
+	if len(registered) != 1 {
+		t.Fatalf("registered %d files, want 1", len(registered))
+	}
+	f := registered[0]
+	if f.Path != NamespacedPath("rocket-01", testPath) {
+		t.Errorf("registered path = %q, want the namespaced path", f.Path)
+	}
+	if f.SourcePath != testPath {
+		t.Errorf("SourcePath = %q, want the spoke's original %q", f.SourcePath, testPath)
+	}
+	if f.SpokeID != "rocket-01" || f.SHA256 != sha256Hex(content) || f.SizeBytes != int64(len(content)) {
+		t.Errorf("registered metadata is wrong: %+v", f)
+	}
+}
+
+func TestReceiver_RegistrationFailureKeepsBytes(t *testing.T) {
+	ctx := context.Background()
+	dir, err := os.MkdirTemp("", "sync-receive-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	r, err := NewReceiver(ReceiverConfig{
+		Backend: backend,
+		Logger:  zerolog.Nop(),
+		RegisterFile: func(context.Context, *ReceivedFile) error {
+			return errors.New("raft unavailable")
+		},
+	})
+	if err != nil {
+		t.Fatalf("new receiver: %v", err)
+	}
+
+	content := []byte("payload")
+	if _, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(content), int64(len(content)), 0, bytes.NewReader(content)); err == nil {
+		t.Fatal("a manifest failure was reported as success")
+	}
+
+	// The verified bytes must survive. Deleting them over a transient manifest
+	// failure would discard a completed transfer; the spoke retries and gets
+	// AlreadyPresent, and registration is attempted again.
+	if exists, _ := backend.Exists(ctx, NamespacedPath("rocket-01", testPath)); !exists {
+		t.Error("verified content was discarded because the manifest write failed")
+	}
+}
+
+func TestReceiver_RequiresBackend(t *testing.T) {
+	if _, err := NewReceiver(ReceiverConfig{Logger: zerolog.Nop()}); err == nil {
+		t.Error("a nil backend was accepted")
+	}
+}
+
+func TestReceiver_StagingIsOutsideQueryableNamespace(t *testing.T) {
+	// Staged bytes must not be reachable as data. The staging prefix begins
+	// with a dot, which validateSyncPath rejects, so a spoke cannot address
+	// another spoke's staging area by declaring a crafted path.
+	if !strings.HasPrefix(StagingPrefix, ".") {
+		t.Error("the staging prefix must start with a dot so it cannot be a database name")
+	}
+	if err := validateSyncPath(StagingPrefix + "/rocket-02/f.parquet"); err == nil {
+		t.Error("a path into the staging area was accepted")
+	}
+}
+
+func TestNamespacedPath(t *testing.T) {
+	got := NamespacedPath("rocket-01", "metrics/cpu/f.parquet")
+	want := "rocket-01/metrics/cpu/f.parquet"
+	if got != want {
+		t.Errorf("NamespacedPath = %q, want %q", got, want)
+	}
+}
+
+// nonAppendingBackend wraps a Backend to hide AppendingBackend, simulating S3
+// or Azure — where a partial transfer cannot be resumed.
+type nonAppendingBackend struct{ storage.Backend }
+
+func TestReceiver_NoResumeSupportRestartsFromZero(t *testing.T) {
+	ctx := context.Background()
+	dir, err := os.MkdirTemp("", "sync-receive-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	local, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { local.Close() })
+
+	r, err := NewReceiver(ReceiverConfig{Backend: nonAppendingBackend{local}, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("new receiver: %v", err)
+	}
+	if r.SupportsResume() {
+		t.Fatal("the wrapper should hide AppendingBackend")
+	}
+
+	content := []byte("the complete parquet payload for this file")
+	digest := sha256Hex(content)
+
+	// A short body on a non-appending backend must report zero accepted, so
+	// the spoke restarts from the beginning rather than resuming into a
+	// prefix the hub cannot extend.
+	res, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content[:10]))
+	if err != nil {
+		t.Fatalf("partial: %v", err)
+	}
+	if res.Outcome != OutcomePartial {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomePartial)
+	}
+	if res.BytesAccepted != 0 {
+		t.Errorf("accepted = %d, want 0 — this backend cannot be resumed into", res.BytesAccepted)
+	}
+
+	// An attempted resume must fail loudly rather than silently corrupting.
+	if _, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 10, bytes.NewReader(content[10:])); !errors.Is(err, storage.ErrResumeNotSupported) {
+		t.Errorf("resume on a non-appending backend: err = %v, want ErrResumeNotSupported", err)
+	}
+
+	// A full re-send still succeeds.
+	res2, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("full re-send: %v", err)
+	}
+	if res2.Outcome != OutcomeCommitted {
+		t.Errorf("outcome = %q, want %q", res2.Outcome, OutcomeCommitted)
+	}
+}
+
+func TestReceiver_ShortBodyIsNotCommitted(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	// A body that ends early must never be treated as complete, even though
+	// its bytes are a valid prefix — the declared size is the contract.
+	content := []byte("the complete parquet payload")
+	res, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(content), int64(len(content)), 0,
+		io.LimitReader(bytes.NewReader(content), 5))
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	if res.Outcome != OutcomePartial {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomePartial)
+	}
+	if exists, _ := backend.Exists(ctx, NamespacedPath("rocket-01", testPath)); exists {
+		t.Error("a short body was committed to the final path")
+	}
+}
+
+func TestReceivedFile_DerivesArcNamespace(t *testing.T) {
+	// The hub prepends the spoke ID, so database/measurement/partition must be
+	// derived from the spoke's ORIGINAL path — reading them off the namespaced
+	// path would make the spoke ID look like the database name.
+	f := &ReceivedFile{
+		SpokeID:    "rocket-01",
+		SourcePath: "metrics/cpu/2026/08/07/14/cpu_123.parquet",
+		Path:       NamespacedPath("rocket-01", "metrics/cpu/2026/08/07/14/cpu_123.parquet"),
+	}
+
+	if got := f.Database(); got != "metrics" {
+		t.Errorf("Database() = %q, want %q — the spoke ID leaked into the database name", got, "metrics")
+	}
+	if got := f.Measurement(); got != "cpu" {
+		t.Errorf("Measurement() = %q, want %q", got, "cpu")
+	}
+
+	// PartitionTime is load-bearing: tiering filters queries by it and computes
+	// file age from it, so a zero value would make the file look infinitely old
+	// and drop it from time-ranged queries.
+	want := time.Date(2026, 8, 7, 14, 0, 0, 0, time.UTC)
+	if got := f.PartitionTime(); !got.Equal(want) {
+		t.Errorf("PartitionTime() = %v, want %v", got, want)
+	}
+	if got := f.PartitionTime(); got.Location() != time.UTC {
+		t.Errorf("PartitionTime location = %v, want UTC", got.Location())
+	}
+}
+
+func TestReceivedFile_UnparseablePathsYieldZeroValues(t *testing.T) {
+	// A path that does not carry a partition must report the zero time rather
+	// than a wrong one — "unknown" is recoverable, epoch is silently wrong.
+	tests := []struct{ name, path string }{
+		{"too short", "metrics/cpu/f.parquet"},
+		{"non-numeric partition", "metrics/cpu/YYYY/MM/DD/HH/f.parquet"},
+		{"impossible date", "metrics/cpu/2026/13/45/99/f.parquet"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &ReceivedFile{SourcePath: tt.path}
+			if got := f.PartitionTime(); !got.IsZero() {
+				t.Errorf("PartitionTime() = %v, want the zero time", got)
+			}
+		})
+	}
+
+	short := &ReceivedFile{SourcePath: "onlyone"}
+	if short.Database() != "" || short.Measurement() != "" {
+		t.Error("a path too short to carry a namespace returned non-empty values")
+	}
+}
+
+// wedgeBackend fails ReadTo on the final path exactly once, simulating a
+// promote that dies after staging but before the rename.
+type wedgeBackend struct {
+	storage.Backend
+	failOn string
+	failed bool
+}
+
+func (w *wedgeBackend) ReadTo(ctx context.Context, p string, out io.Writer) error {
+	if p == w.failOn && !w.failed {
+		w.failed = true
+		return errors.New("simulated transient read failure")
+	}
+	return w.Backend.ReadTo(ctx, p, out)
+}
+
+func TestReceiver_StalePartDoesNotWedgeThePath(t *testing.T) {
+	ctx := context.Background()
+	dir, err := os.MkdirTemp("", "sync-wedge-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	local, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { local.Close() })
+
+	staging := stagingPathFor("rocket-01", testPath)
+	backend := &wedgeBackend{Backend: local, failOn: staging}
+	r, err := NewReceiver(ReceiverConfig{Backend: backend, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+
+	content := []byte("parquet payload")
+	digest := sha256Hex(content)
+
+	// First attempt: verification succeeds, promote fails mid-copy. That can
+	// leave "{finalPath}.part" behind with the final file absent.
+	if _, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content)); err == nil {
+		t.Fatal("expected the seeded promote failure")
+	}
+
+	// The retry must succeed. LocalBackend.StatFile falls back to the .part
+	// file, so a stale one would be read as "the file already exists" and the
+	// identity branch would then fail forever on ReadTo — wedging this path
+	// permanently, with no retry able to clear it.
+	res, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("retry after a failed promote: %v — the path is wedged", err)
+	}
+	if res.Outcome != OutcomeCommitted {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeCommitted)
+	}
+
+	stored, err := backend.Read(ctx, NamespacedPath("rocket-01", testPath))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(stored, content) {
+		t.Error("the recovered file does not match what was sent")
+	}
+}
+
+func TestReceiver_PartialResultsAlwaysValidate(t *testing.T) {
+	ctx := context.Background()
+	r, _ := newTestReceiver(t)
+
+	// A staged prefix longer than a newly-declared size means the two sides
+	// disagree about the file itself, not just the offset. Reporting the
+	// staged length would return BytesAccepted > SizeBytes — which
+	// PutResult.Validate rejects — so the spoke would hard-error on the hub's
+	// own reply. PR 2 has the agent call Validate on everything it receives,
+	// so the hub must never emit a result its own validator refuses.
+	big := []byte("0123456789012345678901234567890123456789012345678901234567890123456789")
+	if _, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(big), 100, 0, bytes.NewReader(big[:60])); err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+
+	const smaller = 50
+	res, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(big[:smaller]), smaller, 10, bytes.NewReader(big[10:smaller]))
+	if err != nil {
+		t.Fatalf("re-declare at a smaller size: %v", err)
+	}
+
+	entry := &LedgerEntry{Path: testPath, SHA256: sha256Hex(big[:smaller]), SizeBytes: smaller}
+	if verr := res.Validate(entry); verr != nil {
+		t.Errorf("the hub returned a result its own Validate rejects: %v", verr)
+	}
+	if res.BytesAccepted > smaller {
+		t.Errorf("BytesAccepted = %d exceeds the declared size %d", res.BytesAccepted, smaller)
+	}
+}
+
+func TestReceiver_SweepStagingReclaimsAbandonedPartials(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	// Three abandoned transfers: a spoke declares a size, sends a prefix, and
+	// never returns. Nothing else in the system reclaims these, so without a
+	// sweep a spoke can fill the hub's disk with fresh paths.
+	content := []byte("the complete parquet payload for this file")
+	for i := 0; i < 3; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/abandoned_%d.parquet", i)
+		if _, err := r.Receive(ctx, "rocket-01", p, sha256Hex(content), int64(len(content)), 0, bytes.NewReader(content[:10])); err != nil {
+			t.Fatalf("abandon %d: %v", i, err)
+		}
+	}
+
+	// A sweep with a long horizon must keep them: a staged prefix IS a
+	// legitimate resume checkpoint, and deleting it turns a recoverable
+	// transfer into a restart from zero.
+	removed, err := r.SweepStaging(ctx, 24*time.Hour, time.Now())
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("swept %d fresh partials; a recent checkpoint must be preserved", removed)
+	}
+
+	// Pretending the files are old: everything past the horizon goes.
+	removed, err = r.SweepStaging(ctx, time.Hour, time.Now().Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if removed < 3 {
+		t.Errorf("swept %d, want at least the 3 abandoned partials", removed)
+	}
+
+	for i := 0; i < 3; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/abandoned_%d.parquet", i)
+		staging := stagingPathFor("rocket-01", p)
+		if exists, _ := backend.Exists(ctx, staging); exists {
+			t.Errorf("abandoned staging file %d survived the sweep", i)
+		}
+		if exists, _ := backend.Exists(ctx, partSuffix(staging)); exists {
+			t.Errorf("abandoned .part file %d survived the sweep", i)
+		}
+	}
+}
+
+func TestReceiver_SweepStagingLeavesCommittedFilesAlone(t *testing.T) {
+	ctx := context.Background()
+	r, backend := newTestReceiver(t)
+
+	content := []byte("committed payload")
+	if _, err := r.Receive(ctx, "rocket-01", testPath, sha256Hex(content), int64(len(content)), 0, bytes.NewReader(content)); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// The sweep must only ever touch the staging prefix — a bug here would
+	// delete verified, committed data.
+	if _, err := r.SweepStaging(ctx, time.Hour, time.Now().Add(48*time.Hour)); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	stored, err := backend.Read(ctx, NamespacedPath("rocket-01", testPath))
+	if err != nil {
+		t.Fatalf("the sweep deleted a committed file: %v", err)
+	}
+	if !bytes.Equal(stored, content) {
+		t.Error("committed content changed during a staging sweep")
+	}
+}
+
+func TestReceiver_RetryRecoversFromAFailedRegistration(t *testing.T) {
+	ctx := context.Background()
+	dir, err := os.MkdirTemp("", "sync-reg-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	// Fails once — a Raft election or a quorum blip — then recovers.
+	var attempts int
+	var registered []string
+	r, err := NewReceiver(ReceiverConfig{
+		Backend: backend,
+		Logger:  zerolog.Nop(),
+		RegisterFile: func(_ context.Context, f *ReceivedFile) error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("raft: leadership lost")
+			}
+			registered = append(registered, f.Path)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+
+	content := []byte("payload")
+	digest := sha256Hex(content)
+
+	// First attempt: bytes commit, manifest write fails. The file is on disk
+	// but invisible to every reader.
+	if _, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content)); err == nil {
+		t.Fatal("expected the seeded registration failure")
+	}
+	if exists, _ := backend.Exists(ctx, NamespacedPath("rocket-01", testPath)); !exists {
+		t.Fatal("verified bytes were discarded over a transient manifest failure")
+	}
+
+	// The spoke retries and gets AlreadyPresent. Registration MUST be
+	// re-attempted here: without it the spoke marks the file synced and never
+	// sends it again, so nothing would ever register it and the data stays
+	// invisible permanently.
+	res, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if res.Outcome != OutcomeAlreadyPresent {
+		t.Fatalf("outcome = %q, want %q", res.Outcome, OutcomeAlreadyPresent)
+	}
+	if len(registered) != 1 || registered[0] != NamespacedPath("rocket-01", testPath) {
+		t.Errorf("registered = %v; the retry did not re-attempt registration, so the file is permanently unreadable", registered)
+	}
+}


### PR DESCRIPTION
Fourth of nine PRs for edge sync — see [#569](https://github.com/Basekick-Labs/arc/issues/569). Follows #570 (ledger), #571 (rename), #572 (transport), #573 (HMAC).

**First PR in this sequence with a real HTTP endpoint**, so it carries the auth non-negotiables and the binary-run gate.

## Summary

`POST /api/v1/sync/file` accepts an authenticated file push from a spoke. Bytes stream into a staging area while Arc hashes them, the digest is compared against what the spoke declared, and **only on a match** is the file promoted to its final namespaced location. A mismatch is discarded, so corrupt bytes never appear where a reader would find them.

New config: `edge_sync.enabled` (default false), `edge_sync.hub_id`, `edge_sync.max_file_bytes` (512MiB default).

## A design constraint §5.2 did not anticipate

The design specifies "atomic-rename into the final namespaced path". `storage.Backend` **has no rename**, and resume needs `AppendingBackend`, which only `LocalBackend` implements.

Resolution ([recorded on the issue](https://github.com/Basekick-Labs/arc/issues/569#issuecomment-5219316040)): promote by streaming copy rather than rename — the same pipe pattern `tiering/migrator.go` already uses. Verify-before-commit is preserved on **every** backend; the cost is an extra read+write on object storage. Resume degrades rather than failing: where the backend cannot append, a dropped transfer restarts from zero, matching what the peer-fetch puller already does for `ErrResumeNotSupported`.

An earlier version of this analysis concluded the hub had to be local-only, mirroring Iceberg. That was wrong — it confused "no rename" with "no verify-before-commit" and would have refused a working configuration.

## Two blockers found by adversarial review

Both reproduced before fixing; both have regression tests that fail against the pre-fix code.

**A failed promote wedged the path permanently.** `LocalBackend.StatFile` falls back to `{path}.part` when the final file is absent; `ReadTo` does not. An interrupted promote left a `.part` that the identity check read as "the file exists", and every retry then failed hashing it — **forever**, surviving restart, with no cleanup path anywhere. Fixed by using `Exists` (not `.part`-aware) and clearing stale `.part` at the destination before promoting.

**A pre-auth memory DoS.** Fiber buffers the body before routing — so before auth — and `server.max_payload_size` defaults to **1GB**. Anyone able to reach the port could pin 1GB per connection with **no token and no spoke secret**. `edge_sync.max_file_bytes` is now checked on `Content-Length` and on the declared size, and config load refuses a cap above the server limit because the larger value could never take effect.

## Other findings fixed

- **The hub returned a result its own validator rejects** — a staged prefix longer than a re-declared size gave `BytesAccepted > SizeBytes`, which `PutResult.Validate` refuses, so a spoke would hard-error on a well-formed reply.
- **A Raft election told the spoke its request was malformed** — every non-resume error mapped to 400. Hub-side failures are now **503** with no internal error text.
- **`AlreadyPresent` never re-attempted registration** — a file whose manifest write failed stayed on disk but **invisible to every reader permanently**, because the spoke marks it synced and never sends it again.
- **`..` was only rejected as a whole segment**, but `LocalBackend` replaces every `..` substring with `_`, so `a..b.parquet` and `a_b.parquet` collided on disk and produced an unresolvable 409 naming a digest the spoke never uploaded.
- **`PartitionTime` was unset** in the cluster wiring (found before either reviewer reported it) — `tiering/router.go` filters time-ranged queries by it, so synced files would have vanished from those queries.
- **Duplicate `component` JSON key** in every log line.
- **`SweepStaging`** added — staging had no reclamation path at all, so an abandoned transfer leaked disk forever.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, `enabled=false` (default) | **No** — block skipped, no routes | n/a. **Verified live:** endpoint 404 |
| OSS standalone, `enabled=true` + `hub_id` | Yes | `clusterCoordinator` **nil** → `registerFile` nil, guarded in `Receive`. **Verified live** |
| `hub_id` empty | **No** — config load fails | **Verified live:** refuses to start |
| `hub_id` with `/` or NUL | **No** — config load fails | **Verified live** |
| `max_file_bytes` > `server.max_payload_size` | **No** — config load fails | **Verified live** |
| Cluster + `enabled=true` | Yes — `registerFile` proposes to Raft | `RegisterFileInManifest` handles leader **and** follower (forwards). **Not exercised live** |
| `auth.enabled=true` | Yes — `RequireAdmin` mounted | `authManager` nil-guarded |
| S3/Azure hub | Yes — `SupportsResume()` false | Restarts from zero. **Not exercised live** |

Two rows not exercised live; both reviewers were pointed at them specifically.

## Test plan

- [x] `go build ./cmd/... ./internal/...`, `go vet`, `gofmt -l` clean
- [x] `go test` + `-race` clean across `edgesync`, `api`, `config`
- [x] **Binary runs at non-default values**: enabled + `hub_id`, `max_file_bytes=256MiB`, plus three configs that must refuse to start — all verified
- [x] **Real end-to-end over HTTP**: authenticated upload committed and landed under `rocket-01/metrics/...`; **replay refused** with `reason: replay`; unauthenticated and forged requests rejected with nothing written; oversized upload **413**
- [x] Every new regression test verified to fail pre-fix

## Review

Security-focused pass, deep pass, and a third review. Both of the first two independently found the wedge.

## Notes

- **Docs:** new `docs/advanced/edge-sync.md`, with a limitations section stating plainly that no spoke can be registered yet.
- **Deliberately shipping enable-able but not usable:** spoke registration lands in PR 7, so an enabled hub rejects every request and warns at startup — visible and fails closed.
- **`SweepStaging` is unwired:** scheduling it needs the agent's scheduler (PR 8).