### PR TITLE
docs(release-notes): describe both edge-sync transports in the intro

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -66,9 +66,16 @@ Out-of-range values fall back to the default with a startup warning rather than 
 
 Arc runs at the edge today — a standalone binary with local storage in a vehicle, a factory cell, or a forward deployment — with no first-class way to ship that data to a central Arc. Backup is a full DR snapshot rather than incremental sync, and Parquet import re-ingests rows through the write path, which breaks the end-to-end checksum and double-counts on retry.
 
-**Edge sync** ([#569](https://github.com/Basekick-Labs/arc/issues/569)) addresses this by shipping immutable Parquet *files* from a spoke (edge) to a hub (central Arc): the spoke initiates, the hub verifies each file's SHA256 before committing it, and re-delivery of an already-received file is a no-op. Connectivity is treated as the exception rather than the norm — discovery is a single batched round-trip regardless of backlog size, and transfers resume from a byte offset when a link drops mid-file.
+**Edge sync** ([#569](https://github.com/Basekick-Labs/arc/issues/569)) addresses this by shipping immutable Parquet *files* from a spoke (edge) to a hub (central Arc). The hub verifies each file's SHA256 before committing it, and re-delivery of an already-received file is a no-op.
 
-The hub receive endpoint is the first piece an operator can turn on:
+It ships over **two transports**, because "the edge" is not one thing:
+
+- **Network** — the spoke initiates, so an edge behind NAT with no inbound reachability still works. Connectivity is the exception rather than the norm: discovery is a single batched round-trip regardless of backlog size, and transfers resume from a byte offset when a link drops mid-file.
+- **Air gap** — for a spoke with no network path at all (a submarine, a classified facility, a vehicle whose data comes off on a drive), the spoke writes a signed bundle to removable media, the hub imports it, and a signed receipt travels back on the same drive.
+
+Both are **manual** in this release: an operator triggers each step. Everything below is OSS; the scheduled agent that automates it is Enterprise and lands later.
+
+Start with the hub receive endpoint:
 
 ```toml
 [edge_sync]
@@ -116,8 +123,6 @@ Three admin endpoints drive it:
 A pass recovers transfers interrupted by a crash, discovers new files, reconciles the backlog, and streams what the hub lacks — **newest first**, so a contact window that closes mid-backlog has already delivered the freshest telemetry. It **pages until the backlog drains**, so one pass on a spoke returning from a long outage moves everything, not just the first batch. Conflicts are reported in full rather than counted and are not retried: the same path holding different content means a spoke-ID collision or corruption, and re-sending would either be refused or destroy evidence.
 
 Files are hashed once at discovery, and the ledger survives restarts, so a spoke re-run after a crash neither re-hashes nor re-sends what already landed. Nothing is deleted from the spoke — sync is a copy, and local retention stays in the operator's hands.
-
-This is the **manual** form, and it is OSS. The automatic scheduled agent will be an Enterprise feature.
 
 ### Air-gap bundles
 


### PR DESCRIPTION
## Summary

The edge-sync section of the 26.09.1 notes was written when only the hub receive endpoint existed, and the intro never caught up with what shipped across #570–#576 and #580–#583.

**Two drifts fixed:**

- **"the spoke initiates"** described only the network path. The air-gap transport initiates nothing over a network — an operator carries a drive. The intro now names both transports and says what each is for, since "the edge" is not one thing and a reader choosing between them needs that up front.
- **"The hub receive endpoint is the first piece an operator can turn on"** was true when the rest was unshipped. Everything ships now, so it reads as "start with the hub receive endpoint".

Also removes a duplicated "this is the manual form, and it is OSS" sentence — the new intro states it once for both transports.

## Verified against the code, not by reading

- Every documented endpoint (`/api/v1/spoke-sync/{run,status,ledger,export,ack}`, `/api/v1/bundle-import`, `/api/v1/sync/{file,reconcile}`, `/api/v1/sync-spokes`) matches a registered route.
- Every `edge_sync.*` key mentioned has a `v.SetDefault` in `setDefaults`.
- Documented default **values** match the code: `false`, empty list, `10000`, and `68719476736` = `int64(64)<<30`.
- No stale "not yet" / "lands next" language remains except the Enterprise scheduled agent, which is genuinely future work.

The four edge-sync subsections (spoke side, air-gap bundles, import, acknowledgment) were already present and accurate — only the intro and one duplicated sentence needed changing.

## Related

Basekick-Labs/docs.basekick.net#24 got the matching audit: all endpoints and keys check out, and `Current limitations` is renamed **`Network-transport limitations`** with a pointer to the air-gap block, since it sits mid-page before the air-gap sections and all five of its entries describe the network path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)