### PR TITLE
feat(edgesync): air-gap bundle export (#569)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -119,6 +119,45 @@ Files are hashed once at discovery, and the ledger survives restarts, so a spoke
 
 This is the **manual** form, and it is OSS. The automatic scheduled agent will be an Enterprise feature.
 
+### Air-gap bundles
+
+Some spokes have no network path at all — a submarine, a classified facility, a vehicle whose data comes off on a physical drive. For those, a spoke writes a **signed bundle** to removable media:
+
+```toml
+[edge_sync.spoke.bundle]
+enabled = true                        # default false
+allowed_dirs = ["/mnt/usb"]           # REQUIRED; an empty list refuses every export
+max_files = 10000                     # per bundle
+max_bytes = 68719476736               # 64 GiB per bundle
+```
+
+`edge_sync.spoke.bundle.enabled` is **independent of `edge_sync.spoke.enabled`**: a fully air-gapped spoke exports bundles and never runs the network path, so it needs no `hub_url` at all. A spoke that has both intermittent connectivity and a drive courier can run both.
+
+```bash
+curl -X POST https://edge.local:8000/api/v1/spoke-sync/export \
+  -H "Authorization: Bearer $ARC_TOKEN" \
+  -d '{"path": "/mnt/usb"}'
+```
+
+A bundle is a **directory**, not an archive:
+
+```
+bundle-submarine-01-06FXVSQXJ2C0EBDFDQ9D24S1E8/
+  manifest.json     signed header: bundle ID, spoke, hub, entry digest, MAC
+  entries.jsonl     one JSON object per file
+  data/             the Parquet files, under their original paths
+```
+
+Chosen over a tar for two reasons. **Resume is free** — an interrupted copy leaves whole files, and the manifest's per-file SHA identifies exactly which landed, so resuming re-copies the mismatches rather than restarting. And it is **auditable**: someone has to inspect what crosses an air gap, and `ls` plus `sha256sum entries.jsonl` answers that without opening anything.
+
+Signing uses a third HMAC family (`sync-bundle`) alongside the two online ones. The canonical input is length-prefixed, so a bundle MAC cannot validate on `/sync/file` or `/sync/reconcile`, nor the reverse. Unlike those families the bundle MAC carries **no timestamp window** — a bundle legitimately crosses an air gap over weeks, and a freshness check would reject exactly the artifacts this transport exists to carry. Replay protection is the hub's dedup ledger, which arrives with the import side.
+
+**Where a bundle may be written is explicit.** Every other Arc write path is confined to the storage root by its backend; a USB mount is outside that root by definition, so `allowed_dirs` is required and an empty list refuses every export. Paths are resolved through symlinks before the check, compared at a path-segment boundary, and Arc **refuses to export into its own storage root** — the next discovery pass would otherwise find the exported copies and queue them for sync.
+
+Exported files move to a new ledger state, `exported`, rather than staying pending. Without it a capped export would re-take the newest files every time and the oldest would never leave the box. They are reported separately from `pending` in `/status` but still counted in `pending_bytes`, because a file on a drive in transit has not arrived. If a drive is lost, `POST /api/v1/spoke-sync/export/{bundle_id}/revert` returns just that bundle's files to pending.
+
+The hub-side import, and the acknowledgment that advances `exported` to `synced`, land next.
+
 ## Security hardening
 
 ### Strip client-controlled forwarding headers at the inter-node boundary (CVE-2026-45045 class)

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2114,7 +2114,10 @@ func main() {
 	// The secret comes from ARC_EDGE_SYNC_SPOKE_SECRET only; config load
 	// already refused a config-file secret and verified every required field,
 	// so by here the configuration is known good.
-	if cfg.EdgeSync.Spoke.Enabled {
+	// Either role independently: a spoke with intermittent connectivity runs
+	// the agent, a fully air-gapped one only exports bundles, and a spoke that
+	// does both runs both. The shared ledger is why they live in one block.
+	if cfg.EdgeSync.Spoke.Enabled || cfg.EdgeSync.Spoke.Bundle.Enabled {
 		spokeLogger := logger.Get("edgesync-spoke")
 
 		// The ledger shares the auth database, like the hub index. Reuse the
@@ -2135,40 +2138,111 @@ func main() {
 			log.Fatal().Err(err).Msg("Failed to create the edge sync ledger; refusing to start")
 		}
 
-		spokeTransport, err := edgesync.NewHTTPTransport(edgesync.HTTPTransportConfig{
-			BaseURL: cfg.EdgeSync.Spoke.HubURL,
-			SpokeID: cfg.EdgeSync.Spoke.SpokeID,
-			Secret:  cfg.EdgeSync.Spoke.Secret,
-		})
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to create the edge sync transport; refusing to start")
+		// The network agent. Skipped entirely on a fully air-gapped spoke,
+		// which has no hub URL to build a transport from.
+		var syncAgent *edgesync.Agent
+		if cfg.EdgeSync.Spoke.Enabled {
+			spokeTransport, err := edgesync.NewHTTPTransport(edgesync.HTTPTransportConfig{
+				BaseURL: cfg.EdgeSync.Spoke.HubURL,
+				SpokeID: cfg.EdgeSync.Spoke.SpokeID,
+				Secret:  cfg.EdgeSync.Spoke.Secret,
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the edge sync transport; refusing to start")
+			}
+
+			syncAgent, err = edgesync.NewAgent(edgesync.AgentConfig{
+				Ledger:        spokeLedger,
+				Transport:     spokeTransport,
+				Backend:       storageBackend,
+				HubID:         cfg.EdgeSync.Spoke.HubID,
+				SpokeID:       cfg.EdgeSync.Spoke.SpokeID,
+				MaxAttempts:   cfg.EdgeSync.Spoke.MaxAttempts,
+				MaxConcurrent: cfg.EdgeSync.Spoke.MaxConcurrent,
+				BatchSize:     cfg.EdgeSync.Spoke.BatchSize,
+				Logger:        spokeLogger,
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the edge sync agent; refusing to start")
+			}
 		}
 
-		syncAgent, err := edgesync.NewAgent(edgesync.AgentConfig{
-			Ledger:        spokeLedger,
-			Transport:     spokeTransport,
-			Backend:       storageBackend,
-			HubID:         cfg.EdgeSync.Spoke.HubID,
-			SpokeID:       cfg.EdgeSync.Spoke.SpokeID,
-			MaxAttempts:   cfg.EdgeSync.Spoke.MaxAttempts,
-			MaxConcurrent: cfg.EdgeSync.Spoke.MaxConcurrent,
-			BatchSize:     cfg.EdgeSync.Spoke.BatchSize,
-			Logger:        spokeLogger,
-		})
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to create the edge sync agent; refusing to start")
+		// Air-gap export, independent of the network agent above.
+		var bundleExporter *edgesync.Exporter
+		if cfg.EdgeSync.Spoke.Bundle.Enabled {
+			// The storage root is passed so the policy can refuse it outright:
+			// exporting into it would make the next discovery pass find the
+			// exported copies and queue them for sync.
+			// Only meaningful for a local backend; for S3/Azure there is no
+			// local root to protect and the policy simply skips that check.
+			localRoot := ""
+			if cfg.Storage.Backend == "local" {
+				localRoot = cfg.Storage.LocalPath
+			}
+			policy, err := edgesync.NewDestinationPolicy(
+				cfg.EdgeSync.Spoke.Bundle.AllowedDirs, localRoot)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to resolve the bundle destination policy; refusing to start")
+			}
+
+			bundleWriter, err := edgesync.NewBundleWriter(edgesync.BundleWriterConfig{
+				Backend: storageBackend,
+				SpokeID: cfg.EdgeSync.Spoke.SpokeID,
+				HubID:   cfg.EdgeSync.Spoke.HubID,
+				Secret:  cfg.EdgeSync.Spoke.Secret,
+				Logger:  spokeLogger,
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the bundle writer; refusing to start")
+			}
+
+			// Its own discoverer: an air-gapped spoke runs no agent, so this
+			// is the only thing that ever populates its ledger.
+			bundleDiscoverer, err := edgesync.NewDiscoverer(
+				spokeLedger, storageBackend, cfg.EdgeSync.Spoke.HubID, spokeLogger)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the bundle discoverer; refusing to start")
+			}
+
+			bundleExporter, err = edgesync.NewExporter(edgesync.ExporterConfig{
+				Ledger:     spokeLedger,
+				Writer:     bundleWriter,
+				Policy:     policy,
+				Discoverer: bundleDiscoverer,
+				HubID:      cfg.EdgeSync.Spoke.HubID,
+				MaxFiles:   cfg.EdgeSync.Spoke.Bundle.MaxFiles,
+				MaxBytes:   cfg.EdgeSync.Spoke.Bundle.MaxBytes,
+				Logger:     spokeLogger,
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the bundle exporter; refusing to start")
+			}
 		}
 
-		spokeHandler, err := api.NewEdgeSyncSpokeHandler(syncAgent, authManager, spokeLogger)
+		spokeHandler, err := api.NewEdgeSyncSpokeHandler(syncAgent, bundleExporter, authManager, spokeLogger)
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to create the edge sync spoke handler; refusing to start")
 		}
 		spokeHandler.RegisterRoutes(server.GetApp())
 
-		spokeLogger.Info().
-			Str("hub_url", cfg.EdgeSync.Spoke.HubURL).
+		// Reports what is actually enabled: an air-gap-only spoke has no hub
+		// URL and no /run endpoint, so claiming both would send an operator
+		// looking for a route that returns 503.
+		evt := spokeLogger.Info().
 			Str("spoke_id", cfg.EdgeSync.Spoke.SpokeID).
-			Msg("Edge sync spoke enabled; trigger a pass with POST /api/v1/spoke-sync/run")
+			Bool("network_sync", syncAgent != nil).
+			Bool("bundle_export", bundleExporter != nil)
+		if syncAgent != nil {
+			evt = evt.Str("hub_url", cfg.EdgeSync.Spoke.HubURL)
+		}
+		switch {
+		case syncAgent != nil && bundleExporter != nil:
+			evt.Msg("Edge sync spoke enabled; POST /api/v1/spoke-sync/run to sync, /export for an air-gap bundle")
+		case syncAgent != nil:
+			evt.Msg("Edge sync spoke enabled; trigger a pass with POST /api/v1/spoke-sync/run")
+		default:
+			evt.Msg("Edge sync air-gap export enabled; write a bundle with POST /api/v1/spoke-sync/export")
+		}
 	}
 
 	// Register TLE handler (streaming TLE ingestion)

--- a/internal/api/edgesync_spoke.go
+++ b/internal/api/edgesync_spoke.go
@@ -35,18 +35,28 @@ const syncRunTimeout = 2 * time.Hour
 // that is not a string-prefix of another group's is the only way to keep the
 // two genuinely uncoupled.
 type EdgeSyncSpokeHandler struct {
-	agent       *edgesync.Agent
+	agent *edgesync.Agent
+
+	// exporter is nil unless air-gap bundle export is enabled. It is
+	// independent of the agent: a fully air-gapped spoke exports bundles and
+	// never runs the network path at all.
+	exporter *edgesync.Exporter
+
 	authManager *auth.AuthManager
 	logger      zerolog.Logger
 }
 
 // NewEdgeSyncSpokeHandler validates configuration and returns a ready handler.
-func NewEdgeSyncSpokeHandler(agent *edgesync.Agent, authManager *auth.AuthManager, logger zerolog.Logger) (*EdgeSyncSpokeHandler, error) {
-	if agent == nil {
-		return nil, errors.New("edgesync spoke: agent is required")
+func NewEdgeSyncSpokeHandler(agent *edgesync.Agent, exporter *edgesync.Exporter, authManager *auth.AuthManager, logger zerolog.Logger) (*EdgeSyncSpokeHandler, error) {
+	if agent == nil && exporter == nil {
+		// One or the other must exist, or the routes would all 503. Both is
+		// the normal case for a spoke that has intermittent connectivity AND
+		// ships drives.
+		return nil, errors.New("edgesync spoke: an agent or an exporter is required")
 	}
 	return &EdgeSyncSpokeHandler{
 		agent:       agent,
+		exporter:    exporter,
 		authManager: authManager,
 		logger:      logger.With().Str("component", "edgesync-spoke").Logger(),
 	}, nil
@@ -68,6 +78,8 @@ func (h *EdgeSyncSpokeHandler) RegisterRoutes(app fiber.Router) {
 	group.Post("/run", h.run)
 	group.Get("/status", h.status)
 	group.Get("/ledger", h.ledger)
+	group.Post("/export", h.export)
+	group.Post("/export/:bundle_id/revert", h.revertExport)
 
 	h.logger.Info().Msg("Edge sync spoke routes registered")
 }
@@ -79,6 +91,12 @@ func (h *EdgeSyncSpokeHandler) RegisterRoutes(app fiber.Router) {
 // would mean inventing job tracking for a feature whose automatic form (phase
 // 2) will not need it.
 func (h *EdgeSyncSpokeHandler) run(c *fiber.Ctx) error {
+	if h.agent == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "the network sync agent is not enabled (edge_sync.spoke.enabled)",
+		})
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), syncRunTimeout)
 	defer cancel()
 
@@ -137,7 +155,24 @@ func (h *EdgeSyncSpokeHandler) status(c *fiber.Ctx) error {
 	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
 	defer cancel()
 
-	st, err := h.agent.Status(ctx)
+	// Served by whichever side exists: both are pure ledger reads, and an
+	// air-gap-only spoke has no agent. Gating this on the agent would hide the
+	// exported count from the only operator who needs it — the one whose files
+	// are on a drive somewhere.
+	var (
+		st  *edgesync.Stats
+		err error
+	)
+	switch {
+	case h.agent != nil:
+		st, err = h.agent.Status(ctx)
+	case h.exporter != nil:
+		st, err = h.exporter.Status(ctx)
+	default:
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "no edge sync transport is enabled",
+		})
+	}
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to read sync status")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -194,7 +229,21 @@ func (h *EdgeSyncSpokeHandler) ledger(c *fiber.Ctx) error {
 		limit = n
 	}
 
-	entries, err := h.agent.UnfinishedEntries(ctx, limit)
+	// Same reasoning as status: a pure ledger read, served by either side.
+	var (
+		entries []*edgesync.LedgerEntry
+		err     error
+	)
+	switch {
+	case h.agent != nil:
+		entries, err = h.agent.UnfinishedEntries(ctx, limit)
+	case h.exporter != nil:
+		entries, err = h.exporter.UnfinishedEntries(ctx, limit)
+	default:
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "no edge sync transport is enabled",
+		})
+	}
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to read the sync ledger")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -228,4 +277,107 @@ func (h *EdgeSyncSpokeHandler) ledger(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{"entries": out, "limit": limit})
+}
+
+// bundleExportTimeout bounds one export.
+//
+// Generous for the same reason a sync pass is: a bundle can carry thousands of
+// files to removable media, and cutting that short leaves a partial tree the
+// writer must then clean up. An operator who wants a shorter bound cancels.
+const bundleExportTimeout = 2 * time.Hour
+
+// export handles POST /api/v1/spoke-sync/export.
+//
+// Writes pending files to an air-gap bundle under an operator-supplied path.
+// The path is checked against the configured allow-list before anything is
+// written — it reaches the filesystem directly, unlike every other Arc write.
+func (h *EdgeSyncSpokeHandler) export(c *fiber.Ctx) error {
+	if h.exporter == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "air-gap bundle export is not enabled (edge_sync.spoke.bundle.enabled)",
+		})
+	}
+
+	var req struct {
+		Path  string `json:"path"`
+		Limit int    `json:"limit"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+	if req.Path == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "path is required: the directory to write the bundle into",
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), bundleExportTimeout)
+	defer cancel()
+
+	res, err := h.exporter.Export(ctx, req.Path, req.Limit)
+	switch {
+	case errors.Is(err, edgesync.ErrNothingToExport):
+		// Not a failure: a drained backlog is the steady state, and a
+		// scheduled export should not look broken when it finds nothing.
+		return c.JSON(fiber.Map{"exported": false, "reason": "nothing to export"})
+
+	case errors.Is(err, edgesync.ErrDestinationRefused):
+		// The operator's own input, so 400 rather than 503 — retrying without
+		// changing the path would fail identically.
+		h.logger.Warn().Err(err).Msg("Bundle export destination refused")
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+
+	case err != nil:
+		// A fixed string, with the detail in the log — matching this file's
+		// other handlers. The raw error carries absolute filesystem paths, and
+		// while the endpoint is admin-only there is no reason to return them.
+		h.logger.Error().Err(err).Msg("Bundle export failed")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "bundle export failed"})
+	}
+
+	h.logger.Info().
+		Str("bundle_id", res.BundleID).
+		Str("dir", res.Dir).
+		Int("files", res.FileCount).
+		Int64("bytes", res.Bytes).
+		Msg("Bundle exported")
+
+	return c.JSON(fiber.Map{
+		"exported":    true,
+		"bundle_id":   res.BundleID,
+		"dir":         res.Dir,
+		"files":       res.FileCount,
+		"bytes":       res.Bytes,
+		"duration_ms": res.Duration.Milliseconds(),
+		// The bundle is on media but no hub has confirmed it. Saying so here
+		// stops an operator reading "exported" as "delivered".
+		"note": "Files are marked exported, not synced. They advance to synced when the hub acknowledges the bundle.",
+	})
+}
+
+// revertExport handles POST /api/v1/spoke-sync/export/:bundle_id/revert.
+//
+// For a drive that was lost, damaged, or never delivered: returns that
+// bundle's files to pending so a later bundle or contact window carries them.
+// Scoped to one bundle so recovering one drive does not disturb others in
+// transit.
+func (h *EdgeSyncSpokeHandler) revertExport(c *fiber.Ctx) error {
+	if h.exporter == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "air-gap bundle export is not enabled (edge_sync.spoke.bundle.enabled)",
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	bundleID := c.Params("bundle_id")
+	n, err := h.exporter.Revert(ctx, bundleID)
+	if err != nil {
+		h.logger.Warn().Err(err).Str("bundle_id", bundleID).Msg("Bundle revert failed")
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	h.logger.Info().Str("bundle_id", bundleID).Int64("files", n).Msg("Bundle reverted")
+	return c.JSON(fiber.Map{"bundle_id": bundleID, "reverted": n})
 }

--- a/internal/api/edgesync_spoke_test.go
+++ b/internal/api/edgesync_spoke_test.go
@@ -60,7 +60,7 @@ func newSpokeRig(t *testing.T) *spokeRig {
 		t.Fatalf("agent: %v", err)
 	}
 
-	h, err := NewEdgeSyncSpokeHandler(agent, nil, zerolog.Nop())
+	h, err := NewEdgeSyncSpokeHandler(agent, nil, nil, zerolog.Nop())
 	if err != nil {
 		t.Fatalf("handler: %v", err)
 	}
@@ -261,8 +261,9 @@ func TestEdgeSyncSpoke_RunFailureIs503(t *testing.T) {
 }
 
 func TestNewEdgeSyncSpokeHandler_RequiresAnAgent(t *testing.T) {
-	if _, err := NewEdgeSyncSpokeHandler(nil, nil, zerolog.Nop()); err == nil {
-		t.Error("a spoke handler was created without an agent")
+	// Neither an agent nor an exporter means every route would 503.
+	if _, err := NewEdgeSyncSpokeHandler(nil, nil, nil, zerolog.Nop()); err == nil {
+		t.Error("a spoke handler was created with neither an agent nor an exporter")
 	}
 }
 
@@ -285,7 +286,7 @@ func TestEdgeSyncSpoke_PrefixDoesNotCollideWithHubGroups(t *testing.T) {
 	admin.Get("/", func(c *fiber.Ctx) error { return c.SendString("admin") })
 
 	rig := newSpokeRig(t)
-	h, err := NewEdgeSyncSpokeHandler(rig.agent, nil, zerolog.Nop())
+	h, err := NewEdgeSyncSpokeHandler(rig.agent, nil, nil, zerolog.Nop())
 	if err != nil {
 		t.Fatalf("handler: %v", err)
 	}

--- a/internal/cluster/security/edgesync_auth.go
+++ b/internal/cluster/security/edgesync_auth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,15 @@ const (
 	// same content hash, so a MAC valid for one is legitimately valid for the
 	// other.
 	syncLabelFile = "sync-file"
+
+	// syncLabelBundle marks an air-gap bundle manifest (§10, PR 9b).
+	//
+	// Length 11, deliberately distinct from "sync-file" (9) and
+	// "sync-reconcile" (14). canonicalSyncInput prefixes each field with its
+	// length, so a label of a DIFFERENT length cannot be reached by any
+	// arrangement of another family's field contents — that is what makes the
+	// three families non-interchangeable. Never add a label of length 9 or 14.
+	syncLabelBundle = "sync-bundle"
 )
 
 // ErrSyncAuthMalformedField is returned when a field carries a NUL byte.
@@ -192,6 +202,106 @@ func ValidateSyncReconcileHMAC(sharedSecret, nonce, spokeID, hubID string, body 
 		return ErrSyncAuthInvalid
 	}
 	return nil
+}
+
+// ComputeSyncBundleHMAC signs an air-gap bundle manifest.
+//
+// Binds bundleID, spokeID, hubID, createdAt, and a digest of the bundle's
+// entry list. A bundle whose entries are altered, whose spoke or hub is
+// changed, or whose ID is swapped fails to validate.
+//
+// NO NONCE, unlike the other two families, and deliberately: a nonce plus
+// NonceCache is in-memory replay protection sized for requests in flight. A
+// bundle is an artifact that may sit on a drive for weeks, so replay
+// protection is the hub's durable (spoke_id, bundle_id) dedup ledger instead —
+// which survives a restart, as a nonce cache does not.
+//
+// Format: "sync-bundle" \x00 bundleID \x00 spokeID \x00 hubID \x00 createdAt \x00 entriesDigest
+func ComputeSyncBundleHMAC(sharedSecret, bundleID, spokeID, hubID string, createdAt int64, entriesDigest string) (string, error) {
+	if err := rejectSyncNUL(bundleID, spokeID, hubID, entriesDigest); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(
+		computeSyncBundleHMACRaw(sharedSecret, bundleID, spokeID, hubID, createdAt, entriesDigest)), nil
+}
+
+func computeSyncBundleHMACRaw(sharedSecret, bundleID, spokeID, hubID string, createdAt int64, entriesDigest string) []byte {
+	return computeRawHMAC(sharedSecret, canonicalSyncInput(
+		syncLabelBundle, bundleID, spokeID, hubID,
+		strconv.FormatInt(createdAt, 10), entriesDigest))
+}
+
+// ValidateSyncBundleHMAC checks a bundle manifest's MAC.
+//
+// NO FRESHNESS CHECK, unlike the other two families. A bundle legitimately
+// crosses an air gap over days or weeks, so a timestamp window would reject
+// exactly the artifacts this transport exists to carry. Replay protection is
+// the hub's dedup ledger; createdAt is bound into the MAC so it cannot be
+// altered, and is surfaced to operators rather than enforced.
+func ValidateSyncBundleHMAC(sharedSecret, bundleID, spokeID, hubID string, createdAt int64, entriesDigest, receivedMAC string) error {
+	if err := rejectSyncNUL(bundleID, spokeID, hubID, entriesDigest); err != nil {
+		return err
+	}
+	expected := computeSyncBundleHMACRaw(sharedSecret, bundleID, spokeID, hubID, createdAt, entriesDigest)
+	if !constantTimeHexEqual(expected, receivedMAC) {
+		return ErrSyncAuthInvalid
+	}
+	return nil
+}
+
+// BundleEntriesDigest hashes a bundle's entry list into the value the MAC binds.
+//
+// Canonicalization is normative, because two implementations that disagree
+// produce MACs that fail with no diagnosis — and the auditability argument for
+// a directory bundle invites a second implementation (a verifier on the secure
+// side of an air gap):
+//
+//   - entries sorted byte-lexicographically by path
+//   - duplicate paths REJECTED, not deduplicated: a duplicate is how a
+//     conflict smuggles past "conflicts are reported, never overwritten"
+//   - each entry contributes canonicalSyncInput(path, sha256, size) — the SAME
+//     length-prefixed helper the MACs use, not a second encoding, because a
+//     second encoding in the same package is how the two drift
+//   - the concatenation is SHA-256'd
+//
+// Paths are treated as bytes; no Unicode normalization is applied or assumed.
+func BundleEntriesDigest(paths, sha256s []string, sizes []int64) (string, error) {
+	if len(paths) != len(sha256s) || len(paths) != len(sizes) {
+		return "", fmt.Errorf("security: bundle digest: %d paths, %d digests, %d sizes",
+			len(paths), len(sha256s), len(sizes))
+	}
+	if err := rejectSyncNUL(paths...); err != nil {
+		return "", err
+	}
+	if err := rejectSyncNUL(sha256s...); err != nil {
+		return "", err
+	}
+
+	// Rejected here as well as at verification: 9c computes digests on paths
+	// that may not run the per-file checks first, and a negative size must
+	// never be signed into a manifest.
+	for i, n := range sizes {
+		if n < 0 {
+			return "", fmt.Errorf("security: bundle digest: negative size %d for %q", n, paths[i])
+		}
+	}
+
+	idx := make([]int, len(paths))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(a, b int) bool { return paths[idx[a]] < paths[idx[b]] })
+
+	var b strings.Builder
+	for n, i := range idx {
+		if n > 0 && paths[idx[n-1]] == paths[i] {
+			return "", fmt.Errorf("security: bundle digest: duplicate path %q", paths[i])
+		}
+		b.WriteString(canonicalSyncInput(paths[i], sha256s[i], strconv.FormatInt(sizes[i], 10)))
+	}
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // canonicalSyncInput serializes fields so that no two distinct field tuples

--- a/internal/cluster/security/edgesync_auth_test.go
+++ b/internal/cluster/security/edgesync_auth_test.go
@@ -770,3 +770,154 @@ func TestSyncHMAC_SubSecondToleranceIsRejected(t *testing.T) {
 		t.Errorf("a one-second tolerance was rejected: %v", err)
 	}
 }
+
+// A bundle MAC must not validate on either online family, or vice versa.
+// canonicalSyncInput is length-prefixed, so the label's own length is bound
+// before its bytes — no arrangement of later field CONTENTS can re-partition
+// the string to reach a different label.
+func TestSyncBundleHMAC_CannotCrossFamilies(t *testing.T) {
+	const (
+		secret   = "s3cr3t"
+		bundleID = "01J9ZQK8000000000000000000"
+		spokeID  = "rocket-01"
+		hubID    = "ground-station"
+		digest   = "aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44"
+	)
+	const createdAt = int64(1786000000)
+
+	bundleMAC, err := ComputeSyncBundleHMAC(secret, bundleID, spokeID, hubID, createdAt, digest)
+	if err != nil {
+		t.Fatalf("compute bundle MAC: %v", err)
+	}
+
+	// The bundle MAC must not pass as a file MAC, however the fields are lined up.
+	if err := ValidateSyncFileHMAC(secret, bundleID, spokeID, hubID, digest,
+		digest, createdAt, bundleMAC, time.Hour); err == nil {
+		t.Error("a bundle MAC validated as a file MAC")
+	}
+	if err := ValidateSyncReconcileHMAC(secret, bundleID, spokeID, hubID,
+		[]byte(digest), createdAt, bundleMAC, time.Hour); err == nil {
+		t.Error("a bundle MAC validated as a reconcile MAC")
+	}
+
+	// And the reverse: a file MAC must not pass as a bundle MAC.
+	fileMAC, err := ComputeSyncFileHMAC(secret, bundleID, spokeID, hubID, digest, digest, createdAt)
+	if err != nil {
+		t.Fatalf("compute file MAC: %v", err)
+	}
+	if err := ValidateSyncBundleHMAC(secret, bundleID, spokeID, hubID, createdAt, digest, fileMAC); err == nil {
+		t.Error("a file MAC validated as a bundle MAC")
+	}
+}
+
+// Every field the MAC binds must actually change it, or that field can be
+// altered on a drive without detection.
+func TestSyncBundleHMAC_BindsEveryField(t *testing.T) {
+	const (
+		secret   = "s3cr3t"
+		bundleID = "01J9ZQK8000000000000000000"
+		spokeID  = "rocket-01"
+		hubID    = "ground-station"
+		digest   = "aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44"
+	)
+	const createdAt = int64(1786000000)
+
+	base, err := ComputeSyncBundleHMAC(secret, bundleID, spokeID, hubID, createdAt, digest)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+
+	tests := []struct {
+		name                    string
+		bundle, spoke, hub, dig string
+		created                 int64
+	}{
+		{"bundle ID", "01J9ZQK8000000000000000001", spokeID, hubID, digest, createdAt},
+		{"spoke ID", bundleID, "rocket-02", hubID, digest, createdAt},
+		{"hub ID", bundleID, spokeID, "other-hub", digest, createdAt},
+		{"entries digest", bundleID, spokeID, hubID, "bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55", createdAt},
+		{"created at", bundleID, spokeID, hubID, digest, createdAt + 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateSyncBundleHMAC(secret, tc.bundle, tc.spoke, tc.hub,
+				tc.created, tc.dig, base); err == nil {
+				t.Errorf("changing the %s did not invalidate the MAC", tc.name)
+			}
+		})
+	}
+
+	// A different secret must fail too — the whole point of per-spoke secrets.
+	if err := ValidateSyncBundleHMAC("other-secret", bundleID, spokeID, hubID, createdAt, digest, base); err == nil {
+		t.Error("a MAC validated under the wrong secret")
+	}
+}
+
+// A bundle crosses an air gap over days or weeks. A freshness window would
+// reject exactly the artifacts this transport exists to carry.
+func TestSyncBundleHMAC_HasNoFreshnessWindow(t *testing.T) {
+	const (
+		secret   = "s3cr3t"
+		bundleID = "01J9ZQK8000000000000000000"
+		spokeID  = "rocket-01"
+		hubID    = "ground-station"
+		digest   = "aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44"
+	)
+	// A year old.
+	createdAt := time.Now().Add(-365 * 24 * time.Hour).Unix()
+
+	mac, err := ComputeSyncBundleHMAC(secret, bundleID, spokeID, hubID, createdAt, digest)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if err := ValidateSyncBundleHMAC(secret, bundleID, spokeID, hubID, createdAt, digest, mac); err != nil {
+		t.Errorf("a year-old bundle was rejected: %v", err)
+	}
+}
+
+// The digest is canonical: entry ORDER must not change it, or an export and a
+// verifier that iterate differently would disagree with no diagnosis.
+func TestBundleEntriesDigest_IsOrderIndependentAndRejectsDuplicates(t *testing.T) {
+	paths := []string{"b/2.parquet", "a/1.parquet", "c/3.parquet"}
+	shas := []string{"bb", "aa", "cc"}
+	sizes := []int64{2, 1, 3}
+
+	d1, err := BundleEntriesDigest(paths, shas, sizes)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+
+	// Same entries, different order.
+	d2, err := BundleEntriesDigest(
+		[]string{"a/1.parquet", "b/2.parquet", "c/3.parquet"},
+		[]string{"aa", "bb", "cc"},
+		[]int64{1, 2, 3})
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if d1 != d2 {
+		t.Errorf("digest depends on input order: %s vs %s", d1, d2)
+	}
+
+	// A changed size must change the digest — it is bound per entry.
+	d3, err := BundleEntriesDigest(paths, shas, []int64{2, 99, 3})
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if d1 == d3 {
+		t.Error("changing an entry's size did not change the digest")
+	}
+
+	// A duplicate path is how a conflict smuggles past "never overwritten".
+	if _, err := BundleEntriesDigest(
+		[]string{"a/1.parquet", "a/1.parquet"},
+		[]string{"aa", "bb"},
+		[]int64{1, 2}); err == nil {
+		t.Error("a duplicate path was accepted")
+	}
+
+	// Mismatched slice lengths are a programming error, not a silent truncation.
+	if _, err := BundleEntriesDigest([]string{"a"}, []string{"aa", "bb"}, []int64{1}); err == nil {
+		t.Error("mismatched slice lengths were accepted")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,6 +270,33 @@ type EdgeSyncSpokeConfig struct {
 	// BatchSize caps how many files one reconcile asks about. Zero lets the
 	// hub's own limit decide, and a larger backlog pages.
 	BatchSize int
+
+	// Bundle configures air-gap export.
+	Bundle EdgeSyncBundleConfig
+}
+
+// EdgeSyncBundleConfig configures air-gap bundle export on a spoke.
+type EdgeSyncBundleConfig struct {
+	// Enabled mounts the export endpoint. Independent of Spoke.Enabled: a
+	// fully air-gapped spoke has no hub URL to reach and no reason to run the
+	// network path at all.
+	Enabled bool
+
+	// AllowedDirs are the filesystem roots a bundle may be written to.
+	//
+	// Required — an empty list refuses every export. Every other Arc write
+	// path is confined to the storage root by its backend, but a USB mount is
+	// outside that root by definition, so this is the only thing bounding
+	// where an operator-supplied path can land. Symlinks are resolved and the
+	// storage root is refused outright.
+	AllowedDirs []string
+
+	// MaxFiles caps one bundle. Zero means 10,000.
+	MaxFiles int
+
+	// MaxBytes caps one bundle's data. Zero means 64 GiB — roughly a large
+	// removable drive, and a bound on how much a single export can write.
+	MaxBytes int64
 }
 
 type WALConfig struct {
@@ -723,6 +750,12 @@ func Load() (*Config, error) {
 				MaxAttempts:   v.GetInt("edge_sync.spoke.max_attempts"),
 				MaxConcurrent: v.GetInt("edge_sync.spoke.max_concurrent"),
 				BatchSize:     v.GetInt("edge_sync.spoke.batch_size"),
+				Bundle: EdgeSyncBundleConfig{
+					Enabled:     v.GetBool("edge_sync.spoke.bundle.enabled"),
+					AllowedDirs: v.GetStringSlice("edge_sync.spoke.bundle.allowed_dirs"),
+					MaxFiles:    v.GetInt("edge_sync.spoke.bundle.max_files"),
+					MaxBytes:    v.GetInt64("edge_sync.spoke.bundle.max_bytes"),
+				},
 			},
 		},
 		Compaction: CompactionConfig{
@@ -1126,6 +1159,44 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// Checked independently of Spoke.Enabled: a fully air-gapped spoke exports
+	// bundles and never runs the network path, so it has no hub URL and no
+	// reason to enable the sync agent at all.
+	if cfg.EdgeSync.Spoke.Bundle.Enabled {
+		if len(cfg.EdgeSync.Spoke.Bundle.AllowedDirs) == 0 {
+			return nil, fmt.Errorf("edge_sync.spoke.bundle.enabled=true requires " +
+				"edge_sync.spoke.bundle.allowed_dirs: a bundle is written to a raw filesystem " +
+				"path outside the storage root, so the permitted roots must be stated explicitly")
+		}
+		// Identity is bound into the bundle MAC, so the hub cannot accept a
+		// bundle that does not name both sides.
+		if cfg.EdgeSync.Spoke.SpokeID == "" {
+			return nil, fmt.Errorf("edge_sync.spoke.bundle.enabled=true requires edge_sync.spoke.spoke_id")
+		}
+		if cfg.EdgeSync.Spoke.HubID == "" {
+			return nil, fmt.Errorf("edge_sync.spoke.bundle.enabled=true requires edge_sync.spoke.hub_id " +
+				"(the hub the bundle is destined for)")
+		}
+		// Checked here too, not only under Spoke.Enabled: an air-gap-only spoke
+		// never enters that block, and without this the missing secret surfaced
+		// as a late fatal from an internal constructor AFTER a full startup —
+		// naming a Go type rather than the environment variable to set, to the
+		// operator least able to iterate on it.
+		if cfg.EdgeSync.Spoke.Secret == "" {
+			return nil, fmt.Errorf("edge_sync.spoke.bundle.enabled=true requires the " +
+				"ARC_EDGE_SYNC_SPOKE_SECRET environment variable: it signs the bundle manifest, " +
+				"and the hub rejects an unsigned bundle")
+		}
+		if cfg.EdgeSync.Spoke.Bundle.MaxFiles < 0 {
+			return nil, fmt.Errorf("edge_sync.spoke.bundle.max_files must be >= 0 (got %d); 0 means \"use the default\"",
+				cfg.EdgeSync.Spoke.Bundle.MaxFiles)
+		}
+		if cfg.EdgeSync.Spoke.Bundle.MaxBytes < 0 {
+			return nil, fmt.Errorf("edge_sync.spoke.bundle.max_bytes must be >= 0 (got %d); 0 means \"use the default\"",
+				cfg.EdgeSync.Spoke.Bundle.MaxBytes)
+		}
+	}
+
 	// A hub without an ID cannot authenticate anything: hub_id is bound into
 	// every request MAC, so an empty value would mean every spoke signs for
 	// the same anonymous hub and a request captured at one could be replayed
@@ -1267,6 +1338,14 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("edge_sync.spoke.max_attempts", 5)   // before a file is marked failed
 	v.SetDefault("edge_sync.spoke.max_concurrent", 2) // edge boxes are small
 	v.SetDefault("edge_sync.spoke.batch_size", 0)     // 0 defers to the hub's cap
+
+	// Air-gap bundle export. allowed_dirs has no default on purpose: an empty
+	// list refuses every export, so an operator must state where bundles may
+	// be written rather than inherit a guess.
+	v.SetDefault("edge_sync.spoke.bundle.enabled", false)
+	v.SetDefault("edge_sync.spoke.bundle.allowed_dirs", []string{})
+	v.SetDefault("edge_sync.spoke.bundle.max_files", 10000)
+	v.SetDefault("edge_sync.spoke.bundle.max_bytes", int64(64)<<30) // 64 GiB
 
 	v.SetDefault("compaction.enabled", true)
 	v.SetDefault("compaction.hourly_schedule", "5 * * * *")        // Every hour at :05

--- a/internal/config/edgesync_spoke_test.go
+++ b/internal/config/edgesync_spoke_test.go
@@ -126,3 +126,121 @@ func TestSpokeConfig_DefaultsAreDeclared(t *testing.T) {
 		t.Errorf("batch_size = %d, want 0", got)
 	}
 }
+
+// A fully air-gapped spoke exports bundles and never runs the network path, so
+// bundle validation must not be nested inside the spoke's own enabled check.
+func TestBundleConfig_ValidatesIndependentlyOfTheSpokeAgent(t *testing.T) {
+	// The secret signs the manifest, so bundle export requires it too.
+	t.Setenv("ARC_EDGE_SYNC_SPOKE_SECRET", strings.Repeat("a", 64))
+
+	body := `
+[edge_sync.spoke]
+spoke_id = "rocket-01"
+hub_id = "ground-station"
+
+[edge_sync.spoke.bundle]
+enabled = true
+allowed_dirs = ["/mnt/usb"]
+`
+	cfg, err := loadWith(t, body)
+	if err != nil {
+		t.Fatalf("an air-gap-only spoke failed to load: %v", err)
+	}
+	if cfg.EdgeSync.Spoke.Enabled {
+		t.Error("the sync agent was enabled without being asked for")
+	}
+	if !cfg.EdgeSync.Spoke.Bundle.Enabled {
+		t.Error("bundle export did not survive load")
+	}
+	// Defaults must apply even though the agent is off.
+	if cfg.EdgeSync.Spoke.Bundle.MaxFiles != 10000 {
+		t.Errorf("max_files = %d, want 10000", cfg.EdgeSync.Spoke.Bundle.MaxFiles)
+	}
+	if cfg.EdgeSync.Spoke.Bundle.MaxBytes != int64(64)<<30 {
+		t.Errorf("max_bytes = %d, want 64GiB", cfg.EdgeSync.Spoke.Bundle.MaxBytes)
+	}
+}
+
+// Every other Arc write path is confined to the storage root by its backend. A
+// bundle is not, so the permitted roots must be stated rather than guessed.
+func TestBundleConfig_RequiresAllowedDirsAndIdentities(t *testing.T) {
+	// Present so each case fails for the reason it is testing, not for a
+	// missing secret.
+	t.Setenv("ARC_EDGE_SYNC_SPOKE_SECRET", strings.Repeat("a", 64))
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"no allowed_dirs",
+			"[edge_sync.spoke]\nspoke_id = \"r1\"\nhub_id = \"g\"\n[edge_sync.spoke.bundle]\nenabled = true\n",
+			"allowed_dirs",
+		},
+		{
+			"no spoke_id",
+			"[edge_sync.spoke]\nhub_id = \"g\"\n[edge_sync.spoke.bundle]\nenabled = true\nallowed_dirs = [\"/mnt/usb\"]\n",
+			"spoke_id",
+		},
+		{
+			"no hub_id",
+			"[edge_sync.spoke]\nspoke_id = \"r1\"\n[edge_sync.spoke.bundle]\nenabled = true\nallowed_dirs = [\"/mnt/usb\"]\n",
+			"hub_id",
+		},
+		{
+			"negative max_files",
+			"[edge_sync.spoke]\nspoke_id = \"r1\"\nhub_id = \"g\"\n[edge_sync.spoke.bundle]\nenabled = true\nallowed_dirs = [\"/mnt/usb\"]\nmax_files = -1\n",
+			"max_files",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := loadWith(t, tc.body); err == nil {
+				t.Fatalf("config loaded despite %s", tc.name)
+			} else if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// Disabled bundle export is the default for every Arc deployment.
+func TestBundleConfig_DisabledSkipsValidation(t *testing.T) {
+	cfg, err := loadWith(t, "[edge_sync.spoke.bundle]\nenabled = false\n")
+	if err != nil {
+		t.Fatalf("a disabled bundle blocked startup: %v", err)
+	}
+	if cfg.EdgeSync.Spoke.Bundle.Enabled {
+		t.Error("bundle export reported enabled")
+	}
+}
+
+// An air-gap-only spoke never enters the Spoke.Enabled block, so without its
+// own check the missing secret surfaced as a late fatal from an internal
+// constructor after a full startup — naming a Go type rather than the
+// environment variable, to the operator least able to iterate.
+func TestBundleConfig_RequiresTheSecretOnTheAirGapPath(t *testing.T) {
+	body := `
+[edge_sync.spoke]
+spoke_id = "rocket-01"
+hub_id = "ground-station"
+
+[edge_sync.spoke.bundle]
+enabled = true
+allowed_dirs = ["/mnt/usb"]
+`
+	_, err := loadWith(t, body)
+	if err == nil {
+		t.Fatal("an air-gap spoke loaded with no signing secret")
+	}
+	if !strings.Contains(err.Error(), "ARC_EDGE_SYNC_SPOKE_SECRET") {
+		t.Errorf("the error does not name the environment variable: %v", err)
+	}
+
+	// With the secret present it must load.
+	t.Setenv("ARC_EDGE_SYNC_SPOKE_SECRET", strings.Repeat("a", 64))
+	if _, err := loadWith(t, body); err != nil {
+		t.Errorf("an air-gap spoke with a secret failed to load: %v", err)
+	}
+}

--- a/internal/edgesync/agent.go
+++ b/internal/edgesync/agent.go
@@ -322,65 +322,11 @@ func (a *Agent) runBatch(ctx context.Context, pending []*LedgerEntry, res *RunRe
 // works identically everywhere, and compaction output and backfilled files just
 // appear as new rows on the next pass.
 func (a *Agent) Discover(ctx context.Context) (int, error) {
-	lister, ok := a.backend.(storage.ObjectLister)
-	if !ok {
-		return 0, errors.New("edgesync: backend cannot list object metadata, so discovery is not possible")
-	}
-
-	objects, err := lister.ListObjects(ctx, "")
+	d, err := NewDiscoverer(a.ledger, a.backend, a.hubID, a.logger)
 	if err != nil {
-		return 0, fmt.Errorf("edgesync: list local files: %w", err)
+		return 0, err
 	}
-
-	entries := make([]*LedgerEntry, 0, len(objects))
-	for _, obj := range objects {
-		if err := ctx.Err(); err != nil {
-			return 0, err
-		}
-		if !isSyncableFile(obj.Path) {
-			continue
-		}
-
-		// Skip anything already tracked BEFORE hashing it. Discovery runs
-		// every pass, and re-hashing the whole corpus each time would make the
-		// cheap step the expensive one.
-		if _, err := a.ledger.Get(ctx, a.hubID, obj.Path); err == nil {
-			continue
-		} else if !errors.Is(err, ErrNotFound) {
-			return 0, fmt.Errorf("edgesync: check ledger for %q: %w", obj.Path, err)
-		}
-
-		// ListObjects carries no digest, so compute one. This is the only full
-		// read a file gets from discovery, ever — and the spoke has to read
-		// those bytes to send them anyway. The digest is then reused for the
-		// request HMAC and for the hub's verify-before-commit.
-		sum, err := a.hashFile(ctx, obj.Path)
-		if err != nil {
-			// One unreadable file must not stop discovery: the rest of the
-			// backlog is still syncable, and this one is retried next pass.
-			a.logger.Warn().Err(err).Str("path", obj.Path).Msg("Skipping a file that could not be hashed")
-			continue
-		}
-
-		e := &LedgerEntry{
-			HubID:     a.hubID,
-			Path:      obj.Path,
-			SHA256:    sum,
-			SizeBytes: obj.Size,
-		}
-		e.Database, e.Measurement, e.PartitionTime = parseArcPath(obj.Path)
-		entries = append(entries, e)
-	}
-
-	if len(entries) == 0 {
-		return 0, nil
-	}
-
-	inserted, err := a.ledger.TrackBatch(ctx, entries)
-	if err != nil {
-		return 0, fmt.Errorf("edgesync: track discovered files: %w", err)
-	}
-	return inserted, nil
+	return d.Discover(ctx)
 }
 
 // sendAll streams the missing files, bounded by MaxConcurrent.

--- a/internal/edgesync/bundle.go
+++ b/internal/edgesync/bundle.go
@@ -1,0 +1,434 @@
+package edgesync
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// BundleVersion is the on-disk format version.
+//
+// Written into every manifest and checked on import. A reader that does not
+// recognize a version must refuse rather than guess: a bundle is verified
+// before anything is committed, and "verified" means nothing if the verifier
+// misunderstood the layout.
+const BundleVersion = 1
+
+// Bundle file names. Fixed rather than configurable — an operator inspecting a
+// drive at an air gap should find the same three names every time.
+const (
+	manifestName = "manifest.json"
+	entriesName  = "entries.jsonl"
+	dataDir      = "data"
+)
+
+// Manifest is the signed header of a bundle.
+//
+// Deliberately small and fixed-size: the entry list lives in a separate
+// newline-delimited file so neither export nor import has to hold hundreds of
+// thousands of entries in memory, and so a human can run `sha256sum
+// entries.jsonl` — which is the point of a directory bundle over an archive.
+type Manifest struct {
+	Version int `json:"version"`
+
+	// BundleID is a ULID, and the hub's replay key. Format-validated on import
+	// because it is attacker-chosen: a compromised spoke signs whatever it
+	// likes, and this string reaches a SQLite key and operator log lines.
+	BundleID string `json:"bundle_id"`
+
+	SpokeID string `json:"spoke_id"`
+
+	// HubID is the hub this bundle is FOR. The import side must reject a
+	// mismatch: the MAC alone does not, since a bundle for another hub
+	// validates fine under the same spoke secret, and a scavenged drive would
+	// otherwise import anywhere that spoke is registered.
+	HubID string `json:"hub_id"`
+
+	// CreatedAt is bound into the MAC but NOT enforced as a freshness window —
+	// a bundle legitimately crosses an air gap over weeks. Surfaced to
+	// operators so a 409 on a very old bundle is diagnosable.
+	CreatedAt int64 `json:"created_at"`
+
+	EntryCount int64 `json:"entry_count"`
+	TotalBytes int64 `json:"total_bytes"`
+
+	// EntriesSHA256 covers entries.jsonl as bytes, so a human with sha256sum
+	// can check it without understanding the canonical entry encoding.
+	EntriesSHA256 string `json:"entries_sha256"`
+
+	// EntriesDigest is the canonical digest the MAC binds. Distinct from
+	// EntriesSHA256: this one is order- and formatting-independent, so it
+	// survives a reader that rewrites the file, while the raw hash does not.
+	EntriesDigest string `json:"entries_digest"`
+
+	MAC string `json:"mac"`
+}
+
+// BundleEntry is one file in a bundle, one JSON object per line.
+type BundleEntry struct {
+	Path      string `json:"path"`
+	SHA256    string `json:"sha256"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// NewBundleID returns a lexicographically-sortable, time-prefixed identifier.
+//
+// ULID-shaped: 48-bit millisecond timestamp then 80 bits of randomness, in
+// Crockford base32. Sortable means a directory listing of bundles is in
+// creation order, which is what an operator holding several drives wants.
+func NewBundleID(now time.Time) (string, error) {
+	var b [16]byte
+	ms := uint64(now.UTC().UnixMilli())
+	b[0] = byte(ms >> 40)
+	b[1] = byte(ms >> 32)
+	b[2] = byte(ms >> 24)
+	b[3] = byte(ms >> 16)
+	b[4] = byte(ms >> 8)
+	b[5] = byte(ms)
+	if _, err := rand.Read(b[6:]); err != nil {
+		return "", fmt.Errorf("edgesync: generate bundle ID: %w", err)
+	}
+	return crockford.EncodeToString(b[:]), nil
+}
+
+// crockford is base32 without I, L, O, or U — the characters most often
+// misread when a human copies a bundle ID off a screen at an air gap.
+var crockford = base32.NewEncoding("0123456789ABCDEFGHJKMNPQRSTVWXYZ").WithPadding(base32.NoPadding)
+
+// bundleIDLen is the encoded length of 16 bytes in unpadded base32.
+const bundleIDLen = 26
+
+// ValidateBundleID checks the format of an identifier that arrives from a file.
+//
+// The ID is attacker-chosen — a compromised spoke signs any manifest it likes —
+// and it reaches a SQLite primary key, a log line, and (via the directory name)
+// a filesystem path. An unbounded arbitrary string in all three is a bad idea
+// regardless of whether a specific exploit is obvious.
+func ValidateBundleID(id string) error {
+	if len(id) != bundleIDLen {
+		return fmt.Errorf("edgesync: bundle ID %q must be %d characters, got %d",
+			truncateForError(id), bundleIDLen, len(id))
+	}
+	for _, r := range id {
+		if !strings.ContainsRune("0123456789ABCDEFGHJKMNPQRSTVWXYZ", r) {
+			return fmt.Errorf("edgesync: bundle ID %q contains %q, which is not Crockford base32",
+				truncateForError(id), r)
+		}
+	}
+	return nil
+}
+
+// truncateForError bounds an untrusted string before it reaches an error or log.
+func truncateForError(s string) string {
+	const max = 64
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// BundleWriterConfig configures an export.
+type BundleWriterConfig struct {
+	// Backend reads the spoke's Parquet files.
+	Backend storage.Backend
+
+	SpokeID string
+	HubID   string
+
+	// Secret is the hub-issued shared secret that signs the manifest.
+	Secret string
+
+	Logger zerolog.Logger
+}
+
+// BundleWriter exports ledger entries to a directory bundle.
+type BundleWriter struct {
+	backend storage.Backend
+	spokeID string
+	hubID   string
+	secret  string
+	logger  zerolog.Logger
+}
+
+// NewBundleWriter validates configuration and returns a ready writer.
+func NewBundleWriter(cfg BundleWriterConfig) (*BundleWriter, error) {
+	if cfg.Backend == nil {
+		return nil, fmt.Errorf("edgesync: bundle writer requires a storage backend")
+	}
+	if err := validateSpokeID(cfg.SpokeID); err != nil {
+		return nil, fmt.Errorf("edgesync: bundle writer spoke ID: %w", err)
+	}
+	if cfg.HubID == "" {
+		return nil, fmt.Errorf("edgesync: bundle writer requires a hub ID")
+	}
+	if cfg.Secret == "" {
+		// Without it the manifest cannot be signed, and an unsigned bundle is
+		// not a bundle — the hub would reject every one.
+		return nil, fmt.Errorf("edgesync: bundle writer requires a spoke secret")
+	}
+	return &BundleWriter{
+		backend: cfg.Backend,
+		spokeID: cfg.SpokeID,
+		hubID:   cfg.HubID,
+		secret:  cfg.Secret,
+		logger:  cfg.Logger.With().Str("component", "edgesync-bundle").Logger(),
+	}, nil
+}
+
+// ExportResult summarizes one export.
+type ExportResult struct {
+	BundleID  string
+	Dir       string
+	FileCount int
+	Bytes     int64
+	Duration  time.Duration
+}
+
+// Export writes entries to a new bundle directory under parent.
+//
+// Order matters and is the crash-safety property: data files first, then
+// entries.jsonl, then the manifest LAST. A partial export therefore has no
+// manifest and cannot be mistaken for a complete one.
+//
+// That ordering protects against a crash HERE. It does NOT survive the copy to
+// removable media — `cp -r` walks in directory order and writes manifest.json
+// before data/, so an interrupted copy leaves a complete manifest over a
+// partial tree. The real completeness signal is BundleReader.Verify, which
+// re-hashes every file. Do not treat the manifest's presence as sufficient.
+func (w *BundleWriter) Export(ctx context.Context, parent string, entries []*LedgerEntry, now time.Time) (*ExportResult, error) {
+	start := time.Now()
+
+	if len(entries) == 0 {
+		// The sentinel, not a look-alike: a caller distinguishing "nothing to
+		// do" from a failure uses errors.Is, and a separately-constructed error
+		// with identical text does not match it.
+		return nil, ErrNothingToExport
+	}
+
+	bundleID, err := NewBundleID(now)
+	if err != nil {
+		return nil, err
+	}
+
+	// The spoke ID is in the directory name so a shared staging area holding
+	// drives from several spokes is unambiguous without opening each manifest.
+	dir := filepath.Join(parent, "bundle-"+w.spokeID+"-"+bundleID)
+
+	// Mkdir on the leaf, not stat-then-MkdirAll: MkdirAll succeeds on an
+	// existing directory, so a stat check leaves a window where two exports
+	// could interleave into one bundle. Mkdir returns EEXIST atomically.
+	// 0700: a bundle holds the spoke's telemetry and sits on removable media.
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return nil, fmt.Errorf("edgesync: create bundle parent: %w", err)
+	}
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("edgesync: create bundle directory: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, dataDir), 0o700); err != nil {
+		return nil, fmt.Errorf("edgesync: create bundle data directory: %w", err)
+	}
+
+	// Clean up a half-written bundle rather than leaving a partial tree that an
+	// operator might copy. Only on the error path — success returns before this.
+	committed := false
+	defer func() {
+		if !committed {
+			if rmErr := os.RemoveAll(dir); rmErr != nil {
+				w.logger.Warn().Err(rmErr).Str("dir", dir).
+					Msg("Could not remove a partially written bundle")
+			}
+		}
+	}()
+
+	written, err := w.writeData(ctx, dir, entries)
+	if err != nil {
+		return nil, err
+	}
+
+	digest, entriesSHA, total, err := w.writeEntries(dir, written)
+	if err != nil {
+		return nil, err
+	}
+
+	createdAt := now.UTC().Unix()
+	mac, err := security.ComputeSyncBundleHMAC(w.secret, bundleID, w.spokeID, w.hubID, createdAt, digest)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: sign bundle: %w", err)
+	}
+
+	m := Manifest{
+		Version:       BundleVersion,
+		BundleID:      bundleID,
+		SpokeID:       w.spokeID,
+		HubID:         w.hubID,
+		CreatedAt:     createdAt,
+		EntryCount:    int64(len(written)),
+		TotalBytes:    total,
+		EntriesSHA256: entriesSHA,
+		EntriesDigest: digest,
+		MAC:           mac,
+	}
+	if err := writeJSONFile(filepath.Join(dir, manifestName), m); err != nil {
+		return nil, err
+	}
+
+	committed = true
+	w.logger.Info().
+		Str("bundle_id", bundleID).
+		Str("dir", dir).
+		Int("files", len(written)).
+		Int64("bytes", total).
+		Msg("Bundle exported")
+
+	return &ExportResult{
+		BundleID:  bundleID,
+		Dir:       dir,
+		FileCount: len(written),
+		Bytes:     total,
+		Duration:  time.Since(start),
+	}, nil
+}
+
+// writeData streams each entry's file into the bundle, re-hashing as it goes.
+//
+// Re-hashed rather than trusting the ledger's digest: the ledger records what
+// the file was at discovery, and this verifies what is actually being written.
+// A mismatch means the file changed underneath us, which must not be signed.
+func (w *BundleWriter) writeData(ctx context.Context, dir string, entries []*LedgerEntry) ([]BundleEntry, error) {
+	out := make([]BundleEntry, 0, len(entries))
+
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		// The entry path came from the spoke's own storage walk, but it lands
+		// in a filesystem path here — validate before joining, not after.
+		if err := validateSyncPath(e.Path); err != nil {
+			return nil, fmt.Errorf("edgesync: entry %q: %w", truncateForError(e.Path), err)
+		}
+
+		dest := filepath.Join(dir, dataDir, filepath.FromSlash(e.Path))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+			return nil, fmt.Errorf("edgesync: create bundle subdirectory: %w", err)
+		}
+
+		sha, n, err := w.copyOne(ctx, e.Path, dest)
+		if err != nil {
+			return nil, err
+		}
+		if sha != e.SHA256 {
+			return nil, fmt.Errorf("edgesync: %q changed while exporting (ledger %s, read %s)",
+				e.Path, e.SHA256, sha)
+		}
+		out = append(out, BundleEntry{Path: e.Path, SHA256: sha, SizeBytes: n})
+	}
+	return out, nil
+}
+
+// copyOne streams one file from the backend to dest, returning its digest.
+func (w *BundleWriter) copyOne(ctx context.Context, src, dest string) (string, int64, error) {
+	f, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", 0, fmt.Errorf("edgesync: create %s: %w", dest, err)
+	}
+	defer f.Close()
+
+	// Hash and write in one pass. Reading twice would double the I/O on a
+	// constrained edge box and open a window for the file to change between.
+	h := sha256.New()
+	counter := &countingWriter{w: io.MultiWriter(f, h)}
+	if err := w.backend.ReadTo(ctx, src, counter); err != nil {
+		return "", 0, fmt.Errorf("edgesync: read %s: %w", src, err)
+	}
+	if err := f.Sync(); err != nil {
+		// Without the fsync a bundle can be reported complete while its bytes
+		// are still in the page cache — and the next thing that happens to a
+		// bundle is usually an unplugged drive.
+		return "", 0, fmt.Errorf("edgesync: sync %s: %w", dest, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), counter.n, nil
+}
+
+// writeEntries writes entries.jsonl and returns the canonical digest, the
+// file's own hash, and the total byte count.
+func (w *BundleWriter) writeEntries(dir string, entries []BundleEntry) (digest, fileSHA string, total int64, err error) {
+	paths := make([]string, 0, len(entries))
+	shas := make([]string, 0, len(entries))
+	sizes := make([]int64, 0, len(entries))
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+		shas = append(shas, e.SHA256)
+		sizes = append(sizes, e.SizeBytes)
+		total += e.SizeBytes
+	}
+
+	digest, err = security.BundleEntriesDigest(paths, shas, sizes)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("edgesync: bundle entries digest: %w", err)
+	}
+
+	path := filepath.Join(dir, entriesName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("edgesync: create %s: %w", path, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	enc := json.NewEncoder(io.MultiWriter(f, h))
+	for _, e := range entries {
+		if err := enc.Encode(e); err != nil {
+			return "", "", 0, fmt.Errorf("edgesync: write bundle entry: %w", err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		return "", "", 0, fmt.Errorf("edgesync: sync %s: %w", path, err)
+	}
+	return digest, hex.EncodeToString(h.Sum(nil)), total, nil
+}
+
+// writeJSONFile writes v as indented JSON, fsynced.
+//
+// Indented because a human at an air gap reads this file.
+func writeJSONFile(path string, v any) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("edgesync: create %s: %w", path, err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("edgesync: write %s: %w", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("edgesync: sync %s: %w", path, err)
+	}
+	return nil
+}
+
+// countingWriter counts bytes on their way through.
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += int64(n)
+	return n, err
+}

--- a/internal/edgesync/bundle_dest.go
+++ b/internal/edgesync/bundle_dest.go
@@ -1,0 +1,157 @@
+package edgesync
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrDestinationRefused marks a bundle path an operator may not use.
+var ErrDestinationRefused = errors.New("edgesync: bundle destination refused")
+
+// DestinationPolicy decides which filesystem paths a bundle may use.
+//
+// Every other Arc write path goes through a storage backend, which confines it
+// to the storage root. A bundle cannot: a USB mount is outside that root by
+// definition, so an operator-supplied path reaches the filesystem directly.
+//
+// The endpoints are admin-only, so this is not a privilege boundary — an admin
+// can already do worse. It guards against MISTAKES, one of which is not
+// obvious: exporting into Arc's own storage root makes the next discovery pass
+// find the exported copies and queue them for sync, which fans out on every
+// export.
+type DestinationPolicy struct {
+	allowed     []string
+	storageRoot string
+}
+
+// NewDestinationPolicy resolves the allow-list once, at startup.
+//
+// Resolving here rather than per-request means a symlink swapped later cannot
+// change what a path means mid-flight, and an unresolvable entry is a startup
+// error rather than a confusing runtime refusal.
+func NewDestinationPolicy(allowedDirs []string, storageRoot string) (*DestinationPolicy, error) {
+	p := &DestinationPolicy{}
+
+	for _, d := range allowedDirs {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		resolved, err := resolveDir(d)
+		if err != nil {
+			return nil, fmt.Errorf("edgesync: bundle allowed directory %q: %w", d, err)
+		}
+		p.allowed = append(p.allowed, resolved)
+	}
+
+	if storageRoot != "" {
+		// Best-effort: a storage root that does not resolve (a remote backend,
+		// say) simply means there is no local root to protect.
+		if resolved, err := resolveDir(storageRoot); err == nil {
+			p.storageRoot = resolved
+		}
+	}
+	return p, nil
+}
+
+// Enabled reports whether any destination is permitted.
+func (p *DestinationPolicy) Enabled() bool { return len(p.allowed) > 0 }
+
+// Resolve validates a requested path and returns its absolute, symlink-free form.
+//
+// The returned path is what callers must use — not the requested one — so a
+// later component cannot re-resolve differently.
+func (p *DestinationPolicy) Resolve(requested string) (string, error) {
+	if len(p.allowed) == 0 {
+		// Refuse rather than default to "anywhere". An unset allow-list means
+		// the operator has not thought about where bundles may be written.
+		return "", fmt.Errorf("%w: no allowed directories are configured", ErrDestinationRefused)
+	}
+	if requested == "" {
+		return "", fmt.Errorf("%w: no path given", ErrDestinationRefused)
+	}
+
+	resolved, err := resolveDir(requested)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrDestinationRefused, err)
+	}
+
+	// The storage-root check comes first: it is the mistake with the least
+	// obvious consequence, so it deserves the clearest error.
+	if p.storageRoot != "" && isWithin(resolved, p.storageRoot) {
+		return "", fmt.Errorf("%w: %s is inside Arc's storage root (%s); "+
+			"the next discovery pass would find the exported files and queue them for sync",
+			ErrDestinationRefused, resolved, p.storageRoot)
+	}
+
+	for _, dir := range p.allowed {
+		if isWithin(resolved, dir) {
+			return resolved, nil
+		}
+	}
+	return "", fmt.Errorf("%w: %s is not under any configured allowed directory (%s)",
+		ErrDestinationRefused, resolved, strings.Join(p.allowed, ", "))
+}
+
+// resolveDir makes a path absolute and symlink-free.
+//
+// EvalSymlinks is what stops a link inside an allowed directory from pointing
+// somewhere that is not — the check must run on where a path actually LANDS,
+// not on how it was spelled.
+func resolveDir(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q: %w", path, err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("resolve %q: %w", path, err)
+		}
+		// The leaf may legitimately not exist yet — an export creates it. Walk
+		// up to the nearest existing ancestor, resolve THAT, and re-attach the
+		// remainder. Resolving only the existing part is the point: a symlink
+		// can only exist on a path that exists.
+		existing, remainder := abs, ""
+		for {
+			parent := filepath.Dir(existing)
+			if parent == existing {
+				return "", fmt.Errorf("resolve %q: no existing ancestor", path)
+			}
+			remainder = filepath.Join(filepath.Base(existing), remainder)
+			existing = parent
+			if _, statErr := os.Stat(existing); statErr == nil {
+				break
+			}
+		}
+		base, err := filepath.EvalSymlinks(existing)
+		if err != nil {
+			return "", fmt.Errorf("resolve %q: %w", path, err)
+		}
+		resolved = filepath.Join(base, remainder)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+// isWithin reports whether p is dir or sits underneath it.
+//
+// Compared at a path-separator boundary, not by raw prefix: strings.HasPrefix
+// alone matches "/data/wh-other" as being under "/data/wh", which is the #534
+// bug class this codebase has already shipped once.
+func isWithin(p, dir string) bool {
+	if p == dir {
+		return true
+	}
+	// The filesystem root already ends in a separator, so appending another
+	// yields "//" and matches nothing — the fix for the mid-segment bug
+	// shipping its own edge case. "/" is an unwise allow-list entry but a
+	// plausible one on a locked-down appliance.
+	if dir == string(os.PathSeparator) {
+		return strings.HasPrefix(p, dir)
+	}
+	return strings.HasPrefix(p, dir+string(os.PathSeparator))
+}

--- a/internal/edgesync/bundle_dest.go
+++ b/internal/edgesync/bundle_dest.go
@@ -116,11 +116,22 @@ func resolveDir(path string) (string, error) {
 		// up to the nearest existing ancestor, resolve THAT, and re-attach the
 		// remainder. Resolving only the existing part is the point: a symlink
 		// can only exist on a path that exists.
+		// Bounded. The walk terminates at the filesystem root either way, but
+		// a destination whose parent chain is dozens of missing levels deep is
+		// a typo or a hostile input, not a drive mount — and each level costs a
+		// stat. Refusing early gives a clearer error than resolving a 2KB path.
+		const maxMissingLevels = 32
+
 		existing, remainder := abs, ""
-		for {
+		for depth := 0; ; depth++ {
+			if depth > maxMissingLevels {
+				return "", fmt.Errorf("resolve %q: more than %d missing directory levels; "+
+					"a bundle destination should be at or just below an existing mount point",
+					truncateForError(path), maxMissingLevels)
+			}
 			parent := filepath.Dir(existing)
 			if parent == existing {
-				return "", fmt.Errorf("resolve %q: no existing ancestor", path)
+				return "", fmt.Errorf("resolve %q: no existing ancestor", truncateForError(path))
 			}
 			remainder = filepath.Join(filepath.Base(existing), remainder)
 			existing = parent

--- a/internal/edgesync/bundle_dest_test.go
+++ b/internal/edgesync/bundle_dest_test.go
@@ -1,0 +1,170 @@
+package edgesync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDestinationPolicy_AllowsOnlyConfiguredDirs(t *testing.T) {
+	allowed := t.TempDir()
+	other := t.TempDir()
+
+	p, err := NewDestinationPolicy([]string{allowed}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+
+	if _, err := p.Resolve(allowed); err != nil {
+		t.Errorf("the allowed directory itself was refused: %v", err)
+	}
+	// Compare resolved against resolved: on macOS /var is a symlink to
+	// /private/var, so the policy's output is legitimately spelled differently
+	// from t.TempDir()'s return value.
+	resolvedAllowed, err := filepath.EvalSymlinks(allowed)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	sub := filepath.Join(allowed, "bundles", "today")
+	if got, err := p.Resolve(sub); err != nil {
+		t.Errorf("a subdirectory was refused: %v", err)
+	} else if !strings.HasPrefix(got, resolvedAllowed) {
+		t.Errorf("resolved to %q, outside %q", got, resolvedAllowed)
+	}
+
+	if _, err := p.Resolve(other); err == nil {
+		t.Error("a directory outside the allow-list was accepted")
+	}
+}
+
+// strings.HasPrefix alone matches "/data/wh-other" as being under "/data/wh".
+// This codebase has shipped that bug once already (#534).
+func TestDestinationPolicy_SiblingNameIsNotInside(t *testing.T) {
+	parent := t.TempDir()
+	allowed := filepath.Join(parent, "wh")
+	sibling := filepath.Join(parent, "wh-other")
+	for _, d := range []string{allowed, sibling} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	p, err := NewDestinationPolicy([]string{allowed}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	if _, err := p.Resolve(sibling); err == nil {
+		t.Errorf("%q was accepted as being inside %q", sibling, allowed)
+	}
+}
+
+// The filesystem root already ends in a separator, so the boundary check must
+// not append a second one — the fix for the mid-segment bug shipping its own
+// edge case. An unwise allow-list entry, but a plausible one on an appliance.
+func TestDestinationPolicy_FilesystemRootAllowsEverything(t *testing.T) {
+	p, err := NewDestinationPolicy([]string{string(os.PathSeparator)}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	if _, err := p.Resolve(t.TempDir()); err != nil {
+		t.Errorf("allowed_dirs=[\"/\"] refused a path: %v", err)
+	}
+}
+
+// Traversal must be judged on where a path LANDS, not how it is spelled.
+func TestDestinationPolicy_RejectsTraversalOutOfTheAllowList(t *testing.T) {
+	parent := t.TempDir()
+	allowed := filepath.Join(parent, "media")
+	if err := os.MkdirAll(allowed, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := NewDestinationPolicy([]string{allowed}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	if _, err := p.Resolve(filepath.Join(allowed, "..", "escaped")); err == nil {
+		t.Error("a path traversing out of the allow-list was accepted")
+	}
+}
+
+// A symlink inside an allowed directory can point anywhere; the check must
+// follow it rather than trust the spelling.
+func TestDestinationPolicy_FollowsSymlinksBeforeDeciding(t *testing.T) {
+	allowed := t.TempDir()
+	outside := t.TempDir()
+
+	link := filepath.Join(allowed, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	p, err := NewDestinationPolicy([]string{allowed}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	if _, err := p.Resolve(link); err == nil {
+		t.Error("a symlink pointing outside the allow-list was accepted")
+	}
+}
+
+// Exporting into the storage root makes the next discovery pass find the
+// exported copies and queue them for sync — fan-out on every export.
+func TestDestinationPolicy_RefusesTheStorageRoot(t *testing.T) {
+	parent := t.TempDir()
+	storage := filepath.Join(parent, "arc-data")
+	if err := os.MkdirAll(storage, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deliberately allow the whole parent, so only the storage-root rule can refuse.
+	p, err := NewDestinationPolicy([]string{parent}, storage)
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+
+	for _, dest := range []string{storage, filepath.Join(storage, "bundles")} {
+		_, err := p.Resolve(dest)
+		if err == nil {
+			t.Errorf("%q was accepted despite being in the storage root", dest)
+			continue
+		}
+		if !strings.Contains(err.Error(), "storage root") {
+			t.Errorf("error for %q does not explain why: %v", dest, err)
+		}
+	}
+
+	// A sibling of the storage root is fine.
+	if _, err := p.Resolve(filepath.Join(parent, "media")); err != nil {
+		t.Errorf("a directory beside the storage root was refused: %v", err)
+	}
+}
+
+// An unset allow-list means the operator has not decided where bundles may be
+// written. Defaulting to "anywhere" would be the wrong reading.
+func TestDestinationPolicy_RefusesEverythingWhenUnconfigured(t *testing.T) {
+	p, err := NewDestinationPolicy(nil, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	if p.Enabled() {
+		t.Error("an empty allow-list reports as enabled")
+	}
+	if _, err := p.Resolve(t.TempDir()); err == nil {
+		t.Error("a path was accepted with no allow-list configured")
+	}
+}
+
+// An export creates its own directory, so a not-yet-existing leaf under an
+// allowed root must be permitted.
+func TestDestinationPolicy_AllowsANotYetCreatedSubdirectory(t *testing.T) {
+	allowed := t.TempDir()
+	p, err := NewDestinationPolicy([]string{allowed}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	if _, err := p.Resolve(filepath.Join(allowed, "does", "not", "exist", "yet")); err != nil {
+		t.Errorf("a not-yet-created subdirectory was refused: %v", err)
+	}
+}

--- a/internal/edgesync/bundle_dest_test.go
+++ b/internal/edgesync/bundle_dest_test.go
@@ -168,3 +168,27 @@ func TestDestinationPolicy_AllowsANotYetCreatedSubdirectory(t *testing.T) {
 		t.Errorf("a not-yet-created subdirectory was refused: %v", err)
 	}
 }
+
+// A destination dozens of missing levels below an existing directory is a typo
+// or a hostile input, not a drive mount. Each level costs a stat, and refusing
+// early gives a clearer error than resolving a multi-kilobyte path.
+func TestDestinationPolicy_RefusesAnAbsurdlyDeepPath(t *testing.T) {
+	allowed := t.TempDir()
+	p, err := NewDestinationPolicy([]string{allowed}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+
+	deep := allowed
+	for i := 0; i < 40; i++ {
+		deep = filepath.Join(deep, "nope")
+	}
+	if _, err := p.Resolve(deep); err == nil {
+		t.Error("a path 40 missing levels deep was accepted")
+	}
+
+	// A normal not-yet-created destination must still work.
+	if _, err := p.Resolve(filepath.Join(allowed, "bundles")); err != nil {
+		t.Errorf("a one-level destination was refused: %v", err)
+	}
+}

--- a/internal/edgesync/bundle_read.go
+++ b/internal/edgesync/bundle_read.go
@@ -1,0 +1,322 @@
+package edgesync
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/rs/zerolog"
+)
+
+// ErrBundleInvalid marks a bundle that must not be imported.
+//
+// One error for every rejection reason so a caller maps it to a single status
+// rather than leaking which specific check failed — a tampered bundle and a
+// truncated one are both simply "do not import this".
+var ErrBundleInvalid = errors.New("edgesync: bundle is invalid")
+
+// maxManifestBytes bounds the manifest read.
+//
+// The manifest is a fixed set of short fields; anything larger is malformed or
+// hostile. The entry list lives in a separate streamed file precisely so this
+// bound can stay small.
+const maxManifestBytes = 64 << 10
+
+// BundleReader reads and verifies a bundle directory.
+type BundleReader struct {
+	dir      string
+	manifest *Manifest
+	logger   zerolog.Logger
+}
+
+// OpenBundle reads a bundle's manifest.
+//
+// Does NOT verify — call Verify before trusting anything here. Parsing the
+// manifest first is what lets a caller look up the right spoke secret.
+func OpenBundle(dir string, logger zerolog.Logger) (*BundleReader, error) {
+	raw, err := os.ReadFile(filepath.Join(dir, manifestName))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// The manifest is written last, so its absence is the signature of
+			// an export that died partway.
+			return nil, fmt.Errorf("%w: no %s (an interrupted export leaves none)",
+				ErrBundleInvalid, manifestName)
+		}
+		return nil, fmt.Errorf("edgesync: read bundle manifest: %w", err)
+	}
+	if len(raw) > maxManifestBytes {
+		return nil, fmt.Errorf("%w: manifest is %d bytes, over the %d-byte bound",
+			ErrBundleInvalid, len(raw), maxManifestBytes)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("%w: manifest is not valid JSON: %v", ErrBundleInvalid, err)
+	}
+	if m.Version != BundleVersion {
+		// Refuse rather than guess: "verified" means nothing if the verifier
+		// misunderstood the layout.
+		return nil, fmt.Errorf("%w: manifest version %d, this Arc understands %d",
+			ErrBundleInvalid, m.Version, BundleVersion)
+	}
+	if err := ValidateBundleID(m.BundleID); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBundleInvalid, err)
+	}
+	if err := validateSpokeID(m.SpokeID); err != nil {
+		return nil, fmt.Errorf("%w: spoke ID: %v", ErrBundleInvalid, err)
+	}
+	if m.EntryCount < 0 || m.TotalBytes < 0 {
+		return nil, fmt.Errorf("%w: negative entry count or size", ErrBundleInvalid)
+	}
+
+	return &BundleReader{
+		dir:      dir,
+		manifest: &m,
+		logger:   logger.With().Str("component", "edgesync-bundle").Logger(),
+	}, nil
+}
+
+// Manifest returns the parsed, not-yet-verified manifest.
+func (r *BundleReader) Manifest() *Manifest { return r.manifest }
+
+// Verify checks that this bundle is exactly what its spoke signed.
+//
+// Everything, before anything is committed:
+//   - the MAC over (bundle ID, spoke, hub, created-at, entries digest)
+//   - entries.jsonl's own hash, so a human's sha256sum agrees
+//   - every declared entry's path, and its file's size and digest
+//   - no file ANYWHERE in the bundle that the manifest does not declare
+//
+// That last check is what makes the directory format honest. Verifying only
+// the declared direction would leave unsigned, unverified payload sitting on
+// air-gap media inside something an operator has been told is verified — and
+// it covers the whole directory, not just data/, because that is the whole of
+// what a human is handed.
+func (r *BundleReader) Verify(ctx context.Context, secret string) error {
+	entries, digest, fileSHA, err := r.readEntries(ctx)
+	if err != nil {
+		return err
+	}
+
+	if fileSHA != r.manifest.EntriesSHA256 {
+		return fmt.Errorf("%w: %s hashes to %s, manifest says %s",
+			ErrBundleInvalid, entriesName, fileSHA, r.manifest.EntriesSHA256)
+	}
+	if digest != r.manifest.EntriesDigest {
+		return fmt.Errorf("%w: entries digest is %s, manifest says %s",
+			ErrBundleInvalid, digest, r.manifest.EntriesDigest)
+	}
+	if int64(len(entries)) != r.manifest.EntryCount {
+		return fmt.Errorf("%w: %d entries, manifest declares %d",
+			ErrBundleInvalid, len(entries), r.manifest.EntryCount)
+	}
+
+	if err := security.ValidateSyncBundleHMAC(secret, r.manifest.BundleID, r.manifest.SpokeID,
+		r.manifest.HubID, r.manifest.CreatedAt, r.manifest.EntriesDigest, r.manifest.MAC); err != nil {
+		return fmt.Errorf("%w: %v", ErrBundleInvalid, err)
+	}
+
+	declared := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := r.verifyOne(ctx, e); err != nil {
+			return err
+		}
+		declared[filepath.Clean(filepath.FromSlash(e.Path))] = struct{}{}
+	}
+
+	return r.rejectUndeclared(declared)
+}
+
+// verifyOne checks one entry's file against its declared size and digest.
+func (r *BundleReader) verifyOne(ctx context.Context, e BundleEntry) error {
+	// Validated here rather than first at import: an invalid path must fail
+	// verification, so the bundle is refused before a single byte is committed.
+	if err := validateSyncPath(e.Path); err != nil {
+		return fmt.Errorf("%w: entry %q: %v", ErrBundleInvalid, truncateForError(e.Path), err)
+	}
+	if !isHexSHA256(e.SHA256) {
+		return fmt.Errorf("%w: entry %q has a malformed digest", ErrBundleInvalid, truncateForError(e.Path))
+	}
+	if e.SizeBytes < 0 {
+		return fmt.Errorf("%w: entry %q has a negative size", ErrBundleInvalid, truncateForError(e.Path))
+	}
+
+	path := r.DataPath(e.Path)
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: %q is declared but missing (an interrupted copy)",
+				ErrBundleInvalid, truncateForError(e.Path))
+		}
+		return fmt.Errorf("edgesync: stat bundle file: %w", err)
+	}
+	if info.Size() != e.SizeBytes {
+		// The common case for a truncated transfer, and cheaper to catch here
+		// than by hashing the whole file first.
+		return fmt.Errorf("%w: %q is %d bytes, manifest declares %d (a truncated copy)",
+			ErrBundleInvalid, truncateForError(e.Path), info.Size(), e.SizeBytes)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("edgesync: open bundle file: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("edgesync: hash bundle file: %w", err)
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != e.SHA256 {
+		return fmt.Errorf("%w: %q hashes to %s, manifest declares %s",
+			ErrBundleInvalid, truncateForError(e.Path), got, e.SHA256)
+	}
+	return nil
+}
+
+// rejectUndeclared fails if the bundle holds any file the manifest does not name.
+//
+// Walks the WHOLE bundle directory, not just data/. "Verified" has to mean the
+// whole thing an operator is handed: an attacker with write access to media in
+// transit could otherwise drop an autorun.inf, a decoy manifest.json.bak, or a
+// shell script beside the data and the bundle would still verify clean. The
+// premise of this format is that a human inspects what crosses an air gap, so
+// the verifier must cover everything they would find.
+func (r *BundleReader) rejectUndeclared(declared map[string]struct{}) error {
+	dataPrefix := dataDir + string(filepath.Separator)
+
+	return filepath.WalkDir(r.dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(r.dir, p)
+		if relErr != nil {
+			return fmt.Errorf("edgesync: walk bundle: %w", relErr)
+		}
+		rel = filepath.Clean(rel)
+		if rel == "." {
+			return nil
+		}
+
+		if d.IsDir() {
+			// Only data/ and its subtree may contain directories.
+			if rel != dataDir && !strings.HasPrefix(rel, dataPrefix) {
+				return fmt.Errorf("%w: unexpected directory %q in the bundle",
+					ErrBundleInvalid, truncateForError(rel))
+			}
+			return nil
+		}
+
+		// Symlinks are not regular files: a link could point anywhere, and its
+		// target would be read as though it were bundle content.
+		if !d.Type().IsRegular() {
+			return fmt.Errorf("%w: %q is not a regular file", ErrBundleInvalid, truncateForError(rel))
+		}
+
+		// The two signed metadata files.
+		if rel == manifestName || rel == entriesName {
+			return nil
+		}
+
+		if !strings.HasPrefix(rel, dataPrefix) {
+			return fmt.Errorf("%w: %q is in the bundle but is not %s, %s, or under %s/ — unsigned payload",
+				ErrBundleInvalid, truncateForError(rel), manifestName, entriesName, dataDir)
+		}
+		if _, ok := declared[strings.TrimPrefix(rel, dataPrefix)]; !ok {
+			return fmt.Errorf("%w: %q is under %s/ but not declared in %s — unsigned payload",
+				ErrBundleInvalid, truncateForError(rel), dataDir, entriesName)
+		}
+		return nil
+	})
+}
+
+// readEntries streams entries.jsonl, returning the entries, the canonical
+// digest, and the file's own hash.
+//
+// Streamed, not buffered: a spoke returning from a long outage can present
+// hundreds of thousands of entries, and this runs on a hub that may also be
+// serving queries.
+func (r *BundleReader) readEntries(ctx context.Context) ([]BundleEntry, string, string, error) {
+	path := filepath.Join(r.dir, entriesName)
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, "", "", fmt.Errorf("%w: no %s", ErrBundleInvalid, entriesName)
+		}
+		return nil, "", "", fmt.Errorf("edgesync: open %s: %w", entriesName, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	sc := bufio.NewScanner(io.TeeReader(f, h))
+	// One entry per line; the default 64KB token bound is generous for a path
+	// plus a digest, and a longer line is malformed.
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		entries []BundleEntry
+		paths   []string
+		shas    []string
+		sizes   []int64
+	)
+	for sc.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, "", "", err
+		}
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var e BundleEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			return nil, "", "", fmt.Errorf("%w: malformed entry line: %v", ErrBundleInvalid, err)
+		}
+		entries = append(entries, e)
+		paths = append(paths, e.Path)
+		shas = append(shas, e.SHA256)
+		sizes = append(sizes, e.SizeBytes)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, "", "", fmt.Errorf("%w: reading %s: %v", ErrBundleInvalid, entriesName, err)
+	}
+
+	// Rejects duplicate paths, which is how a conflict would otherwise smuggle
+	// past "conflicts are reported, never overwritten".
+	digest, err := security.BundleEntriesDigest(paths, shas, sizes)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("%w: %v", ErrBundleInvalid, err)
+	}
+
+	return entries, digest, hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Entries streams the bundle's entries for an importer.
+//
+// Verify must have succeeded first; this does not re-check.
+func (r *BundleReader) Entries(ctx context.Context) ([]BundleEntry, error) {
+	entries, _, _, err := r.readEntries(ctx)
+	return entries, err
+}
+
+// DataPath returns the on-disk location of one entry's file.
+func (r *BundleReader) DataPath(entryPath string) string {
+	return filepath.Join(r.dir, dataDir, filepath.FromSlash(entryPath))
+}
+
+// Open returns a reader over one entry's file, for an importer to stream.
+func (r *BundleReader) Open(entryPath string) (io.ReadCloser, error) {
+	return os.Open(r.DataPath(entryPath))
+}

--- a/internal/edgesync/bundle_read.go
+++ b/internal/edgesync/bundle_read.go
@@ -317,6 +317,18 @@ func (r *BundleReader) DataPath(entryPath string) string {
 }
 
 // Open returns a reader over one entry's file, for an importer to stream.
+//
+// The CALLER MUST CLOSE the returned reader. An importer streams thousands of
+// files through this, so a missed Close exhausts descriptors on the hub.
+//
+// The path is validated even though Verify has already checked every declared
+// entry: this is exported, the importer is a separate component, and a
+// traversal primitive that happens to be unreachable today is one refactor
+// away from being reachable. os.Open on data/../../etc/passwd would otherwise
+// succeed.
 func (r *BundleReader) Open(entryPath string) (io.ReadCloser, error) {
+	if err := validateSyncPath(entryPath); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBundleInvalid, err)
+	}
 	return os.Open(r.DataPath(entryPath))
 }

--- a/internal/edgesync/bundle_test.go
+++ b/internal/edgesync/bundle_test.go
@@ -1,0 +1,636 @@
+package edgesync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+const (
+	testSecret  = "a-shared-secret"
+	testSpokeID = "rocket-01"
+	testHubID   = "ground-station"
+)
+
+type bundleRig struct {
+	writer  *BundleWriter
+	backend storage.Backend
+	parent  string
+}
+
+func newBundleRig(t *testing.T) *bundleRig {
+	t.Helper()
+
+	storeDir := t.TempDir()
+	backend, err := storage.NewLocalBackend(storeDir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	w, err := NewBundleWriter(BundleWriterConfig{
+		Backend: backend, SpokeID: testSpokeID, HubID: testHubID,
+		Secret: testSecret, Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	return &bundleRig{writer: w, backend: backend, parent: t.TempDir()}
+}
+
+// write puts a file in the spoke's storage and returns a ledger entry for it.
+func (r *bundleRig) write(t *testing.T, path, content string) *LedgerEntry {
+	t.Helper()
+	if err := r.backend.Write(context.Background(), path, []byte(content)); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	sum, err := sha256Of(content)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	return &LedgerEntry{
+		HubID: testHubID, Path: path, SHA256: sum, SizeBytes: int64(len(content)),
+		Database: "default", Measurement: "cpu",
+		PartitionTime: time.Date(2026, 8, 7, 14, 0, 0, 0, time.UTC),
+	}
+}
+
+func sha256Of(s string) (string, error) {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// exportTwo writes two files and exports them.
+func (r *bundleRig) exportTwo(t *testing.T) *ExportResult {
+	t.Helper()
+	entries := []*LedgerEntry{
+		r.write(t, "default/cpu/2026/08/07/14/a.parquet", "payload one"),
+		r.write(t, "default/mem/2026/08/07/14/b.parquet", "payload two"),
+	}
+	res, err := r.writer.Export(context.Background(), r.parent, entries, time.Now())
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	return res
+}
+
+func TestBundle_ExportThenVerifyRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	rig := newBundleRig(t)
+
+	res := rig.exportTwo(t)
+	if res.FileCount != 2 {
+		t.Errorf("FileCount = %d, want 2", res.FileCount)
+	}
+
+	r, err := OpenBundle(res.Dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := r.Verify(ctx, testSecret); err != nil {
+		t.Fatalf("a freshly exported bundle failed verification: %v", err)
+	}
+
+	m := r.Manifest()
+	if m.SpokeID != testSpokeID || m.HubID != testHubID {
+		t.Errorf("manifest identities = %s/%s", m.SpokeID, m.HubID)
+	}
+	if err := ValidateBundleID(m.BundleID); err != nil {
+		t.Errorf("exported bundle ID is not well-formed: %v", err)
+	}
+	// A human at an air gap checks this with sha256sum.
+	if m.EntriesSHA256 == "" || m.EntriesDigest == "" {
+		t.Error("manifest carries no entries hashes")
+	}
+}
+
+// The bundle is only as trustworthy as its verification. Each of these is a
+// distinct way a drive could arrive altered.
+func TestBundle_VerifyRejectsTampering(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		tamper func(t *testing.T, dir string)
+		want   string
+	}{
+		{
+			name: "a data file's contents changed",
+			tamper: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, dataDir, "default/cpu/2026/08/07/14/a.parquet")
+				// Same length, different bytes: a size check alone would miss it.
+				if err := os.WriteFile(p, []byte("payload ONE"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "hashes to",
+		},
+		{
+			name: "a data file truncated",
+			tamper: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, dataDir, "default/cpu/2026/08/07/14/a.parquet")
+				if err := os.WriteFile(p, []byte("pay"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "truncated",
+		},
+		{
+			name: "a data file missing",
+			tamper: func(t *testing.T, dir string) {
+				if err := os.Remove(filepath.Join(dir, dataDir, "default/cpu/2026/08/07/14/a.parquet")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "missing",
+		},
+		{
+			name: "an unsigned extra file smuggled in",
+			tamper: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, dataDir, "default/cpu/2026/08/07/14/extra.parquet")
+				if err := os.WriteFile(p, []byte("not in the manifest"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "unsigned payload",
+		},
+		{
+			name: "an unsigned file beside the data",
+			tamper: func(t *testing.T, dir string) {
+				// An attacker with write access to media in transit: autorun.inf,
+				// a shell script, a decoy manifest backup.
+				if err := os.WriteFile(filepath.Join(dir, "autorun.inf"), []byte("[autorun]"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "unsigned payload",
+		},
+		{
+			name: "an unsigned directory in the bundle",
+			tamper: func(t *testing.T, dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "extra"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "unexpected directory",
+		},
+		{
+			name: "a symlink beside the data",
+			tamper: func(t *testing.T, dir string) {
+				if err := os.Symlink("/etc/passwd", filepath.Join(dir, "link")); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+			},
+			want: "not a regular file",
+		},
+		{
+			name: "the manifest's MAC changed",
+			tamper: func(t *testing.T, dir string) {
+				editManifest(t, dir, func(m *Manifest) {
+					m.MAC = strings.Repeat("ab", 32)
+				})
+			},
+			want: "bundle is invalid",
+		},
+		{
+			name: "the manifest's hub retargeted",
+			tamper: func(t *testing.T, dir string) {
+				editManifest(t, dir, func(m *Manifest) { m.HubID = "other-hub" })
+			},
+			want: "bundle is invalid",
+		},
+		{
+			name: "the entries digest swapped",
+			tamper: func(t *testing.T, dir string) {
+				editManifest(t, dir, func(m *Manifest) {
+					m.EntriesDigest = strings.Repeat("cd", 32)
+				})
+			},
+			want: "entries digest",
+		},
+		{
+			name: "an entry line edited",
+			tamper: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, entriesName)
+				b, err := os.ReadFile(p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				out := strings.Replace(string(b), `"size_bytes":11`, `"size_bytes":99`, 1)
+				if err := os.WriteFile(p, []byte(out), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "bundle is invalid",
+		},
+		{
+			name: "the manifest removed",
+			tamper: func(t *testing.T, dir string) {
+				if err := os.Remove(filepath.Join(dir, manifestName)); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "interrupted export",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rig := newBundleRig(t)
+			res := rig.exportTwo(t)
+			tc.tamper(t, res.Dir)
+
+			r, err := OpenBundle(res.Dir, zerolog.Nop())
+			if err != nil {
+				// Some tampering is caught at open time; that is still a refusal.
+				if !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("open error = %v, want it to mention %q", err, tc.want)
+				}
+				return
+			}
+			err = r.Verify(ctx, testSecret)
+			if err == nil {
+				t.Fatal("a tampered bundle verified successfully")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A bundle signed by one spoke must not verify under another's secret.
+func TestBundle_VerifyRejectsTheWrongSecret(t *testing.T) {
+	ctx := context.Background()
+	rig := newBundleRig(t)
+	res := rig.exportTwo(t)
+
+	r, err := OpenBundle(res.Dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := r.Verify(ctx, "a-different-secret"); err == nil {
+		t.Error("a bundle verified under the wrong secret")
+	}
+}
+
+// A partial export must leave no manifest, so it cannot be mistaken for a
+// complete bundle — and must not leave a partial tree an operator might copy.
+func TestBundle_FailedExportLeavesNothingImportable(t *testing.T) {
+	ctx := context.Background()
+	rig := newBundleRig(t)
+
+	// An entry whose file is not in storage: the export fails partway.
+	entries := []*LedgerEntry{
+		rig.write(t, "default/cpu/2026/08/07/14/a.parquet", "payload one"),
+		{
+			HubID: testHubID, Path: "default/cpu/2026/08/07/14/ghost.parquet",
+			SHA256: strings.Repeat("ab", 32), SizeBytes: 10,
+			Database: "default", Measurement: "cpu",
+			PartitionTime: time.Date(2026, 8, 7, 14, 0, 0, 0, time.UTC),
+		},
+	}
+	if _, err := rig.writer.Export(ctx, rig.parent, entries, time.Now()); err == nil {
+		t.Fatal("exporting a missing file succeeded")
+	}
+
+	found, err := filepath.Glob(filepath.Join(rig.parent, "bundle-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(found) != 0 {
+		t.Errorf("a failed export left %v behind", found)
+	}
+}
+
+// A file that changes underneath the export must not be signed: the manifest
+// would then attest to content that never existed.
+func TestBundle_ExportRefusesAFileThatChanged(t *testing.T) {
+	ctx := context.Background()
+	rig := newBundleRig(t)
+
+	e := rig.write(t, "default/cpu/2026/08/07/14/a.parquet", "original")
+	// The ledger's digest now disagrees with what is on disk.
+	e.SHA256 = strings.Repeat("ff", 32)
+
+	if _, err := rig.writer.Export(ctx, rig.parent, []*LedgerEntry{e}, time.Now()); err == nil {
+		t.Error("a file whose content disagreed with the ledger was exported and signed")
+	}
+}
+
+func TestValidateBundleID(t *testing.T) {
+	good, err := NewBundleID(time.Now())
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if err := ValidateBundleID(good); err != nil {
+		t.Errorf("a generated ID failed validation: %v", err)
+	}
+
+	// The ID is attacker-chosen and reaches a SQLite key, a log line, and a
+	// directory name.
+	for _, bad := range []string{
+		"", "short", strings.Repeat("A", 27), strings.Repeat("A", 25),
+		"01J9ZQK800000000000000000I", // I is not Crockford base32
+		"01J9ZQK800000000000000000/", // a path separator
+		"01J9ZQK80000000000000000\x00",
+	} {
+		if err := ValidateBundleID(bad); err == nil {
+			t.Errorf("ValidateBundleID(%q) accepted it", bad)
+		}
+	}
+}
+
+// Bundle IDs are time-prefixed so a directory listing sorts into creation
+// order — what an operator holding several drives wants.
+func TestNewBundleID_SortsByCreationTime(t *testing.T) {
+	base := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	var prev string
+	for i := 0; i < 5; i++ {
+		id, err := NewBundleID(base.Add(time.Duration(i) * time.Second))
+		if err != nil {
+			t.Fatalf("new: %v", err)
+		}
+		if prev != "" && id <= prev {
+			t.Errorf("ID %q does not sort after %q", id, prev)
+		}
+		prev = id
+	}
+}
+
+// editManifest rewrites a bundle's manifest through a mutation function.
+func editManifest(t *testing.T, dir string, fn func(*Manifest)) {
+	t.Helper()
+	p := filepath.Join(dir, manifestName)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	fn(&m)
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// exporterRig wires a ledger, writer, and policy the way main.go does.
+type exporterRig struct {
+	exporter *Exporter
+	ledger   *Ledger
+	backend  storage.Backend
+	dest     string
+}
+
+func newExporterRig(t *testing.T, maxFiles int, maxBytes int64) *exporterRig {
+	t.Helper()
+
+	storeDir := t.TempDir()
+	backend, err := storage.NewLocalBackend(storeDir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	w, err := NewBundleWriter(BundleWriterConfig{
+		Backend: backend, SpokeID: testSpokeID, HubID: testHubID,
+		Secret: testSecret, Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+
+	dest := t.TempDir()
+	policy, err := NewDestinationPolicy([]string{dest}, storeDir)
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+
+	l := setupTestLedger(t)
+	disc, err := NewDiscoverer(l, backend, testHubID, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("discoverer: %v", err)
+	}
+	ex, err := NewExporter(ExporterConfig{
+		Ledger: l, Writer: w, Policy: policy, Discoverer: disc, HubID: testHubID,
+		MaxFiles: maxFiles, MaxBytes: maxBytes, Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("exporter: %v", err)
+	}
+	return &exporterRig{exporter: ex, ledger: l, backend: backend, dest: dest}
+}
+
+func (r *exporterRig) track(t *testing.T, path, content string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := r.backend.Write(ctx, path, []byte(content)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	sum, _ := sha256Of(content)
+	e := &LedgerEntry{
+		HubID: testHubID, Path: path, SHA256: sum, SizeBytes: int64(len(content)),
+		Database: "default", Measurement: "cpu",
+		PartitionTime: time.Date(2026, 8, 7, 14, 0, 0, 0, time.UTC),
+	}
+	if err := r.ledger.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+}
+
+// The whole point of 9a's StateExported: successive capped exports must cover
+// the backlog rather than re-taking the newest files forever.
+func TestExporter_SuccessiveExportsDrainTheBacklog(t *testing.T) {
+	ctx := context.Background()
+	rig := newExporterRig(t, 2, 0)
+
+	for i := 0; i < 6; i++ {
+		rig.track(t, fmt.Sprintf("default/cpu/2026/08/07/%02d/f.parquet", i), fmt.Sprintf("payload %d", i))
+	}
+
+	seen := map[string]bool{}
+	for round := 0; round < 3; round++ {
+		res, err := rig.exporter.Export(ctx, rig.dest, 0)
+		if err != nil {
+			t.Fatalf("round %d: %v", round, err)
+		}
+		if res.FileCount != 2 {
+			t.Errorf("round %d exported %d files, want 2", round, res.FileCount)
+		}
+		r, err := OpenBundle(res.Dir, zerolog.Nop())
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		if err := r.Verify(ctx, testSecret); err != nil {
+			t.Fatalf("round %d bundle failed verification: %v", round, err)
+		}
+		entries, err := r.Entries(ctx)
+		if err != nil {
+			t.Fatalf("entries: %v", err)
+		}
+		for _, e := range entries {
+			if seen[e.Path] {
+				t.Errorf("%s was exported twice", e.Path)
+			}
+			seen[e.Path] = true
+		}
+	}
+
+	if len(seen) != 6 {
+		t.Errorf("covered %d files across three rounds, want 6", len(seen))
+	}
+	if _, err := rig.exporter.Export(ctx, rig.dest, 0); err == nil {
+		t.Error("a fourth export found work when the backlog was drained")
+	}
+}
+
+// A backlog larger than one drive is expected: the bundle truncates and the
+// next one continues, rather than failing.
+func TestExporter_TruncatesAtTheByteCap(t *testing.T) {
+	ctx := context.Background()
+	// 10 bytes: enough for one "payload N" (9 bytes), not two.
+	rig := newExporterRig(t, 100, 10)
+
+	for i := 0; i < 3; i++ {
+		rig.track(t, fmt.Sprintf("default/cpu/2026/08/07/%02d/f.parquet", i), fmt.Sprintf("payload %d", i))
+	}
+
+	res, err := rig.exporter.Export(ctx, rig.dest, 0)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if res.FileCount != 1 {
+		t.Errorf("exported %d files under a 10-byte cap, want 1", res.FileCount)
+	}
+
+	// The remainder is still available.
+	if _, err := rig.exporter.Export(ctx, rig.dest, 0); err != nil {
+		t.Errorf("the remainder was not exportable: %v", err)
+	}
+}
+
+// A single file larger than the cap must still go, or it wedges the queue.
+func TestExporter_ExportsAnOversizedFileRatherThanWedging(t *testing.T) {
+	ctx := context.Background()
+	rig := newExporterRig(t, 100, 5)
+
+	rig.track(t, "default/cpu/2026/08/07/14/big.parquet", "a payload well over the cap")
+
+	res, err := rig.exporter.Export(ctx, rig.dest, 0)
+	if err != nil {
+		t.Fatalf("a file larger than the byte cap wedged the queue: %v", err)
+	}
+	if res.FileCount != 1 {
+		t.Errorf("FileCount = %d, want 1", res.FileCount)
+	}
+}
+
+// The destination policy is the only thing bounding where a bundle lands.
+func TestExporter_RefusesADestinationOutsideThePolicy(t *testing.T) {
+	ctx := context.Background()
+	rig := newExporterRig(t, 100, 0)
+	rig.track(t, "default/cpu/2026/08/07/14/f.parquet", "payload")
+
+	if _, err := rig.exporter.Export(ctx, t.TempDir(), 0); err == nil {
+		t.Error("a destination outside the allow-list was accepted")
+	}
+
+	// And nothing was marked exported, since no bundle was written.
+	pending, err := rig.ledger.Pending(ctx, testHubID, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Errorf("pending = %d after a refused export, want 1", len(pending))
+	}
+}
+
+// A drive that never arrives must be recoverable.
+func TestExporter_RevertReturnsABundleToPending(t *testing.T) {
+	ctx := context.Background()
+	rig := newExporterRig(t, 100, 0)
+	rig.track(t, "default/cpu/2026/08/07/14/f.parquet", "payload")
+
+	res, err := rig.exporter.Export(ctx, rig.dest, 0)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if pending, _ := rig.ledger.Pending(ctx, testHubID, 0); len(pending) != 0 {
+		t.Fatalf("pending = %d right after export, want 0", len(pending))
+	}
+
+	n, err := rig.exporter.Revert(ctx, res.BundleID)
+	if err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("reverted %d, want 1", n)
+	}
+	if pending, _ := rig.ledger.Pending(ctx, testHubID, 0); len(pending) != 1 {
+		t.Error("the reverted file is not pending again")
+	}
+
+	// A malformed ID is refused rather than silently matching nothing.
+	if _, err := rig.exporter.Revert(ctx, "not-a-ulid"); err == nil {
+		t.Error("a malformed bundle ID was accepted")
+	}
+}
+
+// A spoke with nothing new is the steady state, not a failure.
+func TestExporter_NothingToExportIsDistinguishable(t *testing.T) {
+	ctx := context.Background()
+	rig := newExporterRig(t, 100, 0)
+
+	_, err := rig.exporter.Export(ctx, rig.dest, 0)
+	if !errors.Is(err, ErrNothingToExport) {
+		t.Errorf("error = %v, want ErrNothingToExport", err)
+	}
+}
+
+// The writer's empty-input error must be the same sentinel the API maps to a
+// 200 "nothing to do". A separately-constructed error with identical text does
+// not satisfy errors.Is, so a future caller would get a 500 instead.
+func TestBundleWriter_EmptyExportReturnsTheSentinel(t *testing.T) {
+	rig := newBundleRig(t)
+	_, err := rig.writer.Export(context.Background(), rig.parent, nil, time.Now())
+	if !errors.Is(err, ErrNothingToExport) {
+		t.Errorf("error = %v, want it to satisfy errors.Is(ErrNothingToExport)", err)
+	}
+}
+
+// Two exports must never interleave into one directory. Mkdir on the leaf is
+// atomic; stat-then-MkdirAll leaves a window.
+func TestBundleWriter_RefusesAnExistingBundleDirectory(t *testing.T) {
+	ctx := context.Background()
+	rig := newBundleRig(t)
+	e := rig.write(t, "default/cpu/2026/08/07/14/a.parquet", "payload")
+
+	res, err := rig.writer.Export(ctx, rig.parent, []*LedgerEntry{e}, time.Now())
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	// Re-exporting into the same directory name must fail rather than merge.
+	if err := os.MkdirAll(res.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(res.Dir, manifestName)); err != nil {
+		t.Fatalf("the first bundle is gone: %v", err)
+	}
+}

--- a/internal/edgesync/bundle_test.go
+++ b/internal/edgesync/bundle_test.go
@@ -634,3 +634,41 @@ func TestBundleWriter_RefusesAnExistingBundleDirectory(t *testing.T) {
 		t.Fatalf("the first bundle is gone: %v", err)
 	}
 }
+
+// Open is exported and the importer is a separate component, so it validates
+// rather than trusting that Verify already did. A traversal primitive that is
+// unreachable today is one refactor away from being reachable.
+func TestBundleReader_OpenCannotEscapeTheDataDirectory(t *testing.T) {
+	ctx := context.Background()
+	rig := newBundleRig(t)
+	res := rig.exportTwo(t)
+
+	// A file inside the bundle but outside data/.
+	if err := os.WriteFile(filepath.Join(res.Dir, "secret.txt"), []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := OpenBundle(res.Dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("open bundle: %v", err)
+	}
+
+	for _, bad := range []string{"../secret.txt", "../../etc/passwd", "/etc/passwd", "a/../../secret.txt"} {
+		f, err := r.Open(bad)
+		if err == nil {
+			f.Close()
+			t.Errorf("Open(%q) escaped data/", bad)
+		}
+	}
+
+	// A legitimate entry still opens.
+	entries, err := r.Entries(ctx)
+	if err != nil {
+		t.Fatalf("entries: %v", err)
+	}
+	f, err := r.Open(entries[0].Path)
+	if err != nil {
+		t.Fatalf("a declared entry could not be opened: %v", err)
+	}
+	f.Close()
+}

--- a/internal/edgesync/discover.go
+++ b/internal/edgesync/discover.go
@@ -1,0 +1,120 @@
+package edgesync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// Discoverer walks local storage and tracks new files in the ledger.
+//
+// Separate from Agent because BOTH transports need it and they are
+// independently enabled: a fully air-gapped spoke runs no agent at all, and
+// without its own discovery its ledger would stay empty forever — every export
+// answering "nothing to export" while files piled up on disk.
+type Discoverer struct {
+	ledger  *Ledger
+	backend storage.Backend
+	hubID   string
+	logger  zerolog.Logger
+}
+
+// NewDiscoverer validates configuration and returns a ready discoverer.
+func NewDiscoverer(ledger *Ledger, backend storage.Backend, hubID string, logger zerolog.Logger) (*Discoverer, error) {
+	if ledger == nil {
+		return nil, errors.New("edgesync: discovery requires a ledger")
+	}
+	if backend == nil {
+		return nil, errors.New("edgesync: discovery requires a storage backend")
+	}
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	return &Discoverer{
+		ledger:  ledger,
+		backend: backend,
+		hubID:   hubID,
+		logger:  logger.With().Str("component", "edgesync-discover").Logger(),
+	}, nil
+}
+
+// Discover tracks every syncable local file not already in the ledger.
+//
+// Returns how many entries were newly tracked. Idempotent: a file already
+// tracked is skipped before it is hashed, so running this every pass costs a
+// listing rather than a re-read of the whole corpus.
+func (d *Discoverer) Discover(ctx context.Context) (int, error) {
+	lister, ok := d.backend.(storage.ObjectLister)
+	if !ok {
+		return 0, errors.New("edgesync: backend cannot list object metadata, so discovery is not possible")
+	}
+
+	objects, err := lister.ListObjects(ctx, "")
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: list local files: %w", err)
+	}
+
+	entries := make([]*LedgerEntry, 0, len(objects))
+	for _, obj := range objects {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		if !isSyncableFile(obj.Path) {
+			continue
+		}
+
+		// Skip anything already tracked BEFORE hashing it. Discovery runs
+		// every pass, and re-hashing the whole corpus each time would make the
+		// cheap step the expensive one.
+		if _, err := d.ledger.Get(ctx, d.hubID, obj.Path); err == nil {
+			continue
+		} else if !errors.Is(err, ErrNotFound) {
+			return 0, fmt.Errorf("edgesync: check ledger for %q: %w", obj.Path, err)
+		}
+
+		// ListObjects carries no digest, so compute one. This is the only full
+		// read a file gets from discovery, ever — and the spoke has to read
+		// those bytes to send them anyway. The digest is then reused for the
+		// request HMAC and for the hub's verify-before-commit.
+		sum, err := d.hashFile(ctx, obj.Path)
+		if err != nil {
+			// One unreadable file must not stop discovery: the rest of the
+			// backlog is still syncable, and this one is retried next pass.
+			d.logger.Warn().Err(err).Str("path", obj.Path).Msg("Skipping a file that could not be hashed")
+			continue
+		}
+
+		e := &LedgerEntry{
+			HubID:     d.hubID,
+			Path:      obj.Path,
+			SHA256:    sum,
+			SizeBytes: obj.Size,
+		}
+		e.Database, e.Measurement, e.PartitionTime = parseArcPath(obj.Path)
+		entries = append(entries, e)
+	}
+
+	if len(entries) == 0 {
+		return 0, nil
+	}
+
+	inserted, err := d.ledger.TrackBatch(ctx, entries)
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: track discovered files: %w", err)
+	}
+	return inserted, nil
+}
+
+// hashFile streams a file through SHA-256 without buffering it.
+func (d *Discoverer) hashFile(ctx context.Context, path string) (string, error) {
+	h := sha256.New()
+	if err := d.backend.ReadTo(ctx, path, hasherWriter{h}); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/edgesync/exporter.go
+++ b/internal/edgesync/exporter.go
@@ -1,0 +1,227 @@
+package edgesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Bundle export defaults, applied when a config value is zero.
+const (
+	DefaultBundleMaxFiles = 10000
+	DefaultBundleMaxBytes = int64(64) << 30 // 64 GiB, roughly a large drive
+)
+
+// ExporterConfig configures air-gap export.
+type ExporterConfig struct {
+	Ledger *Ledger
+	Writer *BundleWriter
+	Policy *DestinationPolicy
+
+	// Discoverer finds new local files before an export selects from them.
+	//
+	// Required: an air-gapped spoke runs no sync agent, so without its own
+	// discovery the ledger would never be populated and every export would
+	// answer "nothing to export" while files piled up on disk.
+	Discoverer *Discoverer
+
+	HubID string
+
+	// MaxFiles and MaxBytes cap one bundle. Zero uses the defaults above.
+	MaxFiles int
+	MaxBytes int64
+
+	Logger zerolog.Logger
+}
+
+// Exporter writes pending ledger entries to an air-gap bundle.
+//
+// The export half of the sneakernet transport: it selects what to send, writes
+// it, and advances the ledger. It deliberately does NOT delete anything — sync
+// is a copy, and local retention stays the operator's decision.
+type Exporter struct {
+	ledger     *Ledger
+	writer     *BundleWriter
+	policy     *DestinationPolicy
+	discoverer *Discoverer
+	hubID      string
+	maxFiles   int
+	maxBytes   int64
+	logger     zerolog.Logger
+}
+
+// NewExporter validates configuration and returns a ready exporter.
+func NewExporter(cfg ExporterConfig) (*Exporter, error) {
+	if cfg.Ledger == nil {
+		return nil, fmt.Errorf("edgesync: exporter requires a ledger")
+	}
+	if cfg.Writer == nil {
+		return nil, fmt.Errorf("edgesync: exporter requires a bundle writer")
+	}
+	if cfg.Policy == nil {
+		// Without a policy every operator-supplied path would reach the
+		// filesystem unchecked. Refuse rather than default to permissive.
+		return nil, fmt.Errorf("edgesync: exporter requires a destination policy")
+	}
+	if cfg.Discoverer == nil {
+		return nil, fmt.Errorf("edgesync: exporter requires a discoverer")
+	}
+
+	hubID := cfg.HubID
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	maxFiles := cfg.MaxFiles
+	if maxFiles <= 0 {
+		maxFiles = DefaultBundleMaxFiles
+	}
+	maxBytes := cfg.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultBundleMaxBytes
+	}
+
+	return &Exporter{
+		ledger:     cfg.Ledger,
+		writer:     cfg.Writer,
+		policy:     cfg.Policy,
+		discoverer: cfg.Discoverer,
+		hubID:      hubID,
+		maxFiles:   maxFiles,
+		maxBytes:   maxBytes,
+		logger:     cfg.Logger.With().Str("component", "edgesync-export").Logger(),
+	}, nil
+}
+
+// Export writes one bundle to dest and marks its entries exported.
+//
+// The ledger advance happens AFTER the bundle is written and signed. The
+// reverse order would mark files exported that a failed write never included,
+// and only an operator noticing the gap would ever bring them back.
+func (e *Exporter) Export(ctx context.Context, dest string, limit int) (*ExportResult, error) {
+	resolved, err := e.policy.Resolve(dest)
+	if err != nil {
+		return nil, err
+	}
+
+	if limit <= 0 || limit > e.maxFiles {
+		limit = e.maxFiles
+	}
+
+	// Discover before selecting. On an air-gapped spoke this is the ONLY thing
+	// that ever populates the ledger — there is no sync agent doing it on a
+	// tick — so skipping it would mean every export found nothing while files
+	// accumulated on disk.
+	discovered, err := e.discoverer.Discover(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: discover before export: %w", err)
+	}
+	if discovered > 0 {
+		e.logger.Info().Int("discovered", discovered).Msg("Discovered new files before export")
+	}
+
+	entries, err := e.ledger.Unexported(ctx, e.hubID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: read unexported: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil, ErrNothingToExport
+	}
+
+	// Byte cap applied by truncating the selection, not by failing: a backlog
+	// larger than one drive is the expected case, and the operator's next
+	// bundle continues from where this one stopped. Entries are newest-first,
+	// so a truncated bundle carries the freshest telemetry.
+	//
+	// At least one file is always included, even if it alone exceeds the cap —
+	// otherwise a single large file would wedge the queue permanently.
+	var (
+		selected []*LedgerEntry
+		total    int64
+	)
+	for i, entry := range entries {
+		if i > 0 && total+entry.SizeBytes > e.maxBytes {
+			break
+		}
+		selected = append(selected, entry)
+		total += entry.SizeBytes
+	}
+	if len(selected) < len(entries) {
+		e.logger.Info().
+			Int("selected", len(selected)).
+			Int("eligible", len(entries)).
+			Int64("max_bytes", e.maxBytes).
+			Msg("Bundle truncated at the byte cap; the remainder goes in the next one")
+	}
+
+	res, err := e.writer.Export(ctx, resolved, selected, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	// A file that cannot be marked is NOT fatal: it is already in a signed,
+	// verified bundle on disk. Leaving it pending means a later bundle carries
+	// it again and the hub answers already_present — wasteful, not wrong.
+	// Failing here would instead discard a bundle that is entirely valid.
+	marked := 0
+	for _, entry := range selected {
+		if err := e.ledger.MarkExported(ctx, e.hubID, entry.Path, res.BundleID); err != nil {
+			e.logger.Warn().Err(err).
+				Str("path", entry.Path).
+				Str("bundle_id", res.BundleID).
+				Msg("Bundle written but the ledger entry could not be marked exported")
+			continue
+		}
+		marked++
+	}
+	if marked != len(selected) {
+		e.logger.Warn().
+			Int("marked", marked).
+			Int("files", len(selected)).
+			Str("bundle_id", res.BundleID).
+			Msg("Some entries stayed pending; a later bundle will include them again")
+	}
+
+	return res, nil
+}
+
+// ErrNothingToExport means no file is eligible for a bundle.
+//
+// Distinct from an error: a spoke with nothing new is the steady state once a
+// backlog has drained, and an operator running a scheduled export should not
+// see a failure for it.
+var ErrNothingToExport = errors.New("edgesync: nothing to export")
+
+// Revert returns a bundle's entries to pending, for a drive that never arrived.
+func (e *Exporter) Revert(ctx context.Context, bundleID string) (int64, error) {
+	if err := ValidateBundleID(bundleID); err != nil {
+		return 0, err
+	}
+	n, err := e.ledger.RevertExported(ctx, e.hubID, bundleID)
+	if err != nil {
+		return 0, err
+	}
+	e.logger.Info().
+		Str("bundle_id", bundleID).
+		Int64("files", n).
+		Msg("Bundle reverted to pending")
+	return n, nil
+}
+
+// Status reports the ledger summary for this hub.
+//
+// Mirrors Agent.Status: both are pure ledger reads needing no transport, and
+// an air-gap-only spoke has no agent to ask. Without this the operator who
+// most needs the `exported` count — the one whose files are on a drive
+// somewhere — would be the only one unable to see it.
+func (e *Exporter) Status(ctx context.Context) (*Stats, error) {
+	return e.ledger.Stats(ctx, e.hubID)
+}
+
+// UnfinishedEntries returns files that have not reached the hub, given-up ones
+// first. Mirrors Agent.UnfinishedEntries.
+func (e *Exporter) UnfinishedEntries(ctx context.Context, limit int) ([]*LedgerEntry, error) {
+	return e.ledger.Unfinished(ctx, e.hubID, limit)
+}


### PR DESCRIPTION
> **PR 9b of 4** for the air-gap bundle (item 9 of #569). Follows #580 (`StateExported`). Next: 9c hub-side import + dedup, 9d acknowledgment.

## Summary

A spoke with **no network path** — a submarine, a classified facility, a vehicle whose data comes off on a drive — writes its files to a signed directory bundle on removable media.

`edge_sync.spoke.bundle.enabled` is **independent of `edge_sync.spoke.enabled`**: a fully air-gapped spoke needs no `hub_url` and never runs the network path.

## Two format decisions

**Replay protection is a bundle ID + hub-side dedup ledger, not a timestamp window.** `checkSyncFreshness` works for a request in flight, where the network itself guarantees "recent". A bundle legitimately sits on a drive for weeks, so a clock is the wrong instrument — and a widened window would leave replay protection off for exactly the period bundles exist.

**A directory, not a tar.** Resume falls out for free (an interrupted copy leaves whole files; per-file SHAs say which landed), and `ls` + `sha256sum entries.jsonl` lets a human audit what crosses the air gap without special tooling.

```
bundle-<spoke>-<ulid>/
  manifest.json   signed header: IDs, entries digest, MAC
  entries.jsonl   one JSON object per file, streamed not buffered
  data/           the Parquet files under their original paths
```

Signing adds a third HMAC family, `sync-bundle` (length 11, vs `sync-file` 9 and `sync-reconcile` 14). `canonicalSyncInput` is length-prefixed, so no arrangement of one family's field *contents* can produce another's byte string — **tested in both directions**. No nonce, no freshness check, deliberately.

**Where a bundle may be written is explicit.** Every other Arc write path is confined to the storage root by its backend; a USB mount is outside it by definition. So `allowed_dirs` is required, paths resolve through symlinks before the check, containment compares at a segment boundary, and the storage root is refused outright — exporting into it would make the next discovery pass queue the copies for sync.

## The bug only the binary run found

**An air-gap-only spoke could never export anything.** `Discover` lived on the `Agent`, which such a spoke never constructs — so its ledger stayed empty and every export answered "nothing to export" while files piled up on disk. The feature was inert in exactly the deployment it exists for. Unit tests passed because they built the exporter directly. Fixed by extracting `Discoverer`.

## Deep-review findings, all fixed

| Finding | Impact |
|---|---|
| **Blocker:** air-gap spoke with no secret | Failed as a late fatal from an internal constructor **after full startup**, naming a Go type rather than the env var. Now a config-load error. |
| **High:** `allowed_dirs = ["/"]` | Refused every export — appending a separator to the root yields `//`. The mid-segment fix shipping its own edge case (#534 corollary). |
| **High:** `Verify` only walked `data/` | An `autorun.inf` or decoy `manifest.json.bak` beside it verified clean. Now covers the whole directory — "verified" must mean the whole thing an operator is handed. |
| Medium ×4 | Look-alike of `ErrNothingToExport` that `errors.Is` missed; negative sizes now rejected at the digest; `Mkdir` on the leaf replaces stat-then-`MkdirAll`; raw error no longer returned to clients. |
| Observation | `status`/`ledger` were gated on the agent, hiding the `exported` count from the only operator who needs it. Both are pure ledger reads, now served by either side. |

## Test plan

- [x] **12 tamper cases**: content change, truncation, missing file, unsigned file under `data/` **and beside it**, unsigned directory, symlink, MAC, retargeted hub, swapped digest, edited entry line, absent manifest
- [x] Cross-family MAC rejection proven **in both directions**
- [x] `DestinationPolicy`: traversal, symlink ancestor, sibling prefix, storage root, filesystem root, unconfigured
- [x] **Live air-gap-only spoke**: 7 files at `max_files=3` drained over three bundles — **7 distinct files, no repeats**; `sha256sum entries.jsonl` matched the manifest **by hand**
- [x] A **real on-disk bundle** with a smuggled `autorun.inf` refused with a message naming the problem
- [x] Missing secret now fails at config load; `/run` still 503s on an air-gap spoke while `status`/`ledger` serve
- [x] `go test -race`, `go vet`, `gofmt` clean

## Docs

Basekick-Labs/docs.basekick.net#21 — states plainly what is **not** here: no import, no ack (so ledgers do not prune yet), and bundles are signed but **not encrypted**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)