### PR TITLE
feat(edgesync): hub-side air-gap bundle import (#569)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -156,7 +156,42 @@ Signing uses a third HMAC family (`sync-bundle`) alongside the two online ones. 
 
 Exported files move to a new ledger state, `exported`, rather than staying pending. Without it a capped export would re-take the newest files every time and the oldest would never leave the box. They are reported separately from `pending` in `/status` but still counted in `pending_bytes`, because a file on a drive in transit has not arrived. If a drive is lost, `POST /api/v1/spoke-sync/export/{bundle_id}/revert` returns just that bundle's files to pending.
 
-The hub-side import, and the acknowledgment that advances `exported` to `synced`, land next.
+### Importing a drive on the hub
+
+The other half. A hub takes a bundle off removable media:
+
+```toml
+[edge_sync.import]
+enabled = true                        # default false
+allowed_dirs = ["/mnt/usb"]           # REQUIRED; an empty list refuses every import
+max_files = 10000                     # refuses a manifest declaring more
+```
+
+Independent of `edge_sync.enabled`: a hub that only ever takes drives exposes **no** network-writable surface — `/api/v1/sync/file` returns 404.
+
+```bash
+curl -X POST https://hub.example.com/api/v1/bundle-import \
+  -H "Authorization: Bearer $ARC_TOKEN" \
+  -d '{"path": "/mnt/usb/bundle-submarine-01-06FXW4H1BHR3XHWK2J826G28JG"}'
+```
+
+**Nothing is committed until the whole bundle verifies.** The MAC, `entries.jsonl`'s own hash, the canonical entries digest, every file's size and digest, and the absence of any undeclared file are all checked first. A tampered drive is refused with `422` naming the offending file, and not one byte reaches storage.
+
+Three refusals an operator will actually meet:
+
+| Situation | Response |
+|---|---|
+| Already imported | `409`, with when it arrived and how many files |
+| Tampered, truncated, wrong hub, unknown or disabled spoke | `422`, naming what failed |
+| Path outside `allowed_dirs` | `400` |
+
+**Replay protection is a dedup ledger, not a clock.** The hub records every imported bundle keyed `(spoke_id, bundle_id)` — namespaced, so a compromised spoke cannot burn IDs in another's space. A re-imported drive is refused rather than re-applied. A *refused* bundle is never recorded, so a corrected drive still imports.
+
+In cluster mode, manifest registrations are **batched at 1000 ops per Raft proposal**. The online path is naturally rate-limited to one proposal per HTTP request; an import is a tight loop, so a 2,500-file bundle costs 3 proposals rather than 2,500.
+
+`GET /api/v1/bundle-import/history/{spoke_id}` answers "did last month's drive ever arrive?" — which, on a link with no telemetry, nothing else can.
+
+The acknowledgment that advances `exported` to `synced` lands next.
 
 ## Security hardening
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1945,7 +1945,10 @@ func main() {
 	// construct), but clusterCoordinator may be nil: OSS standalone runs a hub
 	// with no Raft manifest, where the backend's own listing is the manifest.
 	// RegisterFile is therefore nil in that mode rather than assumed present.
-	if cfg.EdgeSync.Enabled {
+	// Either role independently: a hub can take network pushes, drives off an
+	// air gap, or both. They share the registry, index, and receiver, which is
+	// why they live in one block.
+	if cfg.EdgeSync.Enabled || cfg.EdgeSync.Import.Enabled {
 		var registerFile func(context.Context, *edgesync.ReceivedFile) error
 		if clusterCoordinator != nil {
 			coord := clusterCoordinator
@@ -2053,20 +2056,130 @@ func main() {
 		}
 		syncAdminHandler.RegisterRoutes(server.GetApp())
 
-		syncHandler, err := api.NewEdgeSyncHandler(api.EdgeSyncHandlerConfig{
-			Receiver:     receiver,
-			Reconciler:   reconciler,
-			SpokeSecrets: api.RegistrySpokeSecrets(spokeRegistry, logger.Get("edgesync")),
-			Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
-			HubID:        cfg.EdgeSync.HubID,
-			MaxFileBytes: cfg.EdgeSync.MaxFileBytes,
-			AuthManager:  authManager,
-			Logger:       logger.Get("edgesync"),
-		})
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to create edge sync handler; refusing to start")
+		// The spoke-facing receive endpoints mount ONLY for a network hub. An
+		// import-only hub takes drives and must not expose a remotely-writable
+		// surface just because it can read a bundle off a mount point.
+		if cfg.EdgeSync.Enabled {
+			syncHandler, err := api.NewEdgeSyncHandler(api.EdgeSyncHandlerConfig{
+				Receiver:     receiver,
+				Reconciler:   reconciler,
+				SpokeSecrets: api.RegistrySpokeSecrets(spokeRegistry, logger.Get("edgesync")),
+				Replay:       security.NewNonceCache(security.HMACTimestampTolerance),
+				HubID:        cfg.EdgeSync.HubID,
+				MaxFileBytes: cfg.EdgeSync.MaxFileBytes,
+				AuthManager:  authManager,
+				Logger:       logger.Get("edgesync"),
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create edge sync handler; refusing to start")
+			}
+			syncHandler.RegisterRoutes(server.GetApp())
 		}
-		syncHandler.RegisterRoutes(server.GetApp())
+
+		// Air-gap import, independent of the network receive endpoints.
+		if cfg.EdgeSync.Import.Enabled {
+			importLogger := logger.Get("edgesync-import")
+
+			localRoot := ""
+			if cfg.Storage.Backend == "local" {
+				localRoot = cfg.Storage.LocalPath
+			}
+			importPolicy, err := edgesync.NewDestinationPolicy(cfg.EdgeSync.Import.AllowedDirs, localRoot)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to resolve the bundle import policy; refusing to start")
+			}
+
+			bundleIndex, err := edgesync.NewBundleIndex(syncDB, importLogger)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the bundle index; refusing to start")
+			}
+
+			// A SEPARATE receiver whose RegisterFile collects rather than
+			// proposes. The online receiver above proposes to the Raft
+			// manifest once per file, which is right at one file per HTTP
+			// request but would emit one proposal per file in an import's
+			// tight loop — 10,000 for a 10,000-file bundle, against the
+			// Cluster Operations Checklist's batch-at-1000 rule.
+			collector := edgesync.NewCollectingRegistrar()
+			importReceiver, err := edgesync.NewReceiver(edgesync.ReceiverConfig{
+				Backend:      storageBackend,
+				Index:        hubIndex,
+				Logger:       importLogger,
+				RegisterFile: collector.Register,
+				RecordActivity: func(ctx context.Context, spokeID string, files, bytes int64) {
+					if err := spokeRegistry.RecordActivity(ctx, spokeID, files, bytes); err != nil {
+						importLogger.Warn().Err(err).Str("spoke_id", spokeID).
+							Msg("Failed to record spoke activity")
+					}
+				},
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the bundle import receiver; refusing to start")
+			}
+
+			// Nil in standalone mode: there is no manifest to update, and the
+			// hub index the receiver already wrote is the whole record.
+			var flushManifest func(context.Context, []*edgesync.ReceivedFile) error
+			if clusterCoordinator != nil {
+				coord := clusterCoordinator
+				flushManifest = func(_ context.Context, files []*edgesync.ReceivedFile) error {
+					ops := make([]clusterraft.BatchFileOp, 0, len(files))
+					for _, f := range files {
+						payload, err := json.Marshal(clusterraft.RegisterFilePayload{
+							File: clusterraft.FileEntry{
+								Path:        f.Path,
+								SHA256:      f.SHA256,
+								SizeBytes:   f.SizeBytes,
+								Database:    f.Database(),
+								Measurement: f.Measurement(),
+								// Same reasoning as the online path: a zero
+								// PartitionTime would make the file look
+								// infinitely old to the tiering migrator and
+								// drop it from time-ranged queries.
+								PartitionTime: f.PartitionTime(),
+								OriginNodeID:  f.SpokeID,
+								Tier:          "hot",
+								CreatedAt:     time.Now().UTC(),
+							},
+						})
+						if err != nil {
+							return fmt.Errorf("marshal manifest entry for %q: %w", f.Path, err)
+						}
+						ops = append(ops, clusterraft.BatchFileOp{
+							Type:    clusterraft.CommandRegisterFile,
+							Payload: payload,
+						})
+					}
+					return coord.BatchFileOpsInManifest(ops)
+				}
+			}
+
+			importer, err := edgesync.NewImporter(edgesync.ImporterConfig{
+				Receiver:      importReceiver,
+				Collector:     collector,
+				Index:         bundleIndex,
+				Registry:      spokeRegistry,
+				HubID:         cfg.EdgeSync.HubID,
+				MaxFiles:      cfg.EdgeSync.Import.MaxFiles,
+				FlushManifest: flushManifest,
+				Logger:        importLogger,
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the bundle importer; refusing to start")
+			}
+
+			importHandler, err := api.NewEdgeSyncImportHandler(
+				importer, importPolicy, bundleIndex, authManager, importLogger)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create the bundle import handler; refusing to start")
+			}
+			importHandler.RegisterRoutes(server.GetApp())
+
+			importLogger.Info().
+				Str("hub_id", cfg.EdgeSync.HubID).
+				Bool("clustered", clusterCoordinator != nil).
+				Msg("Edge sync bundle import enabled; import a drive with POST /api/v1/bundle-import")
+		}
 
 		// A hub with no registered spokes rejects everything, which is correct
 		// but easy to mistake for a broken deployment. Say so once at startup

--- a/internal/api/edgesync_import.go
+++ b/internal/api/edgesync_import.go
@@ -1,0 +1,238 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/edgesync"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// bundleImportTimeout bounds one import.
+//
+// Generous for the same reason the export is: a bundle can carry thousands of
+// files off removable media, every one hashed twice (verify, then commit). An
+// operator who wants a shorter bound cancels the request.
+const bundleImportTimeout = 4 * time.Hour
+
+// EdgeSyncImportHandler exposes the hub's air-gap import controls.
+//
+// Mounted at /api/v1/bundle-import, deliberately NOT under /api/v1/sync-*.
+// Fiber's Group().Use() matches by string PREFIX, not path segment, so a group
+// at "/api/v1/sync" also matches "/api/v1/sync-import/..." — the spoke-facing
+// HMAC group's body limit and middleware would silently run on these operator
+// routes. A prefix that is not a string-prefix of another group's is the only
+// way to keep them uncoupled.
+//
+// Different audience from the hub's receive endpoints: those are called by
+// spokes and authenticated per-spoke by HMAC; these are called by an operator
+// who has just plugged in a drive, and are authenticated by an admin token.
+type EdgeSyncImportHandler struct {
+	importer    *edgesync.Importer
+	policy      *edgesync.DestinationPolicy
+	index       *edgesync.BundleIndex
+	authManager *auth.AuthManager
+	logger      zerolog.Logger
+}
+
+// NewEdgeSyncImportHandler validates configuration and returns a ready handler.
+func NewEdgeSyncImportHandler(
+	importer *edgesync.Importer,
+	policy *edgesync.DestinationPolicy,
+	index *edgesync.BundleIndex,
+	authManager *auth.AuthManager,
+	logger zerolog.Logger,
+) (*EdgeSyncImportHandler, error) {
+	if importer == nil {
+		return nil, errors.New("edgesync import: importer is required")
+	}
+	if policy == nil {
+		// The bundle path is operator-supplied and reaches the filesystem
+		// directly. Without a policy it would be unchecked.
+		return nil, errors.New("edgesync import: destination policy is required")
+	}
+	if index == nil {
+		return nil, errors.New("edgesync import: bundle index is required")
+	}
+	return &EdgeSyncImportHandler{
+		importer:    importer,
+		policy:      policy,
+		index:       index,
+		authManager: authManager,
+		logger:      logger.With().Str("component", "edgesync-import").Logger(),
+	}, nil
+}
+
+// RegisterRoutes mounts the import controls. Admin-only.
+//
+// Importing writes a spoke's data into hub storage, and the history endpoint
+// reveals which edge deployments have delivered and when. Neither is something
+// a read-scoped token should reach.
+func (h *EdgeSyncImportHandler) RegisterRoutes(app fiber.Router) {
+	group := app.Group("/api/v1/bundle-import")
+
+	if h.authManager != nil {
+		group.Use(auth.RequireAdmin(h.authManager))
+	}
+
+	group.Post("/", h.importBundle)
+	group.Get("/history/:spoke_id", h.history)
+
+	h.logger.Info().Msg("Edge sync bundle import routes registered")
+}
+
+// importBundle handles POST /api/v1/bundle-import.
+//
+// Verifies the whole bundle before committing a single byte, then imports.
+func (h *EdgeSyncImportHandler) importBundle(c *fiber.Ctx) error {
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+	if req.Path == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "path is required: the bundle directory to import",
+		})
+	}
+
+	// Checked against the allow-list before anything opens it, for the same
+	// reason export is: this path reaches the filesystem directly.
+	resolved, err := h.policy.Resolve(req.Path)
+	if err != nil {
+		h.logger.Warn().Err(err).Msg("Bundle import path refused")
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), bundleImportTimeout)
+	defer cancel()
+
+	h.logger.Info().Str("dir", resolved).Msg("Bundle import starting")
+
+	res, err := h.importer.Import(ctx, resolved)
+	switch {
+	case errors.Is(err, edgesync.ErrBundleAlreadyImported):
+		// 409, not an error: the hub already holds this bundle's contents, so
+		// the operator's goal is met. The message carries when it arrived, so
+		// a duplicate drive is diagnosable rather than mysterious.
+		h.logger.Info().Err(err).Msg("Bundle already imported")
+		return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+			"imported": false,
+			"reason":   "already imported",
+			"detail":   err.Error(),
+		})
+
+	case errors.Is(err, edgesync.ErrBundleInvalid):
+		// The bundle itself is bad — tampered, truncated, for another hub, or
+		// from an unknown spoke. Retrying the same drive fails identically, so
+		// this is the operator's problem to look at, not a transient failure.
+		h.logger.Error().Err(err).Str("dir", resolved).Msg("Bundle refused")
+		return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
+			"imported": false,
+			"error":    err.Error(),
+		})
+
+	case err != nil:
+		h.logger.Error().Err(err).Str("dir", resolved).Msg("Bundle import failed")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"imported": false,
+			"error":    "bundle import failed",
+		})
+	}
+
+	out := fiber.Map{
+		"imported":        true,
+		"bundle_id":       res.BundleID,
+		"spoke_id":        res.SpokeID,
+		"created_at":      res.CreatedAt,
+		"committed":       res.Committed,
+		"already_present": res.AlreadyPresent,
+		"bytes_written":   res.BytesWritten,
+		"duration_ms":     res.Duration.Milliseconds(),
+	}
+	// Warnings accumulate: an import can both hit conflicts AND fail to record,
+	// and assigning "warning" twice would silently drop the first.
+	var warnings []string
+	if !res.Recorded {
+		// Surfaced rather than left to the log: /history will not show this
+		// bundle, and an operator comparing the two deserves to know why.
+		out["recorded"] = false
+		warnings = append(warnings,
+			"The files were imported, but this bundle could not be recorded. "+
+				"It will not appear in the import history, and re-importing the same drive will not be refused.")
+	}
+
+	// Reported in full rather than counted: each needs a human to decide which
+	// copy is right, and a count alone would not say which files to look at.
+	conflicts := make([]fiber.Map, 0, len(res.Conflicts))
+	for _, cf := range res.Conflicts {
+		conflicts = append(conflicts, fiber.Map{
+			"path":         cf.Path,
+			"their_sha256": cf.TheirSHA256,
+		})
+	}
+	out["conflicts"] = conflicts
+	if len(conflicts) > 0 {
+		warnings = append(warnings,
+			"Some paths already hold different content on this hub. "+
+				"They were not overwritten; investigate before re-importing.")
+	}
+	if len(warnings) > 0 {
+		out["warnings"] = warnings
+	}
+
+	return c.JSON(out)
+}
+
+// history handles GET /api/v1/bundle-import/history/:spoke_id.
+//
+// Which bundles this hub has taken from a spoke, and when. The answer to "did
+// last month's drive ever arrive?" — which, on an air-gap link with no
+// telemetry, nothing else can answer.
+func (h *EdgeSyncImportHandler) history(c *fiber.Ctx) error {
+	spokeID := c.Params("spoke_id")
+	if spokeID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "spoke_id is required"})
+	}
+
+	limit := 100
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid limit"})
+		}
+		if n > 1000 {
+			n = 1000
+		}
+		limit = n
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	bundles, err := h.index.ListBySpoke(ctx, spokeID, limit)
+	if err != nil {
+		h.logger.Error().Err(err).Str("spoke_id", spokeID).Msg("Failed to list imported bundles")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to list imported bundles",
+		})
+	}
+
+	out := make([]fiber.Map, 0, len(bundles))
+	for _, b := range bundles {
+		out = append(out, fiber.Map{
+			"bundle_id":   b.BundleID,
+			"created_at":  b.CreatedAt,
+			"imported_at": b.ImportedAt,
+			"file_count":  b.FileCount,
+			"bytes_total": b.BytesTotal,
+			"conflicts":   b.Conflicts,
+		})
+	}
+	return c.JSON(fiber.Map{"spoke_id": spokeID, "bundles": out, "limit": limit})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,6 +222,31 @@ type EdgeSyncConfig struct {
 	// spoke page keeps what matters — discovery costs O(batches), not
 	// O(files) — while bounding the exposure. Default 10,000 entries (~2MB).
 	MaxReconcileEntries int
+
+	// Import is the hub's air-gap side: taking a bundle off removable media.
+	Import EdgeSyncImportConfig
+}
+
+// EdgeSyncImportConfig configures air-gap bundle import on a hub.
+type EdgeSyncImportConfig struct {
+	// Enabled mounts the import endpoint. Independent of the receive
+	// endpoints: a hub that only ever takes drives has no reason to expose a
+	// network-writable surface, and one that only takes network pushes has no
+	// reason to read the filesystem.
+	Enabled bool
+
+	// AllowedDirs are the filesystem roots a bundle may be READ from.
+	//
+	// Required — an empty list refuses every import. Same reasoning as the
+	// spoke's export list: a mount point is outside the storage root by
+	// definition, so nothing else bounds where an operator-supplied path can
+	// point. Separate from the spoke's list because a hub is a different
+	// machine with different mounts.
+	AllowedDirs []string
+
+	// MaxFiles refuses a manifest declaring more than this, independently of
+	// whatever the exporting spoke was configured with. Zero means 10,000.
+	MaxFiles int64
 }
 
 // EdgeSyncSpokeConfig configures the push side of edge sync (#569).
