### PR TITLE
feat(edgesync): batch reconcile with a hub-side received index (#569 PR 5/9)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -75,11 +75,14 @@ The hub receive endpoint is the first piece an operator can turn on:
 enabled = true                     # default false
 hub_id = "ground-station"          # required when enabled; bound into every request's HMAC
 max_file_bytes = 536870912         # 512MiB default; must not exceed server.max_payload_size
+max_reconcile_entries = 10000      # ~2MB per discovery batch
 ```
 
-With it enabled, `POST /api/v1/sync/file` accepts an authenticated file push from a registered spoke. Every upload is streamed to a staging area, hashed on the way in, and **verified before it is promoted** to its final location — a checksum mismatch is discarded and never appears where a reader would find it. Redelivering a file the hub already holds is a no-op; the same path arriving with *different* content is refused with `409` rather than overwritten, because one of the two copies is wrong and silently replacing either destroys the evidence.
+With it enabled, `POST /api/v1/sync/file` accepts an authenticated file push from a registered spoke, and `POST /api/v1/sync/reconcile` answers — in **one round-trip** — which of a spoke's pending files the hub already holds. That second endpoint is what makes a long disconnection survivable: a spoke returning with 5,000 pending files asks once rather than 5,000 times, and any file whose acknowledgment was lost is discovered in bulk rather than re-uploaded. Every upload is streamed to a staging area, hashed on the way in, and **verified before it is promoted** to its final location — a checksum mismatch is discarded and never appears where a reader would find it. Redelivering a file the hub already holds is a no-op; the same path arriving with *different* content is refused with `409` rather than overwritten, because one of the two copies is wrong and silently replacing either destroys the evidence.
 
 Two independent authentication layers apply: Arc's API token middleware, and a per-spoke HMAC binding the spoke, the hub, the path, and the content digest. **There is no way to register a spoke yet** (that lands with the spoke registry), so an enabled hub currently rejects every request and logs a warning saying so — visible and safe, rather than silently accepting unauthenticated writes.
+
+Reconcile is answered from a hub-side index of received files rather than by reading Parquet, so it stays cheap regardless of backlog size and works identically on a standalone hub and a clustered one. A batch larger than `max_reconcile_entries` is refused with `413` and the limit, so a spoke pages rather than sending an unbounded body — the request body is buffered before authentication, so an uncapped batch would be a memory claim by an unauthenticated caller.
 
 Resume is supported on local storage. On S3 and Azure a dropped transfer restarts from zero, because block objects cannot be appended to; this is a throughput cost on intermittent links, not a correctness problem.
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1968,13 +1968,49 @@ func main() {
 			}
 		}
 
+		// The hub index lives in the shared SQLite DB alongside auth and audit
+		// data. It is what lets reconcile answer without reading parquet
+		// bytes — the Raft manifest only exists in cluster mode, so a
+		// standalone hub would otherwise have to hash every candidate file.
+		//
+		// sharedSQLiteHandle borrows the auth manager's handle when auth is
+		// enabled and opens a dedicated one otherwise, so a hub works with
+		// auth disabled (an OSS deployment behind its own perimeter) without
+		// a second handle on the same file.
+		syncDB, syncOwnsDB, err := sharedSQLiteHandle(authManager, cfg.Auth.DBPath)
+		if err != nil {
+			log.Fatal().Err(err).Str("path", cfg.Auth.DBPath).Msg("Failed to open the edge sync database; refusing to start")
+		}
+		if syncOwnsDB {
+			// Close only a handle this block opened. A borrowed one belongs to
+			// the auth manager, which closes it at PriorityAuth.
+			shutdownCoordinator.RegisterHook("edgesync-db", func(context.Context) error {
+				return syncDB.Close()
+			}, shutdown.PriorityDatabase)
+		}
+
+		hubIndex, err := edgesync.NewHubIndex(syncDB, logger.Get("edgesync"))
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create edge sync hub index; refusing to start")
+		}
+
 		receiver, err := edgesync.NewReceiver(edgesync.ReceiverConfig{
 			Backend:      storageBackend,
+			Index:        hubIndex,
 			Logger:       logger.Get("edgesync"),
 			RegisterFile: registerFile,
 		})
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to create edge sync receiver; refusing to start")
+		}
+
+		reconciler, err := edgesync.NewReconciler(edgesync.ReconcilerConfig{
+			Index:      hubIndex,
+			Backend:    storageBackend,
+			MaxEntries: cfg.EdgeSync.MaxReconcileEntries,
+		})
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create edge sync reconciler; refusing to start")
 		}
 
 		// TODO(#569 PR 7): spoke secrets come from the SQLite registry. Until
@@ -1983,6 +2019,7 @@ func main() {
 		// rather than silently accepting unauthenticated writes.
 		syncHandler, err := api.NewEdgeSyncHandler(api.EdgeSyncHandlerConfig{
 			Receiver:     receiver,
+			Reconciler:   reconciler,
 			SpokeSecrets: api.StaticSpokeSecrets(nil),
 			Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
 			HubID:        cfg.EdgeSync.HubID,

--- a/internal/api/edgesync.go
+++ b/internal/api/edgesync.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"strconv"
 	"time"
@@ -32,6 +33,11 @@ const (
 // Parquet file over a constrained link is the expected case, not an anomaly.
 const receiveTimeout = 30 * time.Minute
 
+// reconcileTimeout bounds a discovery request. Much shorter than a transfer:
+// reconcile is a bounded SQLite lookup, so anything slow is a symptom rather
+// than a large file.
+const reconcileTimeout = 2 * time.Minute
+
 // SpokeSecretLookup returns the shared secret registered for a spoke.
 //
 // Per-spoke secrets are the point: revoking one edge must not re-key the
@@ -42,6 +48,7 @@ type SpokeSecretLookup func(ctx context.Context, spokeID string) (secret string,
 // EdgeSyncHandler serves the hub side of edge-to-cloud sync.
 type EdgeSyncHandler struct {
 	receiver     *edgesync.Receiver
+	reconciler   *edgesync.Reconciler
 	lookup       SpokeSecretLookup
 	replay       security.ReplayGuard
 	authManager  *auth.AuthManager
@@ -53,6 +60,10 @@ type EdgeSyncHandler struct {
 // EdgeSyncHandlerConfig configures the handler.
 type EdgeSyncHandlerConfig struct {
 	Receiver *edgesync.Receiver
+
+	// Reconciler answers batch discovery. Required — without it a spoke
+	// returning from a long outage would have to probe file by file.
+	Reconciler *edgesync.Reconciler
 
 	// SpokeSecrets resolves a spoke's shared secret. Required — without it
 	// every request would be unauthenticated.
@@ -83,6 +94,9 @@ func NewEdgeSyncHandler(cfg EdgeSyncHandlerConfig) (*EdgeSyncHandler, error) {
 	if cfg.Receiver == nil {
 		return nil, errors.New("edgesync handler: receiver is required")
 	}
+	if cfg.Reconciler == nil {
+		return nil, errors.New("edgesync handler: reconciler is required")
+	}
 	if cfg.SpokeSecrets == nil {
 		return nil, errors.New("edgesync handler: spoke secret lookup is required")
 	}
@@ -97,6 +111,7 @@ func NewEdgeSyncHandler(cfg EdgeSyncHandlerConfig) (*EdgeSyncHandler, error) {
 	}
 	return &EdgeSyncHandler{
 		receiver:     cfg.Receiver,
+		reconciler:   cfg.Reconciler,
 		lookup:       cfg.SpokeSecrets,
 		replay:       cfg.Replay,
 		authManager:  cfg.AuthManager,
@@ -122,11 +137,30 @@ func NewEdgeSyncHandler(cfg EdgeSyncHandlerConfig) (*EdgeSyncHandler, error) {
 func (h *EdgeSyncHandler) RegisterRoutes(app fiber.Router) {
 	group := app.Group("/api/v1/sync")
 
+	// A route-level body limit, ahead of everything else. The Content-Length
+	// pre-checks below cannot bound a chunked request (there is no declared
+	// length to check), and the body is buffered before routing — so without
+	// this an unauthenticated caller could stream past both caps. Sized to the
+	// larger of the two per-route limits, since one group serves both.
+	bodyLimit := h.maxFileBytes
+	if rb := h.maxReconcileBytes(); rb > bodyLimit {
+		bodyLimit = rb
+	}
+	group.Use(func(c *fiber.Ctx) error {
+		if int64(len(c.Body())) > bodyLimit {
+			return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+				"error": "request body exceeds the edge sync limit",
+			})
+		}
+		return c.Next()
+	})
+
 	if h.authManager != nil {
 		group.Use(auth.RequireAdmin(h.authManager))
 	}
 
 	group.Post("/file", h.receiveFile)
+	group.Post("/reconcile", h.reconcile)
 
 	h.logger.Info().
 		Str("hub_id", h.hubID).
@@ -284,6 +318,142 @@ func (h *EdgeSyncHandler) receiveFile(c *fiber.Ctx) error {
 	}
 
 	return h.writeOutcome(c, res)
+}
+
+// reconcile handles POST /api/v1/sync/reconcile.
+//
+// One round-trip tells a spoke which of its pending files the hub already
+// holds, which is what makes a long disconnection survivable: 5,000 pending
+// files cost one request rather than 5,000.
+func (h *EdgeSyncHandler) reconcile(c *fiber.Ctx) error {
+	// Size check first, before anything reads the body. The body is buffered
+	// before routing (StreamRequestBody=false), so this is the only bound on
+	// what an unauthenticated caller can make the hub hold.
+	if cl := c.Request().Header.ContentLength(); cl > 0 && int64(cl) > h.maxReconcileBytes() {
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+			"error":       "reconcile batch too large",
+			"max_entries": h.reconciler.MaxEntries(),
+		})
+	}
+
+	spokeID := string(append([]byte(nil), c.Request().Header.Peek(headerSpokeID)...))
+	hubID := string(append([]byte(nil), c.Request().Header.Peek(headerHubID)...))
+	nonce := string(append([]byte(nil), c.Request().Header.Peek(headerNonce)...))
+	mac := string(append([]byte(nil), c.Request().Header.Peek(headerMAC)...))
+
+	if spokeID == "" || nonce == "" || mac == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "missing required sync headers",
+		})
+	}
+	if hubID != h.hubID {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "hub ID mismatch"})
+	}
+
+	ts, err := strconv.ParseInt(c.Get(headerTS), 10, 64)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "invalid or missing " + headerTS,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), reconcileTimeout)
+	defer cancel()
+
+	secret, ok := h.lookup(ctx, spokeID)
+	if !ok {
+		h.logger.Warn().Str("spoke_id", spokeID).Msg("Reconcile rejected: unknown or disabled spoke")
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication failed"})
+	}
+
+	// The MAC binds a digest of the body, so a replayed request cannot
+	// substitute a different path list and use the hub as an oracle for what
+	// data exists. Validated against the RAW bytes, before parsing — hashing a
+	// re-serialized form would compare a different byte sequence.
+	body := c.Body()
+	if err := security.ValidateSyncReconcileHMACWithReplay(
+		h.replay, secret, nonce, spokeID, hubID, body, ts, mac,
+		security.HMACTimestampTolerance,
+	); err != nil {
+		return h.authFailure(c, spokeID, err)
+	}
+
+	var req reconcileRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "malformed reconcile body",
+		})
+	}
+
+	res, err := h.reconciler.Reconcile(ctx, spokeID, req.Entries)
+	if err != nil {
+		if errors.Is(err, edgesync.ErrReconcileTooLarge) {
+			return c.Status(fiber.StatusRequestEntityTooLarge).JSON(fiber.Map{
+				"error":       err.Error(),
+				"max_entries": h.reconciler.MaxEntries(),
+			})
+		}
+		if errors.Is(err, edgesync.ErrReceiveInternal) {
+			h.logger.Error().Err(err).Str("spoke_id", spokeID).Msg("Reconcile failed for a hub-side reason")
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"error":  "hub temporarily unable to reconcile",
+				"reason": "hub_unavailable",
+			})
+		}
+		h.logger.Warn().Err(err).Str("spoke_id", spokeID).Msg("Reconcile rejected an invalid request")
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	// Empty slices rather than null: a spoke iterating the response should not
+	// have to special-case a missing field.
+	return c.Status(fiber.StatusOK).JSON(reconcileResponse{
+		Missing:   orEmpty(res.Missing),
+		Present:   orEmpty(res.Present),
+		Conflicts: orEmptyConflicts(res.Conflicts),
+	})
+}
+
+// maxReconcileBytes bounds the request body from the entry cap.
+//
+// Derived rather than configured separately so the two cannot drift. The
+// figure is measured, not guessed: a minimal legal entry JSON-encodes to 96
+// bytes (a one-character path plus a 64-character digest) and a realistic Arc
+// entry — a full compacted path with a size — to 189. An earlier version used
+// 512, which sounded "generous" but let the byte check admit roughly five
+// times the entry cap, so the only bound applied BEFORE authentication was
+// five times looser than intended.
+//
+// 256 covers a realistic entry with room to spare while keeping the pre-auth
+// bound close to the entry cap. A batch of legitimately long paths that
+// overshoots is still answered correctly — it is refused with a 413 naming the
+// entry limit, which is what a spoke needs to page under.
+func (h *EdgeSyncHandler) maxReconcileBytes() int64 {
+	const bytesPerEntry = 256
+	return int64(h.reconciler.MaxEntries()) * bytesPerEntry
+}
+
+type reconcileRequest struct {
+	Entries []edgesync.ReconcileEntry `json:"entries"`
+}
+
+type reconcileResponse struct {
+	Missing   []string            `json:"missing"`
+	Present   []string            `json:"present"`
+	Conflicts []edgesync.Conflict `json:"conflicts"`
+}
+
+func orEmpty(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func orEmptyConflicts(c []edgesync.Conflict) []edgesync.Conflict {
+	if c == nil {
+		return []edgesync.Conflict{}
+	}
+	return c
 }
 
 // authFailure reports an authentication problem without leaking which check

--- a/internal/api/edgesync_test.go
+++ b/internal/api/edgesync_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -21,6 +22,7 @@ import (
 	"github.com/basekick-labs/arc/internal/edgesync"
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/gofiber/fiber/v2"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog"
 )
 
@@ -58,13 +60,19 @@ func newSyncTestRig(t *testing.T) *syncTestRig {
 	}
 	t.Cleanup(func() { backend.Close() })
 
-	recv, err := edgesync.NewReceiver(edgesync.ReceiverConfig{Backend: backend, Logger: zerolog.Nop()})
+	idx := newTestAPIHubIndex(t)
+	recv, err := edgesync.NewReceiver(edgesync.ReceiverConfig{Backend: backend, Index: idx, Logger: zerolog.Nop()})
 	if err != nil {
 		t.Fatalf("receiver: %v", err)
+	}
+	rec, err := edgesync.NewReconciler(edgesync.ReconcilerConfig{Index: idx, Backend: backend, MaxEntries: 100})
+	if err != nil {
+		t.Fatalf("reconciler: %v", err)
 	}
 
 	h, err := NewEdgeSyncHandler(EdgeSyncHandlerConfig{
 		Receiver:     recv,
+		Reconciler:   rec,
 		SpokeSecrets: StaticSpokeSecrets(map[string]string{testSpokeID: testSecret}),
 		Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
 		HubID:        testHubID,
@@ -453,6 +461,7 @@ func TestNewEdgeSyncHandler_RequiresSecurityDependencies(t *testing.T) {
 
 	base := EdgeSyncHandlerConfig{
 		Receiver:     recv,
+		Reconciler:   mustReconciler(t),
 		SpokeSecrets: StaticSpokeSecrets(map[string]string{testSpokeID: testSecret}),
 		Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
 		HubID:        testHubID,
@@ -467,6 +476,7 @@ func TestNewEdgeSyncHandler_RequiresSecurityDependencies(t *testing.T) {
 		mutate func(*EdgeSyncHandlerConfig)
 	}{
 		{"no receiver", func(c *EdgeSyncHandlerConfig) { c.Receiver = nil }},
+		{"no reconciler", func(c *EdgeSyncHandlerConfig) { c.Reconciler = nil }},
 		{"no spoke secrets", func(c *EdgeSyncHandlerConfig) { c.SpokeSecrets = nil }},
 		{"no replay guard", func(c *EdgeSyncHandlerConfig) { c.Replay = nil }},
 		{"no hub ID", func(c *EdgeSyncHandlerConfig) { c.HubID = "" }},
@@ -657,8 +667,13 @@ func TestEdgeSyncHandler_HubSideFailureIs503NotBadRequest(t *testing.T) {
 		t.Fatalf("receiver: %v", err)
 	}
 
+	rec2, err := edgesync.NewReconciler(edgesync.ReconcilerConfig{Index: newTestAPIHubIndex(t), Backend: backend, MaxEntries: 100})
+	if err != nil {
+		t.Fatalf("reconciler: %v", err)
+	}
 	h, err := NewEdgeSyncHandler(EdgeSyncHandlerConfig{
 		Receiver:     recv,
+		Reconciler:   rec2,
 		SpokeSecrets: StaticSpokeSecrets(map[string]string{testSpokeID: testSecret}),
 		Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
 		HubID:        testHubID,
@@ -687,5 +702,272 @@ func TestEdgeSyncHandler_HubSideFailureIs503NotBadRequest(t *testing.T) {
 	// The message must not leak hub internals to a spoke.
 	if msg, _ := got["error"].(string); strings.Contains(msg, "raft") {
 		t.Errorf("error message leaks hub internals: %q", msg)
+	}
+}
+
+// newTestAPIHubIndex builds a hub index on a temp SQLite file.
+func newTestAPIHubIndex(t *testing.T) *edgesync.HubIndex {
+	t.Helper()
+	f, err := os.CreateTemp("", "api-hub-index-*.db")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+	db, err := sql.Open("sqlite3", f.Name())
+	if err != nil {
+		os.Remove(f.Name())
+		t.Fatalf("open sqlite: %v", err)
+	}
+	idx, err := edgesync.NewHubIndex(db, zerolog.Nop())
+	if err != nil {
+		db.Close()
+		os.Remove(f.Name())
+		t.Fatalf("hub index: %v", err)
+	}
+	t.Cleanup(func() { db.Close(); os.Remove(f.Name()) })
+	return idx
+}
+
+func mustReconciler(t *testing.T) *edgesync.Reconciler {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "api-recon-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	b, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { b.Close() })
+	r, err := edgesync.NewReconciler(edgesync.ReconcilerConfig{Index: newTestAPIHubIndex(t), Backend: b, MaxEntries: 100})
+	if err != nil {
+		t.Fatalf("reconciler: %v", err)
+	}
+	return r
+}
+
+// reconcileReq builds a signed reconcile request.
+type reconcileReqSpec struct {
+	spokeID, hubID string
+	nonce          string
+	ts             int64
+	body           []byte
+	macOverride    string
+	secret         string
+}
+
+func defaultReconcileReq(entries []edgesync.ReconcileEntry) reconcileReqSpec {
+	nonce, _ := security.GenerateNonce()
+	body, _ := json.Marshal(map[string]any{"entries": entries})
+	return reconcileReqSpec{
+		spokeID: testSpokeID,
+		hubID:   testHubID,
+		nonce:   nonce,
+		ts:      time.Now().Unix(),
+		body:    body,
+		secret:  testSecret,
+	}
+}
+
+func (r reconcileReqSpec) do(t *testing.T, rig *syncTestRig) *http.Response {
+	t.Helper()
+	mac := r.macOverride
+	if mac == "" {
+		var err error
+		mac, err = security.ComputeSyncReconcileHMAC(r.secret, r.nonce, r.spokeID, r.hubID, r.body, r.ts)
+		if err != nil {
+			t.Fatalf("compute MAC: %v", err)
+		}
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync/reconcile", bytes.NewReader(r.body))
+	req.Header.Set(headerSpokeID, r.spokeID)
+	req.Header.Set(headerHubID, r.hubID)
+	req.Header.Set(headerNonce, r.nonce)
+	req.Header.Set(headerTS, strconv.FormatInt(r.ts, 10))
+	req.Header.Set(headerMAC, mac)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := rig.app.Test(req, 10_000)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	return resp
+}
+
+func TestEdgeSyncHandler_ReconcileRoundTrip(t *testing.T) {
+	rig := newSyncTestRig(t)
+
+	// Upload one file so the hub has something to report as present.
+	body := []byte("parquet payload")
+	if resp := defaultReq(body).do(t, rig); resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("seed upload: status %d", resp.StatusCode)
+	}
+
+	entries := []edgesync.ReconcileEntry{
+		{Path: testSyncPth, SHA256: testDigest(body)},
+		{Path: "metrics/cpu/2026/08/07/14/never_sent.parquet", SHA256: testDigest([]byte("other"))},
+	}
+	resp := defaultReconcileReq(entries).do(t, rig)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%v", resp.StatusCode, decodeBody(t, resp))
+	}
+
+	got := decodeBody(t, resp)
+	present, _ := got["present"].([]any)
+	missing, _ := got["missing"].([]any)
+	if len(present) != 1 || present[0] != testSyncPth {
+		t.Errorf("present = %v, want the uploaded file", present)
+	}
+	if len(missing) != 1 {
+		t.Errorf("missing = %v, want the file never sent", missing)
+	}
+	// Empty slices rather than null, so a spoke need not special-case the field.
+	if _, ok := got["conflicts"].([]any); !ok {
+		t.Errorf("conflicts = %v, want an empty array not null", got["conflicts"])
+	}
+}
+
+func TestEdgeSyncHandler_ReconcileRejectsUnauthenticated(t *testing.T) {
+	rig := newSyncTestRig(t)
+	entries := []edgesync.ReconcileEntry{{Path: testSyncPth, SHA256: testDigest([]byte("x"))}}
+
+	tests := []struct {
+		name   string
+		mutate func(*reconcileReqSpec)
+	}{
+		{"wrong secret", func(r *reconcileReqSpec) { r.secret = "not-the-secret" }},
+		{"unknown spoke", func(r *reconcileReqSpec) { r.spokeID = "rocket-99"; r.secret = "its-own-secret" }},
+		{"expired timestamp", func(r *reconcileReqSpec) {
+			r.ts = time.Now().Add(-2 * security.HMACTimestampTolerance).Unix()
+		}},
+		{"body swapped after signing", func(r *reconcileReqSpec) {
+			// The MAC binds a digest of the body precisely so a replayed
+			// request cannot substitute a different path list and use the hub
+			// as an oracle for what data exists.
+			mac, _ := security.ComputeSyncReconcileHMAC(r.secret, r.nonce, r.spokeID, r.hubID, r.body, r.ts)
+			r.macOverride = mac
+			r.body, _ = json.Marshal(map[string]any{"entries": []edgesync.ReconcileEntry{
+				{Path: "metrics/secret/2026/08/07/14/probe.parquet", SHA256: testDigest([]byte("probe"))},
+			}})
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := defaultReconcileReq(entries)
+			tt.mutate(&r)
+			if resp := r.do(t, rig); resp.StatusCode != fiber.StatusUnauthorized {
+				t.Errorf("status = %d, want 401", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestEdgeSyncHandler_ReconcileRejectsReplay(t *testing.T) {
+	rig := newSyncTestRig(t)
+	r := defaultReconcileReq([]edgesync.ReconcileEntry{{Path: testSyncPth, SHA256: testDigest([]byte("x"))}})
+
+	if resp := r.do(t, rig); resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("first: status %d", resp.StatusCode)
+	}
+	resp := r.do(t, rig)
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("replay: status = %d, want 401", resp.StatusCode)
+	}
+	if got := decodeBody(t, resp); got["reason"] != "replay" {
+		t.Errorf("reason = %v, want replay", got["reason"])
+	}
+}
+
+func TestEdgeSyncHandler_ReconcileRejectsOversizedBatch(t *testing.T) {
+	rig := newSyncTestRig(t)
+
+	// The rig caps at 100 entries. An unbounded batch is a pre-auth memory
+	// claim, since the body is buffered before routing.
+	entries := make([]edgesync.ReconcileEntry, 101)
+	for i := range entries {
+		entries[i] = edgesync.ReconcileEntry{
+			Path:   fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%d.parquet", i),
+			SHA256: testDigest([]byte(fmt.Sprint(i))),
+		}
+	}
+
+	resp := defaultReconcileReq(entries).do(t, rig)
+	if resp.StatusCode != fiber.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+	if got := decodeBody(t, resp); got["max_entries"] == nil {
+		t.Error("the 413 response does not tell the spoke the limit it must page under")
+	}
+}
+
+func TestEdgeSyncHandler_ReconcileRejectsMalformedBody(t *testing.T) {
+	rig := newSyncTestRig(t)
+
+	r := defaultReconcileReq(nil)
+	r.body = []byte("{not json")
+	// The MAC must still be computed over the malformed bytes, so this
+	// exercises body parsing rather than authentication.
+	mac, err := security.ComputeSyncReconcileHMAC(r.secret, r.nonce, r.spokeID, r.hubID, r.body, r.ts)
+	if err != nil {
+		t.Fatalf("mac: %v", err)
+	}
+	r.macOverride = mac
+
+	if resp := r.do(t, rig); resp.StatusCode != fiber.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestEdgeSyncHandler_ReconcileRejectsMaliciousPaths(t *testing.T) {
+	rig := newSyncTestRig(t)
+
+	// Signed by a legitimate spoke, so this models a COMPROMISED edge trying
+	// to probe outside its namespace. The MAC proves who is asking, not that
+	// what they ask about is theirs.
+	for _, p := range []string{
+		"../../../etc/passwd.parquet",
+		"/absolute/path.parquet",
+		".sync-staging/rocket-02/steal.parquet",
+	} {
+		t.Run(p, func(t *testing.T) {
+			entries := []edgesync.ReconcileEntry{{Path: p, SHA256: testDigest([]byte("x"))}}
+			if resp := defaultReconcileReq(entries).do(t, rig); resp.StatusCode == fiber.StatusOK {
+				t.Errorf("path %q was accepted", p)
+			}
+		})
+	}
+}
+
+func TestEdgeSyncHandler_ReconcileRejectsOversizedBodyBeforeAuth(t *testing.T) {
+	rig := newSyncTestRig(t)
+
+	// The Content-Length guard is the ONLY bound applied before
+	// authentication, so it must be exercised by a body that actually exceeds
+	// it. An earlier version of this suite could not: with a 100-entry cap the
+	// byte threshold was 25,600 while a 101-entry body was only ~12KB, so the
+	// guard was unreachable and deleting it left every test green.
+	//
+	// Padding the paths pushes the body past the byte threshold while keeping
+	// the entry count under the cap, isolating the pre-auth guard.
+	pad := strings.Repeat("p", 400)
+	entries := make([]edgesync.ReconcileEntry, 90)
+	for i := range entries {
+		entries[i] = edgesync.ReconcileEntry{
+			Path:   fmt.Sprintf("metrics/cpu/2026/08/07/14/%s_%d.parquet", pad, i),
+			SHA256: testDigest([]byte(fmt.Sprint(i))),
+		}
+	}
+
+	r := defaultReconcileReq(entries)
+	if len(r.body) <= 90*256 {
+		t.Fatalf("test body is %d bytes, not above the %d-byte guard — the guard would not be exercised",
+			len(r.body), 90*256)
+	}
+
+	resp := r.do(t, rig)
+	if resp.StatusCode != fiber.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413 — an oversized body was accepted before auth", resp.StatusCode)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,6 +204,15 @@ type EdgeSyncConfig struct {
 	// Default 512MiB, comfortably above a compacted Parquet file
 	// (compaction.max_files_per_batch keeps those well below it).
 	MaxFileBytes int64
+
+	// MaxReconcileEntries caps one batch-discovery request.
+	//
+	// The design wants a spoke's whole pending set in one round-trip, but the
+	// request body is buffered before authentication (see MaxFileBytes), so an
+	// unbounded batch is a pre-auth memory claim. Capping and letting the
+	// spoke page keeps what matters — discovery costs O(batches), not
+	// O(files) — while bounding the exposure. Default 10,000 entries (~2MB).
+	MaxReconcileEntries int
 }
 
 type WALConfig struct {
@@ -644,9 +653,10 @@ func Load() (*Config, error) {
 			ForceBootstrap: v.GetBool("auth.force_bootstrap"),
 		},
 		EdgeSync: EdgeSyncConfig{
-			Enabled:      v.GetBool("edge_sync.enabled"),
-			HubID:        v.GetString("edge_sync.hub_id"),
-			MaxFileBytes: int64(v.GetInt64("edge_sync.max_file_bytes")),
+			Enabled:             v.GetBool("edge_sync.enabled"),
+			HubID:               v.GetString("edge_sync.hub_id"),
+			MaxFileBytes:        int64(v.GetInt64("edge_sync.max_file_bytes")),
+			MaxReconcileEntries: v.GetInt("edge_sync.max_reconcile_entries"),
 		},
 		Compaction: CompactionConfig{
 			Enabled:                     v.GetBool("compaction.enabled"),
@@ -1003,6 +1013,19 @@ func Load() (*Config, error) {
 		if len(cfg.EdgeSync.HubID) > 128 {
 			return nil, fmt.Errorf("edge_sync.hub_id is %d bytes; the maximum is 128", len(cfg.EdgeSync.HubID))
 		}
+		if cfg.EdgeSync.MaxReconcileEntries <= 0 {
+			return nil, fmt.Errorf("edge_sync.max_reconcile_entries must be > 0 (got %d)", cfg.EdgeSync.MaxReconcileEntries)
+		}
+		// An upper bound matters as much as the lower one: this cap is what
+		// bounds a pre-authentication memory claim, so a value large enough to
+		// make it meaningless defeats its only purpose. 1,000,000 entries is
+		// already ~190MB of body at a realistic entry size.
+		const maxReconcileEntriesCeiling = 1_000_000
+		if cfg.EdgeSync.MaxReconcileEntries > maxReconcileEntriesCeiling {
+			return nil, fmt.Errorf("edge_sync.max_reconcile_entries is %d; the maximum is %d "+
+				"(the cap exists to bound a pre-auth memory claim, so an unbounded value defeats it)",
+				cfg.EdgeSync.MaxReconcileEntries, maxReconcileEntriesCeiling)
+		}
 		if cfg.EdgeSync.MaxFileBytes <= 0 {
 			return nil, fmt.Errorf("edge_sync.max_file_bytes must be > 0 (got %d)", cfg.EdgeSync.MaxFileBytes)
 		}
@@ -1095,6 +1118,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("edge_sync.enabled", false)
 	v.SetDefault("edge_sync.hub_id", "")
 	v.SetDefault("edge_sync.max_file_bytes", 512*1024*1024) // 512MiB per upload
+	v.SetDefault("edge_sync.max_reconcile_entries", 10000)  // ~2MB per discovery batch
 
 	v.SetDefault("compaction.enabled", true)
 	v.SetDefault("compaction.hourly_schedule", "5 * * * *")        // Every hour at :05

--- a/internal/edgesync/hubindex.go
+++ b/internal/edgesync/hubindex.go
@@ -1,0 +1,253 @@
+package edgesync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// HubIndex records what a hub has received, so reconcile can answer without
+// touching parquet bytes.
+//
+// §5.1 assumes the hub answers missing/present/conflicts "from its manifest in
+// O(N) lookups, no I/O on the parquet bytes". That manifest is the Raft FSM,
+// which exists only in cluster mode — in OSS standalone there is no file index
+// at all, and distinguishing present from conflict would mean reading and
+// hashing every candidate file. For a spoke returning from a long outage that
+// is gigabytes of disk reads on the one request that exists to be cheap.
+//
+// So the hub keeps its own index. The receive path already knows every file's
+// path, digest, and size at commit time, so recording them costs one small
+// write on a path that has just done a full hash and a promote.
+//
+// It is keyed by the SPOKE's path rather than the hub's namespaced path,
+// because that is what a spoke asks about: it has no idea the hub prepends a
+// namespace.
+type HubIndex struct {
+	db     *sql.DB
+	logger zerolog.Logger
+}
+
+// ReceivedRecord is one file the hub holds, as the spoke knows it.
+type ReceivedRecord struct {
+	SpokeID    string
+	SourcePath string // the spoke's own path, before hub namespacing
+	HubPath    string // where the hub actually stored it
+	SHA256     string
+	SizeBytes  int64
+	ReceivedAt time.Time
+}
+
+// NewHubIndex creates the index and initializes its schema.
+func NewHubIndex(db *sql.DB, logger zerolog.Logger) (*HubIndex, error) {
+	if db == nil {
+		return nil, errors.New("edgesync: hub index requires a non-nil database")
+	}
+	h := &HubIndex{db: db, logger: logger}
+	if err := h.initSchema(); err != nil {
+		return nil, fmt.Errorf("edgesync: initialize hub index schema: %w", err)
+	}
+	return h, nil
+}
+
+func (h *HubIndex) initSchema() error {
+	const schema = `
+	CREATE TABLE IF NOT EXISTS sync_received (
+		id           INTEGER PRIMARY KEY AUTOINCREMENT,
+		spoke_id     TEXT NOT NULL,
+		source_path  TEXT NOT NULL,
+		hub_path     TEXT NOT NULL,
+		sha256       TEXT NOT NULL,
+		size_bytes   INTEGER NOT NULL,
+		received_at  TIMESTAMP NOT NULL,
+		UNIQUE(spoke_id, source_path)
+	);
+
+	-- Reconcile looks up (spoke_id, source_path) for every entry in a batch,
+	-- so the UNIQUE index above is the hot path. This one serves operator
+	-- queries ("what has rocket-07 sent, newest first") without scanning.
+	CREATE INDEX IF NOT EXISTS idx_sync_received_spoke
+		ON sync_received(spoke_id, received_at);
+	`
+
+	if _, err := h.db.Exec(schema); err != nil {
+		return fmt.Errorf("create sync_received table: %w", err)
+	}
+	h.logger.Debug().Msg("Sync hub index schema initialized")
+	return nil
+}
+
+// Record notes that the hub holds a file.
+//
+// Upserts on (spoke_id, source_path): the digest is allowed to change here
+// because the receive path only reaches this point after verifying the bytes,
+// so a differing digest means the file was legitimately replaced rather than
+// that two spokes collided. A conflicting upload never gets this far — it is
+// refused with 409 before promotion.
+func (h *HubIndex) Record(ctx context.Context, r *ReceivedRecord) error {
+	receivedAt := r.ReceivedAt
+	if receivedAt.IsZero() {
+		receivedAt = time.Now()
+	}
+
+	_, err := h.db.ExecContext(ctx, `
+		INSERT INTO sync_received
+			(spoke_id, source_path, hub_path, sha256, size_bytes, received_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(spoke_id, source_path) DO UPDATE SET
+			hub_path    = excluded.hub_path,
+			sha256      = excluded.sha256,
+			size_bytes  = excluded.size_bytes,
+			received_at = excluded.received_at`,
+		r.SpokeID, r.SourcePath, r.HubPath, r.SHA256, r.SizeBytes, receivedAt.UTC())
+	if err != nil {
+		return fmt.Errorf("edgesync: record received %q: %w", r.SourcePath, err)
+	}
+	return nil
+}
+
+// Lookup returns the digests the hub holds for the given paths from one spoke.
+//
+// Batched deliberately: reconcile asks about thousands of paths at once, and
+// issuing one query per path would make the round-trip the design saved on the
+// wire reappear as a query storm against SQLite. The result maps source path
+// to digest; a path absent from the map is one the hub does not hold.
+func (h *HubIndex) Lookup(ctx context.Context, spokeID string, paths []string) (map[string]string, error) {
+	out := make(map[string]string, len(paths))
+	if len(paths) == 0 {
+		return out, nil
+	}
+
+	// Chunked well below SQLITE_MAX_VARIABLE_NUMBER. The limit in this build
+	// is 32766, not the 999 of older SQLite — measured, not assumed — but 900
+	// is kept deliberately: it stays under the historical limit so the code
+	// does not depend on which SQLite a deployment links, and it bounds how
+	// long any single statement holds the shared writer.
+	const chunkSize = 900
+
+	for start := 0; start < len(paths); start += chunkSize {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		end := start + chunkSize
+		if end > len(paths) {
+			end = len(paths)
+		}
+		chunk := paths[start:end]
+
+		query := `SELECT source_path, sha256 FROM sync_received WHERE spoke_id = ? AND source_path IN (?` +
+			strings.Repeat(",?", len(chunk)-1) + `)`
+
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, spokeID)
+		for _, p := range chunk {
+			args = append(args, p)
+		}
+
+		// Scanned inside a closure so rows.Close is deferred rather than
+		// called manually on each path. sharedSQLiteHandle sets
+		// SetMaxOpenConns(1), so a single leaked cursor blocks every
+		// subsequent query on a handle shared with auth, audit, and ingest
+		// file-registration — a scan error here would wedge all of them.
+		if err := func() error {
+			rows, err := h.db.QueryContext(ctx, query, args...)
+			if err != nil {
+				return fmt.Errorf("edgesync: lookup received: %w", err)
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				var p, sha string
+				if err := rows.Scan(&p, &sha); err != nil {
+					return fmt.Errorf("edgesync: scan received: %w", err)
+				}
+				out[p] = sha
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("edgesync: iterate received: %w", err)
+			}
+			return nil
+		}(); err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// Forget removes a spoke's record for a path.
+//
+// TODO(#569): NOT YET CALLED IN PRODUCTION, and the gap has teeth. If hub-side
+// retention deletes a synced file from storage without calling this, the index
+// keeps claiming the hub holds it, so reconcile reports it `present` and the
+// spoke marks it synced. A spoke configured with delete_after_sync (phase 3)
+// would then be free to delete its only copy of data the hub no longer has.
+//
+// Two things keep that from being a live hazard today: delete_after_sync does
+// not exist yet, and nothing on the hub deletes files inside a spoke namespace
+// — Arc retention operates on its own ingested databases. Whoever adds either
+// MUST call this, and phase 3 must not ship before it is wired.
+func (h *HubIndex) Forget(ctx context.Context, spokeID, sourcePath string) error {
+	_, err := h.db.ExecContext(ctx,
+		`DELETE FROM sync_received WHERE spoke_id = ? AND source_path = ?`,
+		spokeID, sourcePath)
+	if err != nil {
+		return fmt.Errorf("edgesync: forget %q: %w", sourcePath, err)
+	}
+	return nil
+}
+
+// ForgetBatch removes several of a spoke's records in one statement per chunk.
+//
+// Batched because the alternative — one DELETE per stale row inside a request
+// handler — lands on the SQLite handle shared with ingest file-registration,
+// auth, and audit. A spoke reconciling after a retention sweep can present
+// thousands of stale rows at once, and issuing that many separate implicit
+// transactions on the single writer would contend with ingest for the duration
+// of the request.
+func (h *HubIndex) ForgetBatch(ctx context.Context, spokeID string, paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	const chunkSize = 900
+	for start := 0; start < len(paths); start += chunkSize {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := start + chunkSize
+		if end > len(paths) {
+			end = len(paths)
+		}
+		chunk := paths[start:end]
+
+		query := `DELETE FROM sync_received WHERE spoke_id = ? AND source_path IN (?` +
+			strings.Repeat(",?", len(chunk)-1) + `)`
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, spokeID)
+		for _, p := range chunk {
+			args = append(args, p)
+		}
+
+		if _, err := h.db.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("edgesync: forget batch: %w", err)
+		}
+	}
+	return nil
+}
+
+// CountForSpoke returns how many files the hub holds from a spoke.
+func (h *HubIndex) CountForSpoke(ctx context.Context, spokeID string) (int64, error) {
+	var n int64
+	err := h.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sync_received WHERE spoke_id = ?`, spokeID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: count received for %q: %w", spokeID, err)
+	}
+	return n, nil
+}

