### PR TITLE
feat(edgesync): spoke agent and manual sync pass (#569)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -62,7 +62,7 @@ This is a **file-count** bound, not a byte bound — compacted output size track
 
 Out-of-range values fall back to the default with a startup warning rather than failing. **`1` is not usable** and is treated as out of range: compaction's adaptive retry rejects any batch below two files, so a batch size of one would fail every batch of every partition.
 
-## Groundwork: edge-to-cloud sync (not yet usable)
+## New: edge-to-cloud sync (manual)
 
 Arc runs at the edge today — a standalone binary with local storage in a vehicle, a factory cell, or a forward deployment — with no first-class way to ship that data to a central Arc. Backup is a full DR snapshot rather than incremental sync, and Parquet import re-ingests rows through the write path, which breaks the end-to-end checksum and double-counts on retry.
 
@@ -88,9 +88,36 @@ Reconcile is answered from a hub-side index of received files rather than by rea
 
 Resume is supported on local storage. On S3 and Azure a dropped transfer restarts from zero, because block objects cannot be appended to; this is a throughput cost on intermittent links, not a correctness problem.
 
-The rest of the work is still internal: the spoke-side ledger, the `SyncTransport` interface, and the HMAC scheme. Manual export/import will be OSS when it ships; the automatic scheduled agent will be an Enterprise feature.
+### The spoke side
 
-Manual export/import will be OSS when it ships; the automatic scheduled agent will be an Enterprise feature.
+An edge Arc now syncs to a hub on demand. Enable it on the spoke:
+
+```toml
+[edge_sync.spoke]
+enabled = true                        # default false
+hub_url = "https://hub.example.com"   # required when enabled
+spoke_id = "rocket-01"                # this spoke's ID, as registered on the hub
+hub_id = "ground-station"             # the REMOTE hub's edge_sync.hub_id
+max_attempts = 5                      # attempts before a file is marked failed
+max_concurrent = 2                    # simultaneous transfers
+batch_size = 0                        # files per reconcile round-trip; 0 = hub default
+```
+
+The secret is **environment-only**: `ARC_EDGE_SYNC_SPOKE_SECRET`, the value the hub returned once at registration. A secret in the config file is **refused at startup** rather than ignored — one that is ignored still leaks, and leaving it in place makes the committed copy look load-bearing. `hub_id` is validated at load for the same reason it is easy to get wrong: it is bound into every request MAC, so a mismatch fails *every* request with a `400` that looks like a hub problem.
+
+Three admin endpoints drive it:
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/v1/spoke-sync/run` | Run one sync pass and return what it did. |
+| `GET /api/v1/spoke-sync/status` | Pending/synced/failed counts and sync lag. |
+| `GET /api/v1/spoke-sync/ledger` | Per-file state, attempts, and last error. |
+
+A pass recovers transfers interrupted by a crash, discovers new files, reconciles the backlog, and streams what the hub lacks — **newest first**, so a contact window that closes mid-backlog has already delivered the freshest telemetry. It **pages until the backlog drains**, so one pass on a spoke returning from a long outage moves everything, not just the first batch. Conflicts are reported in full rather than counted and are not retried: the same path holding different content means a spoke-ID collision or corruption, and re-sending would either be refused or destroy evidence.
+
+Files are hashed once at discovery, and the ledger survives restarts, so a spoke re-run after a crash neither re-hashes nor re-sends what already landed. Nothing is deleted from the spoke — sync is a copy, and local retention stays in the operator's hands.
+
+This is the **manual** form, and it is OSS. The automatic scheduled agent will be an Enterprise feature.
 
 ## Security hardening
 
@@ -373,7 +400,7 @@ The forwarding-header and loop-guard changes are cluster-only; the partition-pru
 2. **No API or on-disk format changes.** Reads, queries, and storage layout are untouched. Queries with a start date earlier than `1970-01-01` are pruned from the epoch forward; since Arc stores no pre-epoch data, results are unchanged.
 3. **Clustered operators:** if any external tooling deliberately sets `X-Arc-Forwarded-By`, `X-Real-IP`, or `X-Forwarded-*` headers on requests to Arc and expects them to survive an inter-node forward, note that these are now stripped on the forwarding hop and re-established by Arc. Client IP has never been derived from these headers, so log/audit attribution is unchanged.
 4. **Active licenses keep working.** No re-activation required.
-5. **Edge sync is off by default and nothing changes unless you enable it.** With `edge_sync.enabled=false` (the default) no routes are mounted and `/api/v1/sync/file` returns 404. The `sync_ledger` and `sync_history` tables are still not created — the spoke side is not yet wired into startup.
+5. **Edge sync is off by default and nothing changes unless you enable it.** With `edge_sync.enabled=false` (the default) the hub mounts no routes and `/api/v1/sync/file` returns 404. With `edge_sync.spoke.enabled=false` (the default) no spoke routes are mounted, no `sync_ledger` or `sync_history` tables are created, and nothing is read from local storage. Both sides are independent: a hub need not be a spoke, and a spoke need not be a hub.
 
 ## Dependencies
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2107,6 +2107,70 @@ func main() {
 		}
 	}
 
+	// Register the edge-sync SPOKE side (#569) — this instance pushing its
+	// files to a hub. Independent of the hub block above: an Arc can be a hub,
+	// a spoke, both, or neither.
+	//
+	// The secret comes from ARC_EDGE_SYNC_SPOKE_SECRET only; config load
+	// already refused a config-file secret and verified every required field,
+	// so by here the configuration is known good.
+	if cfg.EdgeSync.Spoke.Enabled {
+		spokeLogger := logger.Get("edgesync-spoke")
+
+		// The ledger shares the auth database, like the hub index. Reuse the
+		// handle opened for the hub block when both roles are enabled on one
+		// instance, rather than opening a second one on the same file.
+		spokeDB, spokeOwnsDB, err := sharedSQLiteHandle(authManager, cfg.Auth.DBPath)
+		if err != nil {
+			log.Fatal().Err(err).Str("path", cfg.Auth.DBPath).Msg("Failed to open the edge sync spoke database; refusing to start")
+		}
+		if spokeOwnsDB {
+			shutdownCoordinator.RegisterHook("edgesync-spoke-db", func(context.Context) error {
+				return spokeDB.Close()
+			}, shutdown.PriorityDatabase)
+		}
+
+		spokeLedger, err := edgesync.NewLedger(spokeDB, spokeLogger)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create the edge sync ledger; refusing to start")
+		}
+
+		spokeTransport, err := edgesync.NewHTTPTransport(edgesync.HTTPTransportConfig{
+			BaseURL: cfg.EdgeSync.Spoke.HubURL,
+			SpokeID: cfg.EdgeSync.Spoke.SpokeID,
+			Secret:  cfg.EdgeSync.Spoke.Secret,
+		})
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create the edge sync transport; refusing to start")
+		}
+
+		syncAgent, err := edgesync.NewAgent(edgesync.AgentConfig{
+			Ledger:        spokeLedger,
+			Transport:     spokeTransport,
+			Backend:       storageBackend,
+			HubID:         cfg.EdgeSync.Spoke.HubID,
+			SpokeID:       cfg.EdgeSync.Spoke.SpokeID,
+			MaxAttempts:   cfg.EdgeSync.Spoke.MaxAttempts,
+			MaxConcurrent: cfg.EdgeSync.Spoke.MaxConcurrent,
+			BatchSize:     cfg.EdgeSync.Spoke.BatchSize,
+			Logger:        spokeLogger,
+		})
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create the edge sync agent; refusing to start")
+		}
+
+		spokeHandler, err := api.NewEdgeSyncSpokeHandler(syncAgent, authManager, spokeLogger)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to create the edge sync spoke handler; refusing to start")
+		}
+		spokeHandler.RegisterRoutes(server.GetApp())
+
+		spokeLogger.Info().
+			Str("hub_url", cfg.EdgeSync.Spoke.HubURL).
+			Str("spoke_id", cfg.EdgeSync.Spoke.SpokeID).
+			Msg("Edge sync spoke enabled; trigger a pass with POST /api/v1/spoke-sync/run")
+	}
+
 	// Register TLE handler (streaming TLE ingestion)
 	tleHandler := api.NewTLEHandler(arrowBuffer, logger.Get("tle"))
 	if authManager != nil && rbacManager != nil {

--- a/internal/api/edgesync_e2e_test.go
+++ b/internal/api/edgesync_e2e_test.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/edgesync"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// TestEdgeSync_SpokeToHubEndToEnd drives the real spoke agent against the real
+// hub handlers over real HTTP.
+//
+// Every other test in this sequence exercises one side against an in-process
+// stand-in. This is the only one that proves the two halves interoperate — the
+// header names, the HMAC field order, the status-code mapping, and the resume
+// offsets all have to agree, and each was written from the design doc rather
+// than from the other side's code.
+func TestEdgeSync_SpokeToHubEndToEnd(t *testing.T) {
+	ctx := context.Background()
+
+	// --- Hub ---
+	hubDir, err := os.MkdirTemp("", "e2e-hub-*")
+	if err != nil {
+		t.Fatalf("hub dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(hubDir) })
+
+	hubBackend, err := storage.NewLocalBackend(hubDir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("hub backend: %v", err)
+	}
+	t.Cleanup(func() { hubBackend.Close() })
+
+	hubIndex := newTestAPIHubIndex(t)
+	receiver, err := edgesync.NewReceiver(edgesync.ReceiverConfig{
+		Backend: hubBackend, Index: hubIndex, Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+	reconciler, err := edgesync.NewReconciler(edgesync.ReconcilerConfig{
+		Index: hubIndex, Backend: hubBackend, MaxEntries: 100,
+	})
+	if err != nil {
+		t.Fatalf("reconciler: %v", err)
+	}
+
+	const spokeID, hubID, secret = "rocket-01", "ground-station", "e2e-shared-secret"
+	handler, err := NewEdgeSyncHandler(EdgeSyncHandlerConfig{
+		Receiver:     receiver,
+		Reconciler:   reconciler,
+		SpokeSecrets: StaticSpokeSecrets(map[string]string{spokeID: secret}),
+		Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
+		HubID:        hubID,
+		MaxFileBytes: 8 << 20,
+		Logger:       zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true, BodyLimit: 32 << 20})
+	handler.RegisterRoutes(app)
+
+	// A real HTTP listener, so the transport exercises actual network I/O
+	// rather than Fiber's in-process test harness.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp, err := app.Test(r, testRequestTimeoutMS)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+		for k, vs := range resp.Header {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = copyBody(w, resp.Body)
+	}))
+	t.Cleanup(srv.Close)
+
+	// --- Spoke ---
+	spokeDir, err := os.MkdirTemp("", "e2e-spoke-*")
+	if err != nil {
+		t.Fatalf("spoke dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(spokeDir) })
+
+	spokeBackend, err := storage.NewLocalBackend(spokeDir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("spoke backend: %v", err)
+	}
+	t.Cleanup(func() { spokeBackend.Close() })
+
+	ledgerDB, err := sql.Open("sqlite3", spokeDir+"/ledger.db")
+	if err != nil {
+		t.Fatalf("ledger db: %v", err)
+	}
+	t.Cleanup(func() { ledgerDB.Close() })
+	ledger, err := edgesync.NewLedger(ledgerDB, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	transport, err := edgesync.NewHTTPTransport(edgesync.HTTPTransportConfig{
+		BaseURL: srv.URL, SpokeID: spokeID, Secret: secret,
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	agent, err := edgesync.NewAgent(edgesync.AgentConfig{
+		Ledger: ledger, Transport: transport, Backend: spokeBackend,
+		HubID: hubID, SpokeID: spokeID, Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("agent: %v", err)
+	}
+
+	// --- The spoke produces three files ---
+	contents := map[string][]byte{}
+	for i := 0; i < 3; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/1%d/cpu_%d.parquet", i, i)
+		c := []byte(fmt.Sprintf("parquet payload number %d", i))
+		contents[p] = c
+		if err := spokeBackend.Write(ctx, p, c); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	res, err := agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if res.Discovered != 3 {
+		t.Errorf("discovered = %d, want 3", res.Discovered)
+	}
+	if res.Sent != 3 {
+		t.Fatalf("sent = %d, want 3 (failed=%d partial=%d)", res.Sent, res.Failed, res.Partial)
+	}
+
+	// The hub must hold each file under the spoke's namespace, byte-identical.
+	for p, want := range contents {
+		got, err := hubBackend.Read(ctx, edgesync.NamespacedPath(spokeID, p))
+		if err != nil {
+			t.Errorf("hub is missing %s: %v", p, err)
+			continue
+		}
+		if string(got) != string(want) {
+			t.Errorf("%s: hub content differs from the spoke's", p)
+		}
+		// The digest the hub indexed must be the file's real one, or reconcile
+		// would report it missing on the next pass.
+		wantSHA := sha256.Sum256(want)
+		held, err := hubIndex.Lookup(ctx, spokeID, []string{p})
+		if err != nil {
+			t.Errorf("%s: index lookup: %v", p, err)
+		} else if held[p] != hex.EncodeToString(wantSHA[:]) {
+			t.Errorf("%s: hub indexed digest %q, want %q", p, held[p], hex.EncodeToString(wantSHA[:]))
+		}
+	}
+
+	// --- A second pass must be free ---
+	res2, err := agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if res2.Sent != 0 || res2.BytesSent != 0 {
+		t.Errorf("second pass sent %d files / %d bytes; an already-synced corpus must cost nothing",
+			res2.Sent, res2.BytesSent)
+	}
+
+	// --- A new file syncs incrementally ---
+	newPath := "metrics/cpu/2026/08/07/19/cpu_new.parquet"
+	newContent := []byte("a freshly compacted file")
+	if err := spokeBackend.Write(ctx, newPath, newContent); err != nil {
+		t.Fatalf("write new: %v", err)
+	}
+	res3, err := agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("third sync: %v", err)
+	}
+	if res3.Discovered != 1 || res3.Sent != 1 {
+		t.Errorf("incremental pass: discovered=%d sent=%d, want 1/1", res3.Discovered, res3.Sent)
+	}
+
+	// --- Status reflects reality ---
+	st, err := agent.Status(ctx)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if st.Pending != 0 {
+		t.Errorf("pending = %d after a full sync, want 0", st.Pending)
+	}
+	if st.Synced != 4 {
+		t.Errorf("synced = %d, want 4", st.Synced)
+	}
+}
+
+func copyBody(w http.ResponseWriter, r io.Reader) (int64, error) {
+	return io.Copy(w, r)
+}

--- a/internal/api/edgesync_spoke.go
+++ b/internal/api/edgesync_spoke.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/edgesync"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// syncRunTimeout bounds one manual sync pass.
+//
+// Generous because a pass drains whatever backlog exists: a spoke returning
+// from a long outage may have thousands of files to send, and cutting that
+// short would leave it worse off than not having run at all. An operator who
+// wants a shorter bound cancels the request.
+const syncRunTimeout = 2 * time.Hour
+
+// EdgeSyncSpokeHandler exposes the manual sync controls on a spoke.
+//
+// Distinct from EdgeSyncHandler, which is the hub's receive side. The two have
+// different audiences and different authentication — a hub's endpoints are
+// called by spokes and authenticated per-spoke by HMAC; these are called by an
+// operator on the edge box and authenticated by an Arc admin token. Mounting
+// them together would invite the wrong middleware.
+//
+// Mounted at /api/v1/spoke-sync, NOT under /api/v1/sync-*. Fiber's
+// Group().Use() matches by string PREFIX, not by path segment, so a group at
+// "/api/v1/sync" also matches "/api/v1/sync-spoke/..." — the hub's body limit
+// and its middleware would silently run on these operator routes. A prefix
+// that is not a string-prefix of another group's is the only way to keep the
+// two genuinely uncoupled.
+type EdgeSyncSpokeHandler struct {
+	agent       *edgesync.Agent
+	authManager *auth.AuthManager
+	logger      zerolog.Logger
+}
+
+// NewEdgeSyncSpokeHandler validates configuration and returns a ready handler.
+func NewEdgeSyncSpokeHandler(agent *edgesync.Agent, authManager *auth.AuthManager, logger zerolog.Logger) (*EdgeSyncSpokeHandler, error) {
+	if agent == nil {
+		return nil, errors.New("edgesync spoke: agent is required")
+	}
+	return &EdgeSyncSpokeHandler{
+		agent:       agent,
+		authManager: authManager,
+		logger:      logger.With().Str("component", "edgesync-spoke").Logger(),
+	}, nil
+}
+
+// RegisterRoutes mounts the spoke's manual sync controls.
+//
+// All admin-only. Triggering a sync moves data off this box and consumes
+// whatever link budget it has; the ledger view exposes which measurements
+// exist and how far behind they are. Neither is something a read-scoped token
+// should reach.
+func (h *EdgeSyncSpokeHandler) RegisterRoutes(app fiber.Router) {
+	group := app.Group("/api/v1/spoke-sync")
+
+	if h.authManager != nil {
+		group.Use(auth.RequireAdmin(h.authManager))
+	}
+
+	group.Post("/run", h.run)
+	group.Get("/status", h.status)
+	group.Get("/ledger", h.ledger)
+
+	h.logger.Info().Msg("Edge sync spoke routes registered")
+}
+
+// run handles POST /api/v1/spoke-sync/run.
+//
+// Synchronous: the caller gets the pass's outcome rather than a job ID to poll.
+// A manual trigger is something an operator watches, and returning immediately
+// would mean inventing job tracking for a feature whose automatic form (phase
+// 2) will not need it.
+func (h *EdgeSyncSpokeHandler) run(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), syncRunTimeout)
+	defer cancel()
+
+	h.logger.Info().Msg("Manual sync pass starting")
+
+	res, err := h.agent.Run(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Manual sync pass failed")
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	h.logger.Info().
+		Int("discovered", res.Discovered).
+		Int("sent", res.Sent).
+		Int64("bytes_sent", res.BytesSent).
+		Int("already_present", res.AlreadyPresent).
+		Int("partial", res.Partial).
+		Int("failed", res.Failed).
+		Int("conflicts", len(res.Conflicts)).
+		Dur("duration", res.Duration).
+		Msg("Manual sync pass complete")
+
+	out := fiber.Map{
+		"discovered":      res.Discovered,
+		"recovered":       res.Recovered,
+		"already_present": res.AlreadyPresent,
+		"sent":            res.Sent,
+		"bytes_sent":      res.BytesSent,
+		"partial":         res.Partial,
+		"failed":          res.Failed,
+		"duration_ms":     res.Duration.Milliseconds(),
+	}
+
+	// Conflicts are reported in full rather than counted. Each one needs a
+	// human to decide which copy is right, and a count alone would not say
+	// which files to look at.
+	conflicts := make([]fiber.Map, 0, len(res.Conflicts))
+	for _, cf := range res.Conflicts {
+		conflicts = append(conflicts, fiber.Map{
+			"path":         cf.Path,
+			"their_sha256": cf.TheirSHA256,
+		})
+	}
+	out["conflicts"] = conflicts
+	if len(conflicts) > 0 {
+		out["warning"] = "Some paths hold different content on the hub. These are not retried; investigate before re-syncing."
+	}
+
+	return c.JSON(out)
+}
+
+// status handles GET /api/v1/spoke-sync/status.
+func (h *EdgeSyncSpokeHandler) status(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	st, err := h.agent.Status(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to read sync status")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to read sync status",
+		})
+	}
+
+	out := fiber.Map{
+		"hub_id":        st.HubID,
+		"pending":       st.Pending,
+		"in_flight":     st.InFlight,
+		"synced":        st.Synced,
+		"failed":        st.Failed,
+		"pending_bytes": st.PendingBytes,
+	}
+	if st.LastSyncedAt != nil {
+		out["last_synced_at"] = *st.LastSyncedAt
+		// Sync lag is the number an operator actually watches: how long since
+		// anything reached the hub. Derived here so a dashboard does not have
+		// to do clock arithmetic against a timestamp it may parse differently.
+		out["seconds_since_last_sync"] = int64(time.Since(*st.LastSyncedAt).Seconds())
+	}
+	return c.JSON(out)
+}
+
+// ledger handles GET /api/v1/spoke-sync/ledger.
+//
+// For troubleshooting: which files are stuck, how many attempts they have
+// taken, and what the last error was. Without this an operator would have to
+// open the SQLite file to answer "why is this not syncing?".
+//
+// Includes entries that exhausted their retries, not just queued ones — those
+// are terminal until someone intervenes, so a pending-only view would omit the
+// files most likely to have prompted the question.
+func (h *EdgeSyncSpokeHandler) ledger(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	// Bounded by default. The ledger has one row per file the spoke has ever
+	// produced, so an unbounded response on a long-running edge box would be
+	// enormous.
+	limit := 100
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid limit"})
+		}
+		if n > 1000 {
+			n = 1000
+		}
+		limit = n
+	}
+
+	entries, err := h.agent.UnfinishedEntries(ctx, limit)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to read the sync ledger")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to read the sync ledger",
+		})
+	}
+
+	out := make([]fiber.Map, 0, len(entries))
+	for _, e := range entries {
+		row := fiber.Map{
+			"path":           e.Path,
+			"sha256":         e.SHA256,
+			"size_bytes":     e.SizeBytes,
+			"state":          string(e.State),
+			"attempts":       e.Attempts,
+			"bytes_sent":     e.BytesSent,
+			"partition_time": e.PartitionTime,
+		}
+		if e.LastError != "" {
+			row["last_error"] = e.LastError
+		}
+		out = append(out, row)
+	}
+
+	return c.JSON(fiber.Map{"entries": out, "limit": limit})
+}

--- a/internal/api/edgesync_spoke_test.go
+++ b/internal/api/edgesync_spoke_test.go
@@ -1,0 +1,341 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/edgesync"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+)
+
+type spokeRig struct {
+	app       *fiber.App
+	agent     *edgesync.Agent
+	backend   storage.Backend
+	transport *edgesync.MemoryTransport
+}
+
+func newSpokeRig(t *testing.T) *spokeRig {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "spoke-api-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	db, err := sql.Open("sqlite3", dir+"/ledger.db")
+	if err != nil {
+		t.Fatalf("ledger db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ledger, err := edgesync.NewLedger(db, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	transport := edgesync.NewMemoryTransport()
+
+	agent, err := edgesync.NewAgent(edgesync.AgentConfig{
+		Ledger: ledger, Transport: transport, Backend: backend,
+		HubID: "ground-station", SpokeID: "rocket-01", Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("agent: %v", err)
+	}
+
+	h, err := NewEdgeSyncSpokeHandler(agent, nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	h.RegisterRoutes(app)
+	return &spokeRig{app: app, agent: agent, backend: backend, transport: transport}
+}
+
+func (r *spokeRig) do(t *testing.T, method, path string) (*http.Response, map[string]any) {
+	t.Helper()
+	resp, err := r.app.Test(httptest.NewRequest(method, path, nil), 30_000)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var out map[string]any
+	if len(raw) > 0 {
+		json.Unmarshal(raw, &out)
+	}
+	return resp, out
+}
+
+func TestEdgeSyncSpoke_RunReportsWhatHappened(t *testing.T) {
+	rig := newSpokeRig(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%d.parquet", i)
+		if err := rig.backend.Write(ctx, p, []byte(fmt.Sprintf("payload %d", i))); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	resp, body := rig.do(t, http.MethodPost, "/api/v1/spoke-sync/run")
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%v", resp.StatusCode, body)
+	}
+	if body["discovered"] != float64(3) {
+		t.Errorf("discovered = %v, want 3", body["discovered"])
+	}
+	if body["sent"] != float64(3) {
+		t.Errorf("sent = %v, want 3", body["sent"])
+	}
+	// Empty rather than null, so a caller need not special-case the field.
+	if _, ok := body["conflicts"].([]any); !ok {
+		t.Errorf("conflicts = %v, want an empty array", body["conflicts"])
+	}
+	if body["warning"] != nil {
+		t.Errorf("a clean run carried a warning: %v", body["warning"])
+	}
+}
+
+func TestEdgeSyncSpoke_RunSurfacesConflicts(t *testing.T) {
+	rig := newSpokeRig(t)
+	ctx := context.Background()
+
+	const p = "metrics/cpu/2026/08/07/14/contested.parquet"
+	if err := rig.backend.Write(ctx, p, []byte("the spoke's version")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// The hub holds different content at the same path.
+	rig.transport.Seed("ground-station", p, "aa"+fmt.Sprint(1), 19)
+
+	resp, body := rig.do(t, http.MethodPost, "/api/v1/spoke-sync/run")
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Reported in full, not counted: an operator has to know which files to
+	// look at, and a count alone would not say.
+	conflicts, _ := body["conflicts"].([]any)
+	if len(conflicts) != 1 {
+		t.Fatalf("conflicts = %v, want one", body["conflicts"])
+	}
+	first, _ := conflicts[0].(map[string]any)
+	if first["path"] != p {
+		t.Errorf("conflict path = %v, want %q", first["path"], p)
+	}
+	if body["warning"] == nil {
+		t.Error("a run with conflicts carried no warning")
+	}
+}
+
+func TestEdgeSyncSpoke_StatusReportsLag(t *testing.T) {
+	rig := newSpokeRig(t)
+	ctx := context.Background()
+
+	if err := rig.backend.Write(ctx, "metrics/cpu/2026/08/07/14/f.parquet", []byte("payload")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Before any sync there is nothing to be behind.
+	_, before := rig.do(t, http.MethodGet, "/api/v1/spoke-sync/status")
+	if before["last_synced_at"] != nil {
+		t.Error("a spoke that has never synced reports a last-synced time")
+	}
+
+	rig.do(t, http.MethodPost, "/api/v1/spoke-sync/run")
+
+	_, after := rig.do(t, http.MethodGet, "/api/v1/spoke-sync/status")
+	if after["pending"] != float64(0) {
+		t.Errorf("pending = %v after a full sync, want 0", after["pending"])
+	}
+	if after["synced"] != float64(1) {
+		t.Errorf("synced = %v, want 1", after["synced"])
+	}
+	// The number an operator actually watches.
+	if after["seconds_since_last_sync"] == nil {
+		t.Error("status does not report sync lag")
+	}
+}
+
+func TestEdgeSyncSpoke_LedgerShowsStuckFiles(t *testing.T) {
+	rig := newSpokeRig(t)
+	ctx := context.Background()
+
+	const p = "metrics/cpu/2026/08/07/14/stuck.parquet"
+	if err := rig.backend.Write(ctx, p, []byte("payload")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// A hub that keeps rejecting the content.
+	rig.transport.ScriptPut("ground-station", p, &edgesync.PutResult{Outcome: edgesync.OutcomeChecksumMismatch})
+	rig.do(t, http.MethodPost, "/api/v1/spoke-sync/run")
+
+	resp, body := rig.do(t, http.MethodGet, "/api/v1/spoke-sync/ledger")
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	entries, _ := body["entries"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("entries = %v, want one", body["entries"])
+	}
+	row, _ := entries[0].(map[string]any)
+
+	// Without this an operator would have to open the SQLite file to answer
+	// "why is this not syncing?".
+	if row["attempts"] != float64(1) {
+		t.Errorf("attempts = %v, want 1", row["attempts"])
+	}
+	if row["last_error"] == nil {
+		t.Error("the ledger view does not show why the transfer failed")
+	}
+}
+
+func TestEdgeSyncSpoke_LedgerLimitIsBounded(t *testing.T) {
+	rig := newSpokeRig(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%02d.parquet", i)
+		if err := rig.backend.Write(ctx, p, []byte("payload")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	// Discovery only, no send, so everything stays pending.
+	rig.transport.Close()
+	rig.do(t, http.MethodPost, "/api/v1/spoke-sync/run")
+
+	_, body := rig.do(t, http.MethodGet, "/api/v1/spoke-sync/ledger?limit=2")
+	entries, _ := body["entries"].([]any)
+	if len(entries) != 2 {
+		t.Errorf("entries = %d with limit=2, want 2", len(entries))
+	}
+
+	// An unbounded response on a long-running edge box would be enormous, so
+	// the cap is enforced rather than trusted.
+	_, capped := rig.do(t, http.MethodGet, "/api/v1/spoke-sync/ledger?limit=99999")
+	if capped["limit"] != float64(1000) {
+		t.Errorf("limit = %v for an oversized request, want it capped at 1000", capped["limit"])
+	}
+
+	for _, bad := range []string{"0", "-1", "abc"} {
+		resp, _ := rig.do(t, http.MethodGet, "/api/v1/spoke-sync/ledger?limit="+bad)
+		if resp.StatusCode != fiber.StatusBadRequest {
+			t.Errorf("limit=%q: status = %d, want 400", bad, resp.StatusCode)
+		}
+	}
+}
+
+func TestEdgeSyncSpoke_RunFailureIs503(t *testing.T) {
+	rig := newSpokeRig(t)
+	ctx := context.Background()
+
+	if err := rig.backend.Write(ctx, "metrics/cpu/2026/08/07/14/f.parquet", []byte("payload")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// A hub that cannot be reached. The pass failed for a reason outside the
+	// operator's request, so 503 tells them to retry rather than to fix their
+	// call.
+	rig.transport.Close()
+
+	resp, _ := rig.do(t, http.MethodPost, "/api/v1/spoke-sync/run")
+	if resp.StatusCode != fiber.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestNewEdgeSyncSpokeHandler_RequiresAnAgent(t *testing.T) {
+	if _, err := NewEdgeSyncSpokeHandler(nil, nil, zerolog.Nop()); err == nil {
+		t.Error("a spoke handler was created without an agent")
+	}
+}
+
+// Fiber's Group().Use() matches by string PREFIX, not by path segment, so a
+// group at "/api/v1/sync" also matches "/api/v1/sync-spoke/...". Mounting the
+// operator controls under such a name would silently subject them to the hub's
+// body limit and middleware. This pins the property rather than the name: any
+// future rename that reintroduces the collision fails here.
+func TestEdgeSyncSpoke_PrefixDoesNotCollideWithHubGroups(t *testing.T) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+
+	hubRan := false
+	hub := app.Group("/api/v1/sync")
+	hub.Use(func(c *fiber.Ctx) error { hubRan = true; return c.Next() })
+	hub.Post("/file", func(c *fiber.Ctx) error { return c.SendString("hub") })
+
+	adminRan := false
+	admin := app.Group("/api/v1/sync-spokes")
+	admin.Use(func(c *fiber.Ctx) error { adminRan = true; return c.Next() })
+	admin.Get("/", func(c *fiber.Ctx) error { return c.SendString("admin") })
+
+	rig := newSpokeRig(t)
+	h, err := NewEdgeSyncSpokeHandler(rig.agent, nil, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	h.RegisterRoutes(app)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/api/v1/spoke-sync/status", nil), 30_000)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hubRan {
+		t.Error("the hub group's middleware ran on a spoke route: the prefixes collide")
+	}
+	if adminRan {
+		t.Error("the spoke-admin group's middleware ran on a spoke route: the prefixes collide")
+	}
+}
+
+// A file that exhausted its retries is terminal until someone intervenes, and
+// is the one most likely to have prompted an operator to open this endpoint.
+// A pending-only view would hide exactly that.
+func TestEdgeSyncSpoke_LedgerShowsExhaustedFiles(t *testing.T) {
+	rig := newSpokeRig(t)
+	ctx := context.Background()
+
+	const p = "metrics/cpu/2026/08/07/14/doomed.parquet"
+	if err := rig.backend.Write(ctx, p, []byte("payload")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Keep failing it until the agent gives up.
+	for i := 0; i < edgesync.DefaultMaxAttempts+2; i++ {
+		rig.transport.ScriptPut("ground-station", p, &edgesync.PutResult{Outcome: edgesync.OutcomeChecksumMismatch})
+		rig.do(t, http.MethodPost, "/api/v1/spoke-sync/run")
+	}
+
+	_, body := rig.do(t, http.MethodGet, "/api/v1/spoke-sync/ledger")
+	entries, _ := body["entries"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("entries = %v, want the exhausted file to still be listed", body["entries"])
+	}
+	row, _ := entries[0].(map[string]any)
+	if row["state"] != "failed" {
+		t.Errorf("state = %v, want %q: an exhausted file is invisible in the ledger view", row["state"], "failed")
+	}
+	if row["last_error"] == nil {
+		t.Error("the exhausted file does not say why it failed")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"runtime"
@@ -205,6 +206,14 @@ type EdgeSyncConfig struct {
 	// (compaction.max_files_per_batch keeps those well below it).
 	MaxFileBytes int64
 
+	// Spoke is the push side: this Arc instance sending its files to a hub.
+	//
+	// Separate from the hub keys above because an Arc can be a hub, a spoke,
+	// both, or neither, and the two roles share no settings. A flat block
+	// would leave an operator unable to tell which keys apply to their
+	// deployment.
+	Spoke EdgeSyncSpokeConfig
+
 	// MaxReconcileEntries caps one batch-discovery request.
 	//
 	// The design wants a spoke's whole pending set in one round-trip, but the
@@ -213,6 +222,54 @@ type EdgeSyncConfig struct {
 	// spoke page keeps what matters — discovery costs O(batches), not
 	// O(files) — while bounding the exposure. Default 10,000 entries (~2MB).
 	MaxReconcileEntries int
+}
+
+// EdgeSyncSpokeConfig configures the push side of edge sync (#569).
+type EdgeSyncSpokeConfig struct {
+	// Enabled mounts the manual sync controls. Off by default: pushing data
+	// off a box is a deliberate decision.
+	Enabled bool
+
+	// HubURL is the hub's root, e.g. https://ground-station.example.com.
+	HubURL string
+
+	// SpokeID is this instance's identity, as registered on the hub with
+	// POST /api/v1/sync-spokes. Becomes the first path segment of everything
+	// this spoke writes there.
+	SpokeID string
+
+	// HubID is the REMOTE hub's identity, and must match that hub's
+	// edge_sync.hub_id exactly.
+	//
+	// It is bound into every request MAC, so the hub rejects anything signed
+	// for a different one — which is what stops a request captured en route to
+	// one hub from being replayed at another that shares this spoke's secret.
+	// A mismatch fails every request with a 400, so it is validated at load
+	// rather than discovered on the first contact window.
+	HubID string
+
+	// Secret is the hub-issued shared secret, read ONLY from
+	// ARC_EDGE_SYNC_SPOKE_SECRET.
+	//
+	// Deliberately not a config key. Viper binds every key to an env var, so
+	// declaring one would also make it settable from arc.toml — and a live
+	// write credential in a config file is a credential in every copy, backup,
+	// and commit of that file. ARC_ENCRYPTION_KEY sets the same precedent.
+	// Arc refuses to start if a secret appears in the config file rather than
+	// quietly preferring the environment, because a silent preference leaves
+	// the committed copy looking load-bearing while still being leaked.
+	Secret string
+
+	// MaxAttempts before a file is given up on. Zero uses the package default.
+	MaxAttempts int
+
+	// MaxConcurrent bounds simultaneous transfers. Zero means 2 — edge boxes
+	// are small.
+	MaxConcurrent int
+
+	// BatchSize caps how many files one reconcile asks about. Zero lets the
+	// hub's own limit decide, and a larger backlog pages.
+	BatchSize int
 }
 
 type WALConfig struct {
@@ -657,6 +714,16 @@ func Load() (*Config, error) {
 			HubID:               v.GetString("edge_sync.hub_id"),
 			MaxFileBytes:        int64(v.GetInt64("edge_sync.max_file_bytes")),
 			MaxReconcileEntries: v.GetInt("edge_sync.max_reconcile_entries"),
+			Spoke: EdgeSyncSpokeConfig{
+				Enabled:       v.GetBool("edge_sync.spoke.enabled"),
+				HubURL:        v.GetString("edge_sync.spoke.hub_url"),
+				SpokeID:       v.GetString("edge_sync.spoke.spoke_id"),
+				HubID:         v.GetString("edge_sync.spoke.hub_id"),
+				Secret:        os.Getenv("ARC_EDGE_SYNC_SPOKE_SECRET"),
+				MaxAttempts:   v.GetInt("edge_sync.spoke.max_attempts"),
+				MaxConcurrent: v.GetInt("edge_sync.spoke.max_concurrent"),
+				BatchSize:     v.GetInt("edge_sync.spoke.batch_size"),
+			},
 		},
 		Compaction: CompactionConfig{
 			Enabled:                     v.GetBool("compaction.enabled"),
@@ -989,6 +1056,76 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// The spoke secret must come from the environment. Refuse rather than
+	// silently prefer it: a config-file secret that is ignored still leaks,
+	// and leaving it in place makes the committed copy look load-bearing.
+	//
+	// InConfig, not IsSet: with AutomaticEnv in play IsSet also consults the
+	// environment, so it fires on ARC_EDGE_SYNC_SPOKE_SECRET — the one way an
+	// operator is supposed to supply the secret — and refuses to start in the
+	// configuration this check exists to require. InConfig reads only the
+	// parsed file, which is the thing being prohibited.
+	if v.InConfig("edge_sync.spoke.secret") || v.InConfig("edge_sync.spoke.shared_secret") {
+		return nil, fmt.Errorf("edge_sync.spoke.secret must not be set in the configuration file; " +
+			"supply it via the ARC_EDGE_SYNC_SPOKE_SECRET environment variable so a write credential " +
+			"is not stored in a file that gets copied, backed up, and committed")
+	}
+
+	if cfg.EdgeSync.Spoke.Enabled {
+		if cfg.EdgeSync.Spoke.HubURL == "" {
+			return nil, fmt.Errorf("edge_sync.spoke.enabled=true requires edge_sync.spoke.hub_url")
+		}
+		// Parsed, not prefix-matched. The transport builds request URLs by
+		// concatenating endpoint paths onto this value, so a fragment or query
+		// string swallows the path — "https://hub#f" + "/api/v1/sync/file"
+		// requests "/" with the endpoint buried in the fragment, and the hub
+		// answers with something that looks nothing like a config error.
+		hubURL, err := url.Parse(cfg.EdgeSync.Spoke.HubURL)
+		if err != nil {
+			return nil, fmt.Errorf("edge_sync.spoke.hub_url %q is not a valid URL: %w", cfg.EdgeSync.Spoke.HubURL, err)
+		}
+		if hubURL.Scheme != "http" && hubURL.Scheme != "https" {
+			return nil, fmt.Errorf("edge_sync.spoke.hub_url %q must start with http:// or https://", cfg.EdgeSync.Spoke.HubURL)
+		}
+		if hubURL.Host == "" {
+			return nil, fmt.Errorf("edge_sync.spoke.hub_url %q has no host", cfg.EdgeSync.Spoke.HubURL)
+		}
+		if hubURL.RawQuery != "" || hubURL.Fragment != "" {
+			return nil, fmt.Errorf("edge_sync.spoke.hub_url %q must not carry a query string or fragment: "+
+				"endpoint paths are appended to it, and either one would swallow them", cfg.EdgeSync.Spoke.HubURL)
+		}
+		if cfg.EdgeSync.Spoke.SpokeID == "" {
+			return nil, fmt.Errorf("edge_sync.spoke.enabled=true requires edge_sync.spoke.spoke_id (the ID registered on the hub)")
+		}
+
+		// Negative tuning values are rejected rather than clamped silently.
+		// batch_size in particular reaches a make() capacity on the sync path,
+		// so a negative one crashes the spoke on the pass it was configured
+		// for; the agent clamps defensively, but an operator who typed it
+		// should be told at startup rather than have it quietly ignored.
+		if cfg.EdgeSync.Spoke.BatchSize < 0 {
+			return nil, fmt.Errorf("edge_sync.spoke.batch_size must be >= 0 (got %d); 0 means \"use the hub's cap\"",
+				cfg.EdgeSync.Spoke.BatchSize)
+		}
+		if cfg.EdgeSync.Spoke.MaxAttempts < 0 {
+			return nil, fmt.Errorf("edge_sync.spoke.max_attempts must be >= 0 (got %d); 0 means \"use the default\"",
+				cfg.EdgeSync.Spoke.MaxAttempts)
+		}
+		if cfg.EdgeSync.Spoke.MaxConcurrent < 0 {
+			return nil, fmt.Errorf("edge_sync.spoke.max_concurrent must be >= 0 (got %d); 0 means \"use the default\"",
+				cfg.EdgeSync.Spoke.MaxConcurrent)
+		}
+		if cfg.EdgeSync.Spoke.HubID == "" {
+			return nil, fmt.Errorf("edge_sync.spoke.enabled=true requires edge_sync.spoke.hub_id: " +
+				"it is bound into every request's HMAC and must match the remote hub's edge_sync.hub_id, " +
+				"so a wrong or missing value fails every request")
+		}
+		if cfg.EdgeSync.Spoke.Secret == "" {
+			return nil, fmt.Errorf("edge_sync.spoke.enabled=true requires the ARC_EDGE_SYNC_SPOKE_SECRET environment variable; " +
+				"it is the secret the hub issued when this spoke was registered")
+		}
+	}
+
 	// A hub without an ID cannot authenticate anything: hub_id is bound into
 	// every request MAC, so an empty value would mean every spoke signs for
 	// the same anonymous hub and a request captured at one could be replayed
@@ -1119,6 +1256,17 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("edge_sync.hub_id", "")
 	v.SetDefault("edge_sync.max_file_bytes", 512*1024*1024) // 512MiB per upload
 	v.SetDefault("edge_sync.max_reconcile_entries", 10000)  // ~2MB per discovery batch
+
+	// Spoke side. Declared here rather than relying only on the agent's
+	// zero-value fallbacks so the defaults are visible to an operator reading
+	// the config, and so the documented value and the code cannot drift apart.
+	v.SetDefault("edge_sync.spoke.enabled", false)
+	v.SetDefault("edge_sync.spoke.hub_url", "")
+	v.SetDefault("edge_sync.spoke.spoke_id", "")
+	v.SetDefault("edge_sync.spoke.hub_id", "")
+	v.SetDefault("edge_sync.spoke.max_attempts", 5)   // before a file is marked failed
+	v.SetDefault("edge_sync.spoke.max_concurrent", 2) // edge boxes are small
+	v.SetDefault("edge_sync.spoke.batch_size", 0)     // 0 defers to the hub's cap
 
 	v.SetDefault("compaction.enabled", true)
 	v.SetDefault("compaction.hourly_schedule", "5 * * * *")        // Every hour at :05

--- a/internal/config/edgesync_spoke_test.go
+++ b/internal/config/edgesync_spoke_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loadWith installs body as arc.toml in a temp working directory and loads it.
+// Load discovers its config file from the working directory, so the chdir is
+// how a test controls what it reads.
+func loadWith(t *testing.T, body string) (*Config, error) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "arc.toml"), []byte(body), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(oldWd) })
+	return Load()
+}
+
+const validSpokeConfig = `
+[edge_sync.spoke]
+enabled = true
+hub_url = "https://hub.example.com"
+spoke_id = "rocket-01"
+hub_id = "ground-station"
+`
+
+// The secret's only sanctioned home is the environment, so a config that
+// supplies it there must load. Guarding this with viper's IsSet rejects it —
+// IsSet consults the environment under AutomaticEnv — which left the feature
+// unusable in exactly the setup it requires.
+func TestSpokeConfig_SecretFromEnvironmentIsAccepted(t *testing.T) {
+	t.Setenv("ARC_EDGE_SYNC_SPOKE_SECRET", strings.Repeat("a", 64))
+
+	cfg, err := loadWith(t, validSpokeConfig)
+	if err != nil {
+		t.Fatalf("a spoke supplying its secret via the environment failed to load: %v", err)
+	}
+	if cfg.EdgeSync.Spoke.Secret == "" {
+		t.Error("the secret from the environment did not reach the config")
+	}
+}
+
+// A secret in the file is refused rather than ignored: one that is ignored
+// still leaks, and leaving it makes the committed copy look load-bearing.
+func TestSpokeConfig_SecretInFileIsRefused(t *testing.T) {
+	for _, key := range []string{"secret", "shared_secret"} {
+		t.Run(key, func(t *testing.T) {
+			_, err := loadWith(t, validSpokeConfig+key+` = "hunter2"`+"\n")
+			if err == nil {
+				t.Fatalf("a config file carrying %s loaded without complaint", key)
+			}
+			if !strings.Contains(err.Error(), "ARC_EDGE_SYNC_SPOKE_SECRET") {
+				t.Errorf("the error does not say where the secret belongs: %v", err)
+			}
+		})
+	}
+}
+
+// A mismatched or missing hub_id fails every request with a 400. Catching it
+// at load turns a silent total failure into a startup message.
+func TestSpokeConfig_RequiresIdentitiesAndURL(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"no hub_url", "[edge_sync.spoke]\nenabled = true\nspoke_id = \"r1\"\nhub_id = \"g\"\n", "hub_url"},
+		{"no spoke_id", "[edge_sync.spoke]\nenabled = true\nhub_url = \"https://h\"\nhub_id = \"g\"\n", "spoke_id"},
+		{"no hub_id", "[edge_sync.spoke]\nenabled = true\nhub_url = \"https://h\"\nspoke_id = \"r1\"\n", "hub_id"},
+		{"scheme-less hub_url", "[edge_sync.spoke]\nenabled = true\nhub_url = \"hub.example.com\"\nspoke_id = \"r1\"\nhub_id = \"g\"\n", "http"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := loadWith(t, tc.body); err == nil {
+				t.Fatalf("config loaded despite %s", tc.name)
+			} else if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A disabled spoke is the default for every Arc deployment, so an incomplete
+// block must not block startup.
+func TestSpokeConfig_DisabledSpokeSkipsValidation(t *testing.T) {
+	cfg, err := loadWith(t, "[edge_sync.spoke]\nenabled = false\n")
+	if err != nil {
+		t.Fatalf("a disabled spoke blocked startup: %v", err)
+	}
+	if cfg.EdgeSync.Spoke.Enabled {
+		t.Error("spoke reported enabled")
+	}
+}
+
+// Defaults are declared with v.SetDefault rather than left to the agent's
+// zero-value fallbacks, so an operator reading the config sees them and the
+// documented value cannot drift from the code.
+func TestSpokeConfig_DefaultsAreDeclared(t *testing.T) {
+	cfg, err := loadWith(t, "[server]\nport = 8000\n")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.EdgeSync.Spoke.Enabled {
+		t.Error("the spoke is enabled by default")
+	}
+	if got := cfg.EdgeSync.Spoke.MaxAttempts; got != 5 {
+		t.Errorf("max_attempts = %d, want 5", got)
+	}
+	if got := cfg.EdgeSync.Spoke.MaxConcurrent; got != 2 {
+		t.Errorf("max_concurrent = %d, want 2", got)
+	}
+	// 0 means "defer to the hub's cap", which is a real value here, not an
+	// unset field.
+	if got := cfg.EdgeSync.Spoke.BatchSize; got != 0 {
+		t.Errorf("batch_size = %d, want 0", got)
+	}
+}

--- a/internal/edgesync/agent.go
+++ b/internal/edgesync/agent.go
@@ -1,0 +1,626 @@
+package edgesync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// DefaultMaxAttempts is how many times a file is retried before the ledger
+// gives up on it.
+//
+// Deliberately generous: on an intermittent link most failures are the link,
+// not the file, and a spoke that abandons data after two bad contact windows
+// is worse than one that keeps trying. A genuinely broken file (a checksum
+// mismatch that reproduces) still stops after this many.
+const DefaultMaxAttempts = 5
+
+// MaxAllowedConcurrent caps simultaneous transfers regardless of configuration.
+//
+// Each transfer holds an open file handle and an io.Pipe, and a spoke is by
+// definition a small machine. An operator typo in max_concurrent should not be
+// able to exhaust its file descriptors.
+const MaxAllowedConcurrent = 64
+
+// Agent runs one sync pass: discover local files, ask the hub what it is
+// missing, and stream those files to it.
+//
+// This is the manual half of the design. §8.2 describes a connectivity-adaptive
+// background loop, but that is the Enterprise feature (§9) — here the pass is
+// triggered by an operator and runs once. The internals are the same either
+// way, so phase 2 adds a ticker and a license gate rather than a rewrite.
+type Agent struct {
+	ledger    *Ledger
+	transport SyncTransport
+	backend   storage.Backend
+	hubID     string
+	spokeID   string
+	logger    zerolog.Logger
+
+	maxAttempts   int
+	maxConcurrent int
+	batchSize     int
+}
+
+// AgentConfig configures a sync Agent.
+type AgentConfig struct {
+	Ledger    *Ledger
+	Transport SyncTransport
+	Backend   storage.Backend
+
+	// HubID names the hub this agent syncs to. Keyed into every ledger row, so
+	// changing it starts a fresh sync history rather than resuming another
+	// hub's.
+	HubID string
+
+	// SpokeID is this edge instance's identity, as registered on the hub.
+	SpokeID string
+
+	// MaxAttempts before a file is marked failed. Zero uses DefaultMaxAttempts.
+	MaxAttempts int
+
+	// MaxConcurrent bounds simultaneous transfers. Zero means 2 — edge boxes
+	// are small, and §8.2 caps this low deliberately.
+	MaxConcurrent int
+
+	// BatchSize caps how many files one reconcile asks about. Zero means the
+	// hub's own default. A spoke with a larger backlog pages.
+	BatchSize int
+
+	Logger zerolog.Logger
+}
+
+// RunResult summarizes one sync pass.
+type RunResult struct {
+	// Discovered is how many local files were newly added to the ledger.
+	Discovered int
+
+	// Recovered is how many interrupted transfers were reset to pending.
+	//
+	// int like its sibling counters, though the ledger reports RowsAffected as
+	// int64 — a RunResult is a per-pass summary, and a mixed-width struct is
+	// awkward for every caller that formats it.
+	Recovered int
+
+	// AlreadyPresent is how many files the hub reported it already had —
+	// the lost-acknowledgment path, resolved without sending bytes.
+	AlreadyPresent int
+
+	// Sent is how many files were transferred and acknowledged this pass.
+	Sent int
+
+	// BytesSent counts only bytes actually put on the wire, so a resumed
+	// transfer contributes its tail rather than the whole file.
+	BytesSent int64
+
+	// Partial is how many transfers ended mid-file. Not failures: each left a
+	// resume checkpoint and continues on the next pass.
+	Partial int
+
+	// Failed is how many transfers errored.
+	Failed int
+
+	// Conflicts are same-path-different-content disagreements. These need an
+	// operator, not a retry, so they are surfaced rather than counted away.
+	Conflicts []Conflict
+
+	Duration time.Duration
+}
+
+// NewAgent validates configuration and returns a ready Agent.
+func NewAgent(cfg AgentConfig) (*Agent, error) {
+	if cfg.Ledger == nil {
+		return nil, errors.New("edgesync: agent requires a ledger")
+	}
+	if cfg.Transport == nil {
+		return nil, errors.New("edgesync: agent requires a transport")
+	}
+	if cfg.Backend == nil {
+		return nil, errors.New("edgesync: agent requires a storage backend")
+	}
+	if err := validateSpokeID(cfg.SpokeID); err != nil {
+		return nil, fmt.Errorf("edgesync: agent spoke ID: %w", err)
+	}
+
+	hubID := cfg.HubID
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	maxAttempts := cfg.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultMaxAttempts
+	}
+	maxConcurrent := cfg.MaxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = 2
+	}
+	if maxConcurrent > MaxAllowedConcurrent {
+		// An edge box is the machine least able to absorb a goroutine and an
+		// open file handle per pending file. Clamp rather than fail: a typo in
+		// a field like this should not stop a spoke from syncing at all.
+		maxConcurrent = MaxAllowedConcurrent
+	}
+	// Clamped like its siblings above. A negative value reaches make()'s
+	// capacity argument in the paging loop and panics the process on the first
+	// pass — a crash on the edge box, for a value an operator can set in
+	// arc.toml.
+	batchSize := cfg.BatchSize
+	if batchSize < 0 {
+		batchSize = 0
+	}
+
+	return &Agent{
+		ledger:        cfg.Ledger,
+		transport:     cfg.Transport,
+		backend:       cfg.Backend,
+		hubID:         hubID,
+		spokeID:       cfg.SpokeID,
+		logger:        cfg.Logger,
+		maxAttempts:   maxAttempts,
+		maxConcurrent: maxConcurrent,
+		batchSize:     batchSize,
+	}, nil
+}
+
+// Run performs one sync pass.
+//
+// The order matters and follows §8.2: recover interrupted transfers, discover
+// new files, reconcile the whole backlog in one round-trip, then stream what
+// the hub is missing — newest first, so that if a contact window closes
+// mid-backlog the freshest telemetry has already landed.
+func (a *Agent) Run(ctx context.Context) (*RunResult, error) {
+	start := time.Now()
+	res := &RunResult{}
+
+	// A transfer that was in flight when the process died cannot still be
+	// running, so reset it before discovery. Re-sending a file the hub already
+	// committed is harmless — it answers AlreadyPresent.
+	recovered, err := a.ledger.RecoverInFlight(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: recover interrupted transfers: %w", err)
+	}
+	res.Recovered = int(recovered)
+
+	discovered, err := a.Discover(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res.Discovered = discovered
+
+	// Page until the backlog drains. A pass that moved only the first batch
+	// and reported success would silently strand the rest — and the case that
+	// matters most, a spoke returning from a long outage, is exactly the one
+	// with more pending files than a batch holds.
+	//
+	// Paging is by "have I already offered this path?", not by counting
+	// progress: Pending returns state='pending' in a stable order, and the
+	// states a pass does not resolve — a conflict, an exhausted retry, a
+	// partial transfer — stay pending. A page is therefore fetched wider than
+	// it is used, skipping what this pass already handled, so unresolved rows
+	// at the head cannot hide the fresh ones behind them.
+	offered := make(map[string]struct{})
+	for {
+		// Fetch past what has already been offered. Without the growing
+		// window, a backlog whose first rows all stay pending — every one a
+		// conflict, say — would return the same page forever.
+		limit := 0
+		if a.batchSize > 0 {
+			limit = a.batchSize + len(offered)
+		}
+		pending, err := a.ledger.Pending(ctx, a.hubID, limit)
+		if err != nil {
+			return nil, fmt.Errorf("edgesync: read pending: %w", err)
+		}
+
+		fresh := make([]*LedgerEntry, 0, a.batchSize)
+		for _, e := range pending {
+			if _, seen := offered[e.Path]; seen {
+				continue
+			}
+			offered[e.Path] = struct{}{}
+			fresh = append(fresh, e)
+			if a.batchSize > 0 && len(fresh) == a.batchSize {
+				break
+			}
+		}
+		if len(fresh) == 0 {
+			break
+		}
+
+		if err := a.runBatch(ctx, fresh, res); err != nil {
+			return nil, err
+		}
+	}
+
+	res.Duration = time.Since(start)
+	return res, nil
+}
+
+// runBatch reconciles one page of pending files and sends what the hub lacks.
+func (a *Agent) runBatch(ctx context.Context, pending []*LedgerEntry, res *RunResult) error {
+	// One round-trip for the whole backlog. This is the property that makes a
+	// long disconnection survivable: 5,000 pending files cost one request.
+	reconciled, err := a.transport.Reconcile(ctx, a.hubID, pending)
+	if err != nil {
+		return fmt.Errorf("edgesync: reconcile: %w", err)
+	}
+	if err := reconciled.Validate(); err != nil {
+		return fmt.Errorf("edgesync: hub returned an invalid reconcile result: %w", err)
+	}
+
+	// Files the hub already holds are advanced without sending a byte. This is
+	// the lost-ack path: a transfer that completed but whose acknowledgment
+	// never arrived is resolved here in bulk.
+	for _, p := range reconciled.Present {
+		if err := a.ledger.MarkSynced(ctx, a.hubID, p); err != nil {
+			// Not fatal: the file is on the hub either way, and the next pass
+			// re-discovers the discrepancy. Failing the run would strand the
+			// files still queued behind it.
+			a.logger.Warn().Err(err).Str("path", p).Msg("Could not mark a hub-confirmed file as synced")
+			continue
+		}
+		res.AlreadyPresent++
+	}
+
+	// Conflicts need a human. Surfacing them beats retrying: the same path
+	// holding different content means a spoke-ID collision or corruption, and
+	// re-sending would either be refused or destroy evidence.
+	// Appended, not assigned: a pass spans several pages, and overwriting
+	// would report only the last page's conflicts.
+	res.Conflicts = append(res.Conflicts, reconciled.Conflicts...)
+	for _, c := range reconciled.Conflicts {
+		a.logger.Error().
+			Str("path", c.Path).
+			Str("hub_sha256", c.TheirSHA256).
+			Msg("Sync conflict: the hub holds different content at this path; not retrying")
+
+		// Marked failed for the same reason the transfer path does it
+		// (see sendOne): a content disagreement needs a human, and retrying
+		// cannot resolve it. Left pending, a conflict would ride along in
+		// every future reconcile payload forever — unbounded growth on a
+		// spoke with a permanent conflict, and the two conflict paths would
+		// disagree about whether the same condition is terminal.
+		if err := a.ledger.MarkConflicted(ctx, a.hubID, c.Path, "conflict: hub holds different content"); err != nil {
+			a.logger.Warn().Err(err).Str("path", c.Path).Msg("Could not mark a conflicted file failed")
+		}
+	}
+
+	// Newest-first. If the link drops mid-backlog, the most recent telemetry
+	// has already reached the hub and backfill catches up next pass — Pending
+	// already returns this order, so preserve it rather than re-sorting.
+	//
+	// Set membership, not a linear scan per entry: at the 10,000-entry batch
+	// the hub allows, a nested loop would be 100M comparisons for a step that
+	// should be free.
+	missingSet := make(map[string]struct{}, len(reconciled.Missing))
+	for _, p := range reconciled.Missing {
+		missingSet[p] = struct{}{}
+	}
+	missing := make([]*LedgerEntry, 0, len(reconciled.Missing))
+	for _, e := range pending {
+		if _, ok := missingSet[e.Path]; ok {
+			missing = append(missing, e)
+		}
+	}
+
+	a.sendAll(ctx, missing, res)
+	return nil
+}
+
+// Discover walks local storage and adds files the ledger does not know about.
+//
+// §8.2 says to walk the manifest, which does not exist on a standalone spoke —
+// and even in cluster mode it is a different subsystem's index. Walking storage
+// works identically everywhere, and compaction output and backfilled files just
+// appear as new rows on the next pass.
+func (a *Agent) Discover(ctx context.Context) (int, error) {
+	lister, ok := a.backend.(storage.ObjectLister)
+	if !ok {
+		return 0, errors.New("edgesync: backend cannot list object metadata, so discovery is not possible")
+	}
+
+	objects, err := lister.ListObjects(ctx, "")
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: list local files: %w", err)
+	}
+
+	entries := make([]*LedgerEntry, 0, len(objects))
+	for _, obj := range objects {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		if !isSyncableFile(obj.Path) {
+			continue
+		}
+
+		// Skip anything already tracked BEFORE hashing it. Discovery runs
+		// every pass, and re-hashing the whole corpus each time would make the
+		// cheap step the expensive one.
+		if _, err := a.ledger.Get(ctx, a.hubID, obj.Path); err == nil {
+			continue
+		} else if !errors.Is(err, ErrNotFound) {
+			return 0, fmt.Errorf("edgesync: check ledger for %q: %w", obj.Path, err)
+		}
+
+		// ListObjects carries no digest, so compute one. This is the only full
+		// read a file gets from discovery, ever — and the spoke has to read
+		// those bytes to send them anyway. The digest is then reused for the
+		// request HMAC and for the hub's verify-before-commit.
+		sum, err := a.hashFile(ctx, obj.Path)
+		if err != nil {
+			// One unreadable file must not stop discovery: the rest of the
+			// backlog is still syncable, and this one is retried next pass.
+			a.logger.Warn().Err(err).Str("path", obj.Path).Msg("Skipping a file that could not be hashed")
+			continue
+		}
+
+		e := &LedgerEntry{
+			HubID:     a.hubID,
+			Path:      obj.Path,
+			SHA256:    sum,
+			SizeBytes: obj.Size,
+		}
+		e.Database, e.Measurement, e.PartitionTime = parseArcPath(obj.Path)
+		entries = append(entries, e)
+	}
+
+	if len(entries) == 0 {
+		return 0, nil
+	}
+
+	inserted, err := a.ledger.TrackBatch(ctx, entries)
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: track discovered files: %w", err)
+	}
+	return inserted, nil
+}
+
+// sendAll streams the missing files, bounded by MaxConcurrent.
+func (a *Agent) sendAll(ctx context.Context, missing []*LedgerEntry, res *RunResult) {
+	type outcome struct {
+		sent      bool
+		partial   bool
+		failed    bool
+		bytesSent int64
+	}
+
+	sem := make(chan struct{}, a.maxConcurrent)
+	results := make(chan outcome, len(missing))
+
+	for _, e := range missing {
+		// Checked before the select, not as one of its cases. With both a
+		// cancelled context and a free semaphore slot ready, select picks
+		// uniformly at random — so a cancelled pass would still launch about
+		// half its remaining transfers, which is the opposite of "stop".
+		if ctx.Err() != nil {
+			// The contact window closed. Whatever is in flight finishes or
+			// fails on its own, and its ledger state is correct either way.
+			results <- outcome{}
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			results <- outcome{}
+			continue
+		case sem <- struct{}{}:
+		}
+
+		go func(entry *LedgerEntry) {
+			defer func() { <-sem }()
+			sent, partial, n, err := a.sendOne(ctx, entry)
+			results <- outcome{sent: sent, partial: partial, failed: err != nil, bytesSent: n}
+		}(e)
+	}
+
+	for range missing {
+		o := <-results
+		switch {
+		case o.sent:
+			res.Sent++
+		case o.partial:
+			res.Partial++
+		case o.failed:
+			res.Failed++
+		}
+		res.BytesSent += o.bytesSent
+	}
+}
+
+// sendOne transfers a single file, resuming from its checkpoint if it has one.
+func (a *Agent) sendOne(ctx context.Context, e *LedgerEntry) (sent, partial bool, bytesSent int64, err error) {
+	if err := a.ledger.MarkInFlight(ctx, a.hubID, e.Path); err != nil {
+		// Usually a concurrent pass already claimed it. Not an error worth
+		// failing the run over.
+		a.logger.Debug().Err(err).Str("path", e.Path).Msg("Could not claim a file for transfer")
+		return false, false, 0, err
+	}
+
+	offset := e.BytesSent
+	body, err := a.openAt(ctx, e.Path, offset)
+	if err != nil {
+		a.fail(ctx, e, fmt.Sprintf("open: %v", err))
+		return false, false, 0, err
+	}
+	defer body.Close()
+
+	res, err := a.transport.PutFile(ctx, a.hubID, e, body, offset)
+	if err != nil {
+		// A resume the hub cannot honour: it no longer holds the prefix our
+		// checkpoint refers to. That happens when a hub restarts, sweeps its
+		// staging area, or runs on a backend that cannot append at all. The
+		// file is fine — only the checkpoint is stale — so clear it and let
+		// the next pass start from zero. Without this the agent would retry
+		// the same impossible offset until it gave up on healthy data.
+		if isStaleCheckpoint(err) && offset > 0 {
+			a.logger.Info().
+				Str("path", e.Path).
+				Int64("stale_offset", offset).
+				Msg("Hub no longer holds our partial; restarting this file from the beginning")
+			if resetErr := a.ledger.RecordProgress(ctx, a.hubID, e.Path, 0); resetErr != nil {
+				a.logger.Warn().Err(resetErr).Str("path", e.Path).Msg("Could not clear a stale resume checkpoint")
+			}
+		}
+		a.fail(ctx, e, err.Error())
+		return false, false, 0, err
+	}
+	// A hub is remote code as far as the spoke is concerned; an inconsistent
+	// answer must not become ledger state.
+	if err := res.Validate(e); err != nil {
+		a.fail(ctx, e, fmt.Sprintf("invalid hub response: %v", err))
+		return false, false, 0, err
+	}
+
+	switch {
+	case res.Outcome.Done():
+		if err := a.ledger.MarkSynced(ctx, a.hubID, e.Path); err != nil {
+			return false, false, 0, err
+		}
+		// A file the hub already had cost no bytes; only count a real transfer.
+		if res.Outcome == OutcomeCommitted {
+			return true, false, res.BytesAccepted - offset, nil
+		}
+		return true, false, 0, nil
+
+	case res.Outcome == OutcomePartial:
+		// Record the hub's offset, not our own guess: the two can disagree,
+		// and appending at the wrong place would corrupt the file.
+		if err := a.ledger.RecordProgress(ctx, a.hubID, e.Path, res.BytesAccepted); err != nil {
+			a.logger.Warn().Err(err).Str("path", e.Path).Msg("Could not record a resume checkpoint")
+		}
+		a.fail(ctx, e, "transfer ended early; will resume")
+		return false, true, res.BytesAccepted - offset, nil
+
+	case res.Outcome == OutcomeConflict:
+		// Terminal by design. Retrying cannot resolve a content disagreement,
+		// and MarkFailed with a cap of 1 stops it immediately rather than
+		// burning attempts on something a human must look at.
+		a.logger.Error().
+			Str("path", e.Path).
+			Str("hub_sha256", res.TheirSHA256).
+			Msg("Sync conflict on transfer; the hub holds different content")
+		if err := a.ledger.MarkFailed(ctx, a.hubID, e.Path, "conflict: hub holds different content", 1); err != nil {
+			a.logger.Warn().Err(err).Str("path", e.Path).Msg("Could not mark a conflicted file failed")
+		}
+		return false, false, 0, nil
+
+	default:
+		// Checksum mismatch or backpressure: retryable, so let the attempt
+		// counter decide when to give up.
+		a.fail(ctx, e, string(res.Outcome))
+		return false, false, 0, nil
+	}
+}
+
+// isStaleCheckpoint reports whether an error means the hub cannot resume from
+// the offset we hold.
+//
+// Matched on the error text because the condition arises inside a transport
+// implementation rather than from a sentinel the interface defines — a real
+// HTTP transport surfaces it as a status code, and a future one may not use
+// either. Treated as a hint: the worst case of a false negative is the
+// pre-existing behaviour, and of a false positive is one redundant full
+// re-send of a file that was going to be retried anyway.
+func isStaleCheckpoint(err error) bool {
+	if errors.Is(err, storage.ErrResumeNotSupported) {
+		return true
+	}
+	return strings.Contains(err.Error(), "no staged prefix")
+}
+
+// fail records a transfer failure against the attempt cap.
+func (a *Agent) fail(ctx context.Context, e *LedgerEntry, msg string) {
+	if err := a.ledger.MarkFailed(ctx, a.hubID, e.Path, msg, a.maxAttempts); err != nil {
+		a.logger.Warn().Err(err).Str("path", e.Path).Msg("Could not record a transfer failure")
+	}
+}
+
+// openAt returns a reader positioned at offset.
+//
+// Streams rather than buffering: a compacted Parquet file can be hundreds of
+// megabytes, and an edge box is the machine least able to hold one in memory.
+func (a *Agent) openAt(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
+	pr, pw := io.Pipe()
+
+	go func() {
+		var err error
+		if offset > 0 {
+			err = a.backend.ReadToAt(ctx, path, pw, offset)
+		} else {
+			err = a.backend.ReadTo(ctx, path, pw)
+		}
+		_ = pw.CloseWithError(err)
+	}()
+
+	return pr, nil
+}
+
+// hashFile computes a file's SHA-256 without holding it in memory.
+func (a *Agent) hashFile(ctx context.Context, path string) (string, error) {
+	h := sha256.New()
+	if err := a.backend.ReadTo(ctx, path, hasherWriter{h}); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// UnfinishedEntries returns files that have not reached the hub — those still
+// queued and those that gave up — with the given-up ones first.
+//
+// The troubleshooting view. It deliberately includes failed entries: a file
+// that exhausted its retries is the one an operator most needs to see, and a
+// pending-only view would hide exactly that.
+//
+// Exposed through the agent rather than by handing callers the ledger: the
+// handler has no business driving state transitions, and routing reads through
+// here keeps the ledger's mutating API out of the HTTP layer entirely.
+func (a *Agent) UnfinishedEntries(ctx context.Context, limit int) ([]*LedgerEntry, error) {
+	return a.ledger.Unfinished(ctx, a.hubID, limit)
+}
+
+// Status reports what the spoke still has to send.
+func (a *Agent) Status(ctx context.Context) (*Stats, error) {
+	return a.ledger.Stats(ctx, a.hubID)
+}
+
+// isSyncableFile reports whether a storage path is one the spoke should sync.
+//
+// The sync unit is an immutable Parquet file. Staging areas and dot-prefixed
+// paths are excluded — a spoke syncing the hub's own staging directory, or its
+// own, would ship transient state that is not data.
+func isSyncableFile(p string) bool {
+	if !strings.HasSuffix(p, ".parquet") {
+		return false
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if strings.HasPrefix(seg, ".") {
+			return false
+		}
+	}
+	return validateSyncPath(p) == nil
+}
+
+// parseArcPath extracts the Arc namespace from a storage path.
+//
+// Layout is {database}/{measurement}/{YYYY}/{MM}/{DD}/{HH}/file.parquet.
+// Returns zero values for a path that does not carry them, which is safe: the
+// fields are metadata for operators, not part of the sync identity.
+func parseArcPath(p string) (database, measurement string, partition time.Time) {
+	parts := strings.Split(p, "/")
+	if len(parts) >= 2 {
+		database, measurement = parts[0], parts[1]
+	}
+	if len(parts) >= 7 {
+		if t, err := time.Parse("2006/01/02/15", parts[2]+"/"+parts[3]+"/"+parts[4]+"/"+parts[5]); err == nil {
+			partition = t.UTC()
+		}
+	}
+	return database, measurement, partition
+}

--- a/internal/edgesync/agent_test.go
+++ b/internal/edgesync/agent_test.go
@@ -1,0 +1,808 @@
+package edgesync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+type agentRig struct {
+	agent     *Agent
+	ledger    *Ledger
+	transport *MemoryTransport
+	backend   storage.Backend
+}
+
+func newAgentRig(t *testing.T) *agentRig {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "agent-storage-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	backend, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	ledger := setupTestLedger(t)
+	transport := NewMemoryTransport()
+
+	agent, err := NewAgent(AgentConfig{
+		Ledger:    ledger,
+		Transport: transport,
+		Backend:   backend,
+		HubID:     DefaultHubID,
+		SpokeID:   "rocket-01",
+		Logger:    zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+
+	return &agentRig{agent: agent, ledger: ledger, transport: transport, backend: backend}
+}
+
+// writeFile puts a Parquet file into the spoke's local storage.
+func (r *agentRig) writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := r.backend.Write(context.Background(), path, content); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const agentPath = "metrics/cpu/2026/08/07/14/cpu_001.parquet"
+
+func TestAgent_RunSyncsDiscoveredFiles(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	content := []byte("parquet payload one")
+	rig.writeFile(t, agentPath, content)
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Discovered != 1 {
+		t.Errorf("discovered = %d, want 1", res.Discovered)
+	}
+	if res.Sent != 1 {
+		t.Errorf("sent = %d, want 1", res.Sent)
+	}
+	if res.BytesSent != int64(len(content)) {
+		t.Errorf("bytes = %d, want %d", res.BytesSent, len(content))
+	}
+
+	// The hub must hold the exact bytes, under the digest discovery computed.
+	sha, ok := rig.transport.Has(DefaultHubID, agentPath)
+	if !ok {
+		t.Fatal("the hub does not have the file")
+	}
+	if sha != sha256Hex(content) {
+		t.Error("the hub holds a different digest than the file's content")
+	}
+
+	// And the ledger must reflect it, or the next pass re-sends.
+	entry, err := rig.ledger.Get(ctx, DefaultHubID, agentPath)
+	if err != nil {
+		t.Fatalf("ledger get: %v", err)
+	}
+	if entry.State != StateSynced {
+		t.Errorf("state = %q, want %q", entry.State, StateSynced)
+	}
+}
+
+func TestAgent_SecondRunSendsNothing(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+	rig.writeFile(t, agentPath, []byte("payload"))
+
+	if _, err := rig.agent.Run(ctx); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	// A pass over an already-synced corpus must be free. If discovery
+	// re-tracked or the ledger did not advance, this is where a spoke would
+	// re-upload its entire backlog on every contact.
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if res.Discovered != 0 {
+		t.Errorf("discovered = %d on a second pass, want 0", res.Discovered)
+	}
+	if res.Sent != 0 || res.BytesSent != 0 {
+		t.Errorf("sent %d files / %d bytes on a second pass, want 0", res.Sent, res.BytesSent)
+	}
+}
+
+func TestAgent_LostAckIsResolvedWithoutResending(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	content := []byte("payload the hub already has")
+	rig.writeFile(t, agentPath, content)
+
+	// The hub received this file, but the acknowledgment never arrived — so
+	// the spoke's ledger still says pending. Reconcile must resolve it in bulk
+	// rather than re-uploading.
+	rig.transport.Seed(DefaultHubID, agentPath, sha256Hex(content), int64(len(content)))
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.AlreadyPresent != 1 {
+		t.Errorf("already-present = %d, want 1", res.AlreadyPresent)
+	}
+	if res.BytesSent != 0 {
+		t.Errorf("bytes sent = %d, want 0 — the file was re-uploaded despite the hub having it", res.BytesSent)
+	}
+
+	entry, err := rig.ledger.Get(ctx, DefaultHubID, agentPath)
+	if err != nil {
+		t.Fatalf("ledger get: %v", err)
+	}
+	if entry.State != StateSynced {
+		t.Errorf("state = %q, want %q", entry.State, StateSynced)
+	}
+}
+
+func TestAgent_NewestFirstOrdering(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	// Three partitions across different hours. When a contact window closes
+	// mid-backlog, the freshest telemetry must already have landed — so the
+	// agent has to send newest-first, not in discovery order.
+	hours := []string{"10", "14", "12"}
+	for i, h := range hours {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/%s/cpu_%d.parquet", h, i)
+		rig.writeFile(t, p, []byte(fmt.Sprintf("payload %d", i)))
+	}
+
+	if _, err := rig.agent.Discover(ctx); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	pending, err := rig.ledger.Pending(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(pending) != 3 {
+		t.Fatalf("pending = %d, want 3", len(pending))
+	}
+	for i := 1; i < len(pending); i++ {
+		if pending[i].PartitionTime.After(pending[i-1].PartitionTime) {
+			t.Errorf("entry %d (%s) is newer than %d (%s) — not newest-first",
+				i, pending[i].PartitionTime, i-1, pending[i-1].PartitionTime)
+		}
+	}
+	// The 14:00 partition must lead: it is the freshest.
+	if pending[0].PartitionTime.Hour() != 14 {
+		t.Errorf("first entry is hour %d, want 14", pending[0].PartitionTime.Hour())
+	}
+}
+
+func TestAgent_DiscoveryComputesDigestsAndNamespace(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	content := []byte("parquet payload")
+	rig.writeFile(t, agentPath, content)
+
+	if _, err := rig.agent.Discover(ctx); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+
+	entry, err := rig.ledger.Get(ctx, DefaultHubID, agentPath)
+	if err != nil {
+		t.Fatalf("ledger get: %v", err)
+	}
+
+	// The digest is the integrity anchor — §6.1 makes (path, sha256) the
+	// file's identity, and ListObjects does not supply one.
+	if entry.SHA256 != sha256Hex(content) {
+		t.Errorf("sha256 = %q, want the file's actual digest", entry.SHA256)
+	}
+	if entry.SizeBytes != int64(len(content)) {
+		t.Errorf("size = %d, want %d", entry.SizeBytes, len(content))
+	}
+	if entry.Database != "metrics" || entry.Measurement != "cpu" {
+		t.Errorf("namespace = %s/%s, want metrics/cpu", entry.Database, entry.Measurement)
+	}
+	want := time.Date(2026, 8, 7, 14, 0, 0, 0, time.UTC)
+	if !entry.PartitionTime.Equal(want) {
+		t.Errorf("partition = %v, want %v", entry.PartitionTime, want)
+	}
+}
+
+func TestAgent_DiscoverySkipsNonSyncableFiles(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	rig.writeFile(t, agentPath, []byte("real"))
+	// Not Parquet, and dot-prefixed staging. A spoke shipping either would be
+	// sending transient state rather than data.
+	rig.writeFile(t, "metrics/cpu/2026/08/07/14/notes.txt", []byte("x"))
+	rig.writeFile(t, ".sync-staging/rocket-02/leftover.parquet", []byte("x"))
+
+	n, err := rig.agent.Discover(ctx)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("discovered = %d, want only the parquet file", n)
+	}
+}
+
+func TestAgent_ResumesAPartialTransfer(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	content := []byte("the complete parquet payload for this file")
+	rig.writeFile(t, agentPath, content)
+
+	// Discover the file whole, so the ledger holds the real digest and size.
+	if _, err := rig.agent.Discover(ctx); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+
+	// Now truncate it, so the transfer delivers only a prefix and the hub
+	// genuinely stages one. Scripting a partial result instead would claim an
+	// offset the hub never retained — a different scenario, covered by
+	// TestAgent_RecoversFromAStaleCheckpoint.
+	const accepted = 15
+	if err := rig.backend.Write(ctx, agentPath, content[:accepted]); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if res.Partial != 1 {
+		t.Errorf("partial = %d, want 1", res.Partial)
+	}
+	if res.Sent != 0 {
+		t.Errorf("sent = %d, want 0 — a partial transfer is not a completed one", res.Sent)
+	}
+
+	// The checkpoint must survive: restarting a large file from zero is what
+	// resume exists to prevent.
+	entry, err := rig.ledger.Get(ctx, DefaultHubID, agentPath)
+	if err != nil {
+		t.Fatalf("ledger get: %v", err)
+	}
+	if entry.BytesSent != accepted {
+		t.Fatalf("checkpoint = %d, want %d", entry.BytesSent, accepted)
+	}
+
+	// Restore the rest of the file, as though writing had completed, and let
+	// the next pass resume from the checkpoint.
+	if err := rig.backend.Write(ctx, agentPath, content); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	res2, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if res2.Sent != 1 {
+		t.Errorf("sent = %d on resume, want 1", res2.Sent)
+	}
+
+	// The reassembled file must match — a resume that mis-splices corrupts
+	// silently, which is what the whole-file digest exists to catch.
+	sha, ok := rig.transport.Has(DefaultHubID, agentPath)
+	if !ok {
+		t.Fatal("the hub does not have the resumed file")
+	}
+	if sha != sha256Hex(content) {
+		t.Error("the resumed file does not match the original")
+	}
+}
+
+func TestAgent_RecoversFromAStaleCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	content := []byte("the complete parquet payload for this file")
+	rig.writeFile(t, agentPath, content)
+
+	// The ledger holds a checkpoint the hub cannot honour — it restarted,
+	// swept its staging area, or runs on a backend that cannot append. The
+	// file itself is fine; only the checkpoint is stale.
+	//
+	// Without recovery the agent retries the same impossible offset until the
+	// attempt cap, then abandons healthy data.
+	rig.transport.ScriptPut(DefaultHubID, agentPath,
+		&PutResult{Outcome: OutcomePartial, BytesAccepted: 15})
+	if _, err := rig.agent.Run(ctx); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	entry, err := rig.ledger.Get(ctx, DefaultHubID, agentPath)
+	if err != nil {
+		t.Fatalf("ledger get: %v", err)
+	}
+	if entry.BytesSent != 15 {
+		t.Fatalf("checkpoint = %d, want the hub's claimed 15", entry.BytesSent)
+	}
+
+	// This pass discovers the hub has no such prefix and clears the checkpoint.
+	if _, err := rig.agent.Run(ctx); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	entry, err = rig.ledger.Get(ctx, DefaultHubID, agentPath)
+	if err != nil {
+		t.Fatalf("ledger get: %v", err)
+	}
+	if entry.BytesSent != 0 {
+		t.Fatalf("checkpoint = %d after a rejected resume, want it cleared", entry.BytesSent)
+	}
+
+	// And the next pass sends the whole file successfully.
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("third run: %v", err)
+	}
+	if res.Sent != 1 {
+		t.Fatalf("sent = %d, want 1 — a stale checkpoint stranded a healthy file", res.Sent)
+	}
+	sha, ok := rig.transport.Has(DefaultHubID, agentPath)
+	if !ok || sha != sha256Hex(content) {
+		t.Error("the recovered file does not match the original")
+	}
+}
+
+func TestAgent_ConflictIsTerminalNotRetried(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	spokeContent := []byte("the spoke's version")
+	rig.writeFile(t, agentPath, spokeContent)
+	// The hub holds different content at the same path.
+	rig.transport.Seed(DefaultHubID, agentPath, sha256Hex([]byte("the hub's version")), 19)
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// Surfaced at reconcile time for the whole backlog at once, rather than
+	// discovered one 409 at a time during transfer.
+	if len(res.Conflicts) != 1 {
+		t.Fatalf("conflicts = %v, want one", res.Conflicts)
+	}
+	if res.Conflicts[0].Path != agentPath {
+		t.Errorf("conflict path = %q, want %q", res.Conflicts[0].Path, agentPath)
+	}
+	if res.Sent != 0 {
+		t.Error("a conflicted file was sent; re-sending cannot resolve a content disagreement")
+	}
+
+	// It must not silently retry forever on later passes either.
+	res2, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if res2.Sent != 0 {
+		t.Error("a conflicted file was sent on a later pass")
+	}
+}
+
+func TestAgent_ChecksumMismatchIsRetriedThenGivesUp(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	content := []byte("payload")
+	rig.writeFile(t, agentPath, content)
+
+	// A mismatch is retryable — the corruption may be in flight, or in the
+	// edge's own flash — so it burns attempts rather than failing at once.
+	const maxAttempts = 3
+	agent, err := NewAgent(AgentConfig{
+		Ledger: rig.ledger, Transport: rig.transport, Backend: rig.backend,
+		HubID: DefaultHubID, SpokeID: "rocket-01", MaxAttempts: maxAttempts,
+		Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("agent: %v", err)
+	}
+
+	for i := 0; i < maxAttempts; i++ {
+		rig.transport.ScriptPut(DefaultHubID, agentPath, &PutResult{Outcome: OutcomeChecksumMismatch})
+	}
+	for i := 0; i < maxAttempts; i++ {
+		if _, err := agent.Run(ctx); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+
+	entry, err := rig.ledger.Get(ctx, DefaultHubID, agentPath)
+	if err != nil {
+		t.Fatalf("ledger get: %v", err)
+	}
+	if entry.State != StateFailed {
+		t.Errorf("state = %q after %d mismatches, want %q", entry.State, maxAttempts, StateFailed)
+	}
+}
+
+func TestAgent_RecoversInterruptedTransfers(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	content := []byte("payload")
+	rig.writeFile(t, agentPath, content)
+	if _, err := rig.agent.Discover(ctx); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+
+	// Simulate a crash mid-transfer: the row is left in_flight with no process
+	// behind it, so nothing would ever pick it up again.
+	if err := rig.ledger.MarkInFlight(ctx, DefaultHubID, agentPath); err != nil {
+		t.Fatalf("mark in-flight: %v", err)
+	}
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Recovered != 1 {
+		t.Errorf("recovered = %d, want 1 — a stranded transfer was never reset", res.Recovered)
+	}
+	if res.Sent != 1 {
+		t.Errorf("sent = %d, want 1", res.Sent)
+	}
+}
+
+func TestAgent_StatusReportsPendingWork(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	for i := 0; i < 3; i++ {
+		rig.writeFile(t, fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%d.parquet", i), []byte("payload"))
+	}
+	if _, err := rig.agent.Discover(ctx); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+
+	// This is what an operator reads to know whether a contact window is
+	// keeping up with production.
+	st, err := rig.agent.Status(ctx)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if st.Pending != 3 {
+		t.Errorf("pending = %d, want 3", st.Pending)
+	}
+	if st.PendingBytes != 3*int64(len("payload")) {
+		t.Errorf("pending bytes = %d, want %d", st.PendingBytes, 3*len("payload"))
+	}
+
+	if _, err := rig.agent.Run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	st, err = rig.agent.Status(ctx)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if st.Pending != 0 || st.Synced != 3 {
+		t.Errorf("after run: pending=%d synced=%d, want 0/3", st.Pending, st.Synced)
+	}
+	if st.LastSyncedAt == nil {
+		t.Error("last-synced is unset after a successful run")
+	}
+}
+
+func TestAgent_RunWithNothingToDoIsCheap(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	// A spoke with no local files must not error — a dark edge box that has
+	// produced nothing is a normal state, not a failure.
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("run on an empty spoke: %v", err)
+	}
+	if res.Discovered != 0 || res.Sent != 0 {
+		t.Errorf("empty spoke reported discovered=%d sent=%d", res.Discovered, res.Sent)
+	}
+}
+
+func TestAgent_HonorsContextCancellation(t *testing.T) {
+	rig := newAgentRig(t)
+	rig.writeFile(t, agentPath, []byte("payload"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// A contact window that closes must abort rather than finish work against
+	// a link that is already gone.
+	if _, err := rig.agent.Run(ctx); err == nil {
+		t.Error("Run with a cancelled context succeeded")
+	}
+}
+
+func TestNewAgent_RequiresItsDependencies(t *testing.T) {
+	rig := newAgentRig(t)
+
+	base := AgentConfig{
+		Ledger: rig.ledger, Transport: rig.transport, Backend: rig.backend,
+		HubID: DefaultHubID, SpokeID: "rocket-01", Logger: zerolog.Nop(),
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*AgentConfig)
+	}{
+		{"no ledger", func(c *AgentConfig) { c.Ledger = nil }},
+		{"no transport", func(c *AgentConfig) { c.Transport = nil }},
+		{"no backend", func(c *AgentConfig) { c.Backend = nil }},
+		{"no spoke ID", func(c *AgentConfig) { c.SpokeID = "" }},
+		{"spoke ID with a separator", func(c *AgentConfig) { c.SpokeID = "rocket/../other" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			tt.mutate(&cfg)
+			if _, err := NewAgent(cfg); err == nil {
+				t.Error("an agent was built without a required dependency")
+			}
+		})
+	}
+}
+
+func TestAgent_ConcurrentTransfersAreBounded(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	// §8.2 caps concurrency low because edge boxes are small. Run under -race
+	// for this to mean anything.
+	const files = 12
+	for i := 0; i < files; i++ {
+		rig.writeFile(t, fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%02d.parquet", i),
+			[]byte(fmt.Sprintf("payload %d", i)))
+	}
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Sent != files {
+		t.Errorf("sent = %d, want %d", res.Sent, files)
+	}
+
+	for i := 0; i < files; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%02d.parquet", i)
+		if _, ok := rig.transport.Has(DefaultHubID, p); !ok {
+			t.Errorf("file %d did not reach the hub", i)
+		}
+	}
+}
+
+// newAgentRigWithBatch builds a rig whose agent pages at batchSize.
+func newAgentRigWithBatch(t *testing.T, batchSize int) *agentRig {
+	t.Helper()
+	rig := newAgentRig(t)
+
+	agent, err := NewAgent(AgentConfig{
+		Ledger:    rig.ledger,
+		Transport: rig.transport,
+		Backend:   rig.backend,
+		HubID:     DefaultHubID,
+		SpokeID:   "rocket-01",
+		BatchSize: batchSize,
+		Logger:    zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+	rig.agent = agent
+	return rig
+}
+
+// A backlog larger than one batch must drain completely. Reporting success
+// after moving only the first page would silently strand the rest — and a
+// spoke returning from a long outage, the case the feature exists for, is
+// exactly the one whose backlog exceeds a batch.
+func TestAgent_RunPagesThroughABacklogLargerThanOneBatch(t *testing.T) {
+	ctx := context.Background()
+	const batch, total = 3, 10
+	rig := newAgentRigWithBatch(t, batch)
+
+	for i := 0; i < total; i++ {
+		rig.writeFile(t, fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%02d.parquet", i),
+			[]byte(fmt.Sprintf("payload %02d", i)))
+	}
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Discovered != total {
+		t.Errorf("discovered = %d, want %d", res.Discovered, total)
+	}
+	if res.Sent != total {
+		t.Errorf("sent = %d of %d: the pass stopped after one page", res.Sent, total)
+	}
+
+	pending, err := rig.ledger.Pending(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("%d files left pending after a full pass", len(pending))
+	}
+}
+
+// Conflicts stay pending in the ledger, so a paging loop that re-fetched them
+// would spin forever. It must terminate, and must report every page's
+// conflicts rather than only the last page's.
+func TestAgent_RunTerminatesAndAccumulatesConflictsAcrossPages(t *testing.T) {
+	ctx := context.Background()
+	const batch, total = 2, 6
+	rig := newAgentRigWithBatch(t, batch)
+
+	for i := 0; i < total; i++ {
+		p := fmt.Sprintf("metrics/cpu/2026/08/07/14/c_%02d.parquet", i)
+		rig.writeFile(t, p, []byte(fmt.Sprintf("spoke copy %02d", i)))
+		// The hub holds different content at every one of these paths.
+		rig.transport.Seed(DefaultHubID, p, fmt.Sprintf("%064x", i+1), 11)
+	}
+
+	done := make(chan struct{})
+	var res *RunResult
+	var err error
+	go func() {
+		defer close(done)
+		res, err = rig.agent.Run(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("Run did not terminate on an all-conflict backlog")
+	}
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(res.Conflicts) != total {
+		t.Errorf("conflicts = %d, want %d: pages overwrote each other", len(res.Conflicts), total)
+	}
+	if res.Sent != 0 {
+		t.Errorf("sent = %d, want 0: a conflict must not transfer bytes", res.Sent)
+	}
+}
+
+// Newest-first must hold across pages, not just within one. A contact window
+// that closes mid-backlog should have delivered the freshest telemetry, and
+// paging must not reorder that.
+func TestAgent_RunSendsNewestFirstAcrossPages(t *testing.T) {
+	ctx := context.Background()
+	const batch, total = 2, 6
+	rig := newAgentRigWithBatch(t, batch)
+
+	// Hours 00..05; hour 05 is newest.
+	for i := 0; i < total; i++ {
+		rig.writeFile(t, fmt.Sprintf("metrics/cpu/2026/08/07/%02d/f.parquet", i),
+			[]byte(fmt.Sprintf("payload %02d", i)))
+	}
+
+	if _, err := rig.agent.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	order := rig.transport.PutOrder()
+	if len(order) != total {
+		t.Fatalf("sent %d files, want %d", len(order), total)
+	}
+	// Within a page, transfers race — maxConcurrent goroutines reach the
+	// transport in nondeterministic order — so per-file position proves
+	// nothing. The invariant paging must preserve is at the PAGE level: the
+	// first page carries the newest files, so a contact window that closes
+	// after one page has delivered the freshest telemetry.
+	firstPage := make(map[string]bool, batch)
+	for _, p := range order[:batch] {
+		firstPage[p] = true
+	}
+	for _, want := range []string{"/05/", "/04/"} {
+		found := false
+		for p := range firstPage {
+			if strings.Contains(p, want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("hour %s is not in the first page (%v); paging did not send newest-first", want, order[:batch])
+		}
+	}
+
+	// And the oldest must be in the final page, not pulled forward.
+	lastPage := strings.Join(order[total-batch:], " ")
+	if !strings.Contains(lastPage, "/00/") {
+		t.Errorf("the oldest file is not in the last page (%v)", order[total-batch:])
+	}
+}
+
+// batch_size reaches make()'s capacity argument in the paging loop, so a
+// negative value panics the process on the first pass — a crash on the edge
+// box, for a value an operator can set in arc.toml.
+func TestAgent_NegativeBatchSizeDoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRigWithBatch(t, -1)
+	rig.writeFile(t, "metrics/cpu/2026/08/07/14/f.parquet", []byte("payload"))
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Sent != 1 {
+		t.Errorf("sent = %d, want 1: a clamped batch size should behave like the default", res.Sent)
+	}
+}
+
+// max_concurrent is clamped so an operator typo cannot spawn one goroutine and
+// one open file handle per pending file on a small edge box.
+func TestNewAgent_ClampsMaxConcurrent(t *testing.T) {
+	rig := newAgentRig(t)
+
+	agent, err := NewAgent(AgentConfig{
+		Ledger: rig.ledger, Transport: rig.transport, Backend: rig.backend,
+		HubID: DefaultHubID, SpokeID: "rocket-01",
+		MaxConcurrent: 100000,
+		Logger:        zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+	if agent.maxConcurrent != MaxAllowedConcurrent {
+		t.Errorf("maxConcurrent = %d, want it clamped to %d", agent.maxConcurrent, MaxAllowedConcurrent)
+	}
+}
+
+// A conflict found during reconcile must be terminal, exactly as one found
+// during transfer is. Left pending it would ride along in every future
+// reconcile payload forever, and the two paths would disagree about whether
+// the same condition is terminal.
+func TestAgent_ReconcileConflictIsTerminal(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	const p = "metrics/cpu/2026/08/07/14/contested.parquet"
+	rig.writeFile(t, p, []byte("the spoke's version"))
+	rig.transport.Seed(DefaultHubID, p, fmt.Sprintf("%064x", 1), 19)
+
+	if _, err := rig.agent.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	entry, err := rig.ledger.Get(ctx, DefaultHubID, p)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if entry.State != StateFailed {
+		t.Errorf("state = %q, want %q: a reconcile conflict stayed pending and will re-offer forever",
+			entry.State, StateFailed)
+	}
+
+	// And a second pass must not re-offer it.
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("the second pass re-reported %d conflicts; the file should be terminal", len(res.Conflicts))
+	}
+}

--- a/internal/edgesync/ledger.go
+++ b/internal/edgesync/ledger.go
@@ -326,6 +326,58 @@ func (l *Ledger) TrackBatch(ctx context.Context, entries []*LedgerEntry) (int, e
 // hub and backfill catches up on a later pass.
 //
 // A limit <= 0 returns all pending entries.
+// Unfinished returns entries that have not reached the hub, in either state
+// an operator cares about: still queued, or given up on.
+//
+// Separate from Pending rather than a widening of it, because the sync pass
+// depends on Pending returning ONLY 'pending' rows — a failed entry re-offered
+// to the hub would restart a transfer the retry cap deliberately stopped.
+// This is the troubleshooting view: a file that exhausted its attempts is the
+// one an operator most needs to see, and it is exactly the one Pending hides.
+//
+// Failed entries sort first: they need a decision, whereas pending ones are
+// simply waiting for the next pass.
+//
+// A limit <= 0 returns everything unfinished.
+func (l *Ledger) Unfinished(ctx context.Context, hubID string, limit int) ([]*LedgerEntry, error) {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+
+	query := `
+		SELECT id, hub_id, path, sha256, size_bytes, database, measurement,
+		       partition_time, discovered_at, state, attempts, last_attempt,
+		       synced_at, bytes_sent, COALESCE(last_error, '')
+		FROM sync_ledger
+		WHERE hub_id = ? AND state IN (?, ?, ?)
+		ORDER BY CASE state WHEN ? THEN 0 ELSE 1 END, partition_time DESC, id ASC`
+	args := []any{hubID, string(StateFailed), string(StatePending), string(StateInFlight), string(StateFailed)}
+
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := l.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: query unfinished: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*LedgerEntry
+	for rows.Next() {
+		e, err := scanEntry(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("edgesync: iterate unfinished: %w", err)
+	}
+	return out, nil
+}
+
 func (l *Ledger) Pending(ctx context.Context, hubID string, limit int) ([]*LedgerEntry, error) {
 	if hubID == "" {
 		hubID = DefaultHubID
@@ -451,6 +503,35 @@ func (l *Ledger) MarkSynced(ctx context.Context, hubID, path string) error {
 // usually a dropped link, and the bytes the hub already accepted are still
 // valid. Discarding the checkpoint would restart a large file from zero on
 // exactly the link least able to afford it.
+// MarkConflicted terminally fails an entry the hub reports as conflicting.
+//
+// Separate from MarkFailed because that transition is pending→in_flight→failed
+// and requires the row to be in_flight: a conflict found during RECONCILE is
+// still 'pending' — no transfer was ever started for it — so MarkFailed would
+// match no rows and silently leave it pending, to be re-offered in every
+// future reconcile payload forever.
+//
+// Terminal immediately, with no attempt counting: retrying cannot resolve a
+// content disagreement, and the same path holding different bytes on both
+// sides needs a human to decide which copy is right.
+func (l *Ledger) MarkConflicted(ctx context.Context, hubID, path, errMsg string) error {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+
+	// Only from pending: an in_flight row is owned by a running transfer,
+	// which resolves it through sendOne's own conflict path.
+	res, err := l.db.ExecContext(ctx, `
+		UPDATE sync_ledger
+		SET state = ?, last_error = ?
+		WHERE hub_id = ? AND path = ? AND state = ?`,
+		string(StateFailed), errMsg, hubID, path, string(StatePending))
+	if err != nil {
+		return fmt.Errorf("edgesync: mark conflicted %q: %w", path, err)
+	}
+	return l.checkTransition(ctx, res, hubID, path, StatePending)
+}
+
 func (l *Ledger) MarkFailed(ctx context.Context, hubID, path, errMsg string, maxAttempts int) error {
 	if hubID == "" {
 		hubID = DefaultHubID

--- a/internal/edgesync/transport_http.go
+++ b/internal/edgesync/transport_http.go
@@ -1,0 +1,294 @@
+package edgesync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/security"
+)
+
+// HTTPTransport pushes files to a hub over HTTPS.
+//
+// The v1 transport. Everything protocol-shaped — the identity rule, the
+// outcome taxonomy, resume — lives above this in the interface, so an S3-relay
+// or sneakernet transport reuses it unchanged and only the wire format differs.
+type HTTPTransport struct {
+	baseURL string
+	spokeID string
+	secret  string
+	client  *http.Client
+}
+
+// HTTPTransportConfig configures an HTTPTransport.
+type HTTPTransportConfig struct {
+	// BaseURL is the hub's root, e.g. https://ground-station.example.com.
+	BaseURL string
+
+	// SpokeID is this spoke's registered identity, bound into every MAC.
+	SpokeID string
+
+	// Secret is the hub-issued shared secret. Never logged, never persisted
+	// by this package — it arrives from the environment and stays in memory.
+	Secret string
+
+	// Timeout bounds a single request. Zero means 30 minutes, matching the
+	// hub's receive timeout: a large Parquet file over a constrained link is
+	// the expected case, not an anomaly.
+	Timeout time.Duration
+
+	// Client overrides the HTTP client, for tests and for callers that need a
+	// custom TLS config.
+	Client *http.Client
+}
+
+// NewHTTPTransport validates configuration and returns a ready transport.
+func NewHTTPTransport(cfg HTTPTransportConfig) (*HTTPTransport, error) {
+	if cfg.BaseURL == "" {
+		return nil, errors.New("edgesync: HTTP transport requires a hub URL")
+	}
+	if err := validateSpokeID(cfg.SpokeID); err != nil {
+		return nil, fmt.Errorf("edgesync: HTTP transport spoke ID: %w", err)
+	}
+	if cfg.Secret == "" {
+		// Without a secret every request would be rejected, and the failure
+		// would look like a hub problem rather than a missing credential.
+		return nil, errors.New("edgesync: HTTP transport requires a spoke secret")
+	}
+
+	client := cfg.Client
+	if client == nil {
+		timeout := cfg.Timeout
+		if timeout <= 0 {
+			timeout = 30 * time.Minute
+		}
+		client = &http.Client{Timeout: timeout}
+	}
+
+	return &HTTPTransport{
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		spokeID: cfg.SpokeID,
+		secret:  cfg.Secret,
+		client:  client,
+	}, nil
+}
+
+// Reconcile asks the hub which of the pending files it already holds.
+func (t *HTTPTransport) Reconcile(ctx context.Context, hubID string, pending []*LedgerEntry) (*ReconcileResult, error) {
+	entries := make([]ReconcileEntry, 0, len(pending))
+	for _, e := range pending {
+		entries = append(entries, ReconcileEntry{
+			Path:      e.Path,
+			SHA256:    e.SHA256,
+			SizeBytes: e.SizeBytes,
+		})
+	}
+
+	body, err := json.Marshal(map[string]any{"entries": entries})
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: encode reconcile body: %w", err)
+	}
+
+	nonce, err := security.GenerateNonce()
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: generate nonce: %w", err)
+	}
+	ts := time.Now().Unix()
+
+	// The MAC binds a digest of the body, so a captured request cannot be
+	// replayed with a substituted path list to probe what the hub holds.
+	mac, err := security.ComputeSyncReconcileHMAC(t.secret, nonce, t.spokeID, hubID, body, ts)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: sign reconcile: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.baseURL+"/api/v1/sync/reconcile", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: build reconcile request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	t.setAuthHeaders(req, hubID, nonce, ts, mac)
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: reconcile request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, t.statusError(resp, "reconcile")
+	}
+
+	var out struct {
+		Missing   []string   `json:"missing"`
+		Present   []string   `json:"present"`
+		Conflicts []Conflict `json:"conflicts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("edgesync: decode reconcile response: %w", err)
+	}
+
+	return &ReconcileResult{
+		Missing:   out.Missing,
+		Present:   out.Present,
+		Conflicts: out.Conflicts,
+	}, nil
+}
+
+// PutFile streams one file to the hub, resuming from offset.
+func (t *HTTPTransport) PutFile(ctx context.Context, hubID string, entry *LedgerEntry, body io.Reader, offset int64) (*PutResult, error) {
+	if entry == nil {
+		return nil, errors.New("edgesync: PutFile requires an entry")
+	}
+
+	nonce, err := security.GenerateNonce()
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: generate nonce: %w", err)
+	}
+	ts := time.Now().Unix()
+
+	mac, err := security.ComputeSyncFileHMAC(t.secret, nonce, t.spokeID, hubID, entry.Path, entry.SHA256, ts)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: sign file transfer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.baseURL+"/api/v1/sync/file", body)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: build file request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set(headerSyncPath, entry.Path)
+	req.Header.Set(headerSyncSHA256, entry.SHA256)
+	req.Header.Set(headerSyncSize, strconv.FormatInt(entry.SizeBytes, 10))
+	if offset > 0 {
+		req.Header.Set(headerSyncOffset, strconv.FormatInt(offset, 10))
+	}
+	t.setAuthHeaders(req, hubID, nonce, ts, mac)
+
+	// Content-Length so the hub's pre-auth size check can reject an oversized
+	// upload before buffering it. Without this a resumed transfer of unknown
+	// length would look unbounded.
+	req.ContentLength = entry.SizeBytes - offset
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: file request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return t.decodePutResponse(resp, entry)
+}
+
+// decodePutResponse maps the hub's status code to a PutResult.
+func (t *HTTPTransport) decodePutResponse(resp *http.Response, entry *LedgerEntry) (*PutResult, error) {
+	var out struct {
+		Outcome       string `json:"outcome"`
+		BytesAccepted int64  `json:"bytes_accepted"`
+		TheirSHA256   string `json:"their_sha256"`
+		Reason        string `json:"reason"`
+		Error         string `json:"error"`
+	}
+	// A body is expected on every documented status, but a proxy or a
+	// truncated response can produce an empty one — decode failures are
+	// tolerated here so the status code still decides the outcome.
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		outcome := OutcomeCommitted
+		if out.Outcome == string(OutcomeAlreadyPresent) {
+			outcome = OutcomeAlreadyPresent
+		}
+		accepted := out.BytesAccepted
+		if accepted == 0 {
+			// An older or terser hub may omit it; the file is committed, so
+			// the whole size is what was accepted.
+			accepted = entry.SizeBytes
+		}
+		return &PutResult{Outcome: outcome, BytesAccepted: accepted}, nil
+
+	case http.StatusPartialContent:
+		return &PutResult{Outcome: OutcomePartial, BytesAccepted: out.BytesAccepted}, nil
+
+	case http.StatusConflict:
+		// 409 covers two different things. A content disagreement carries the
+		// hub's digest and is terminal; a refused resume is recoverable by
+		// restarting from zero, so it must not be mistaken for the former.
+		if out.Reason == "resume_unsupported" {
+			return nil, fmt.Errorf("edgesync: hub cannot resume: %s", out.Error)
+		}
+		return &PutResult{Outcome: OutcomeConflict, TheirSHA256: out.TheirSHA256}, nil
+
+	case http.StatusUnprocessableEntity:
+		return &PutResult{Outcome: OutcomeChecksumMismatch}, nil
+
+	case http.StatusTooManyRequests:
+		return &PutResult{
+			Outcome:    OutcomeBackpressure,
+			RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+		}, nil
+
+	default:
+		return nil, t.statusError(resp, "file transfer")
+	}
+}
+
+// setAuthHeaders applies the headers every sync request carries.
+func (t *HTTPTransport) setAuthHeaders(req *http.Request, hubID, nonce string, ts int64, mac string) {
+	req.Header.Set(headerSyncSpokeID, t.spokeID)
+	req.Header.Set(headerSyncHubID, hubID)
+	req.Header.Set(headerSyncNonce, nonce)
+	req.Header.Set(headerSyncTimestamp, strconv.FormatInt(ts, 10))
+	req.Header.Set(headerSyncMAC, mac)
+}
+
+// statusError builds an error for an unexpected status.
+//
+// The response body is read but bounded: a hub returning an unexpected status
+// is already misbehaving, and an unbounded read here would let it exhaust the
+// spoke — the machine least able to absorb it.
+func (t *HTTPTransport) statusError(resp *http.Response, op string) error {
+	const maxErrorBody = 4 << 10
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		msg = resp.Status
+	}
+	return fmt.Errorf("edgesync: %s failed with %d: %s", op, resp.StatusCode, msg)
+}
+
+// parseRetryAfter reads a Retry-After header, in seconds.
+//
+// Falls back to a second rather than zero: a zero delay would busy-loop
+// against a hub that has just said it is overloaded.
+func parseRetryAfter(v string) time.Duration {
+	if secs, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return time.Second
+}
+
+// Sync request headers. Duplicated from the api package rather than imported:
+// this package must not depend on the HTTP layer, and the api package already
+// imports this one.
+const (
+	headerSyncSpokeID   = "X-Arc-Spoke-ID"
+	headerSyncHubID     = "X-Arc-Sync-HubID"
+	headerSyncPath      = "X-Arc-Sync-Path"
+	headerSyncSHA256    = "X-Arc-Sync-SHA256"
+	headerSyncSize      = "X-Arc-Sync-Size"
+	headerSyncOffset    = "X-Arc-Sync-Offset"
+	headerSyncNonce     = "X-Arc-Sync-Nonce"
+	headerSyncTimestamp = "X-Arc-Sync-Timestamp"
+	headerSyncMAC       = "X-Arc-Sync-MAC"
+)
+
+// Compile-time check that HTTPTransport satisfies the interface.
+var _ SyncTransport = (*HTTPTransport)(nil)