@@ -741,6 +766,11 @@ func Load() (*Config, error) {
 			HubID:               v.GetString("edge_sync.hub_id"),
 			MaxFileBytes:        int64(v.GetInt64("edge_sync.max_file_bytes")),
 			MaxReconcileEntries: v.GetInt("edge_sync.max_reconcile_entries"),
+			Import: EdgeSyncImportConfig{
+				Enabled:     v.GetBool("edge_sync.import.enabled"),
+				AllowedDirs: v.GetStringSlice("edge_sync.import.allowed_dirs"),
+				MaxFiles:    v.GetInt64("edge_sync.import.max_files"),
+			},
 			Spoke: EdgeSyncSpokeConfig{
 				Enabled:       v.GetBool("edge_sync.spoke.enabled"),
 				HubURL:        v.GetString("edge_sync.spoke.hub_url"),
@@ -1159,6 +1189,24 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// Checked independently of EdgeSync.Enabled: a hub that only takes drives
+	// has no reason to expose the network receive endpoints.
+	if cfg.EdgeSync.Import.Enabled {
+		if len(cfg.EdgeSync.Import.AllowedDirs) == 0 {
+			return nil, fmt.Errorf("edge_sync.import.enabled=true requires " +
+				"edge_sync.import.allowed_dirs: a bundle is read from a raw filesystem path " +
+				"outside the storage root, so the permitted roots must be stated explicitly")
+		}
+		if cfg.EdgeSync.HubID == "" {
+			return nil, fmt.Errorf("edge_sync.import.enabled=true requires edge_sync.hub_id: " +
+				"a bundle names the hub it is destined for, and one addressed elsewhere is refused")
+		}
+		if cfg.EdgeSync.Import.MaxFiles < 0 {
+			return nil, fmt.Errorf("edge_sync.import.max_files must be >= 0 (got %d); 0 means \"use the default\"",
+				cfg.EdgeSync.Import.MaxFiles)
+		}
+	}
+
 	// Checked independently of Spoke.Enabled: a fully air-gapped spoke exports
 	// bundles and never runs the network path, so it has no hub URL and no
 	// reason to enable the sync agent at all.
@@ -1342,6 +1390,12 @@ func setDefaults(v *viper.Viper) {
 	// Air-gap bundle export. allowed_dirs has no default on purpose: an empty
 	// list refuses every export, so an operator must state where bundles may
 	// be written rather than inherit a guess.
+	// Hub-side air-gap import. allowed_dirs has no default for the same reason
+	// the spoke's does not: an operator must state where drives are mounted.
+	v.SetDefault("edge_sync.import.enabled", false)
+	v.SetDefault("edge_sync.import.allowed_dirs", []string{})
+	v.SetDefault("edge_sync.import.max_files", 10000)
+
 	v.SetDefault("edge_sync.spoke.bundle.enabled", false)
 	v.SetDefault("edge_sync.spoke.bundle.allowed_dirs", []string{})
 	v.SetDefault("edge_sync.spoke.bundle.max_files", 10000)

--- a/internal/edgesync/bundleindex.go
+++ b/internal/edgesync/bundleindex.go
@@ -1,0 +1,185 @@
+package edgesync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// ErrBundleAlreadyImported means this bundle's contents are already on the hub.
+var ErrBundleAlreadyImported = errors.New("edgesync: bundle already imported")
+
+// BundleIndex records which bundles a hub has imported.
+//
+// This is the replay protection for the air-gap transport. The online families
+// bind a nonce and a 5-minute timestamp window, which works because a request
+// is in flight and the network guarantees "recent". A bundle legitimately sits
+// on a drive for weeks, so replay protection has to be durable state rather
+// than a measurement — a record that survives a restart, as a nonce cache does
+// not.
+type BundleIndex struct {
+	db     *sql.DB
+	logger zerolog.Logger
+}
+
+// NewBundleIndex creates the table if needed and returns a ready index.
+func NewBundleIndex(db *sql.DB, logger zerolog.Logger) (*BundleIndex, error) {
+	if db == nil {
+		return nil, errors.New("edgesync: bundle index requires a database")
+	}
+	i := &BundleIndex{
+		db:     db,
+		logger: logger.With().Str("component", "edgesync-bundleindex").Logger(),
+	}
+	if err := i.initSchema(); err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+func (i *BundleIndex) initSchema() error {
+	const schema = `
+	-- One row per imported bundle.
+	--
+	-- Keyed (spoke_id, bundle_id), NOT bundle_id alone. The ID is chosen by
+	-- whoever holds a spoke's secret, so a global key would let a compromised
+	-- spoke burn IDs in another spoke's namespace — permanently 409-ing a
+	-- legitimate future bundle with no operator-visible cause. Namespacing
+	-- confines that to the compromised spoke, the same reasoning that makes
+	-- received paths spoke-namespaced.
+	CREATE TABLE IF NOT EXISTS sync_imported_bundles (
+		spoke_id     TEXT NOT NULL,
+		bundle_id    TEXT NOT NULL,
+		created_at   TIMESTAMP NOT NULL,
+		imported_at  TIMESTAMP NOT NULL,
+		file_count   INTEGER NOT NULL DEFAULT 0,
+		bytes_total  INTEGER NOT NULL DEFAULT 0,
+		conflicts    INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (spoke_id, bundle_id)
+	);
+
+	-- "What has this spoke sent me lately", the operator's question.
+	CREATE INDEX IF NOT EXISTS idx_sync_imported_bundles_spoke
+		ON sync_imported_bundles(spoke_id, imported_at DESC);
+	`
+
+	if _, err := i.db.Exec(schema); err != nil {
+		return fmt.Errorf("create sync_imported_bundles: %w", err)
+	}
+	i.logger.Info().Msg("Bundle index schema initialized")
+	return nil
+}
+
+// ImportedBundle is one row of the dedup ledger.
+type ImportedBundle struct {
+	SpokeID    string
+	BundleID   string
+	CreatedAt  time.Time
+	ImportedAt time.Time
+	FileCount  int64
+	BytesTotal int64
+	Conflicts  int64
+}
+
+// Seen reports whether this spoke's bundle has already been imported.
+func (i *BundleIndex) Seen(ctx context.Context, spokeID, bundleID string) (*ImportedBundle, error) {
+	row := i.db.QueryRowContext(ctx, `
+		SELECT spoke_id, bundle_id, created_at, imported_at, file_count, bytes_total, conflicts
+		FROM sync_imported_bundles
+		WHERE spoke_id = ? AND bundle_id = ?`, spokeID, bundleID)
+
+	var b ImportedBundle
+	err := row.Scan(&b.SpokeID, &b.BundleID, &b.CreatedAt, &b.ImportedAt,
+		&b.FileCount, &b.BytesTotal, &b.Conflicts)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: look up bundle %q: %w", bundleID, err)
+	}
+	b.CreatedAt = b.CreatedAt.UTC()
+	b.ImportedAt = b.ImportedAt.UTC()
+	return &b, nil
+}
+
+// Record marks a bundle imported.
+//
+// Written AFTER the import completes, so a run that died partway can be
+// retried — re-importing is idempotent because every file the hub already
+// holds resolves to already_present.
+//
+// Conflicts count as completion, not failure: they are a reported outcome
+// needing a human, and refusing to record would mean re-importing every file
+// to retry a handful — or, if the operator resolves them and re-imports,
+// hitting a 409 on a bundle that was never actually recorded.
+func (i *BundleIndex) Record(ctx context.Context, b *ImportedBundle) error {
+	if b == nil {
+		return errors.New("edgesync: record bundle: nil bundle")
+	}
+	// INSERT, not UPSERT: reaching here for an already-recorded bundle means
+	// the dedup check was skipped, which is a bug worth surfacing rather than
+	// silently overwriting an earlier import's provenance.
+	_, err := i.db.ExecContext(ctx, `
+		INSERT INTO sync_imported_bundles
+			(spoke_id, bundle_id, created_at, imported_at, file_count, bytes_total, conflicts)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		b.SpokeID, b.BundleID, b.CreatedAt.UTC(), time.Now().UTC(),
+		b.FileCount, b.BytesTotal, b.Conflicts)
+	if err != nil {
+		// A primary-key conflict means the row already exists — another import
+		// of this same bundle recorded it. Distinguished because the two mean
+		// opposite things to an operator: a generic failure means a re-import
+		// will NOT be refused, whereas this means it WILL be.
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return fmt.Errorf("%w: %s was recorded concurrently", ErrBundleAlreadyImported, b.BundleID)
+		}
+		return fmt.Errorf("edgesync: record bundle %q: %w", b.BundleID, err)
+	}
+	return nil
+}
+
+// ListBySpoke returns a spoke's imported bundles, newest first.
+func (i *BundleIndex) ListBySpoke(ctx context.Context, spokeID string, limit int) ([]*ImportedBundle, error) {
+	query := `
+		SELECT spoke_id, bundle_id, created_at, imported_at, file_count, bytes_total, conflicts
+		FROM sync_imported_bundles
+		WHERE spoke_id = ?
+		ORDER BY imported_at DESC`
+	args := []any{spokeID}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+
+	rows, err := i.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: list bundles for %q: %w", spokeID, err)
+	}
+	defer rows.Close()
+
+	var out []*ImportedBundle
+	for rows.Next() {
+		var b ImportedBundle
+		if err := rows.Scan(&b.SpokeID, &b.BundleID, &b.CreatedAt, &b.ImportedAt,
+			&b.FileCount, &b.BytesTotal, &b.Conflicts); err != nil {
+			return nil, fmt.Errorf("edgesync: scan bundle row: %w", err)
+		}
+		b.CreatedAt = b.CreatedAt.UTC()
+		b.ImportedAt = b.ImportedAt.UTC()
+		out = append(out, &b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("edgesync: iterate bundles: %w", err)
+	}
+	return out, nil
+}
+
+// No cleanup job, deliberately. 200 spokes shipping weekly bundles for five
+// years is ~52k rows — a table that never needs pruning. A batched DELETE here
+// would be risk (holding the write lock that ingest file-registration shares)
+// for no benefit.

--- a/internal/edgesync/importer.go
+++ b/internal/edgesync/importer.go
@@ -1,0 +1,406 @@
+package edgesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// ImportBatchSize bounds one manifest proposal.
+//
+// The Cluster Operations Checklist caps Raft batches at 1000 ops so a single
+// log entry cannot grow unbounded. It matters more here than on the online
+// path: an HTTP transfer naturally rate-limits proposals to one per request,
+// whereas a bundle import is a tight loop, and a 10,000-file bundle would
+// otherwise emit 10,000 individual proposals as fast as the disk allows.
+const ImportBatchSize = 1000
+
+// ImporterConfig configures bundle import.
+type ImporterConfig struct {
+	// Receiver commits each file: staging, hash, verify, promote, index. Reused
+	// unchanged from the online path so both transports land bytes identically.
+	//
+	// IMPORTANT: this Receiver must be constructed with a RegisterFile that
+	// COLLECTS rather than proposes — see CollectingRegistrar. The online
+	// Receiver proposes to the Raft manifest once per file, which is fine at
+	// one-file-per-HTTP-request but would emit 10,000 proposals in a tight
+	// loop for a 10,000-file bundle.
+	Receiver *Receiver
+
+	// Collector is the sink the Receiver's RegisterFile writes into. The
+	// importer drains it in batches of ImportBatchSize.
+	Collector *CollectingRegistrar
+
+	// Index is the dedup ledger.
+	Index *BundleIndex
+
+	// Registry resolves a spoke's secret to verify the manifest signature.
+	Registry *Registry
+
+	// HubID is this hub's identity. A bundle naming a different hub is
+	// refused: the MAC alone does not stop that, since a bundle for another
+	// hub validates fine under the same spoke's secret, and a scavenged drive
+	// would otherwise import anywhere that spoke is registered.
+	HubID string
+
+	// MaxFiles refuses a manifest declaring more than this. Enforced
+	// independently of the exporting spoke's own cap, which is advisory
+	// against a hostile manifest.
+	MaxFiles int64
+
+	// FlushManifest commits a batch of registered files to the Raft manifest.
+	// Nil in standalone mode, where there is no manifest.
+	FlushManifest func(ctx context.Context, files []*ReceivedFile) error
+
+	Logger zerolog.Logger
+}
+
+// Importer reads a verified bundle into hub storage.
+//
+// Imports are serialized. One collector and one staging area are shared across
+// calls, and a hub takes one drive at a time by nature — but the endpoint is a
+// concurrent Fiber handler, so nothing structural stops two operators (or one
+// retry after a client timeout on a four-hour request) from overlapping.
+// Without the lock they collide in the staging area: both stage the same path,
+// one promotes, the other fails with "file not found" — and Reset truncates
+// the other import's buffered registrations, leaving committed files outside
+// the manifest with no error and no log.
+type Importer struct {
+	// mu serializes Import. Held for the whole call, which is the point:
+	// the shared state is the staging area and the collector, and both span
+	// the entire import.
+	mu sync.Mutex
+
+	receiver      *Receiver
+	collector     *CollectingRegistrar
+	index         *BundleIndex
+	registry      *Registry
+	hubID         string
+	maxFiles      int64
+	flushManifest func(ctx context.Context, files []*ReceivedFile) error
+	logger        zerolog.Logger
+}
+
+// NewImporter validates configuration and returns a ready importer.
+func NewImporter(cfg ImporterConfig) (*Importer, error) {
+	if cfg.Receiver == nil {
+		return nil, errors.New("edgesync: importer requires a receiver")
+	}
+	if cfg.Collector == nil {
+		return nil, errors.New("edgesync: importer requires a collecting registrar")
+	}
+	if cfg.Index == nil {
+		return nil, errors.New("edgesync: importer requires a bundle index")
+	}
+	if cfg.Registry == nil {
+		// Without it there is no secret to verify against, and an unverified
+		// bundle is an unauthenticated write to hub storage.
+		return nil, errors.New("edgesync: importer requires a spoke registry")
+	}
+	if cfg.HubID == "" {
+		return nil, errors.New("edgesync: importer requires a hub ID")
+	}
+
+	maxFiles := cfg.MaxFiles
+	if maxFiles <= 0 {
+		maxFiles = DefaultBundleMaxFiles
+	}
+
+	return &Importer{
+		receiver:      cfg.Receiver,
+		collector:     cfg.Collector,
+		index:         cfg.Index,
+		registry:      cfg.Registry,
+		hubID:         cfg.HubID,
+		maxFiles:      maxFiles,
+		flushManifest: cfg.FlushManifest,
+		logger:        cfg.Logger.With().Str("component", "edgesync-import").Logger(),
+	}, nil
+}
+
+// ImportResult summarizes one import.
+type ImportResult struct {
+	BundleID  string
+	SpokeID   string
+	CreatedAt time.Time
+
+	Committed      int
+	AlreadyPresent int
+	BytesWritten   int64
+
+	// Conflicts are reported in full, not counted: each needs a human to
+	// decide which copy is right, and a count alone would not say which.
+	Conflicts []Conflict
+
+	// Recorded reports whether the dedup ledger write succeeded. False means
+	// the files are committed but a re-import of the same drive will not be
+	// refused — harmless, since it resolves to already_present, but it makes
+	// /history disagree with reality and the operator should know why.
+	Recorded bool
+
+	Duration time.Duration
+}
+
+// Import verifies a bundle and commits its files.
+//
+// Order: open, identity checks, dedup, verify EVERYTHING, then commit. No byte
+// reaches its final path until the whole bundle has been verified — the
+// property that makes an artifact carried on removable media safe to trust.
+func (i *Importer) Import(ctx context.Context, dir string) (*ImportResult, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	start := time.Now()
+
+	r, err := OpenBundle(dir, i.logger)
+	if err != nil {
+		return nil, err
+	}
+	m := r.Manifest()
+
+	// Identity before signature: a bundle for another hub is refused even if
+	// it is perfectly signed, because the signing spoke may be registered on
+	// both and the MAC would validate.
+	if m.HubID != i.hubID {
+		return nil, fmt.Errorf("%w: bundle is addressed to hub %q, this hub is %q",
+			ErrBundleInvalid, truncateForError(m.HubID), i.hubID)
+	}
+	if m.EntryCount <= 0 {
+		// An empty bundle is signable but meaningless, and recording one would
+		// burn a bundle ID for nothing.
+		return nil, fmt.Errorf("%w: bundle declares no entries", ErrBundleInvalid)
+	}
+	if m.EntryCount > i.maxFiles {
+		return nil, fmt.Errorf("%w: bundle declares %d entries, over this hub's limit of %d",
+			ErrBundleInvalid, m.EntryCount, i.maxFiles)
+	}
+
+	spoke, err := i.registry.Get(ctx, m.SpokeID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: unknown spoke %q", ErrBundleInvalid, truncateForError(m.SpokeID))
+	}
+	if !spoke.Enabled {
+		return nil, fmt.Errorf("%w: spoke %q is disabled", ErrBundleInvalid, truncateForError(m.SpokeID))
+	}
+
+	// Dedup BEFORE verification: re-verifying a bundle already imported would
+	// re-hash every file for a result that is already known.
+	if prior, err := i.index.Seen(ctx, m.SpokeID, m.BundleID); err != nil {
+		return nil, err
+	} else if prior != nil {
+		return nil, fmt.Errorf("%w: %s imported at %s (created %s, %d files)",
+			ErrBundleAlreadyImported, m.BundleID,
+			prior.ImportedAt.Format(time.RFC3339), prior.CreatedAt.Format(time.RFC3339),
+			prior.FileCount)
+	}
+
+	secret, err := i.registry.Secret(ctx, m.SpokeID)
+	if err != nil {
+		return nil, fmt.Errorf("edgesync: read spoke secret: %w", err)
+	}
+	if err := r.Verify(ctx, secret); err != nil {
+		return nil, err
+	}
+
+	entries, err := r.Entries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ImportResult{
+		BundleID:  m.BundleID,
+		SpokeID:   m.SpokeID,
+		CreatedAt: time.Unix(m.CreatedAt, 0).UTC(),
+		Recorded:  true,
+	}
+	if err := i.commitAll(ctx, r, m.SpokeID, entries, res); err != nil {
+		return nil, err
+	}
+
+	if err := i.index.Record(ctx, &ImportedBundle{
+		SpokeID:    m.SpokeID,
+		BundleID:   m.BundleID,
+		CreatedAt:  res.CreatedAt,
+		FileCount:  int64(res.Committed + res.AlreadyPresent),
+		BytesTotal: res.BytesWritten,
+		Conflicts:  int64(len(res.Conflicts)),
+	}); err != nil {
+		// The files are committed either way. Failing here would tell the
+		// operator the import failed when it did not, and a retry would then
+		// find everything already present — noise, not recovery.
+		//
+		// The two cases mean opposite things, so they are not logged alike: a
+		// concurrent record means the row EXISTS and a re-import will be
+		// refused; any other failure means it does not and a re-import will
+		// not be.
+		if errors.Is(err, ErrBundleAlreadyImported) {
+			i.logger.Warn().
+				Str("bundle_id", m.BundleID).
+				Msg("Bundle recorded concurrently by another import; a re-import will be refused")
+		} else {
+			i.logger.Error().Err(err).
+				Str("bundle_id", m.BundleID).
+				Msg("Bundle imported but could not be recorded; a re-import will NOT be refused")
+			res.Recorded = false
+		}
+	}
+
+	res.Duration = time.Since(start)
+	i.logger.Info().
+		Str("bundle_id", m.BundleID).
+		Str("spoke_id", m.SpokeID).
+		Int("committed", res.Committed).
+		Int("already_present", res.AlreadyPresent).
+		Int("conflicts", len(res.Conflicts)).
+		Int64("bytes", res.BytesWritten).
+		Dur("duration", res.Duration).
+		Msg("Bundle imported")
+
+	return res, nil
+}
+
+// commitAll streams every entry into storage, flushing manifest ops in batches.
+//
+// The Receiver registers each committed file through the collector rather than
+// proposing directly, so this drains that buffer at ImportBatchSize. That is
+// the difference between one Raft proposal per 1000 files and one per file.
+func (i *Importer) commitAll(ctx context.Context, r *BundleReader, spokeID string, entries []BundleEntry, res *ImportResult) error {
+	i.collector.Reset()
+
+	flush := func() error {
+		files := i.collector.Drain()
+		if len(files) == 0 || i.flushManifest == nil {
+			return nil
+		}
+		if err := i.flushManifest(ctx, files); err != nil {
+			// The bytes are already committed by the receiver, so a failed
+			// manifest update means files exist in storage the cluster cannot
+			// see. Abort rather than continue: a Raft quorum loss is not
+			// transient, and pressing on would widen the gap. The next import
+			// of this bundle re-registers them, since Record never ran.
+			return fmt.Errorf("%w: commit manifest batch: %w", ErrReceiveInternal, err)
+		}
+		return nil
+	}
+
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		size, conflict, err := i.commitOne(ctx, r, spokeID, e)
+		if err != nil {
+			return err
+		}
+		switch {
+		case conflict != nil:
+			res.Conflicts = append(res.Conflicts, *conflict)
+		case size < 0:
+			res.AlreadyPresent++
+		default:
+			res.Committed++
+			res.BytesWritten += size
+		}
+
+		// Checked after EVERY entry, not only after a commit. An
+		// already-present file registers too — resolveExisting re-attempts it,
+		// deliberately, so a file whose bytes landed but whose registration
+		// failed is not stranded — so it also enters the collector. Skipping
+		// the check on that path let a re-imported bundle accumulate past the
+		// cap and emit one oversized proposal, defeating the batching this
+		// exists to provide.
+		if i.collector.Len() >= ImportBatchSize {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+	return flush()
+}
+
+// commitOne stages, verifies, and promotes a single entry.
+//
+// Returns (size, nil, nil) when it committed, (-1, nil, nil) when the hub
+// already holds this exact content, and (0, conflict, nil) when it holds
+// different content at the path.
+func (i *Importer) commitOne(ctx context.Context, r *BundleReader, spokeID string, e BundleEntry) (int64, *Conflict, error) {
+	body, err := r.Open(e.Path)
+	if err != nil {
+		return 0, nil, fmt.Errorf("%w: open %q: %v", ErrBundleInvalid, truncateForError(e.Path), err)
+	}
+	defer body.Close()
+
+	// offset 0: a bundle entry is a whole file, so the resume machinery is not
+	// engaged and a non-appending backend is irrelevant here.
+	out, err := i.receiver.Receive(ctx, spokeID, e.Path, e.SHA256, e.SizeBytes, 0, body)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	switch out.Outcome {
+	case OutcomeCommitted:
+		return e.SizeBytes, nil, nil
+
+	case OutcomeAlreadyPresent:
+		return -1, nil, nil
+
+	case OutcomeConflict:
+		return 0, &Conflict{Path: e.Path, TheirSHA256: out.TheirSHA256}, nil
+
+	case OutcomePartial, OutcomeChecksumMismatch:
+		// Verify re-hashed this file moments ago, so a short read or a digest
+		// mismatch NOW means the media changed underneath the import — a
+		// failing drive, or a race with whoever holds it. Both are the same
+		// diagnosis, and both are the operator's to act on: refuse the whole
+		// bundle with 422 rather than report a generic internal error.
+		return 0, nil, fmt.Errorf("%w: %q changed during import (%s); the media may be failing",
+			ErrBundleInvalid, truncateForError(e.Path), out.Outcome)
+
+	default:
+		return 0, nil, fmt.Errorf("%w: unexpected outcome %q for %q",
+			ErrReceiveInternal, out.Outcome, truncateForError(e.Path))
+	}
+}
+
+// CollectingRegistrar buffers registered files instead of proposing them.
+//
+// The seam that makes batching possible without changing Receiver: the online
+// hub passes a RegisterFile that proposes to Raft immediately, and the importer
+// passes this, draining it at ImportBatchSize.
+//
+// Not safe for concurrent use. That is sound only because Importer.Import
+// holds a mutex for the whole call: one collector is shared across every
+// import, so without that lock two overlapping imports would append to the
+// same buffer and Reset would truncate the other's pending registrations.
+type CollectingRegistrar struct {
+	files []*ReceivedFile
+}
+
+// NewCollectingRegistrar returns an empty collector.
+func NewCollectingRegistrar() *CollectingRegistrar {
+	return &CollectingRegistrar{files: make([]*ReceivedFile, 0, ImportBatchSize)}
+}
+
+// Register is the ReceiverConfig.RegisterFile hook.
+func (c *CollectingRegistrar) Register(_ context.Context, f *ReceivedFile) error {
+	c.files = append(c.files, f)
+	return nil
+}
+
+// Len reports how many files are buffered.
+func (c *CollectingRegistrar) Len() int { return len(c.files) }
+
+// Drain returns the buffered files and empties the buffer.
+func (c *CollectingRegistrar) Drain() []*ReceivedFile {
+	out := c.files
+	c.files = make([]*ReceivedFile, 0, ImportBatchSize)
+	return out
+}
+
+// Reset discards anything buffered, so a new import does not inherit files
+// left over from one that failed partway.
+func (c *CollectingRegistrar) Reset() { c.files = c.files[:0] }

--- a/internal/edgesync/importer_test.go
+++ b/internal/edgesync/importer_test.go
@@ -1,0 +1,448 @@
+package edgesync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+)
+
+type importRig struct {
+	importer *Importer
+	index    *BundleIndex
+	registry *Registry
+	hubStore storage.Backend
+	secret   string
+
+	// batches records the size of each manifest flush, so a test can prove
+	// proposals are batched rather than one-per-file.
+	batches []int
+}
+
+func newImportRig(t *testing.T, clustered bool) *importRig {
+	t.Helper()
+
+	dir := t.TempDir()
+	hubStore, err := storage.NewLocalBackend(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	t.Cleanup(func() { hubStore.Close() })
+
+	db, err := sql.Open("sqlite3", filepath.Join(dir, "hub.db"))
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	hubIndex, err := NewHubIndex(db, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("hub index: %v", err)
+	}
+	bundleIndex, err := NewBundleIndex(db, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("bundle index: %v", err)
+	}
+	registry, err := NewRegistry(db, newTestCipher(t), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	secret, err := registry.Register(context.Background(), testSpokeID, "test spoke")
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	rig := &importRig{index: bundleIndex, registry: registry, hubStore: hubStore, secret: secret}
+
+	collector := NewCollectingRegistrar()
+	receiver, err := NewReceiver(ReceiverConfig{
+		Backend:      hubStore,
+		Index:        hubIndex,
+		Logger:       zerolog.Nop(),
+		RegisterFile: collector.Register,
+	})
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+
+	var flush func(context.Context, []*ReceivedFile) error
+	if clustered {
+		flush = func(_ context.Context, files []*ReceivedFile) error {
+			rig.batches = append(rig.batches, len(files))
+			return nil
+		}
+	}
+
+	imp, err := NewImporter(ImporterConfig{
+		Receiver: receiver, Collector: collector, Index: bundleIndex,
+		Registry: registry, HubID: testHubID, FlushManifest: flush, Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("importer: %v", err)
+	}
+	rig.importer = imp
+	return rig
+}
+
+// exportBundle builds a real bundle from a spoke, for the hub to import.
+func exportBundle(t *testing.T, secret string, n int, hubID string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	storeDir := t.TempDir()
+	backend, err := storage.NewLocalBackend(storeDir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("spoke backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	w, err := NewBundleWriter(BundleWriterConfig{
+		Backend: backend, SpokeID: testSpokeID, HubID: hubID,
+		Secret: secret, Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+
+	entries := make([]*LedgerEntry, 0, n)
+	for i := 0; i < n; i++ {
+		p := fmt.Sprintf("default/cpu/2026/08/07/%02d/f_%04d.parquet", i%24, i)
+		content := fmt.Sprintf("payload %04d", i)
+		if err := backend.Write(ctx, p, []byte(content)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		sum, _ := sha256Of(content)
+		entries = append(entries, &LedgerEntry{
+			HubID: hubID, Path: p, SHA256: sum, SizeBytes: int64(len(content)),
+			Database: "default", Measurement: "cpu",
+			PartitionTime: time.Date(2026, 8, 7, i%24, 0, 0, 0, time.UTC),
+		})
+	}
+
+	res, err := w.Export(ctx, t.TempDir(), entries, time.Now())
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	return res.Dir
+}
+
+func TestImporter_RoundTripsAVerifiedBundle(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 3, testHubID)
+
+	res, err := rig.importer.Import(ctx, dir)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Committed != 3 {
+		t.Errorf("committed = %d, want 3", res.Committed)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("conflicts = %v, want none", res.Conflicts)
+	}
+
+	// The files must be in hub storage, namespaced under the spoke.
+	for i := 0; i < 3; i++ {
+		p := NamespacedPath(testSpokeID, fmt.Sprintf("default/cpu/2026/08/07/%02d/f_%04d.parquet", i, i))
+		if ok, err := rig.hubStore.Exists(ctx, p); err != nil || !ok {
+			t.Errorf("%s is not in hub storage (err=%v)", p, err)
+		}
+	}
+}
+
+// Replay protection for an artifact that sits on a drive for weeks: durable
+// state, not a timestamp window.
+func TestImporter_RefusesAReimport(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 2, testHubID)
+
+	if _, err := rig.importer.Import(ctx, dir); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	_, err := rig.importer.Import(ctx, dir)
+	if !errors.Is(err, ErrBundleAlreadyImported) {
+		t.Fatalf("second import error = %v, want ErrBundleAlreadyImported", err)
+	}
+	// The message must say WHEN, so a duplicate drive is diagnosable.
+	if !strings.Contains(err.Error(), "imported at") {
+		t.Errorf("the refusal does not say when it was imported: %v", err)
+	}
+}
+
+// A bundle for another hub validates fine under the same spoke's secret, so
+// the MAC alone does not stop a scavenged drive importing anywhere.
+func TestImporter_RefusesABundleForAnotherHub(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 2, "some-other-hub")
+
+	_, err := rig.importer.Import(ctx, dir)
+	if !errors.Is(err, ErrBundleInvalid) {
+		t.Fatalf("error = %v, want ErrBundleInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "addressed to hub") {
+		t.Errorf("the refusal does not explain the mismatch: %v", err)
+	}
+}
+
+// A tampered bundle must not commit a single byte.
+func TestImporter_TamperedBundleCommitsNothing(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 3, testHubID)
+
+	// Corrupt one file AFTER export.
+	victim := filepath.Join(dir, dataDir, "default/cpu/2026/08/07/01/f_0001.parquet")
+	if err := os.WriteFile(victim, []byte("tampered!!!"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := rig.importer.Import(ctx, dir); !errors.Is(err, ErrBundleInvalid) {
+		t.Fatalf("error = %v, want ErrBundleInvalid", err)
+	}
+
+	// NOTHING committed — verification runs before any commit.
+	for i := 0; i < 3; i++ {
+		p := NamespacedPath(testSpokeID, fmt.Sprintf("default/cpu/2026/08/07/%02d/f_%04d.parquet", i, i))
+		if ok, _ := rig.hubStore.Exists(ctx, p); ok {
+			t.Errorf("%s was committed from a tampered bundle", p)
+		}
+	}
+	// And no dedup row, so a corrected drive can still be imported.
+	if seen, _ := rig.index.Seen(ctx, testSpokeID, "any"); seen != nil {
+		t.Error("a refused bundle was recorded")
+	}
+}
+
+// An unregistered or disabled spoke must not be able to write to the hub.
+func TestImporter_RefusesUnknownAndDisabledSpokes(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 1, testHubID)
+
+	if err := rig.registry.SetEnabled(ctx, testSpokeID, false); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	_, err := rig.importer.Import(ctx, dir)
+	if !errors.Is(err, ErrBundleInvalid) || !strings.Contains(err.Error(), "disabled") {
+		t.Errorf("a disabled spoke's bundle was not refused for being disabled: %v", err)
+	}
+
+	if err := rig.registry.Delete(ctx, testSpokeID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	_, err = rig.importer.Import(ctx, dir)
+	if !errors.Is(err, ErrBundleInvalid) || !strings.Contains(err.Error(), "unknown spoke") {
+		t.Errorf("an unregistered spoke's bundle was not refused: %v", err)
+	}
+}
+
+// The Cluster Operations Checklist caps Raft batches at 1000. An import is a
+// tight loop, unlike the online path where HTTP rate-limits one proposal per
+// request — so a 2500-file bundle must be three proposals, not 2500.
+func TestImporter_BatchesManifestProposals(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, true)
+
+	const files = ImportBatchSize*2 + 500
+	dir := exportBundle(t, rig.secret, files, testHubID)
+
+	res, err := rig.importer.Import(ctx, dir)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Committed != files {
+		t.Fatalf("committed = %d, want %d", res.Committed, files)
+	}
+
+	if len(rig.batches) != 3 {
+		t.Errorf("manifest flushes = %d (%v), want 3 for %d files", len(rig.batches), rig.batches, files)
+	}
+	for i, n := range rig.batches {
+		if n > ImportBatchSize {
+			t.Errorf("batch %d carried %d ops, over the %d cap", i, n, ImportBatchSize)
+		}
+	}
+	total := 0
+	for _, n := range rig.batches {
+		total += n
+	}
+	if total != files {
+		t.Errorf("batched %d ops for %d files: some were never registered", total, files)
+	}
+}
+
+// A standalone hub has no manifest, so import must work with no flush hook.
+func TestImporter_WorksWithoutAManifest(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 2, testHubID)
+
+	if _, err := rig.importer.Import(ctx, dir); err != nil {
+		t.Fatalf("standalone import failed: %v", err)
+	}
+}
+
+// Re-importing a DIFFERENT bundle carrying files the hub already holds is the
+// lost-drive-then-resent case: no bytes rewritten, no conflict raised.
+func TestImporter_AlreadyPresentFilesAreNotConflicts(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+
+	first := exportBundle(t, rig.secret, 2, testHubID)
+	if _, err := rig.importer.Import(ctx, first); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+
+	// A second bundle with identical content at identical paths.
+	second := exportBundle(t, rig.secret, 2, testHubID)
+	res, err := rig.importer.Import(ctx, second)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if res.AlreadyPresent != 2 {
+		t.Errorf("already_present = %d, want 2", res.AlreadyPresent)
+	}
+	if res.Committed != 0 {
+		t.Errorf("committed = %d, want 0: identical content must not be rewritten", res.Committed)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("identical content raised %d conflicts", len(res.Conflicts))
+	}
+}
+
+// §6.1: the same path holding different content is reported, never overwritten.
+func TestImporter_ConflictsAreReportedNotOverwritten(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+
+	dir := exportBundle(t, rig.secret, 1, testHubID)
+	const rel = "default/cpu/2026/08/07/00/f_0000.parquet"
+
+	// The hub already holds different content at that path.
+	if err := rig.hubStore.Write(ctx, NamespacedPath(testSpokeID, rel), []byte("the hub's version")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res, err := rig.importer.Import(ctx, dir)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(res.Conflicts) != 1 {
+		t.Fatalf("conflicts = %v, want one", res.Conflicts)
+	}
+	if res.Conflicts[0].Path != rel {
+		t.Errorf("conflict path = %q, want %q", res.Conflicts[0].Path, rel)
+	}
+
+	// The hub's copy is untouched.
+	var buf strings.Builder
+	if err := rig.hubStore.ReadTo(ctx, NamespacedPath(testSpokeID, rel), &buf); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if buf.String() != "the hub's version" {
+		t.Errorf("the hub's copy was overwritten: %q", buf.String())
+	}
+}
+
+// A hostile manifest must not be able to exceed the hub's own limit.
+func TestImporter_EnforcesItsOwnFileCap(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 5, testHubID)
+
+	rig.importer.maxFiles = 2
+	_, err := rig.importer.Import(ctx, dir)
+	if !errors.Is(err, ErrBundleInvalid) || !strings.Contains(err.Error(), "limit") {
+		t.Errorf("error = %v, want a refusal citing the hub's limit", err)
+	}
+}
+
+// Already-present files also register (resolveExisting re-attempts it), so
+// they enter the collector too. If the size check only runs on newly-committed
+// files, a re-imported bundle accumulates past the cap and the final flush
+// carries one oversized proposal — violating the rule this exists to satisfy.
+func TestImporter_BatchCapHoldsForAlreadyPresentFiles(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, true)
+
+	const files = ImportBatchSize + 200
+	first := exportBundle(t, rig.secret, files, testHubID)
+	if _, err := rig.importer.Import(ctx, first); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+
+	// A DIFFERENT bundle carrying the same content: every file resolves to
+	// already_present, and every one still registers.
+	rig.batches = nil
+	second := exportBundle(t, rig.secret, files, testHubID)
+	res, err := rig.importer.Import(ctx, second)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if res.AlreadyPresent != files {
+		t.Fatalf("already_present = %d, want %d", res.AlreadyPresent, files)
+	}
+
+	for i, n := range rig.batches {
+		if n > ImportBatchSize {
+			t.Errorf("batch %d carried %d ops, over the %d cap", i, n, ImportBatchSize)
+		}
+	}
+	if len(rig.batches) == 0 {
+		t.Error("already-present files produced no manifest batches at all")
+	}
+}
+
+// The endpoint is a concurrent Fiber handler, and one collector and one
+// staging area are shared across imports. Without serialization two imports
+// collide in staging — both stage the same path, one promotes, the other fails
+// "file not found" — and Reset truncates the other's buffered registrations,
+// leaving committed files outside the manifest with no error.
+func TestImporter_ConcurrentImportsAreSerialized(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, true)
+
+	const each = 60
+	a := exportBundle(t, rig.secret, each, testHubID)
+	b := exportBundle(t, rig.secret, each, testHubID)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i, dir := range []string{a, b} {
+		wg.Add(1)
+		go func(idx int, d string) {
+			defer wg.Done()
+			_, errs[idx] = rig.importer.Import(ctx, d)
+		}(i, dir)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("concurrent import %d failed: %v", i, err)
+		}
+	}
+
+	// Every file from both bundles must reach a manifest batch. A truncated
+	// buffer would silently drop some.
+	total := 0
+	for _, n := range rig.batches {
+		total += n
+	}
+	if total != each*2 {
+		t.Errorf("registered %d files across both imports, want %d", total, each*2)
+	}
+}


### PR DESCRIPTION
> **PR 9c of 4** for the air-gap bundle (item 9 of #569). Follows #580 (ledger state) and #581 (export). Next: 9d, the acknowledgment.

## Summary

**The air-gap loop closes here.** A hub takes a bundle off removable media and commits it, so data written on a disconnected spoke reaches a hub with no network path between them.

**Nothing is committed until the whole bundle verifies** — MAC, `entries.jsonl` hash, canonical digest, every file's size and SHA-256, and the absence of any undeclared file. A tampered drive is refused with `422` naming the offending file, and **not one byte reaches storage**.

| Situation | Response |
|---|---|
| Already imported | `409`, with when it arrived and how many files |
| Tampered, truncated, wrong hub, unknown or disabled spoke | `422`, naming what failed |
| Path outside `allowed_dirs` | `400` |

**Replay protection is a dedup ledger keyed `(spoke_id, bundle_id)`, not a timestamp window.** The online families bind a nonce and a five-minute freshness check, which works because a request is in flight; a bundle sits on a drive for weeks. Namespaced by spoke so a compromised one cannot burn IDs in another's space and `409` its future drives.

`edge_sync.import.enabled` is **independent of `edge_sync.enabled`**: an import-only hub exposes **no** network-writable surface — `/api/v1/sync/file` returns 404, verified against the running binary.

**Cluster mode batches manifest registrations at 1000 ops per Raft proposal.** The online path is naturally rate-limited to one proposal per HTTP request; an import is a tight loop, so a 2,500-file bundle costs **3** proposals rather than 2,500. `Receiver` is reused unchanged via a `CollectingRegistrar` that buffers what it would otherwise propose.

## Two blockers, both reproduced before fixing

**The batch cap did not hold for already-present files.** `resolveExisting` re-registers them deliberately (so a file whose bytes landed but whose registration failed is not stranded), so they enter the collector too — but the size check only ran after a *commit*. A 1,200-file re-import emitted **one 1,200-op proposal**, defeating the batching this exists to provide. This is the realistic case, not an edge one: re-importing an overlapping drive makes every file already-present.

**Imports were not serialized.** One collector and one staging area are shared across calls behind a concurrent Fiber handler. Two overlapping imports collided in staging — both stage the same path, one promotes, the other fails `file not found` — and `Reset` truncated the other's buffered registrations, leaving committed files **outside the manifest with no error and no log**. Reproduced: **200 of 400 files unregistered**. Now serialized with a mutex.

Also fixed: `OutcomeChecksumMismatch` fell to `default` and surfaced as a generic 500, though it means the media changed between verify and commit — the same diagnosis as `OutcomePartial`, now `422`. A PK conflict on `Record` told the operator "a re-import will not be refused" when the **opposite** was true.

## Test plan

- [x] **12 importer tests**: round-trip, replay 409, wrong hub, tampered-commits-nothing, unknown/disabled spoke, batching, no-manifest, already-present, conflicts-not-overwritten, file cap, batch cap for already-present, concurrent imports
- [x] Batching verified to **fail unbatched**: 2,500 proposals vs 3
- [x] Batch-cap fix verified to produce `[1000 200]`, not `[1200]`
- [x] **Live, two processes**: air-gap loop closed end to end, 9 files byte-identical; import-only hub 404s `/sync/file`; a tampered drive refused 422 with nothing committed, then imported cleanly once restored
- [x] **Two concurrent imports both succeed** (3+6 files) where one previously failed outright
- [x] `go test -race`, `go vet`, `gofmt` clean

## Docs

Basekick-Labs/docs.basekick.net#22 — stacked on #21, which is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)