--- a/internal/edgesync/receive.go
+++ b/internal/edgesync/receive.go
@@ -44,6 +44,12 @@ type Receiver struct {
 	backend storage.Backend
 	logger  zerolog.Logger
 
+	// index records what the hub holds so reconcile can answer without
+	// reading parquet bytes. Nil disables recording — reconcile then reports
+	// every file as missing, which is safe (the spoke re-sends and gets
+	// AlreadyPresent) but wasteful, so the hub always wires one.
+	index *HubIndex
+
 	// registerFile publishes a committed file so readers can see it. In
 	// cluster mode this proposes to the Raft manifest; standalone it is nil,
 	// because a local backend's directory listing IS the manifest.
@@ -133,6 +139,10 @@ type ReceiverConfig struct {
 	Backend storage.Backend
 	Logger  zerolog.Logger
 
+	// Index records received files for reconcile. Optional but strongly
+	// recommended; without it reconcile cannot report anything as present.
+	Index *HubIndex
+
 	// RegisterFile is called after a file is verified and promoted. Leave nil
 	// in standalone mode.
 	RegisterFile func(ctx context.Context, f *ReceivedFile) error
@@ -145,6 +155,7 @@ func NewReceiver(cfg ReceiverConfig) (*Receiver, error) {
 	}
 	return &Receiver{
 		backend: cfg.Backend,
+		index:   cfg.Index,
 		// No .Str("component", ...) here: logger.Get already sets it, and a
 		// second one emits a duplicate JSON key that strict parsers and log
 		// aggregators mishandle.
@@ -305,7 +316,33 @@ func (r *Receiver) Receive(ctx context.Context, spokeID, sourcePath, declaredSHA
 		}
 	}
 
+	// Recorded AFTER registration so the index never claims a file that
+	// readers cannot see. The reverse order would make reconcile report a file
+	// as present while it is still invisible, and the spoke would mark it
+	// synced and stop re-sending.
+	if err := r.recordReceived(ctx, spokeID, sourcePath, finalPath, declaredSHA256, declaredSize); err != nil {
+		return nil, err
+	}
+
 	return &PutResult{Outcome: OutcomeCommitted, BytesAccepted: declaredSize}, nil
+}
+
+// recordReceived notes a committed file in the hub index.
+func (r *Receiver) recordReceived(ctx context.Context, spokeID, sourcePath, finalPath, sha string, size int64) error {
+	if r.index == nil {
+		return nil
+	}
+	err := r.index.Record(ctx, &ReceivedRecord{
+		SpokeID:    spokeID,
+		SourcePath: sourcePath,
+		HubPath:    finalPath,
+		SHA256:     sha,
+		SizeBytes:  size,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrReceiveInternal, err)
+	}
+	return nil
 }
 
 // register publishes a committed file to the manifest.
@@ -347,6 +384,13 @@ func (r *Receiver) resolveExisting(ctx context.Context, spokeID, sourcePath, fin
 			if err := r.register(ctx, spokeID, sourcePath, finalPath, declaredSHA256, size); err != nil {
 				return nil, err
 			}
+		}
+		// Re-record for the same reason registration is re-attempted: if a
+		// previous attempt committed the bytes but failed to index them, the
+		// hub would keep reporting this file as missing and the spoke would
+		// keep re-sending it forever.
+		if err := r.recordReceived(ctx, spokeID, sourcePath, finalPath, declaredSHA256, size); err != nil {
+			return nil, err
 		}
 		return &PutResult{Outcome: OutcomeAlreadyPresent, BytesAccepted: size}, nil
 	}