--- a/internal/edgesync/transport_memory.go
+++ b/internal/edgesync/transport_memory.go
@@ -44,7 +44,18 @@ type MemoryTransport struct {
 	// failing link.
 	failures map[string][]*PutResult
 
+	// putOrder records the paths PutFile was called with, in call order, so a
+	// test can assert the agent's newest-first ordering.
+	putOrder []string
+
 	closed bool
+}
+
+// PutOrder returns the paths PutFile was called with, in order.
+func (m *MemoryTransport) PutOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.putOrder...)
 }
 
 type memFile struct {
@@ -211,6 +222,8 @@ func (m *MemoryTransport) PutFile(ctx context.Context, hubID string, entry *Ledg
 	// Phase 1 — decide under the lock whether this transfer should read a body
 	// at all, and grab the staged prefix if resuming.
 	m.mu.Lock()
+	m.putOrder = append(m.putOrder, entry.Path)
+
 	if m.closed {
 		m.mu.Unlock()
 		return nil, ErrTransportClosed


### PR DESCRIPTION
> **Re-targets #578 at `main`.** #578 was stacked on `fix/api-test-race-timeouts` and merged into that branch rather than retargeting when #577 landed, so the spoke agent never reached `main`. This is the same commit (`6338b19`) cherry-picked onto `main` — no content changes, re-verified from a clean build.

## Summary

Completes the edge-sync story: an edge Arc now pushes its Parquet files to a hub on demand. The hub receive side, ledger, transport interface, HMAC scheme, reconcile index, and spoke registry landed in #570–#576; **this is the client that drives them.** Closes item 8 of #569.

A pass recovers transfers interrupted by a crash, discovers new files, reconciles the backlog in one round-trip, then streams what the hub lacks — **newest first**, so a contact window that closes mid-backlog has already delivered the freshest telemetry. It **pages until the backlog drains**, so one pass on a spoke returning from a long outage moves everything rather than the first batch.

Operator surface (admin-only, on `/api/v1/spoke-sync`):

| Endpoint | Purpose |
|---|---|
| `POST /run` | Run one pass, return what it did |
| `GET /status` | Pending/synced/failed counts and sync lag |
| `GET /ledger` | Per-file state, attempts, and last error |

The issue planned `/api/v1/sync/run`; it ships under `/api/v1/spoke-sync` because Fiber's `Group().Use()` matches by string prefix, not path segment — see the fourth row below.

Config lives in `[edge_sync.spoke]`; the secret is environment-only via `ARC_EDGE_SYNC_SPOKE_SECRET`, and Arc refuses to start if one appears in the config file. This is the **manual** form and is OSS; the scheduled agent is Enterprise and lands later.

## Bugs found and fixed during review

Each has a regression test **verified to fail against the pre-fix code**:

| Bug | Impact |
|---|---|
| Secret guard used `v.IsSet` | Consults the environment under `AutomaticEnv`, so Arc refused to start in the **one configuration the guard exists to require**. Now `v.InConfig`, which reads only the file. |
| `Run` fetched a single page | Sent `batch_size` files, **reported success**, and silently stranded the rest. |
| Negative `batch_size` | Reached `make()`'s capacity argument and **panicked the spoke** on its first pass. Clamped in `NewAgent`, rejected at load. |
| Fiber group prefix collision | `Group().Use()` matches by string prefix, so the hub's `/api/v1/sync` group also matched `/api/v1/sync-spoke/*` and its body limit ran on the operator routes. Moved to `/api/v1/spoke-sync`, with a test pinning the **property** rather than the name. |
| Ledger view showed only pending | Hid the exhausted files it exists to diagnose. Added `Ledger.Unfinished`. |
| Reconcile-path conflicts stayed pending | Rode along in every future reconcile payload forever. Added `Ledger.MarkConflicted` — `MarkFailed` requires `in_flight` and silently matched no rows. |

Also: `max_concurrent` is bounded (64), cancellation is checked **before** the `select` rather than as a case (both being ready made it a coin flip, ~50% of transfers still launching), `hub_url` is parsed rather than prefix-matched, and every new key has a `v.SetDefault`.

## Test plan

- [x] 37 new tests across agent, spoke API, e2e, and config
- [x] E2E drives the **real agent against real hub handlers over real HTTP**
- [x] `go test -count=1 -race ./internal/edgesync/ ./internal/api/` — clean on the rebuilt tree
- [x] **Two live processes**: 20 files at `batch_size=7`, all byte-identical on the hub, idempotent re-run, no staging residue
- [x] Non-default `max_attempts` / `max_concurrent` / `batch_size` exercised together
- [x] Auth boundary: forged MAC → 401, unknown spoke → 401, wrong secret writes nothing
- [x] `ARC_ENCRYPTION_KEY` rotation → startup warning + spoke fails closed
- [x] Negative `batch_size` refused at startup with a clear message
- [x] §6.1 identity rule verified live: conflicting content → reported, **0 bytes sent**, hub copy unchanged
- [x] `go vet`, `gofmt` clean

## Follow-ups

- Docs ship in Basekick-Labs/docs.basekick.net#20.
- PR 9 (air-gap export/import bundle) closes out phase 1 of #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)