### PR TITLE
feat(edgesync): add StateExported to the spoke ledger (#569)

### DIFF
--- a/internal/api/edgesync_spoke.go
+++ b/internal/api/edgesync_spoke.go
@@ -146,9 +146,12 @@ func (h *EdgeSyncSpokeHandler) status(c *fiber.Ctx) error {
 	}
 
 	out := fiber.Map{
-		"hub_id":        st.HubID,
-		"pending":       st.Pending,
-		"in_flight":     st.InFlight,
+		"hub_id":    st.HubID,
+		"pending":   st.Pending,
+		"in_flight": st.InFlight,
+		// Files on physical media awaiting an ack. Reported separately so an
+		// operator can tell "queued here" from "in transit on a drive".
+		"exported":      st.Exported,
 		"synced":        st.Synced,
 		"failed":        st.Failed,
 		"pending_bytes": st.PendingBytes,
@@ -212,6 +215,14 @@ func (h *EdgeSyncSpokeHandler) ledger(c *fiber.Ctx) error {
 		}
 		if e.LastError != "" {
 			row["last_error"] = e.LastError
+		}
+		// Which bundle a file left on. The answer an operator needs when a
+		// drive does not arrive and they have to decide what to revert.
+		if e.ExportedBundleID != "" {
+			row["exported_bundle_id"] = e.ExportedBundleID
+		}
+		if e.ExportedAt != nil {
+			row["exported_at"] = *e.ExportedAt
 		}
 		out = append(out, row)
 	}

--- a/internal/edgesync/ledger.go
+++ b/internal/edgesync/ledger.go
@@ -23,6 +23,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -46,6 +47,19 @@ const (
 	// design's ack-then-advance rule means a lost ack costs one extra entry in
 	// the next reconcile, but never a silent gap.
 	StateSynced SyncState = "synced"
+
+	// StateExported — written to an air-gap bundle, awaiting acknowledgment.
+	//
+	// A file on a physical drive in transit is neither pending (re-exporting or
+	// re-sending it wastes the scarce resource: media, or a contact window) nor
+	// synced (no hub has confirmed anything). Without this state, exported rows
+	// stay pending, and because Pending orders partition_time DESC a capped
+	// export takes the newest N every time — the oldest files are never
+	// exported at all. That is a treadmill, not eventual consistency.
+	//
+	// NOT terminal. It advances to synced when an ack bundle returns, and an
+	// operator can revert it to pending if the drive is lost.
+	StateExported SyncState = "exported"
 
 	// StateFailed — exhausted retries. Terminal until an operator intervenes.
 	StateFailed SyncState = "failed"
@@ -103,6 +117,13 @@ type LedgerEntry struct {
 	BytesSent int64
 
 	LastError string
+
+	// ExportedAt / ExportedBundleID identify the air-gap bundle a file left on,
+	// for the operator whose drive did not arrive. Nil and empty unless the
+	// entry is (or once was) exported. RevertExported filters on the bundle ID
+	// in SQL, but an operator needs to READ it to know which ID to revert.
+	ExportedAt       *time.Time
+	ExportedBundleID string
 }
 
 // Ledger is the spoke-side record of sync progress, backed by the shared
@@ -157,6 +178,8 @@ func (l *Ledger) initSchema() error {
 		synced_at      TIMESTAMP,
 		bytes_sent     INTEGER NOT NULL DEFAULT 0,
 		last_error     TEXT,
+		exported_at    TIMESTAMP,
+		exported_bundle_id TEXT,
 		UNIQUE(hub_id, path)
 	);
 
@@ -203,6 +226,23 @@ func (l *Ledger) initSchema() error {
 
 	if _, err := l.db.Exec(schema); err != nil {
 		return fmt.Errorf("create sync tables: %w", err)
+	}
+
+	// CREATE TABLE IF NOT EXISTS leaves an existing table untouched, so a
+	// ledger created before the air-gap columns existed keeps its old shape.
+	// 26.09.1 is unreleased, so this only affects development databases — but
+	// silently running against a table missing exported_at would fail every
+	// export with a confusing SQL error rather than a clear one.
+	//
+	// SQLite has no ADD COLUMN IF NOT EXISTS; a duplicate-column error is the
+	// expected outcome on an up-to-date database and is not a failure.
+	for _, col := range []string{
+		"ALTER TABLE sync_ledger ADD COLUMN exported_at TIMESTAMP",
+		"ALTER TABLE sync_ledger ADD COLUMN exported_bundle_id TEXT",
+	} {
+		if _, err := l.db.Exec(col); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+			return fmt.Errorf("add air-gap columns: %w", err)
+		}
 	}
 
 	l.logger.Info().Msg("Sync ledger schema initialized")
@@ -347,11 +387,13 @@ func (l *Ledger) Unfinished(ctx context.Context, hubID string, limit int) ([]*Le
 	query := `
 		SELECT id, hub_id, path, sha256, size_bytes, database, measurement,
 		       partition_time, discovered_at, state, attempts, last_attempt,
-		       synced_at, bytes_sent, COALESCE(last_error, '')
+		       synced_at, bytes_sent, COALESCE(last_error, ''),
+		       exported_at, COALESCE(exported_bundle_id, '')
 		FROM sync_ledger
-		WHERE hub_id = ? AND state IN (?, ?, ?)
+		WHERE hub_id = ? AND state IN (?, ?, ?, ?)
 		ORDER BY CASE state WHEN ? THEN 0 ELSE 1 END, partition_time DESC, id ASC`
-	args := []any{hubID, string(StateFailed), string(StatePending), string(StateInFlight), string(StateFailed)}
+	args := []any{hubID, string(StateFailed), string(StatePending), string(StateInFlight),
+		string(StateExported), string(StateFailed)}
 
 	if limit > 0 {
 		query += " LIMIT ?"
@@ -386,7 +428,8 @@ func (l *Ledger) Pending(ctx context.Context, hubID string, limit int) ([]*Ledge
 	query := `
 		SELECT id, hub_id, path, sha256, size_bytes, database, measurement,
 		       partition_time, discovered_at, state, attempts, last_attempt,
-		       synced_at, bytes_sent, COALESCE(last_error, '')
+		       synced_at, bytes_sent, COALESCE(last_error, ''),
+		       exported_at, COALESCE(exported_bundle_id, '')
 		FROM sync_ledger
 		WHERE hub_id = ? AND state = ?
 		ORDER BY partition_time DESC, id ASC`
@@ -484,16 +527,132 @@ func (l *Ledger) MarkSynced(ctx context.Context, hubID, path string) error {
 	//     entry, hiding the failure from operators.
 	// Pending is permitted because §5.1's reconcile advances entries the hub
 	// reports as `present` — the lost-ack recovery path — without a transfer.
+	// Exported is permitted because that is exactly what an ack bundle
+	// acknowledges: the file left on physical media and a hub has now
+	// confirmed it. Without this, an air-gap spoke could never reach synced.
 	res, err := l.db.ExecContext(ctx, `
 		UPDATE sync_ledger
 		SET state = ?, synced_at = ?, bytes_sent = size_bytes, last_error = NULL
-		WHERE hub_id = ? AND path = ? AND state IN (?, ?)`,
+		WHERE hub_id = ? AND path = ? AND state IN (?, ?, ?)`,
 		string(StateSynced), time.Now().UTC(), hubID, path,
-		string(StatePending), string(StateInFlight))
+		string(StatePending), string(StateInFlight), string(StateExported))
 	if err != nil {
 		return fmt.Errorf("edgesync: mark synced %q: %w", path, err)
 	}
-	return l.checkTransition(ctx, res, hubID, path, StatePending, StateInFlight)
+	return l.checkTransition(ctx, res, hubID, path, StatePending, StateInFlight, StateExported)
+}
+
+// MarkExported records that a file was written to an air-gap bundle.
+//
+// Only from pending: an in_flight row belongs to a running network transfer,
+// and exporting it concurrently would put the same file on two paths with no
+// way to reconcile which acknowledgment arrived.
+//
+// This is what stops a capped export from starving old files. Pending orders
+// partition_time DESC, so without a state change every export would re-take the
+// newest N and the oldest files would never leave the box.
+func (l *Ledger) MarkExported(ctx context.Context, hubID, path, bundleID string) error {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	if bundleID == "" {
+		// The bundle ID is how an ack finds these rows again. Without it an
+		// exported row is unattributable and could only be recovered by hand.
+		return fmt.Errorf("edgesync: mark exported %q: a bundle ID is required", path)
+	}
+
+	res, err := l.db.ExecContext(ctx, `
+		UPDATE sync_ledger
+		SET state = ?, exported_at = ?, exported_bundle_id = ?, last_error = NULL
+		WHERE hub_id = ? AND path = ? AND state = ?`,
+		string(StateExported), time.Now().UTC(), bundleID, hubID, path,
+		string(StatePending))
+	if err != nil {
+		return fmt.Errorf("edgesync: mark exported %q: %w", path, err)
+	}
+	return l.checkTransition(ctx, res, hubID, path, StatePending)
+}
+
+// RevertExported returns a bundle's files to pending, for a drive that was lost,
+// damaged, or never delivered.
+//
+// Without this an exported row is a dead end until an ack that will never come:
+// the files are neither retryable nor visible as a problem. Scoped to one
+// bundle ID so recovering one lost drive does not disturb others in transit.
+//
+// Returns the number of rows reverted.
+func (l *Ledger) RevertExported(ctx context.Context, hubID, bundleID string) (int64, error) {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	if bundleID == "" {
+		return 0, fmt.Errorf("edgesync: revert exported: a bundle ID is required")
+	}
+
+	// Only exported rows. A file already acknowledged by some other route must
+	// not be dragged back into the queue by an operator recovering a drive.
+	res, err := l.db.ExecContext(ctx, `
+		UPDATE sync_ledger
+		SET state = ?, exported_at = NULL, exported_bundle_id = NULL
+		WHERE hub_id = ? AND exported_bundle_id = ? AND state = ?`,
+		string(StatePending), hubID, bundleID, string(StateExported))
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: revert exported bundle %q: %w", bundleID, err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: revert exported bundle %q: %w", bundleID, err)
+	}
+	return n, nil
+}
+
+// Unexported returns files eligible for an air-gap bundle, newest first.
+//
+// Distinct from Pending only in intent today — both select pending rows — but
+// they diverge the moment anything else can enqueue work, and the export path
+// should not silently inherit a change made for the network path. Ordering
+// matches Pending so a bundle carries the freshest telemetry first.
+//
+// A limit <= 0 returns everything eligible.
+func (l *Ledger) Unexported(ctx context.Context, hubID string, limit int) ([]*LedgerEntry, error) {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+
+	query := `
+		SELECT id, hub_id, path, sha256, size_bytes, database, measurement,
+		       partition_time, discovered_at, state, attempts, last_attempt,
+		       synced_at, bytes_sent, COALESCE(last_error, ''),
+		       exported_at, COALESCE(exported_bundle_id, '')
+		FROM sync_ledger
+		WHERE hub_id = ? AND state = ?
+		ORDER BY partition_time DESC, id ASC`
+	args := []any{hubID, string(StatePending)}
+
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := l.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: query unexported: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*LedgerEntry
+	for rows.Next() {
+		e, err := scanEntry(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("edgesync: iterate unexported: %w", err)
+	}
+	return out, nil
 }
 
 // MarkFailed records a transfer failure. If the entry has reached maxAttempts
@@ -588,12 +747,24 @@ func (l *Ledger) RecoverInFlight(ctx context.Context) (int64, error) {
 
 // Stats summarizes ledger state for one hub.
 type Stats struct {
-	HubID        string
-	Pending      int64
-	InFlight     int64
-	Synced       int64
-	Failed       int64
+	HubID    string
+	Pending  int64
+	InFlight int64
+
+	// Exported — on physical media, awaiting an ack. Counted separately
+	// because it is neither "still queued" nor "delivered", and folding it
+	// into either would misreport how far behind an air-gap spoke is.
+	Exported int64
+
+	Synced int64
+	Failed int64
+
+	// PendingBytes is what has not reached a hub, INCLUDING exported bytes:
+	// a file on a drive in transit has not arrived. Excluding it would make an
+	// air-gap spoke's backlog appear to shrink the moment a bundle is written,
+	// which is precisely when nothing has been delivered yet.
 	PendingBytes int64
+
 	LastSyncedAt *time.Time
 }
 
@@ -609,12 +780,13 @@ func (l *Ledger) Stats(ctx context.Context, hubID string) (*Stats, error) {
 		SELECT
 			COALESCE(SUM(state = 'pending'), 0),
 			COALESCE(SUM(state = 'in_flight'), 0),
+			COALESCE(SUM(state = 'exported'), 0),
 			COALESCE(SUM(state = 'synced'), 0),
 			COALESCE(SUM(state = 'failed'), 0),
-			COALESCE(SUM(CASE WHEN state IN ('pending','in_flight')
+			COALESCE(SUM(CASE WHEN state IN ('pending','in_flight','exported')
 			                  THEN size_bytes - bytes_sent ELSE 0 END), 0)
 		FROM sync_ledger WHERE hub_id = ?`, hubID).
-		Scan(&s.Pending, &s.InFlight, &s.Synced, &s.Failed, &s.PendingBytes)
+		Scan(&s.Pending, &s.InFlight, &s.Exported, &s.Synced, &s.Failed, &s.PendingBytes)
 	if err != nil {
 		return nil, fmt.Errorf("edgesync: ledger stats: %w", err)
 	}
@@ -653,7 +825,8 @@ func (l *Ledger) Get(ctx context.Context, hubID, path string) (*LedgerEntry, err
 	row := l.db.QueryRowContext(ctx, `
 		SELECT id, hub_id, path, sha256, size_bytes, database, measurement,
 		       partition_time, discovered_at, state, attempts, last_attempt,
-		       synced_at, bytes_sent, COALESCE(last_error, '')
+		       synced_at, bytes_sent, COALESCE(last_error, ''),
+		       exported_at, COALESCE(exported_bundle_id, '')
 		FROM sync_ledger WHERE hub_id = ? AND path = ?`, hubID, path)
 
 	e, err := scanEntry(row)
@@ -755,6 +928,7 @@ func scanEntry(s rowScanner) (*LedgerEntry, error) {
 		e           LedgerEntry
 		lastAttempt sql.NullTime
 		syncedAt    sql.NullTime
+		exportedAt  sql.NullTime
 		state       string
 	)
 
@@ -762,6 +936,7 @@ func scanEntry(s rowScanner) (*LedgerEntry, error) {
 		&e.ID, &e.HubID, &e.Path, &e.SHA256, &e.SizeBytes, &e.Database,
 		&e.Measurement, &e.PartitionTime, &e.DiscoveredAt, &state,
 		&e.Attempts, &lastAttempt, &syncedAt, &e.BytesSent, &e.LastError,
+		&exportedAt, &e.ExportedBundleID,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -780,6 +955,10 @@ func scanEntry(s rowScanner) (*LedgerEntry, error) {
 	if syncedAt.Valid {
 		t := syncedAt.Time.UTC()
 		e.SyncedAt = &t
+	}
+	if exportedAt.Valid {
+		t := exportedAt.Time.UTC()
+		e.ExportedAt = &t
 	}
 	return &e, nil
 }

--- a/internal/edgesync/ledger_test.go
+++ b/internal/edgesync/ledger_test.go
@@ -841,3 +841,281 @@ func TestLedger_PendingToSyncedIsReconcilePath(t *testing.T) {
 		t.Errorf("bytes_sent = %d, want %d (a synced row reads as fully sent)", got.BytesSent, e.SizeBytes)
 	}
 }
+
+// testEntryAt builds an entry whose partition time sets its export priority.
+func testEntryAt(path string, hour int) *LedgerEntry {
+	e := testEntry(path)
+	e.PartitionTime = time.Date(2026, 8, 6, hour, 0, 0, 0, time.UTC)
+	return e
+}
+
+// The reason StateExported exists. Pending orders partition_time DESC, so a
+// capped export that leaves rows pending re-takes the newest N every time and
+// the oldest files never leave the box — a treadmill, not eventual
+// consistency. Marking them exported is what lets the backlog drain.
+func TestLedger_CappedExportDrainsTheBacklogInsteadOfStarvingOldFiles(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	const total, batch = 9, 3
+	for i := 0; i < total; i++ {
+		if err := l.Track(ctx, testEntryAt(fmt.Sprintf("m/cpu/2026/08/06/%02d/f.parquet", i), i)); err != nil {
+			t.Fatalf("track: %v", err)
+		}
+	}
+
+	// Three capped export rounds should cover every file exactly once.
+	seen := map[string]int{}
+	for round := 0; round < total/batch; round++ {
+		entries, err := l.Unexported(ctx, DefaultHubID, batch)
+		if err != nil {
+			t.Fatalf("unexported: %v", err)
+		}
+		if len(entries) != batch {
+			t.Fatalf("round %d returned %d entries, want %d", round, len(entries), batch)
+		}
+		bundleID := fmt.Sprintf("bundle-%d", round)
+		for _, e := range entries {
+			seen[e.Path]++
+			if err := l.MarkExported(ctx, DefaultHubID, e.Path, bundleID); err != nil {
+				t.Fatalf("mark exported: %v", err)
+			}
+		}
+	}
+
+	if len(seen) != total {
+		t.Errorf("exported %d distinct files across all rounds, want %d: old files were starved", len(seen), total)
+	}
+	for p, n := range seen {
+		if n != 1 {
+			t.Errorf("%s was exported %d times, want exactly once", p, n)
+		}
+	}
+
+	// The oldest file (hour 00) is the one a treadmill would never reach.
+	if _, ok := seen["m/cpu/2026/08/06/00/f.parquet"]; !ok {
+		t.Error("the oldest file was never exported")
+	}
+
+	left, err := l.Unexported(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("unexported: %v", err)
+	}
+	if len(left) != 0 {
+		t.Errorf("%d files still eligible after exporting everything", len(left))
+	}
+}
+
+// An exported file must not be re-offered to the network path: it is already on
+// media, and re-sending it spends the contact window the bundle existed to save.
+func TestLedger_ExportedFilesAreNotPending(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	const p = "m/cpu/2026/08/06/14/f.parquet"
+	if err := l.Track(ctx, testEntry(p)); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkExported(ctx, DefaultHubID, p, "bundle-1"); err != nil {
+		t.Fatalf("mark exported: %v", err)
+	}
+
+	pending, err := l.Pending(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("an exported file is still pending; the network path would re-send it")
+	}
+
+	// But it must remain visible to an operator asking what has not landed.
+	unfinished, err := l.Unfinished(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("unfinished: %v", err)
+	}
+	if len(unfinished) != 1 {
+		t.Errorf("unfinished = %d entries, want the exported file to be visible", len(unfinished))
+	}
+}
+
+// A drive that is lost or never delivered must be recoverable, scoped to that
+// bundle so other drives in transit are undisturbed.
+func TestLedger_RevertExportedRecoversOneBundleOnly(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	lost := []string{"m/cpu/2026/08/06/10/a.parquet", "m/cpu/2026/08/06/11/b.parquet"}
+	kept := "m/cpu/2026/08/06/12/c.parquet"
+	for _, p := range append(append([]string{}, lost...), kept) {
+		if err := l.Track(ctx, testEntry(p)); err != nil {
+			t.Fatalf("track: %v", err)
+		}
+	}
+	for _, p := range lost {
+		if err := l.MarkExported(ctx, DefaultHubID, p, "lost-drive"); err != nil {
+			t.Fatalf("mark exported: %v", err)
+		}
+	}
+	if err := l.MarkExported(ctx, DefaultHubID, kept, "in-transit"); err != nil {
+		t.Fatalf("mark exported: %v", err)
+	}
+
+	n, err := l.RevertExported(ctx, DefaultHubID, "lost-drive")
+	if err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	if n != int64(len(lost)) {
+		t.Errorf("reverted %d rows, want %d", n, len(lost))
+	}
+
+	pending, err := l.Pending(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(pending) != len(lost) {
+		t.Errorf("pending = %d, want the %d files from the lost drive", len(pending), len(lost))
+	}
+
+	// The other drive is still in transit and must not have been disturbed.
+	entry, err := l.Get(ctx, DefaultHubID, kept)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if entry.State != StateExported {
+		t.Errorf("the in-transit bundle's file is %q, want it left exported", entry.State)
+	}
+}
+
+// An ack bundle acknowledges exported files. Without this transition an
+// air-gap spoke could never reach synced, so PruneSynced would never prune and
+// the ledger would grow forever on the box least able to receive a site visit.
+func TestLedger_ExportedAdvancesToSyncedOnAck(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	const p = "m/cpu/2026/08/06/14/f.parquet"
+	if err := l.Track(ctx, testEntry(p)); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkExported(ctx, DefaultHubID, p, "bundle-1"); err != nil {
+		t.Fatalf("mark exported: %v", err)
+	}
+	if err := l.MarkSynced(ctx, DefaultHubID, p); err != nil {
+		t.Fatalf("an ack for an exported file was rejected: %v", err)
+	}
+
+	entry, err := l.Get(ctx, DefaultHubID, p)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if entry.State != StateSynced {
+		t.Errorf("state = %q, want %q", entry.State, StateSynced)
+	}
+}
+
+// Exporting a file already in flight would put it on two paths at once with no
+// way to reconcile which acknowledgment arrived.
+func TestLedger_MarkExportedRejectsNonPendingStates(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	const p = "m/cpu/2026/08/06/14/f.parquet"
+	if err := l.Track(ctx, testEntry(p)); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkInFlight(ctx, DefaultHubID, p); err != nil {
+		t.Fatalf("mark in flight: %v", err)
+	}
+
+	if err := l.MarkExported(ctx, DefaultHubID, p, "bundle-1"); err == nil {
+		t.Error("an in-flight file was exported; it is now on two paths at once")
+	}
+
+	// And a bundle ID is required, since it is how an ack finds these rows.
+	if err := l.Track(ctx, testEntry("m/cpu/2026/08/06/15/g.parquet")); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkExported(ctx, DefaultHubID, "m/cpu/2026/08/06/15/g.parquet", ""); err == nil {
+		t.Error("a file was exported with no bundle ID; an ack could never attribute it")
+	}
+}
+
+// Exported bytes have NOT arrived, so they must stay in the backlog figure.
+// Excluding them would make an air-gap spoke's backlog appear to shrink at
+// exactly the moment nothing has been delivered.
+func TestLedger_StatsCountExportedSeparatelyButStillAsBacklog(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	for _, p := range []string{"m/cpu/2026/08/06/10/a.parquet", "m/cpu/2026/08/06/11/b.parquet"} {
+		if err := l.Track(ctx, testEntry(p)); err != nil {
+			t.Fatalf("track: %v", err)
+		}
+	}
+	if err := l.MarkExported(ctx, DefaultHubID, "m/cpu/2026/08/06/10/a.parquet", "bundle-1"); err != nil {
+		t.Fatalf("mark exported: %v", err)
+	}
+
+	st, err := l.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if st.Exported != 1 {
+		t.Errorf("Exported = %d, want 1", st.Exported)
+	}
+	if st.Pending != 1 {
+		t.Errorf("Pending = %d, want 1 (the exported file must not be counted twice)", st.Pending)
+	}
+	// 2 files x 1024 bytes: the exported one has not arrived either.
+	if st.PendingBytes != 2048 {
+		t.Errorf("PendingBytes = %d, want 2048: exported bytes are still in transit", st.PendingBytes)
+	}
+}
+
+// The bundle ID must be readable, not just filterable. When a drive does not
+// arrive, an operator has to know which bundle a file left on to decide what to
+// revert — otherwise the only way to find out is to open the SQLite file.
+func TestLedger_ExportedBundleIDIsReadable(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	const p = "m/cpu/2026/08/06/14/f.parquet"
+	if err := l.Track(ctx, testEntry(p)); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkExported(ctx, DefaultHubID, p, "bundle-abc"); err != nil {
+		t.Fatalf("mark exported: %v", err)
+	}
+
+	entry, err := l.Get(ctx, DefaultHubID, p)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if entry.ExportedBundleID != "bundle-abc" {
+		t.Errorf("ExportedBundleID = %q, want %q", entry.ExportedBundleID, "bundle-abc")
+	}
+	if entry.ExportedAt == nil {
+		t.Error("ExportedAt is nil on an exported entry")
+	}
+
+	// And it must survive the list queries an operator actually calls.
+	unfinished, err := l.Unfinished(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("unfinished: %v", err)
+	}
+	if len(unfinished) != 1 || unfinished[0].ExportedBundleID != "bundle-abc" {
+		t.Errorf("the bundle ID did not survive Unfinished: %+v", unfinished)
+	}
+
+	// A never-exported entry carries no bundle, rather than a stale one.
+	if err := l.Track(ctx, testEntry("m/cpu/2026/08/06/15/g.parquet")); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	fresh, err := l.Get(ctx, DefaultHubID, "m/cpu/2026/08/06/15/g.parquet")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fresh.ExportedBundleID != "" || fresh.ExportedAt != nil {
+		t.Errorf("a never-exported entry reports bundle %q at %v", fresh.ExportedBundleID, fresh.ExportedAt)
+	}
+}


### PR DESCRIPTION
> **PR 9a of 4** for the air-gap bundle (item 9 of #569). The ledger state comes first because the format and endpoints depend on it. Next: 9b format/MAC/export, 9c import/dedup, 9d ack.

## Why this is a separate PR

The original plan was one PR that left exported files in `pending`. An adversarial review of the plan caught that this does not converge, and I reproduced it:

```
without StateExported:  9 files, batch 3, 3 rounds -> 3 files, each exported 3x
with it:                9 files, batch 3, 3 rounds -> 9 files, exactly once each
```

`Pending` orders `partition_time DESC` ([ledger.go:392](https://github.com/Basekick-Labs/arc/blob/main/internal/edgesync/ledger.go#L392)), so a capped export re-takes the newest N every time and **the oldest files never leave the box**. A submarine on a 90-day cycle would ship the same recent data forever while its backlog silently starved. That is a treadmill, not eventual consistency.

## Transitions

```
pending  -> exported   MarkExported, bundle ID required
exported -> synced     MarkSynced, widened for the ack path (9d)
exported -> pending    RevertExported, scoped to one bundle
```

`MarkExported` accepts only `pending`: an `in_flight` row belongs to a running network transfer, and exporting it concurrently would put one file on two paths with no way to reconcile which acknowledgment arrived.

`MarkSynced` previously accepted only pending/in_flight, so an ack for an exported file would have been **rejected** — an air-gap spoke could never reach `synced`, `PruneSynced` would never prune, and the ledger would grow forever on the box least able to receive a site visit. Defined now even though the ack ships in 9d.

## Operator surface

- `Stats` counts `exported` separately, but **`PendingBytes` still includes exported bytes** — a file on a drive in transit has not arrived, and excluding it would make the backlog appear to shrink at exactly the moment nothing was delivered.
- `Unfinished` includes exported entries, so they stay visible in the troubleshooting view.
- `exported_at` / `exported_bundle_id` are readable on `LedgerEntry` and on the ledger endpoint. `RevertExported` filters on the bundle ID in SQL, but an operator whose drive did not arrive needs to **read** it to know what to revert. *(Raised in review — previously only reachable by opening the SQLite file.)*

## Schema

Two nullable columns, added with tolerated duplicate-column errors since SQLite has no `ADD COLUMN IF NOT EXISTS`. 26.09.1 is unreleased (no tag), so only development databases are affected.

## Test plan

- [x] 7 new tests; the starvation test **verified to fail pre-change** (3 of 9 files, each 3×), and the bundle-ID test likewise
- [x] Both mutants confirmed to **compile** before trusting the failure — a false negative I have hit before
- [x] Migration verified on a **real pre-9a spoke database**: 20 rows and their states preserved, restart idempotent, no duplicate-column error
- [x] Live binary: `exported` counted separately from `pending`, ledger endpoint lists the exported file **first** rather than hiding it
- [x] `go test -race`, `go vet`, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)