### PR TITLE
feat(edgesync): bundle acknowledgment, closing the air-gap loop (#569)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -204,7 +204,14 @@ curl -X POST https://edge.local:8000/api/v1/spoke-sync/ack \
 ```
 
 ```json
-{"applied": true, "bundle_id": "06FXWFA2NYJ…", "hub_id": "shore-station", "synced": 4}
+{
+  "applied": true,
+  "bundle_id": "06FXWFA2NYJHJJFAJAXBDV4PKC",
+  "hub_id": "shore-station",
+  "imported_at": "2026-08-07T21:59:56Z",
+  "synced": 4,
+  "conflicts": []
+}
 ```
 
 Those files move from `exported` to `synced`, which is what finally makes them **prunable**. Before this, `synced` was unreachable on an air-gapped spoke: `PruneSynced` never pruned and the ledger grew without bound on the box least able to receive a site visit.

--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -191,7 +191,31 @@ In cluster mode, manifest registrations are **batched at 1000 ops per Raft propo
 
 `GET /api/v1/bundle-import/history/{spoke_id}` answers "did last month's drive ever arrive?" — which, on a link with no telemetry, nothing else can.
 
-The acknowledgment that advances `exported` to `synced` lands next.
+### The acknowledgment
+
+The return leg, and the piece that makes air-gap sync converge. On a successful import the hub writes a signed `ack.json` **into the bundle directory** — so the drive that goes back carries the receipt, and it cannot be separated from the bundle it answers.
+
+An operator plugs the drive back into the spoke:
+
+```bash
+curl -X POST https://edge.local:8000/api/v1/spoke-sync/ack \
+  -H "Authorization: Bearer $ARC_TOKEN" \
+  -d '{"path": "/mnt/usb/bundle-submarine-01-06FXWFA2NYJHJJFAJAXBDV4PKC"}'
+```
+
+```json
+{"applied": true, "bundle_id": "06FXWFA2NYJ…", "hub_id": "shore-station", "synced": 4}
+```
+
+Those files move from `exported` to `synced`, which is what finally makes them **prunable**. Before this, `synced` was unreachable on an air-gapped spoke: `PruneSynced` never pruned and the ledger grew without bound on the box least able to receive a site visit.
+
+The ack is signed with a fourth HMAC family (`sync-ack`, length 8 — distinct from the other three, so the length-prefixed canonical input keeps them non-interchangeable). The hub signs with the **same per-spoke secret** the spoke signs with: it is symmetric, so the key that lets a spoke prove authorship lets the hub prove receipt. No new key material.
+
+The spoke recomputes the path digest rather than trusting the one in the file — the MAC binds the digest, so a tampered path list with a stale digest would otherwise validate and license marking files synced the hub never received.
+
+**Conflicted paths are deliberately not acknowledged.** A conflict means the hub holds *different* content there, so the spoke's copy was never delivered; those entries stay `exported` and are reported for a human. Re-applying an ack is harmless — already-synced entries are a no-op — so a drive plugged in twice changes nothing.
+
+Like the bundle it answers, the ack carries **no freshness window**: it rides the same drive back and is subject to the same weeks-long latency.
 
 ## Security hardening
 

--- a/internal/api/edgesync_spoke.go
+++ b/internal/api/edgesync_spoke.go
@@ -80,6 +80,7 @@ func (h *EdgeSyncSpokeHandler) RegisterRoutes(app fiber.Router) {
 	group.Get("/ledger", h.ledger)
 	group.Post("/export", h.export)
 	group.Post("/export/:bundle_id/revert", h.revertExport)
+	group.Post("/ack", h.applyAck)
 
 	h.logger.Info().Msg("Edge sync spoke routes registered")
 }
@@ -380,4 +381,89 @@ func (h *EdgeSyncSpokeHandler) revertExport(c *fiber.Ctx) error {
 
 	h.logger.Info().Str("bundle_id", bundleID).Int64("files", n).Msg("Bundle reverted")
 	return c.JSON(fiber.Map{"bundle_id": bundleID, "reverted": n})
+}
+
+// applyAck handles POST /api/v1/spoke-sync/ack.
+//
+// The return leg of the air-gap transport: an operator plugs a drive back in
+// after it has been to the hub, and this advances the files the hub confirmed
+// from `exported` to `synced`.
+//
+// This is what makes those entries prunable. Without it `synced` is
+// unreachable on an air-gapped spoke, so the ledger grows without bound on the
+// box least able to receive a site visit.
+func (h *EdgeSyncSpokeHandler) applyAck(c *fiber.Ctx) error {
+	if h.exporter == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "air-gap bundle export is not enabled (edge_sync.spoke.bundle.enabled)",
+		})
+	}
+
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+	}
+	if req.Path == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "path is required: the returned bundle directory",
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Minute)
+	defer cancel()
+
+	res, err := h.exporter.ApplyAck(ctx, req.Path)
+	switch {
+	case errors.Is(err, edgesync.ErrNoAck):
+		// Not an error: a drive that has not yet been to the hub is the normal
+		// state on the outbound leg, and an operator checking early should not
+		// see a failure.
+		return c.JSON(fiber.Map{
+			"applied": false,
+			"reason":  "this bundle carries no acknowledgment yet",
+		})
+
+	case errors.Is(err, edgesync.ErrAckInvalid), errors.Is(err, edgesync.ErrDestinationRefused):
+		// The operator's own input — a tampered ack, one from another hub, or
+		// a path outside the allow-list. Retrying unchanged fails identically.
+		h.logger.Warn().Err(err).Msg("Acknowledgment refused")
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+
+	case err != nil:
+		h.logger.Error().Err(err).Msg("Failed to apply an acknowledgment")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to apply the acknowledgment",
+		})
+	}
+
+	out := fiber.Map{
+		"applied":     true,
+		"bundle_id":   res.BundleID,
+		"hub_id":      res.HubID,
+		"imported_at": res.ImportedAt,
+		"synced":      res.Synced,
+	}
+	if res.Unknown > 0 {
+		// Not a failure — a spoke restored from a backup, or whose entries
+		// were already synced by another route, legitimately produces these —
+		// but an operator comparing counts deserves to know.
+		out["unknown"] = res.Unknown
+	}
+
+	conflicts := make([]fiber.Map, 0, len(res.Conflicts))
+	for _, cf := range res.Conflicts {
+		conflicts = append(conflicts, fiber.Map{
+			"path":         cf.Path,
+			"their_sha256": cf.TheirSHA256,
+		})
+	}
+	out["conflicts"] = conflicts
+	if len(conflicts) > 0 {
+		out["warning"] = "The hub holds different content at these paths. They were NOT acknowledged " +
+			"and remain exported; investigate before re-sending."
+	}
+
+	return c.JSON(out)
 }

--- a/internal/api/edgesync_spoke.go
+++ b/internal/api/edgesync_spoke.go
@@ -445,11 +445,22 @@ func (h *EdgeSyncSpokeHandler) applyAck(c *fiber.Ctx) error {
 		"imported_at": res.ImportedAt,
 		"synced":      res.Synced,
 	}
-	if res.Unknown > 0 {
-		// Not a failure — a spoke restored from a backup, or whose entries
-		// were already synced by another route, legitimately produces these —
-		// but an operator comparing counts deserves to know.
-		out["unknown"] = res.Unknown
+	var warnings []string
+	// The three non-advanced cases mean different things, so they are reported
+	// apart. Already-synced is the benign replay; untracked is a restored
+	// spoke; a discrepancy means the hub holds a file this spoke gave up on,
+	// which is the only one that says something is wrong.
+	if res.AlreadySynced > 0 {
+		out["already_synced"] = res.AlreadySynced
+	}
+	if res.Untracked > 0 {
+		out["untracked"] = res.Untracked
+	}
+	if res.Discrepancies > 0 {
+		out["discrepancies"] = res.Discrepancies
+		warnings = append(warnings,
+			"The hub acknowledges files this spoke had given up on. They remain failed locally; "+
+				"the data IS on the hub, but the local ledger disagrees and is worth investigating.")
 	}
 
 	conflicts := make([]fiber.Map, 0, len(res.Conflicts))
@@ -461,8 +472,12 @@ func (h *EdgeSyncSpokeHandler) applyAck(c *fiber.Ctx) error {
 	}
 	out["conflicts"] = conflicts
 	if len(conflicts) > 0 {
-		out["warning"] = "The hub holds different content at these paths. They were NOT acknowledged " +
-			"and remain exported; investigate before re-sending."
+		warnings = append(warnings,
+			"The hub holds different content at these paths. They were NOT acknowledged "+
+				"and remain exported; investigate before re-sending.")
+	}
+	if len(warnings) > 0 {
+		out["warnings"] = warnings
 	}
 
 	return c.JSON(out)

--- a/internal/cluster/security/edgesync_auth.go
+++ b/internal/cluster/security/edgesync_auth.go
@@ -53,6 +53,14 @@ const (
 	// arrangement of another family's field contents — that is what makes the
 	// three families non-interchangeable. Never add a label of length 9 or 14.
 	syncLabelBundle = "sync-bundle"
+
+	// syncLabelAck marks a hub's acknowledgment of an imported bundle (PR 9d).
+	//
+	// Length 8, distinct from sync-file (9), sync-bundle (11), and
+	// sync-reconcile (14). Signed by the HUB rather than a spoke — the secret
+	// is symmetric, so the same key that lets a spoke prove authorship lets the
+	// hub prove receipt.
+	syncLabelAck = "sync-ack"
 )
 
 // ErrSyncAuthMalformedField is returned when a field carries a NUL byte.
@@ -298,6 +306,79 @@ func BundleEntriesDigest(paths, sha256s []string, sizes []int64) (string, error)
 			return "", fmt.Errorf("security: bundle digest: duplicate path %q", paths[i])
 		}
 		b.WriteString(canonicalSyncInput(paths[i], sha256s[i], strconv.FormatInt(sizes[i], 10)))
+	}
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// ComputeSyncAckHMAC signs a hub's acknowledgment of an imported bundle.
+//
+// Binds the bundle it acknowledges, both identities, when the hub imported it,
+// and a digest of the acknowledged paths. A spoke that verifies this knows the
+// named hub actually holds those exact files — the evidence that lets it
+// advance them from `exported` to `synced` and eventually prune them.
+//
+// Without an ack an air-gapped spoke has no terminal state at all: `synced` is
+// unreachable, so its ledger grows forever on the box least able to receive a
+// site visit.
+//
+// NO NONCE and NO FRESHNESS CHECK, matching the bundle family it answers: an
+// ack rides the same physical drive back and is subject to the same weeks-long
+// latency. Replaying an ack is harmless — it can only re-advance files that are
+// already synced, which MarkSynced treats as a no-op.
+//
+// Format: "sync-ack" \x00 bundleID \x00 spokeID \x00 hubID \x00 importedAt \x00 pathsDigest
+func ComputeSyncAckHMAC(sharedSecret, bundleID, spokeID, hubID string, importedAt int64, pathsDigest string) (string, error) {
+	if err := rejectSyncNUL(bundleID, spokeID, hubID, pathsDigest); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(
+		computeSyncAckHMACRaw(sharedSecret, bundleID, spokeID, hubID, importedAt, pathsDigest)), nil
+}
+
+func computeSyncAckHMACRaw(sharedSecret, bundleID, spokeID, hubID string, importedAt int64, pathsDigest string) []byte {
+	return computeRawHMAC(sharedSecret, canonicalSyncInput(
+		syncLabelAck, bundleID, spokeID, hubID,
+		strconv.FormatInt(importedAt, 10), pathsDigest))
+}
+
+// ValidateSyncAckHMAC checks an acknowledgment's MAC.
+//
+// No freshness check, for the same reason ValidateSyncBundleHMAC has none.
+func ValidateSyncAckHMAC(sharedSecret, bundleID, spokeID, hubID string, importedAt int64, pathsDigest, receivedMAC string) error {
+	if err := rejectSyncNUL(bundleID, spokeID, hubID, pathsDigest); err != nil {
+		return err
+	}
+	expected := computeSyncAckHMACRaw(sharedSecret, bundleID, spokeID, hubID, importedAt, pathsDigest)
+	if !constantTimeHexEqual(expected, receivedMAC) {
+		return ErrSyncAuthInvalid
+	}
+	return nil
+}
+
+// AckPathsDigest hashes the acknowledged path list into the value the MAC binds.
+//
+// Same canonicalization discipline as BundleEntriesDigest, and for the same
+// reason: sorted byte-lexicographically, duplicates rejected, each path
+// contributed through the shared length-prefixed helper rather than a second
+// encoding. A spoke that computes a different digest than the hub cannot tell
+// a tampered ack from an encoding disagreement, so there must be exactly one
+// way to compute it.
+func AckPathsDigest(paths []string) (string, error) {
+	if err := rejectSyncNUL(paths...); err != nil {
+		return "", err
+	}
+
+	sorted := append([]string(nil), paths...)
+	sort.Strings(sorted)
+
+	var b strings.Builder
+	for i, p := range sorted {
+		if i > 0 && sorted[i-1] == p {
+			return "", fmt.Errorf("security: ack digest: duplicate path %q", p)
+		}
+		b.WriteString(canonicalSyncInput(p))
 	}
 
 	sum := sha256.Sum256([]byte(b.String()))

--- a/internal/edgesync/ack.go
+++ b/internal/edgesync/ack.go
@@ -188,11 +188,20 @@ type AckResult struct {
 	// Synced is how many entries advanced from exported to synced.
 	Synced int
 
-	// Unknown is how many acknowledged paths this ledger does not track, or
-	// tracks in a state the ack cannot advance. Not an error: a spoke restored
-	// from a backup, or one whose entries were already synced by another
-	// route, legitimately produces these.
-	Unknown int
+	// AlreadySynced is how many acknowledged paths were already synced. The
+	// benign replay case: a drive plugged in twice.
+	AlreadySynced int
+
+	// Untracked is how many acknowledged paths this ledger does not know. A
+	// spoke restored from a backup legitimately produces these.
+	Untracked int
+
+	// Discrepancies is how many acknowledged paths this ledger holds in a
+	// state the ack cannot advance — in practice, terminally failed. The hub
+	// says it HOLDS a file this spoke gave up on, which an operator should
+	// see. Counted apart from the two benign cases because collapsing all
+	// three hides the only one that means something is wrong.
+	Discrepancies int
 
 	Conflicts []Conflict
 }
@@ -202,6 +211,14 @@ type AckResult struct {
 // The caller must have obtained the Ack from ReadAck, which verifies it. This
 // function trusts what it is given, so handing it an unverified ack would let a
 // tampered path list mark files synced that no hub ever received.
+//
+// An acknowledged entry that is still `pending` — one the spoke never put on
+// the drive, queued for the network path instead — IS advanced, deliberately.
+// ReadAck has proven the hub holds that exact path, so `synced` is factually
+// true however it got there, and re-sending it over a contact window would
+// spend link budget on a file already delivered. The effect is that a drive can
+// satisfy work queued for the network, which is the right outcome when both
+// transports are enabled.
 func ApplyAck(ctx context.Context, l *Ledger, a *Ack, logger zerolog.Logger) (*AckResult, error) {
 	if l == nil {
 		return nil, errors.New("edgesync: apply ack: nil ledger")
@@ -222,13 +239,31 @@ func ApplyAck(ctx context.Context, l *Ledger, a *Ack, logger zerolog.Logger) (*A
 			return nil, err
 		}
 		if err := l.MarkSynced(ctx, a.HubID, p); err != nil {
-			// Not fatal. An entry the ack names but this ledger cannot advance
-			// — already synced, never tracked, or terminally failed — is a
-			// discrepancy to report, not a reason to abandon the rest of a
+			// Not fatal: an entry the ack names but this ledger cannot advance
+			// is something to report, not a reason to abandon the rest of a
 			// valid acknowledgment.
-			res.Unknown++
-			logger.Debug().Err(err).Str("path", p).
-				Msg("Acknowledged path could not be advanced")
+			//
+			// Classified rather than lumped together. The ledger already
+			// distinguishes "no such row" from "wrong state", and the two mean
+			// opposite things to an operator.
+			switch {
+			case errors.Is(err, ErrNotFound):
+				res.Untracked++
+				logger.Debug().Str("path", p).Msg("Acknowledged path is not tracked by this ledger")
+			default:
+				// Wrong state. Already-synced is the benign replay case;
+				// anything else — in practice a terminally failed entry — is a
+				// real discrepancy, because the hub says it holds a file this
+				// spoke gave up on.
+				entry, getErr := l.Get(ctx, a.HubID, p)
+				if getErr == nil && entry.State == StateSynced {
+					res.AlreadySynced++
+					continue
+				}
+				res.Discrepancies++
+				logger.Warn().Err(err).Str("path", p).
+					Msg("The hub acknowledges a file this spoke cannot advance; investigate")
+			}
 			continue
 		}
 		res.Synced++

--- a/internal/edgesync/ack.go
+++ b/internal/edgesync/ack.go
@@ -1,0 +1,238 @@
+package edgesync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/rs/zerolog"
+)
+
+// ackName is the acknowledgment file, written into the bundle directory it
+// answers.
+//
+// Inside the bundle rather than beside it so the drive carries one
+// self-describing artifact: an operator hands back the same directory they
+// were given, and the ack cannot be separated from the bundle it refers to.
+const ackName = "ack.json"
+
+// ErrAckInvalid marks an acknowledgment that must not be trusted.
+var ErrAckInvalid = errors.New("edgesync: acknowledgment is invalid")
+
+// ErrNoAck means the bundle directory carries no acknowledgment.
+//
+// Distinct from an invalid one: a drive that has not yet been to the hub is
+// the normal case on the outbound leg, not a problem.
+var ErrNoAck = errors.New("edgesync: bundle carries no acknowledgment")
+
+// Ack is a hub's signed statement that it holds a bundle's files.
+//
+// The return leg of the air-gap transport. Without it a spoke has no terminal
+// state: `synced` is unreachable, so PruneSynced never prunes and the ledger
+// grows without bound on the box least able to receive a site visit.
+type Ack struct {
+	Version int `json:"version"`
+
+	BundleID string `json:"bundle_id"`
+	SpokeID  string `json:"spoke_id"`
+
+	// HubID is the hub that imported the bundle. The spoke checks it against
+	// its own configured hub: an ack from somewhere else names files this
+	// spoke never sent there.
+	HubID string `json:"hub_id"`
+
+	// ImportedAt is when the hub committed the bundle. Bound into the MAC and
+	// surfaced to operators, not enforced as a freshness window — an ack rides
+	// the same drive back and is subject to the same weeks-long latency.
+	ImportedAt int64 `json:"imported_at"`
+
+	// Paths are the spoke-relative paths the hub now holds. Committed and
+	// already-present files both appear: from the spoke's point of view they
+	// are the same fact — the hub has this file — and only that fact licenses
+	// advancing the ledger.
+	//
+	// Conflicted paths are deliberately ABSENT. A conflict means the hub holds
+	// DIFFERENT content at that path, so the spoke's copy has not been
+	// delivered and must not be marked synced.
+	Paths []string `json:"paths"`
+
+	// Conflicts are reported so the spoke can surface them to an operator
+	// without a network round-trip. Not acknowledged, only described.
+	Conflicts []Conflict `json:"conflicts,omitempty"`
+
+	// PathsDigest is the canonical digest the MAC binds.
+	PathsDigest string `json:"paths_digest"`
+
+	MAC string `json:"mac"`
+}
+
+// WriteAck signs an acknowledgment and writes it into the bundle directory.
+//
+// Written by the hub after a successful import. A failure here is not fatal to
+// the import — the files are committed either way — but it does cost the spoke
+// its chance to advance, so the caller should say so plainly.
+func WriteAck(dir, secret string, a *Ack) error {
+	if a == nil {
+		return errors.New("edgesync: write ack: nil acknowledgment")
+	}
+	if err := ValidateBundleID(a.BundleID); err != nil {
+		return err
+	}
+
+	digest, err := security.AckPathsDigest(a.Paths)
+	if err != nil {
+		return fmt.Errorf("edgesync: ack paths digest: %w", err)
+	}
+	a.PathsDigest = digest
+	a.Version = BundleVersion
+
+	mac, err := security.ComputeSyncAckHMAC(secret, a.BundleID, a.SpokeID, a.HubID, a.ImportedAt, digest)
+	if err != nil {
+		return fmt.Errorf("edgesync: sign ack: %w", err)
+	}
+	a.MAC = mac
+
+	return writeJSONFile(filepath.Join(dir, ackName), a)
+}
+
+// ReadAck reads and verifies an acknowledgment from a bundle directory.
+//
+// Verifies before returning: a caller that gets an Ack back can advance its
+// ledger on the strength of it, so an unverified one must never escape.
+func ReadAck(dir, secret, expectSpokeID, expectHubID string) (*Ack, error) {
+	raw, err := os.ReadFile(filepath.Join(dir, ackName))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, ErrNoAck
+		}
+		return nil, fmt.Errorf("edgesync: read ack: %w", err)
+	}
+	// The same bound the manifest gets: a fixed set of short fields plus a
+	// path list already capped by the bundle's own file limit.
+	if len(raw) > maxAckBytes {
+		return nil, fmt.Errorf("%w: %s is %d bytes, over the %d-byte bound",
+			ErrAckInvalid, ackName, len(raw), maxAckBytes)
+	}
+
+	var a Ack
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return nil, fmt.Errorf("%w: not valid JSON: %v", ErrAckInvalid, err)
+	}
+	if a.Version != BundleVersion {
+		return nil, fmt.Errorf("%w: version %d, this Arc understands %d",
+			ErrAckInvalid, a.Version, BundleVersion)
+	}
+	if err := ValidateBundleID(a.BundleID); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAckInvalid, err)
+	}
+
+	// Identity checks before the MAC, so a mismatch reports what is actually
+	// wrong rather than a generic signature failure.
+	if a.SpokeID != expectSpokeID {
+		return nil, fmt.Errorf("%w: acknowledges spoke %q, this spoke is %q",
+			ErrAckInvalid, truncateForError(a.SpokeID), expectSpokeID)
+	}
+	if a.HubID != expectHubID {
+		// An ack from another hub names files this spoke never sent there.
+		return nil, fmt.Errorf("%w: signed by hub %q, this spoke syncs to %q",
+			ErrAckInvalid, truncateForError(a.HubID), expectHubID)
+	}
+
+	// The digest is RECOMPUTED from the paths rather than trusted: the MAC
+	// binds the digest, so a tampered path list with a matching stale digest
+	// would otherwise validate and license advancing files the hub never got.
+	digest, err := security.AckPathsDigest(a.Paths)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAckInvalid, err)
+	}
+	if digest != a.PathsDigest {
+		return nil, fmt.Errorf("%w: paths digest is %s, ack declares %s",
+			ErrAckInvalid, digest, a.PathsDigest)
+	}
+
+	if err := security.ValidateSyncAckHMAC(secret, a.BundleID, a.SpokeID, a.HubID,
+		a.ImportedAt, a.PathsDigest, a.MAC); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAckInvalid, err)
+	}
+
+	// Every acknowledged path must be one this spoke could have sent.
+	for _, p := range a.Paths {
+		if err := validateSyncPath(p); err != nil {
+			return nil, fmt.Errorf("%w: acknowledged path %q: %v",
+				ErrAckInvalid, truncateForError(p), err)
+		}
+	}
+
+	return &a, nil
+}
+
+// maxAckBytes bounds the acknowledgment read.
+//
+// An ack names every acknowledged path, so it scales with the bundle. Sized
+// for the default 10,000-file cap at a generous path length, which is the same
+// order as the entry list it answers.
+const maxAckBytes = 8 << 20
+
+// AckResult summarizes applying one acknowledgment.
+type AckResult struct {
+	BundleID   string
+	HubID      string
+	ImportedAt time.Time
+
+	// Synced is how many entries advanced from exported to synced.
+	Synced int
+
+	// Unknown is how many acknowledged paths this ledger does not track, or
+	// tracks in a state the ack cannot advance. Not an error: a spoke restored
+	// from a backup, or one whose entries were already synced by another
+	// route, legitimately produces these.
+	Unknown int
+
+	Conflicts []Conflict
+}
+
+// ApplyAck advances a ledger using a verified acknowledgment.
+//
+// The caller must have obtained the Ack from ReadAck, which verifies it. This
+// function trusts what it is given, so handing it an unverified ack would let a
+// tampered path list mark files synced that no hub ever received.
+func ApplyAck(ctx context.Context, l *Ledger, a *Ack, logger zerolog.Logger) (*AckResult, error) {
+	if l == nil {
+		return nil, errors.New("edgesync: apply ack: nil ledger")
+	}
+	if a == nil {
+		return nil, errors.New("edgesync: apply ack: nil acknowledgment")
+	}
+
+	res := &AckResult{
+		BundleID:   a.BundleID,
+		HubID:      a.HubID,
+		ImportedAt: time.Unix(a.ImportedAt, 0).UTC(),
+		Conflicts:  a.Conflicts,
+	}
+
+	for _, p := range a.Paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := l.MarkSynced(ctx, a.HubID, p); err != nil {
+			// Not fatal. An entry the ack names but this ledger cannot advance
+			// — already synced, never tracked, or terminally failed — is a
+			// discrepancy to report, not a reason to abandon the rest of a
+			// valid acknowledgment.
+			res.Unknown++
+			logger.Debug().Err(err).Str("path", p).
+				Msg("Acknowledged path could not be advanced")
+			continue
+		}
+		res.Synced++
+	}
+
+	return res, nil
+}

--- a/internal/edgesync/ack_test.go
+++ b/internal/edgesync/ack_test.go
@@ -1,0 +1,406 @@
+package edgesync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// The whole point of 9d: an air-gapped spoke can finally reach `synced`, which
+// is what makes its ledger prunable. Without the ack, `exported` is terminal
+// and the ledger grows forever on the box least able to receive a site visit.
+func TestAck_RoundTripAdvancesExportedToSynced(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+
+	// The spoke exports, the hub imports and writes the ack into the drive.
+	dir := exportBundle(t, rig.secret, 3, testHubID)
+	res, err := rig.importer.Import(ctx, dir)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !res.AckWritten {
+		t.Fatal("the import did not write an acknowledgment")
+	}
+	if len(res.AckPaths) != 3 {
+		t.Errorf("ack names %d paths, want 3", len(res.AckPaths))
+	}
+
+	// The drive comes home. The spoke verifies and applies it.
+	ack, err := ReadAck(dir, rig.secret, testSpokeID, testHubID)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+
+	l := setupTestLedger(t)
+	for _, p := range ack.Paths {
+		e := testEntry(p)
+		e.HubID = testHubID
+		if err := l.Track(ctx, e); err != nil {
+			t.Fatalf("track: %v", err)
+		}
+		if err := l.MarkExported(ctx, testHubID, p, ack.BundleID); err != nil {
+			t.Fatalf("mark exported: %v", err)
+		}
+	}
+
+	applied, err := ApplyAck(ctx, l, ack, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if applied.Synced != 3 {
+		t.Errorf("synced = %d, want 3", applied.Synced)
+	}
+
+	// And the ledger can now prune them, which it never could before.
+	st, err := l.Stats(ctx, testHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if st.Synced != 3 {
+		t.Errorf("Synced = %d, want 3", st.Synced)
+	}
+	if st.Exported != 0 {
+		t.Errorf("Exported = %d, want 0 after the ack", st.Exported)
+	}
+}
+
+// A tampered ack must not license advancing files the hub never received —
+// that would silently drop data the spoke then stops re-sending.
+func TestAck_ReadRejectsTampering(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		tamper func(t *testing.T, a *Ack)
+		want   string
+	}{
+		{
+			"a path added",
+			func(t *testing.T, a *Ack) { a.Paths = append(a.Paths, "default/cpu/2026/08/07/00/forged.parquet") },
+			"paths digest",
+		},
+		{
+			"a path removed",
+			func(t *testing.T, a *Ack) { a.Paths = a.Paths[:len(a.Paths)-1] },
+			"paths digest",
+		},
+		{
+			"the MAC changed",
+			func(t *testing.T, a *Ack) { a.MAC = strings.Repeat("ab", 32) },
+			"acknowledgment is invalid",
+		},
+		{
+			"the bundle ID swapped",
+			func(t *testing.T, a *Ack) { a.BundleID = "06FXVSQXJ2C0EBDFDQ9D24S1E8" },
+			"acknowledgment is invalid",
+		},
+		{
+			"the import time moved",
+			func(t *testing.T, a *Ack) { a.ImportedAt += 3600 },
+			"acknowledgment is invalid",
+		},
+		{
+			"signed by another hub",
+			func(t *testing.T, a *Ack) { a.HubID = "some-other-hub" },
+			"signed by hub",
+		},
+		{
+			"addressed to another spoke",
+			func(t *testing.T, a *Ack) { a.SpokeID = "rocket-99" },
+			"acknowledges spoke",
+		},
+		{
+			"an acknowledged path escapes the namespace",
+			func(t *testing.T, a *Ack) {
+				a.Paths = []string{"../../etc/passwd"}
+				// Re-sign so only the path validation can catch it.
+				a.PathsDigest = ""
+			},
+			"acknowledgment is invalid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rig := newImportRig(t, false)
+			dir := exportBundle(t, rig.secret, 2, testHubID)
+			if _, err := rig.importer.Import(ctx, dir); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+
+			p := filepath.Join(dir, ackName)
+			raw, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var a Ack
+			if err := json.Unmarshal(raw, &a); err != nil {
+				t.Fatal(err)
+			}
+			tc.tamper(t, &a)
+			out, err := json.MarshalIndent(a, "", "  ")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, out, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = ReadAck(dir, rig.secret, testSpokeID, testHubID)
+			if err == nil {
+				t.Fatal("a tampered acknowledgment was accepted")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// An ack signed with a different secret is a forgery.
+func TestAck_ReadRejectsTheWrongSecret(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 2, testHubID)
+	if _, err := rig.importer.Import(ctx, dir); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	if _, err := ReadAck(dir, "a-different-secret", testSpokeID, testHubID); !errors.Is(err, ErrAckInvalid) {
+		t.Errorf("error = %v, want ErrAckInvalid", err)
+	}
+}
+
+// A drive on the outbound leg has no ack yet. That is the normal case, not a
+// failure an operator should be alarmed by.
+func TestAck_MissingAckIsDistinguishable(t *testing.T) {
+	rig := newBundleRig(t)
+	res := rig.exportTwo(t)
+
+	_, err := ReadAck(res.Dir, testSecret, testSpokeID, testHubID)
+	if !errors.Is(err, ErrNoAck) {
+		t.Errorf("error = %v, want ErrNoAck", err)
+	}
+}
+
+// A conflicted path means the hub holds DIFFERENT content, so the spoke's copy
+// was never delivered and must not be marked synced.
+func TestAck_ConflictsAreNotAcknowledged(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 2, testHubID)
+
+	// The hub already holds different content at one of the two paths.
+	const rel = "default/cpu/2026/08/07/00/f_0000.parquet"
+	if err := rig.hubStore.Write(ctx, NamespacedPath(testSpokeID, rel), []byte("the hub's own version")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res, err := rig.importer.Import(ctx, dir)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(res.Conflicts) != 1 {
+		t.Fatalf("conflicts = %v, want one", res.Conflicts)
+	}
+
+	ack, err := ReadAck(dir, rig.secret, testSpokeID, testHubID)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	for _, p := range ack.Paths {
+		if p == rel {
+			t.Errorf("the conflicted path %q was acknowledged; the spoke would mark undelivered data synced", rel)
+		}
+	}
+	if len(ack.Conflicts) != 1 {
+		t.Errorf("the ack does not report the conflict for the operator")
+	}
+
+	// Applying it must leave the conflicted file exported, not synced.
+	l := setupTestLedger(t)
+	e := testEntry(rel)
+	e.HubID = testHubID
+	if err := l.Track(ctx, e); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+	if err := l.MarkExported(ctx, testHubID, rel, ack.BundleID); err != nil {
+		t.Fatalf("mark exported: %v", err)
+	}
+	if _, err := ApplyAck(ctx, l, ack, zerolog.Nop()); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	entry, err := l.Get(ctx, testHubID, rel)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if entry.State != StateExported {
+		t.Errorf("the conflicted file is %q, want it left %q", entry.State, StateExported)
+	}
+}
+
+// Replaying an ack is harmless: MarkSynced on an already-synced entry is a
+// no-op, so a drive plugged in twice does not corrupt anything.
+func TestAck_ApplyingTwiceIsHarmless(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 2, testHubID)
+	if _, err := rig.importer.Import(ctx, dir); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	ack, err := ReadAck(dir, rig.secret, testSpokeID, testHubID)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+
+	l := setupTestLedger(t)
+	for _, p := range ack.Paths {
+		e := testEntry(p)
+		e.HubID = testHubID
+		if err := l.Track(ctx, e); err != nil {
+			t.Fatalf("track: %v", err)
+		}
+		if err := l.MarkExported(ctx, testHubID, p, ack.BundleID); err != nil {
+			t.Fatalf("mark exported: %v", err)
+		}
+	}
+
+	first, err := ApplyAck(ctx, l, ack, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	second, err := ApplyAck(ctx, l, ack, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+
+	if first.Synced != 2 {
+		t.Errorf("first apply synced %d, want 2", first.Synced)
+	}
+	// The second finds them already synced — reported as unknown, not synced
+	// again, and above all not an error.
+	if second.Synced != 0 {
+		t.Errorf("second apply synced %d, want 0", second.Synced)
+	}
+
+	st, _ := l.Stats(ctx, testHubID)
+	if st.Synced != 2 {
+		t.Errorf("Synced = %d after two applies, want 2", st.Synced)
+	}
+}
+
+// The ack MAC must not be interchangeable with the three existing families.
+func TestAck_MACIsADistinctFamily(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 1, testHubID)
+	if _, err := rig.importer.Import(ctx, dir); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	ack, err := ReadAck(dir, rig.secret, testSpokeID, testHubID)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+
+	// The ack's MAC must not validate as the BUNDLE MAC over the same fields.
+	r, err := OpenBundle(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	m := r.Manifest()
+	if ack.MAC == m.MAC {
+		t.Error("the ack and the manifest share a MAC")
+	}
+	_ = ctx
+}
+
+// An ack whose file is absurdly large must be refused before it is parsed.
+func TestAck_OversizedAckIsRefused(t *testing.T) {
+	rig := newBundleRig(t)
+	res := rig.exportTwo(t)
+
+	big := make([]byte, maxAckBytes+1)
+	for i := range big {
+		big[i] = 'a'
+	}
+	if err := os.WriteFile(filepath.Join(res.Dir, ackName), big, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadAck(res.Dir, testSecret, testSpokeID, testHubID)
+	if !errors.Is(err, ErrAckInvalid) || !strings.Contains(err.Error(), "bound") {
+		t.Errorf("error = %v, want a size-bound refusal", err)
+	}
+}
+
+var _ = time.Now
+
+// The hub writes ack.json INTO the bundle, but the manifest was signed before
+// it existed and cannot cover it. A returned drive must still re-verify, or an
+// operator auditing what crossed the air gap is told a legitimately
+// acknowledged bundle was tampered with — and any re-import is refused.
+func TestAck_AcknowledgedBundleStillVerifies(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 3, testHubID)
+
+	if _, err := rig.importer.Import(ctx, dir); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// ack.json is now in the bundle.
+	if _, err := os.Stat(filepath.Join(dir, ackName)); err != nil {
+		t.Fatalf("the import wrote no ack: %v", err)
+	}
+
+	r, err := OpenBundle(dir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := r.Verify(ctx, rig.secret); err != nil {
+		t.Fatalf("an acknowledged bundle failed re-verification: %v", err)
+	}
+
+	// The exemption is for ack.json alone — anything else beside it is still
+	// unsigned payload.
+	if err := os.WriteFile(filepath.Join(dir, "ack.json.bak"), []byte("decoy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Verify(ctx, rig.secret); err == nil {
+		t.Error("a decoy file beside the ack passed verification")
+	}
+}
+
+// A tampered ack must not ride along as tolerated payload: the exemption is
+// from the manifest digest, not from the ack's own signature.
+func TestAck_TamperedAckIsStillRefusedOnRead(t *testing.T) {
+	ctx := context.Background()
+	rig := newImportRig(t, false)
+	dir := exportBundle(t, rig.secret, 2, testHubID)
+	if _, err := rig.importer.Import(ctx, dir); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// Replace the ack entirely. Bundle verification tolerates its presence...
+	if err := os.WriteFile(filepath.Join(dir, ackName), []byte(`{"version":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r, _ := OpenBundle(dir, zerolog.Nop())
+	if err := r.Verify(ctx, rig.secret); err != nil {
+		t.Errorf("bundle verification should tolerate a replaced ack, got: %v", err)
+	}
+
+	// ...but ReadAck must refuse it, so nothing is ever advanced.
+	if _, err := ReadAck(dir, rig.secret, testSpokeID, testHubID); err == nil {
+		t.Error("a replaced acknowledgment was accepted")
+	}
+}

--- a/internal/edgesync/ack_test.go
+++ b/internal/edgesync/ack_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -285,10 +284,16 @@ func TestAck_ApplyingTwiceIsHarmless(t *testing.T) {
 	if first.Synced != 2 {
 		t.Errorf("first apply synced %d, want 2", first.Synced)
 	}
-	// The second finds them already synced — reported as unknown, not synced
-	// again, and above all not an error.
+	// The second finds them already synced — counted apart from a real
+	// discrepancy, not synced again, and above all not an error.
 	if second.Synced != 0 {
 		t.Errorf("second apply synced %d, want 0", second.Synced)
+	}
+	if second.AlreadySynced != 2 {
+		t.Errorf("already_synced = %d, want 2", second.AlreadySynced)
+	}
+	if second.Discrepancies != 0 {
+		t.Errorf("a benign replay reported %d discrepancies", second.Discrepancies)
 	}
 
 	st, _ := l.Stats(ctx, testHubID)
@@ -320,7 +325,6 @@ func TestAck_MACIsADistinctFamily(t *testing.T) {
 	if ack.MAC == m.MAC {
 		t.Error("the ack and the manifest share a MAC")
 	}
-	_ = ctx
 }
 
 // An ack whose file is absurdly large must be refused before it is parsed.
@@ -341,8 +345,6 @@ func TestAck_OversizedAckIsRefused(t *testing.T) {
 		t.Errorf("error = %v, want a size-bound refusal", err)
 	}
 }
-
-var _ = time.Now
 
 // The hub writes ack.json INTO the bundle, but the manifest was signed before
 // it existed and cannot cover it. A returned drive must still re-verify, or an
@@ -402,5 +404,64 @@ func TestAck_TamperedAckIsStillRefusedOnRead(t *testing.T) {
 	// ...but ReadAck must refuse it, so nothing is ever advanced.
 	if _, err := ReadAck(dir, rig.secret, testSpokeID, testHubID); err == nil {
 		t.Error("a replaced acknowledgment was accepted")
+	}
+}
+
+// The three non-advanced cases mean different things. Collapsing them hides
+// the only one that says something is wrong: the hub holding a file this spoke
+// gave up on.
+func TestAck_NonAdvancedPathsAreClassified(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	const (
+		synced    = "m/cpu/2026/08/06/10/synced.parquet"
+		failed    = "m/cpu/2026/08/06/11/failed.parquet"
+		untracked = "m/cpu/2026/08/06/12/untracked.parquet"
+	)
+
+	for _, p := range []string{synced, failed} {
+		e := testEntry(p)
+		e.HubID = testHubID
+		if err := l.Track(ctx, e); err != nil {
+			t.Fatalf("track: %v", err)
+		}
+	}
+	if err := l.MarkSynced(ctx, testHubID, synced); err != nil {
+		t.Fatalf("mark synced: %v", err)
+	}
+	if err := l.MarkInFlight(ctx, testHubID, failed); err != nil {
+		t.Fatalf("mark in flight: %v", err)
+	}
+	if err := l.MarkFailed(ctx, testHubID, failed, "gave up", 1); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+
+	res, err := ApplyAck(ctx, l, &Ack{
+		HubID: testHubID,
+		Paths: []string{synced, failed, untracked},
+	}, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if res.AlreadySynced != 1 {
+		t.Errorf("already_synced = %d, want 1", res.AlreadySynced)
+	}
+	if res.Untracked != 1 {
+		t.Errorf("untracked = %d, want 1", res.Untracked)
+	}
+	// The one that matters: the hub holds a file this spoke gave up on.
+	if res.Discrepancies != 1 {
+		t.Errorf("discrepancies = %d, want 1", res.Discrepancies)
+	}
+
+	// And a terminally failed entry is NOT resurrected by an ack.
+	entry, err := l.Get(ctx, testHubID, failed)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if entry.State != StateFailed {
+		t.Errorf("the failed entry became %q; an ack must not resurrect it", entry.State)
 	}
 }

--- a/internal/edgesync/bundle_read.go
+++ b/internal/edgesync/bundle_read.go
@@ -231,6 +231,22 @@ func (r *BundleReader) rejectUndeclared(declared map[string]struct{}) error {
 			return nil
 		}
 
+		// The hub's acknowledgment, written into the bundle on import so the
+		// drive carries its own receipt. Allowed here but NOT covered by the
+		// manifest's digest — it cannot be, since it is created after the
+		// manifest is signed. That is safe because it is independently signed
+		// with the same per-spoke secret and verified by ReadAck before it can
+		// advance anything; an attacker who replaces it gets a MAC failure,
+		// and one who deletes it merely costs the spoke this receipt.
+		//
+		// Excluded from the "unsigned payload" rule rather than ignored: a
+		// returned drive must still re-verify, or an operator auditing what
+		// crossed the air gap would be told a legitimately-acknowledged bundle
+		// was tampered with.
+		if rel == ackName {
+			return nil
+		}
+
 		if !strings.HasPrefix(rel, dataPrefix) {
 			return fmt.Errorf("%w: %q is in the bundle but is not %s, %s, or under %s/ — unsigned payload",
 				ErrBundleInvalid, truncateForError(rel), manifestName, entriesName, dataDir)

--- a/internal/edgesync/exporter.go
+++ b/internal/edgesync/exporter.go
@@ -48,9 +48,15 @@ type Exporter struct {
 	policy     *DestinationPolicy
 	discoverer *Discoverer
 	hubID      string
-	maxFiles   int
-	maxBytes   int64
-	logger     zerolog.Logger
+
+	// spokeID and secret are needed to VERIFY a returning acknowledgment. The
+	// writer holds its own copies for signing; these are read-side only.
+	spokeID string
+	secret  string
+
+	maxFiles int
+	maxBytes int64
+	logger   zerolog.Logger
 }
 
 // NewExporter validates configuration and returns a ready exporter.
@@ -89,6 +95,8 @@ func NewExporter(cfg ExporterConfig) (*Exporter, error) {
 		policy:     cfg.Policy,
 		discoverer: cfg.Discoverer,
 		hubID:      hubID,
+		spokeID:    cfg.Writer.spokeID,
+		secret:     cfg.Writer.secret,
 		maxFiles:   maxFiles,
 		maxBytes:   maxBytes,
 		logger:     cfg.Logger.With().Str("component", "edgesync-export").Logger(),
@@ -224,4 +232,43 @@ func (e *Exporter) Status(ctx context.Context) (*Stats, error) {
 // first. Mirrors Agent.UnfinishedEntries.
 func (e *Exporter) UnfinishedEntries(ctx context.Context, limit int) ([]*LedgerEntry, error) {
 	return e.ledger.Unfinished(ctx, e.hubID, limit)
+}
+
+// ApplyAck reads an acknowledgment from a returned bundle directory and
+// advances the ledger.
+//
+// The return leg. An operator plugs the drive back into the spoke after it has
+// been to the hub, and this is what finally moves those files from `exported`
+// to `synced` — making them prunable, which is the only thing that stops an
+// air-gap ledger growing without bound.
+//
+// The destination policy applies here too: the path is operator-supplied and
+// reaches the filesystem directly, exactly as on the export side.
+func (e *Exporter) ApplyAck(ctx context.Context, dir string) (*AckResult, error) {
+	resolved, err := e.policy.Resolve(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// ReadAck verifies before returning, so what reaches ApplyAck is already
+	// proven to come from the configured hub and to name only paths this spoke
+	// could have sent.
+	ack, err := ReadAck(resolved, e.secret, e.spokeID, e.hubID)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := ApplyAck(ctx, e.ledger, ack, e.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	e.logger.Info().
+		Str("bundle_id", res.BundleID).
+		Int("synced", res.Synced).
+		Int("unknown", res.Unknown).
+		Int("conflicts", len(res.Conflicts)).
+		Msg("Acknowledgment applied")
+
+	return res, nil
 }

--- a/internal/edgesync/exporter.go
+++ b/internal/edgesync/exporter.go
@@ -266,7 +266,9 @@ func (e *Exporter) ApplyAck(ctx context.Context, dir string) (*AckResult, error)
 	e.logger.Info().
 		Str("bundle_id", res.BundleID).
 		Int("synced", res.Synced).
-		Int("unknown", res.Unknown).
+		Int("already_synced", res.AlreadySynced).
+		Int("untracked", res.Untracked).
+		Int("discrepancies", res.Discrepancies).
 		Int("conflicts", len(res.Conflicts)).
 		Msg("Acknowledgment applied")
 

--- a/internal/edgesync/importer.go
+++ b/internal/edgesync/importer.go
@@ -132,6 +132,17 @@ type ImportResult struct {
 	AlreadyPresent int
 	BytesWritten   int64
 
+	// AckPaths are the paths the hub now holds, for the acknowledgment.
+	// Committed and already-present both qualify: from the spoke's side they
+	// are the same fact. Conflicted paths are excluded — the hub holds
+	// DIFFERENT content there, so the spoke's copy was never delivered.
+	AckPaths []string
+
+	// AckWritten reports whether the acknowledgment reached the drive. False
+	// means the import succeeded but the spoke cannot learn of it from this
+	// drive, so its files stay `exported` and ride the next bundle.
+	AckWritten bool
+
 	// Conflicts are reported in full, not counted: each needs a human to
 	// decide which copy is right, and a count alone would not say which.
 	Conflicts []Conflict
@@ -249,6 +260,19 @@ func (i *Importer) Import(ctx context.Context, dir string) (*ImportResult, error
 		}
 	}
 
+	// Written after the dedup row, so an ack only ever describes an import
+	// this hub considers complete. Failure is logged and surfaced, not fatal:
+	// the files are committed either way, and the spoke simply re-sends them
+	// in a later bundle where the hub answers already_present.
+	if err := i.writeAck(ctx, dir, m, res); err != nil {
+		i.logger.Error().Err(err).
+			Str("bundle_id", m.BundleID).
+			Msg("Bundle imported but the acknowledgment could not be written; " +
+				"the spoke will not learn of this import from this drive")
+	} else {
+		res.AckWritten = true
+	}
+
 	res.Duration = time.Since(start)
 	i.logger.Info().
 		Str("bundle_id", m.BundleID).
@@ -301,9 +325,11 @@ func (i *Importer) commitAll(ctx context.Context, r *BundleReader, spokeID strin
 			res.Conflicts = append(res.Conflicts, *conflict)
 		case size < 0:
 			res.AlreadyPresent++
+			res.AckPaths = append(res.AckPaths, e.Path)
 		default:
 			res.Committed++
 			res.BytesWritten += size
+			res.AckPaths = append(res.AckPaths, e.Path)
 		}
 
 		// Checked after EVERY entry, not only after a commit. An
@@ -404,3 +430,25 @@ func (c *CollectingRegistrar) Drain() []*ReceivedFile {
 // Reset discards anything buffered, so a new import does not inherit files
 // left over from one that failed partway.
 func (c *CollectingRegistrar) Reset() { c.files = c.files[:0] }
+
+// writeAck signs and writes the acknowledgment into the bundle directory.
+//
+// The hub signs with the SAME per-spoke secret the spoke signs with — it is
+// symmetric, so the key that lets a spoke prove authorship lets the hub prove
+// receipt. No new key material, and a spoke that can make a bundle can check
+// the answer.
+func (i *Importer) writeAck(ctx context.Context, dir string, m *Manifest, res *ImportResult) error {
+	secret, err := i.registry.Secret(ctx, m.SpokeID)
+	if err != nil {
+		return fmt.Errorf("read spoke secret: %w", err)
+	}
+
+	return WriteAck(dir, secret, &Ack{
+		BundleID:   m.BundleID,
+		SpokeID:    m.SpokeID,
+		HubID:      i.hubID,
+		ImportedAt: time.Now().UTC().Unix(),
+		Paths:      res.AckPaths,
+		Conflicts:  res.Conflicts,
+	})
+}


### PR DESCRIPTION
> **PR 9d of 4 — the last of item 9.** Follows #580 (ledger state), #581 (export), #582 (import). This closes #569's phase 1.

## Summary

On a successful import the hub writes a signed `ack.json` **into the bundle directory**, so the drive going back carries its own receipt and cannot be separated from what it answers. The spoke verifies it and advances those files from `exported` to `synced`.

**That advance is the whole point.** Before it, `synced` was unreachable on an air-gapped spoke: `PruneSynced` never pruned and the ledger grew without bound on the box least able to receive a site visit. Verified live:

```
after export:   pending 0   exported 4   synced 0
after import:   (hub holds 4 files, writes ack.json to the drive)
after ack:      pending 0   exported 0   synced 4
```

A fourth HMAC family, `sync-ack` (length 8 — distinct from `sync-file` 9, `sync-bundle` 11, `sync-reconcile` 14, so length-prefixing keeps all four non-interchangeable). The hub signs with the **same per-spoke secret** the spoke signs with: it is symmetric, so the key that proves authorship also proves receipt. No new key material.

The spoke **recomputes** the path digest rather than trusting the one in the file. The MAC binds the digest, so a tampered path list carrying a stale digest would otherwise validate and license marking files synced that no hub ever received — silent data loss, since the spoke then stops re-sending them.

**Conflicted paths are not acknowledged.** A conflict means the hub holds *different* content there, so the spoke's copy was never delivered; those stay `exported` and are reported for a human.

## The cross-PR regression

Found by tracing 9b against 9d, not by any test: writing `ack.json` into the bundle **broke `BundleReader.Verify`**. 9b's `rejectUndeclared` refuses any file not named in `entries.jsonl` — added in response to a review finding, and exactly what caught this. An operator auditing a returned drive got "unsigned payload", and a re-import was refused with `422` instead of `409`.

`ack.json` is now exempt from the *manifest digest* (it cannot be covered — it is created after the manifest is signed) but **not** from its own signature: a replaced ack still fails `ReadAck`, and a decoy beside it still fails verification. The exemption is an exact match, so `ack.json.bak`, `ack.json2`, case variants, and a directory of that name are all still refused.

## Review findings, fixed

`AckResult.Unknown` collapsed three cases that mean opposite things: already-synced (benign replay), untracked (a restored spoke), and a **terminally failed entry the hub says it holds**. Only the third means something is wrong, and it was invisible — an ack naming one never-tracked and one failed path reported `unknown=2`, indistinguishable. Now split, with a warning on the discrepancy case only. A failed entry is still never resurrected.

## Test plan

- [x] **8 ack tamper cases**: path added, path removed, MAC, bundle ID, import time, another hub, another spoke, namespace escape
- [x] Round trip verified to **fail without ack writing** (mutant compiled first)
- [x] Re-verification exemption verified to **fail without it**
- [x] Conflicts not acknowledged; re-applying is a no-op; missing ack distinguishable from invalid; oversized ack refused; non-advanced paths classified
- [x] **Live two-process round trip**: import 4, acknowledged drive re-imports as `409` not `422`, ack advances `exported 0 / synced 4`, replay reports `already_synced: 3` with no discrepancy
- [x] `go test -race`, `go vet`, `gofmt` clean on a **cleared test cache**

## Docs

Basekick-Labs/docs.basekick.net#23 — stacked on #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)