--- a/internal/edgesync/reconcile.go
+++ b/internal/edgesync/reconcile.go
@@ -1,0 +1,245 @@
+package edgesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/basekick-labs/arc/internal/storage"
+)
+
+// MaxReconcileEntriesDefault bounds one reconcile batch.
+//
+// §5.1 wants the whole pending set in a single round-trip, and notes 100k
+// entries ≈ 20MB. Arc cannot honor that literally: the Fiber app runs with
+// StreamRequestBody=false (api/server.go) so fasthttp buffers the entire
+// request body before routing — and therefore before authentication. An
+// unbounded reconcile would let anyone able to reach the port make the hub
+// hold tens of megabytes per connection.
+//
+// Capping and letting the spoke page keeps the property that actually matters:
+// discovery costs O(batches), not O(files), so 5,000 pending files is one
+// request rather than 5,000. At ~200 bytes per entry this is ~2MB.
+const MaxReconcileEntriesDefault = 10_000
+
+// ErrReconcileTooLarge is returned when a batch exceeds the configured cap.
+// The spoke's remedy is to split the batch, not to retry it unchanged.
+var ErrReconcileTooLarge = errors.New("edgesync: reconcile batch exceeds the configured maximum")
+
+// ReconcileEntry is one file a spoke is asking about.
+type ReconcileEntry struct {
+	Path      string `json:"path"`
+	SHA256    string `json:"sha256"`
+	SizeBytes int64  `json:"size,omitempty"`
+}
+
+// Reconciler answers "which of these files do you already have?" for a spoke.
+type Reconciler struct {
+	index      *HubIndex
+	backend    storage.Backend
+	maxEntries int
+}
+
+// ReconcilerConfig configures a Reconciler.
+type ReconcilerConfig struct {
+	Index *HubIndex
+
+	// Backend confirms a file the index claims still exists in storage.
+	//
+	// Required, and the reason is data loss rather than tidiness. The index
+	// records what the hub RECEIVED; it does not learn about deletions.
+	// Anything that removes a file from the hub — Arc retention pointed at a
+	// spoke's namespace (its prefix is an operator-chosen string, so
+	// `database = "rocket-01"` sweeps that spoke), a cold-tier migration, an
+	// operator with rm — leaves the index asserting a file the hub no longer
+	// has. Reporting that as `present` makes the spoke mark it synced, and a
+	// spoke configured to reclaim space would then delete its only copy.
+	//
+	// Confirming costs one stat per candidate the index claims (~3µs on local
+	// disk, so ~31ms for a 10k batch) and no parquet reads, which keeps §5.1's
+	// actual promise: reconcile does not read file contents.
+	Backend storage.Backend
+
+	// MaxEntries caps one batch. Zero uses MaxReconcileEntriesDefault.
+	MaxEntries int
+}
+
+// NewReconciler validates configuration and returns a ready Reconciler.
+func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
+	if cfg.Index == nil {
+		return nil, errors.New("edgesync: reconciler requires a hub index")
+	}
+	if cfg.Backend == nil {
+		return nil, errors.New("edgesync: reconciler requires a storage backend to confirm indexed files still exist")
+	}
+	max := cfg.MaxEntries
+	if max <= 0 {
+		max = MaxReconcileEntriesDefault
+	}
+	return &Reconciler{index: cfg.Index, backend: cfg.Backend, maxEntries: max}, nil
+}
+
+// MaxEntries reports the configured per-batch cap, so a handler can reject an
+// oversized request before decoding it.
+func (r *Reconciler) MaxEntries() int { return r.maxEntries }
+
+// Reconcile partitions a spoke's pending set into what the hub is missing,
+// what it already holds, and what disagrees.
+//
+// Answered entirely from the hub index — one batched SQLite lookup, no reads
+// of parquet bytes — which is what makes this affordable for a spoke returning
+// from a long outage. §6.1's identity rule decides each entry: absent is
+// missing, a matching digest is present, and a differing digest is a conflict.
+func (r *Reconciler) Reconcile(ctx context.Context, spokeID string, entries []ReconcileEntry) (*ReconcileResult, error) {
+	if err := validateSpokeID(spokeID); err != nil {
+		return nil, err
+	}
+	if len(entries) > r.maxEntries {
+		return nil, fmt.Errorf("%w: %d entries, maximum %d", ErrReconcileTooLarge, len(entries), r.maxEntries)
+	}
+
+	// Validate before looking anything up. A malformed entry means the spoke
+	// is confused or hostile, and answering part of a bad batch would leave it
+	// unable to tell which entries were actually considered.
+	paths := make([]string, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for i, e := range entries {
+		if err := validateSyncPath(e.Path); err != nil {
+			return nil, fmt.Errorf("edgesync: reconcile entry %d: %w", i, err)
+		}
+		if !isHexSHA256(e.SHA256) {
+			return nil, fmt.Errorf("edgesync: reconcile entry %d: sha256 %q is not a 64-character hex digest", i, e.SHA256)
+		}
+		// A duplicate path within one batch has no correct answer — the same
+		// path cannot be both present and conflicted — and would produce a
+		// result that ReconcileResult.Validate rejects.
+		if _, dup := seen[e.Path]; dup {
+			return nil, fmt.Errorf("edgesync: reconcile batch contains %q twice", e.Path)
+		}
+		seen[e.Path] = struct{}{}
+		paths = append(paths, e.Path)
+	}
+
+	held, err := r.index.Lookup(ctx, spokeID, paths)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrReceiveInternal, err)
+	}
+
+	// Confirm the indexed files still exist before vouching for them, and do
+	// it concurrently. The index records receipts, not deletions, so a stale
+	// row would otherwise make the hub claim a file it no longer holds — see
+	// ReconcilerConfig.Backend.
+	stale, err := r.confirmPresent(ctx, spokeID, entries, held)
+	if err != nil {
+		return nil, err
+	}
+
+	// One batched delete rather than one per stale row. These land on the
+	// SQLite handle shared with ingest file-registration and auth, so a spoke
+	// reconciling after a retention sweep must not turn into a write storm on
+	// the single writer.
+	if len(stale) > 0 {
+		if err := r.index.ForgetBatch(ctx, spokeID, stale); err != nil {
+			return nil, fmt.Errorf("%w: forget stale entries: %w", ErrReceiveInternal, err)
+		}
+		for _, p := range stale {
+			delete(held, p)
+		}
+	}
+
+	res := &ReconcileResult{}
+	for _, e := range entries {
+		existing, ok := held[e.Path]
+
+		switch {
+		case !ok:
+			res.Missing = append(res.Missing, e.Path)
+		case existing == e.SHA256:
+			res.Present = append(res.Present, e.Path)
+		default:
+			// Same path, different content. Surfaced here for the whole
+			// backlog at once rather than discovered one 409 at a time during
+			// transfer — which is the point of doing this proactively.
+			res.Conflicts = append(res.Conflicts, Conflict{
+				Path:        e.Path,
+				TheirSHA256: existing,
+			})
+		}
+	}
+
+	// The hub must never emit a result its own validator would reject; a spoke
+	// calls Validate on everything it receives.
+	if err := res.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: built an invalid reconcile result: %w", ErrReceiveInternal, err)
+	}
+	return res, nil
+}
+
+// confirmExistenceConcurrency bounds how many existence checks run at once.
+//
+// On local disk a check is a ~5µs stat and concurrency barely matters. On S3
+// it is a HeadObject round-trip, and serially that is fatal: 10,000 entries at
+// a 20ms RTT is 200 seconds against a 2-minute request timeout, so an
+// S3-backed hub could not answer a full batch at all. The checks are
+// independent, so fanning them out turns that into a few seconds.
+//
+// 32 is deliberately modest — enough to hide per-request latency without
+// making one spoke's reconcile monopolize the backend's connection pool while
+// other spokes are transferring files.
+const confirmExistenceConcurrency = 32
+
+// confirmPresent checks that every file the index claims is still in storage,
+// and returns the paths that are not.
+func (r *Reconciler) confirmPresent(ctx context.Context, spokeID string, entries []ReconcileEntry, held map[string]string) ([]string, error) {
+	candidates := make([]string, 0, len(held))
+	for _, e := range entries {
+		if _, ok := held[e.Path]; ok {
+			candidates = append(candidates, e.Path)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	var (
+		mu    sync.Mutex
+		stale []string
+		wg    sync.WaitGroup
+	)
+	sem := make(chan struct{}, confirmExistenceConcurrency)
+	// Cancelled on the first failure so in-flight checks stop rather than
+	// finishing work whose result is already discarded.
+	checkCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var firstErr error
+	for _, p := range candidates {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(path string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			present, err := r.backend.Exists(checkCtx, NamespacedPath(spokeID, path))
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("%w: confirm %q: %w", ErrReceiveInternal, path, err)
+					cancel()
+				}
+				return
+			}
+			if !present {
+				stale = append(stale, path)
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return stale, nil
+}

--- a/internal/edgesync/reconcile_test.go
+++ b/internal/edgesync/reconcile_test.go
@@ -1,0 +1,543 @@
+package edgesync
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+)
+
+func newTestHubIndex(t *testing.T) *HubIndex {
+	t.Helper()
+
+	f, err := os.CreateTemp("", "hub-index-*.db")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+
+	db, err := sql.Open("sqlite3", f.Name())
+	if err != nil {
+		os.Remove(f.Name())
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA synchronous = OFF"); err != nil {
+		t.Fatalf("pragma: %v", err)
+	}
+
+	idx, err := NewHubIndex(db, zerolog.Nop())
+	if err != nil {
+		db.Close()
+		os.Remove(f.Name())
+		t.Fatalf("new hub index: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(f.Name())
+	})
+	return idx
+}
+
+// newTestReconciler returns a reconciler plus the backend behind it, so a test
+// can delete a file out from under the index.
+func newTestReconciler(t *testing.T) (*Reconciler, *HubIndex) {
+	t.Helper()
+	rec, idx, _ := newTestReconcilerWithBackend(t)
+	return rec, idx
+}
+
+func newTestReconcilerWithBackend(t *testing.T) (*Reconciler, *HubIndex, storage.Backend) {
+	t.Helper()
+	idx := newTestHubIndex(t)
+	dir, err := os.MkdirTemp("", "reconcile-backend-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	backend := newLocalBackendForTest(t, dir)
+
+	rec, err := NewReconciler(ReconcilerConfig{Index: idx, Backend: backend})
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	return rec, idx, backend
+}
+
+// seedFile records a file in the index AND writes it to storage, so reconcile's
+// existence confirmation finds it.
+func seedFile(t *testing.T, idx *HubIndex, backend storage.Backend, spokeID, path, sha string) {
+	t.Helper()
+	recordFile(t, idx, spokeID, path, sha)
+	if err := backend.Write(context.Background(), NamespacedPath(spokeID, path), []byte("x")); err != nil {
+		t.Fatalf("seed storage %s: %v", path, err)
+	}
+}
+
+func recordFile(t *testing.T, idx *HubIndex, spokeID, path, sha string) {
+	t.Helper()
+	if err := idx.Record(context.Background(), &ReceivedRecord{
+		SpokeID:    spokeID,
+		SourcePath: path,
+		HubPath:    NamespacedPath(spokeID, path),
+		SHA256:     sha,
+		SizeBytes:  100,
+	}); err != nil {
+		t.Fatalf("record %s: %v", path, err)
+	}
+}
+
+func TestReconcile_PartitionsTheBatch(t *testing.T) {
+	ctx := context.Background()
+	rec, idx, backend := newTestReconcilerWithBackend(t)
+
+	missing := ReconcileEntry{Path: "metrics/cpu/2026/08/07/14/a.parquet", SHA256: sha256Hex([]byte("a"))}
+	present := ReconcileEntry{Path: "metrics/cpu/2026/08/07/14/b.parquet", SHA256: sha256Hex([]byte("b"))}
+	conflict := ReconcileEntry{Path: "metrics/cpu/2026/08/07/14/c.parquet", SHA256: sha256Hex([]byte("spoke-version"))}
+
+	seedFile(t, idx, backend, "rocket-01", present.Path, present.SHA256)
+	seedFile(t, idx, backend, "rocket-01", conflict.Path, sha256Hex([]byte("hub-version")))
+
+	res, err := rec.Reconcile(ctx, "rocket-01", []ReconcileEntry{missing, present, conflict})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if err := res.Validate(); err != nil {
+		t.Fatalf("the hub built a result its own validator rejects: %v", err)
+	}
+
+	if len(res.Missing) != 1 || res.Missing[0] != missing.Path {
+		t.Errorf("missing = %v, want [%s]", res.Missing, missing.Path)
+	}
+	if len(res.Present) != 1 || res.Present[0] != present.Path {
+		t.Errorf("present = %v, want [%s]", res.Present, present.Path)
+	}
+	if len(res.Conflicts) != 1 {
+		t.Fatalf("conflicts = %v, want one", res.Conflicts)
+	}
+	// The hub's digest is the operator's only evidence for telling a
+	// spoke_id collision from corruption; echoing the spoke's own would make
+	// the conflict unactionable.
+	if res.Conflicts[0].TheirSHA256 == conflict.SHA256 {
+		t.Error("the conflict reports the spoke's digest; it must report the hub's")
+	}
+	if res.Conflicts[0].TheirSHA256 != sha256Hex([]byte("hub-version")) {
+		t.Errorf("TheirSHA256 = %q, want the hub's", res.Conflicts[0].TheirSHA256)
+	}
+}
+
+func TestReconcile_IsSpokeScoped(t *testing.T) {
+	ctx := context.Background()
+	rec, idx, backend := newTestReconcilerWithBackend(t)
+
+	// Two rockets legitimately produce the same native path. One having sent
+	// it must not make the hub claim it holds the other's.
+	const p = "metrics/cpu/2026/08/07/14/a.parquet"
+	sha := sha256Hex([]byte("payload"))
+	seedFile(t, idx, backend, "rocket-01", p, sha)
+
+	res, err := rec.Reconcile(ctx, "rocket-02", []ReconcileEntry{{Path: p, SHA256: sha}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Present) != 0 {
+		t.Errorf("present = %v, want empty — one spoke's file was credited to another", res.Present)
+	}
+	if len(res.Missing) != 1 {
+		t.Errorf("missing = %v, want the file", res.Missing)
+	}
+}
+
+func TestReconcile_LostAckRecovery(t *testing.T) {
+	ctx := context.Background()
+	rec, idx, backend := newTestReconcilerWithBackend(t)
+
+	// The whole point of `present`: a transfer completed but its ack never
+	// arrived, so the spoke still believes the file is pending. Reconcile
+	// tells it the truth in bulk, and it advances without re-sending bytes.
+	entries := make([]ReconcileEntry, 0, 50)
+	for i := 0; i < 50; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%d.parquet", i)
+		sha := sha256Hex([]byte(fmt.Sprintf("payload %d", i)))
+		seedFile(t, idx, backend, "rocket-01", p, sha)
+		entries = append(entries, ReconcileEntry{Path: p, SHA256: sha})
+	}
+
+	res, err := rec.Reconcile(ctx, "rocket-01", entries)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Present) != 50 {
+		t.Errorf("present = %d, want all 50 — the spoke would re-send files the hub already holds", len(res.Present))
+	}
+	if len(res.Missing) != 0 {
+		t.Errorf("missing = %d, want 0", len(res.Missing))
+	}
+}
+
+func TestReconcile_RejectsOversizedBatch(t *testing.T) {
+	ctx := context.Background()
+	idx := newTestHubIndex(t)
+	rec, err := NewReconciler(ReconcilerConfig{Index: idx, Backend: newLocalBackendForTest(t, t.TempDir()), MaxEntries: 10})
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+
+	// The cap exists because the request body is buffered before auth runs;
+	// an unbounded batch is a pre-auth memory claim.
+	entries := make([]ReconcileEntry, 11)
+	for i := range entries {
+		entries[i] = ReconcileEntry{
+			Path:   fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%d.parquet", i),
+			SHA256: sha256Hex([]byte(fmt.Sprint(i))),
+		}
+	}
+
+	_, err = rec.Reconcile(ctx, "rocket-01", entries)
+	if !errors.Is(err, ErrReconcileTooLarge) {
+		t.Errorf("err = %v, want ErrReconcileTooLarge", err)
+	}
+
+	// Exactly at the cap must be accepted — an off-by-one here would make the
+	// documented limit a lie.
+	if _, err := rec.Reconcile(ctx, "rocket-01", entries[:10]); err != nil {
+		t.Errorf("a batch exactly at the cap was rejected: %v", err)
+	}
+}
+
+func TestReconcile_RejectsMalformedEntries(t *testing.T) {
+	ctx := context.Background()
+	rec, _ := newTestReconciler(t)
+	good := sha256Hex([]byte("payload"))
+
+	// A spoke is semi-trusted, so its declared paths are untrusted input even
+	// though the batch is HMAC-signed: the MAC proves who is asking, not that
+	// what they ask is well-formed.
+	tests := []struct {
+		name  string
+		entry ReconcileEntry
+	}{
+		{"traversal", ReconcileEntry{Path: "../../../etc/passwd.parquet", SHA256: good}},
+		{"absolute", ReconcileEntry{Path: "/etc/passwd.parquet", SHA256: good}},
+		{"staging prefix", ReconcileEntry{Path: ".sync-staging/rocket-02/f.parquet", SHA256: good}},
+		{"not parquet", ReconcileEntry{Path: "metrics/cpu/evil.sh", SHA256: good}},
+		{"empty path", ReconcileEntry{Path: "", SHA256: good}},
+		{"digest not hex", ReconcileEntry{Path: "metrics/cpu/2026/08/07/14/a.parquet", SHA256: strings.Repeat("z", 64)}},
+		{"digest wrong length", ReconcileEntry{Path: "metrics/cpu/2026/08/07/14/a.parquet", SHA256: "abc"}},
+		{"digest empty", ReconcileEntry{Path: "metrics/cpu/2026/08/07/14/a.parquet", SHA256: ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := rec.Reconcile(ctx, "rocket-01", []ReconcileEntry{tt.entry}); err == nil {
+				t.Errorf("entry %+v was accepted", tt.entry)
+			}
+		})
+	}
+}
+
+func TestReconcile_RejectsDuplicatePaths(t *testing.T) {
+	ctx := context.Background()
+	rec, _ := newTestReconciler(t)
+
+	// The same path cannot be both present and conflicted, so a duplicate has
+	// no correct answer and would produce a result ReconcileResult.Validate
+	// rejects. Refusing the batch is clearer than answering it arbitrarily.
+	const p = "metrics/cpu/2026/08/07/14/a.parquet"
+	entries := []ReconcileEntry{
+		{Path: p, SHA256: sha256Hex([]byte("one"))},
+		{Path: p, SHA256: sha256Hex([]byte("two"))},
+	}
+	_, err := rec.Reconcile(ctx, "rocket-01", entries)
+	if err == nil {
+		t.Fatal("a batch with a duplicate path was accepted")
+	}
+	// Assert WHICH guard fired. The input check and the output res.Validate()
+	// both reject this, so testing only `err != nil` lets either be deleted
+	// silently — they mask each other. The input check is the one that should
+	// fire: rejecting a malformed request beats building a result and then
+	// discovering it is invalid.
+	if !strings.Contains(err.Error(), "twice") {
+		t.Errorf("err = %v; want the input duplicate check to reject it, not the output validator", err)
+	}
+}
+
+func TestReconcile_RejectsMaliciousSpokeIDs(t *testing.T) {
+	ctx := context.Background()
+	rec, _ := newTestReconciler(t)
+	entry := ReconcileEntry{Path: "metrics/cpu/2026/08/07/14/a.parquet", SHA256: sha256Hex([]byte("p"))}
+
+	for _, id := range []string{"", "..", "rocket/../other", ".sync-staging", "rocket\x00-01"} {
+		t.Run(id, func(t *testing.T) {
+			if _, err := rec.Reconcile(ctx, id, []ReconcileEntry{entry}); err == nil {
+				t.Errorf("spoke ID %q was accepted", id)
+			}
+		})
+	}
+}
+
+func TestReconcile_EmptyBatchIsValid(t *testing.T) {
+	ctx := context.Background()
+	rec, _ := newTestReconciler(t)
+
+	// A spoke with nothing pending still reconciles — it is how it discovers
+	// files the hub holds that its own ledger has lost.
+	res, err := rec.Reconcile(ctx, "rocket-01", nil)
+	if err != nil {
+		t.Fatalf("empty batch: %v", err)
+	}
+	if len(res.Missing) != 0 || len(res.Present) != 0 || len(res.Conflicts) != 0 {
+		t.Errorf("an empty batch produced a non-empty result: %+v", res)
+	}
+}
+
+func TestReconcile_LookupChunksBeyondSQLiteParameterLimit(t *testing.T) {
+	ctx := context.Background()
+	idx := newTestHubIndex(t)
+	backend := newLocalBackendForTest(t, t.TempDir())
+	rec, err := NewReconciler(ReconcilerConfig{Index: idx, Backend: backend, MaxEntries: 5000})
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+
+	// SQLite's default parameter limit is 999. A naive IN (?,?,...) over a
+	// realistic backlog would blow past it, so Lookup chunks — this proves the
+	// chunking both works and stitches results back together.
+	const n = 2500
+	entries := make([]ReconcileEntry, 0, n)
+	for i := 0; i < n; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%d.parquet", i)
+		sha := sha256Hex([]byte(fmt.Sprint(i)))
+		entries = append(entries, ReconcileEntry{Path: p, SHA256: sha})
+		if i%2 == 0 {
+			seedFile(t, idx, backend, "rocket-01", p, sha)
+		}
+	}
+
+	res, err := rec.Reconcile(ctx, "rocket-01", entries)
+	if err != nil {
+		t.Fatalf("reconcile %d entries: %v", n, err)
+	}
+	if len(res.Present) != n/2 {
+		t.Errorf("present = %d, want %d", len(res.Present), n/2)
+	}
+	if len(res.Missing) != n/2 {
+		t.Errorf("missing = %d, want %d", len(res.Missing), n/2)
+	}
+}
+
+func TestHubIndex_RecordIsIdempotentAndUpdates(t *testing.T) {
+	ctx := context.Background()
+	idx := newTestHubIndex(t)
+
+	const p = "metrics/cpu/2026/08/07/14/a.parquet"
+	recordFile(t, idx, "rocket-01", p, sha256Hex([]byte("v1")))
+	recordFile(t, idx, "rocket-01", p, sha256Hex([]byte("v1")))
+
+	n, err := idx.CountForSpoke(ctx, "rocket-01")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count = %d, want 1 — re-recording created a duplicate row", n)
+	}
+
+	// A legitimate replacement updates the digest. Only verified content
+	// reaches Record, so a differing digest here means the file was genuinely
+	// replaced, not that two spokes collided.
+	recordFile(t, idx, "rocket-01", p, sha256Hex([]byte("v2")))
+	held, err := idx.Lookup(ctx, "rocket-01", []string{p})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if held[p] != sha256Hex([]byte("v2")) {
+		t.Errorf("digest = %q, want the updated one", held[p])
+	}
+}
+
+func TestHubIndex_ForgetStopsReportingPresent(t *testing.T) {
+	ctx := context.Background()
+	rec, idx, backend := newTestReconcilerWithBackend(t)
+
+	const p = "metrics/cpu/2026/08/07/14/a.parquet"
+	sha := sha256Hex([]byte("payload"))
+	seedFile(t, idx, backend, "rocket-01", p, sha)
+
+	if err := idx.Forget(ctx, "rocket-01", p); err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+
+	// Critical: after retention deletes a file from hub storage, reconcile
+	// must stop calling it present. Otherwise the spoke marks it synced and
+	// could delete its only copy of data the hub no longer has.
+	res, err := rec.Reconcile(ctx, "rocket-01", []ReconcileEntry{{Path: p, SHA256: sha}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Present) != 0 {
+		t.Error("a forgotten file is still reported as present; the spoke could delete its only copy")
+	}
+	if len(res.Missing) != 1 {
+		t.Errorf("missing = %v, want the forgotten file", res.Missing)
+	}
+}
+
+func TestHubIndex_RequiresDB(t *testing.T) {
+	if _, err := NewHubIndex(nil, zerolog.Nop()); err == nil {
+		t.Error("a nil database was accepted")
+	}
+}
+
+func TestNewReconciler_RequiresIndex(t *testing.T) {
+	if _, err := NewReconciler(ReconcilerConfig{}); err == nil {
+		t.Error("a reconciler was built without an index")
+	}
+}
+
+func TestReceiver_RecordsCommittedFilesForReconcile(t *testing.T) {
+	ctx := context.Background()
+
+	dir, err := os.MkdirTemp("", "sync-recv-idx-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend := newLocalBackendForTest(t, dir)
+	idx := newTestHubIndex(t)
+
+	r, err := NewReceiver(ReceiverConfig{Backend: backend, Index: idx, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+	rec, err := NewReconciler(ReconcilerConfig{Index: idx, Backend: backend})
+	if err != nil {
+		t.Fatalf("reconciler: %v", err)
+	}
+
+	// End to end: a file that was actually received must then reconcile as
+	// present. Without this wiring the hub would report every file missing and
+	// spokes would re-send their whole backlog on every contact.
+	content := []byte("parquet payload")
+	digest := sha256Hex(content)
+	if _, err := r.Receive(ctx, "rocket-01", testPath, digest, int64(len(content)), 0, bytes.NewReader(content)); err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+
+	res, err := rec.Reconcile(ctx, "rocket-01", []ReconcileEntry{{Path: testPath, SHA256: digest}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Present) != 1 {
+		t.Errorf("present = %v, want the received file — receive did not record it", res.Present)
+	}
+}
+
+// newLocalBackendForTest builds a local backend rooted at dir.
+func newLocalBackendForTest(t *testing.T, dir string) storage.Backend {
+	t.Helper()
+	b, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("local backend: %v", err)
+	}
+	t.Cleanup(func() { b.Close() })
+	return b
+}
+
+func TestReconcile_NeverVouchesForADeletedFile(t *testing.T) {
+	ctx := context.Background()
+	rec, idx, backend := newTestReconcilerWithBackend(t)
+
+	// The index records what the hub RECEIVED; it never learns about
+	// deletions. Arc retention lists on an operator-chosen `policy.Database +
+	// "/"` prefix (api/retention.go), so a policy naming a spoke ID sweeps
+	// that spoke's namespace — and cold-tier migration and a human with rm do
+	// the same thing.
+	//
+	// If reconcile trusted the index alone it would report the file present,
+	// the spoke would mark it synced per §5.1, and a spoke reclaiming space
+	// would delete its only copy. Silent, permanent data loss with no attacker
+	// involved.
+	const p = "metrics/cpu/2026/08/07/14/only_copy.parquet"
+	sha := sha256Hex([]byte("the spoke's only copy"))
+	seedFile(t, idx, backend, "rocket-01", p, sha)
+
+	if err := backend.Delete(ctx, NamespacedPath("rocket-01", p)); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	res, err := rec.Reconcile(ctx, "rocket-01", []ReconcileEntry{{Path: p, SHA256: sha}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Present) != 0 {
+		t.Fatalf("present = %v — the hub vouched for a file it no longer holds", res.Present)
+	}
+	if len(res.Missing) != 1 || res.Missing[0] != p {
+		t.Errorf("missing = %v, want the deleted file so the spoke re-sends it", res.Missing)
+	}
+
+	// The stale row is dropped, so the next reconcile skips the stat rather
+	// than re-confirming a file that is gone.
+	held, err := idx.Lookup(ctx, "rocket-01", []string{p})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if _, stillThere := held[p]; stillThere {
+		t.Error("the stale index row survived; every future reconcile pays a wasted stat")
+	}
+}
+
+// failingExistsBackend fails the existence check for one specific path.
+type failingExistsBackend struct {
+	storage.Backend
+	failFor string
+}
+
+func (f *failingExistsBackend) Exists(ctx context.Context, p string) (bool, error) {
+	if strings.Contains(p, f.failFor) {
+		return false, errors.New("simulated backend failure")
+	}
+	return f.Backend.Exists(ctx, p)
+}
+
+func TestReconcile_ExistenceFailureRejectsTheWholeBatch(t *testing.T) {
+	ctx := context.Background()
+	idx := newTestHubIndex(t)
+	local := newLocalBackendForTest(t, t.TempDir())
+	backend := &failingExistsBackend{Backend: local, failFor: "unlucky"}
+
+	rec, err := NewReconciler(ReconcilerConfig{Index: idx, Backend: backend})
+	if err != nil {
+		t.Fatalf("reconciler: %v", err)
+	}
+
+	// One entry's confirmation fails; the rest would succeed.
+	entries := make([]ReconcileEntry, 0, 3)
+	for _, name := range []string{"fine_a", "unlucky", "fine_b"} {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/%s.parquet", name)
+		sha := sha256Hex([]byte(name))
+		seedFile(t, idx, local, "rocket-01", p, sha)
+		entries = append(entries, ReconcileEntry{Path: p, SHA256: sha})
+	}
+
+	// The whole batch must fail rather than return a partial answer. A
+	// partial result would be indistinguishable from a complete one: the spoke
+	// cannot tell "the hub does not have this" from "the hub could not check",
+	// and treating the second as the first means re-sending files needlessly —
+	// or worse, if the polarity ever flipped, marking unsent files as synced.
+	_, err = rec.Reconcile(ctx, "rocket-01", entries)
+	if err == nil {
+		t.Fatal("a failed existence check produced a result instead of an error")
+	}
+	if !errors.Is(err, ErrReceiveInternal) {
+		t.Errorf("err = %v, want ErrReceiveInternal so the handler answers 503 and the spoke retries", err)
+	}
+}


### PR DESCRIPTION
Fifth of nine PRs for edge sync — see [#569](https://github.com/Basekick-Labs/arc/issues/569). Follows #570, #571, #572, #573, #574.

## Summary

`POST /api/v1/sync/reconcile` answers, in **one round-trip**, which of a spoke's pending files the hub already holds. That is what makes a long disconnection survivable: 5,000 pending files cost one request rather than 5,000, and any file whose acknowledgment was lost is discovered in bulk rather than re-uploaded.

New config: `edge_sync.max_reconcile_entries` (default 10,000).

## Two §5.1 assumptions that don't hold

Both resolutions [recorded on the issue](https://github.com/Basekick-Labs/arc/issues/569#issuecomment-5219790677).

**"The hub answers from its manifest, no I/O on the parquet bytes."** That manifest is the Raft FSM — cluster mode only. In OSS standalone there is no file index at all, so telling `present` from `conflicts` would mean hashing every candidate: gigabytes of reads on the request that exists to be cheap. The hub now keeps **its own index** in SQLite, written on the receive path which already knows each file's path and digest at commit time.

**"Stream the body both ways."** Arc runs Fiber with `StreamRequestBody=false`, so the body is buffered before routing and therefore before auth (established in #574). Capping entries and letting the spoke page keeps the property that matters while bounding what an unauthenticated caller can make the hub hold.

## Two blockers — the second caused by the fix for the first

**The hub vouched for deleted files.** I had claimed Arc's retention cannot touch a spoke namespace. **That was wrong**: retention lists on `policy.Database + "/"`, an operator-chosen string, so a policy named after a spoke sweeps it. Reproduced end to end — delete from storage, reconcile still reports `present`, the spoke marks it synced, and once `delete_after_sync` exists it deletes its only copy. Silent data loss, no attacker.

Fixed by confirming with `backend.Exists` before vouching, and dropping the stale row. Read-time confirmation is correct whatever removed the file; wiring `Forget` into retention would not be, since retention has no concept of spokes.

**That fix then made reconcile unusable on S3.** `Exists` is a `HeadObject` round-trip — 10,000 serial calls at 20ms RTT is **200s against a 120s timeout**, so the request cannot complete. The checks are independent, so they now run with bounded concurrency (32). Measured **30× faster**: 2,000 entries drop from 40s to 1.3s, putting a full batch at ~6.6s.

## Other findings fixed

- **The pre-auth size guard was unreachable in tests** — the byte threshold sat far above what the entry cap allowed, so deleting it left every test green.
- **`512 bytes/entry` was unmeasured guesswork** against a measured 96-byte minimum and 189-byte realistic entry, making the only pre-auth bound ~5× looser than intended. Now 256, with the measurement recorded.
- **`Lookup` closed its cursor manually on error paths** — on the `MaxOpenConns(1)` handle shared with auth, audit, and ingest, one leak wedges all of them.
- **Stale rows were deleted one statement at a time** inside a request handler on that same single writer. Now batched.
- **The duplicate-path check and `res.Validate()` masked each other** — either could be deleted silently.
- **`max_reconcile_entries` had no ceiling**, so a large value defeated the cap's only purpose.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, `enabled=false` (default) | **No** — index and reconciler never constructed | n/a |
| OSS standalone, `enabled=true`, auth **enabled** | Yes | `sharedSQLiteHandle` borrows `authManager.GetDB()`; `syncOwnsDB` false, no double-close |
| OSS standalone, `enabled=true`, auth **disabled** | Yes — `authManager` **nil** | `sharedSQLiteHandle(nil, …)` opens a dedicated handle, closed only when owned. **Verified live** |
| `max_reconcile_entries` non-default (25, 50) | Yes | **Verified live** |
| `max_reconcile_entries` ≤ 0 or > 1,000,000 | **No** — config load fails | **Verified live** |
| **`storage.backend=s3` + `enabled=true`** | Yes — `Exists` becomes a network round-trip per entry | The row nobody had written. Bounded concurrency makes it viable; **not exercised against real S3** |
| Cluster + `enabled=true` | Yes — index writes *and* `registerFile` proposes to Raft | Index is independent of Raft, so reconcile answers during an election. **Not exercised live** |

## Test plan

- [x] `go build`, `go vet`, `gofmt -l`, `go test`, `-race` all clean
- [x] **Mutation-tested**: 10 killed, including trust-the-index-without-confirming, lookup-ignores-spokeID, HMAC-skipped, pre-auth-guard-removed, and swallow-the-error-return-partial
- [x] **Binary runs**: non-default caps (25, 50), invalid caps (0, 999999999) both refusing to start, and **auth disabled** exercising the dedicated-handle path
- [x] **Real end-to-end over HTTP**: upload committed, reconcile returned one `present` and one `missing` from the index, replay refused
- [x] S3 latency modelled with a delaying backend to verify the concurrency fix

## Review

Security pass, deep pass, and a re-review of the fixes. The security pass found the data-loss blocker; the deep pass found that my fix for it broke S3. The re-review observed that cancelled in-flight checks are "lost" — I checked, and it's wrong in the code's favour: any failure fails the whole batch rather than returning a partial answer. Pinned with a test, since a partial result would be indistinguishable from a complete one.

## Open question for the reviewer

An S3 hub now works but reconcile is ~6.6s per full batch versus ~50ms local. Viable, but if Arc should refuse S3 hubs outright as Iceberg does, that is a small config-load change.