### PR TITLE
fix(query): preserve whitespace before bare JOIN

### DIFF
--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -65,10 +65,10 @@ var (
 	patternSimpleTable = regexp.MustCompile(`(?i)\bFROM\s+([a-zA-Z_][a-zA-Z0-9_]*)\b`)
 	// Pattern for database.table in JOIN clauses (e.g., JOIN mydb.mytable)
 	// Includes LATERAL JOIN support: "LATERAL JOIN", "JOIN LATERAL", "CROSS JOIN LATERAL"
-	patternJoinDBTable = regexp.MustCompile(`(?i)\b(?:(?:LEFT|RIGHT|INNER|OUTER|CROSS|NATURAL)?\s*)?(?:LATERAL\s+)?JOIN\s+(?:LATERAL\s+)?([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)\b`)
+	patternJoinDBTable = regexp.MustCompile(`(?i)\b(?:(?:LEFT|RIGHT|INNER|OUTER|CROSS|NATURAL)\s+)?(?:LATERAL\s+)?JOIN\s+(?:LATERAL\s+)?([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)\b`)
 	// Pattern for simple table in JOIN clauses (JOIN table_name)
 	// Includes LATERAL JOIN support: "LATERAL JOIN", "JOIN LATERAL", "CROSS JOIN LATERAL"
-	patternJoinSimpleTable = regexp.MustCompile(`(?i)\b(?:(?:LEFT|RIGHT|INNER|OUTER|CROSS|NATURAL)?\s*)?(?:LATERAL\s+)?JOIN\s+(?:LATERAL\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\b`)
+	patternJoinSimpleTable = regexp.MustCompile(`(?i)\b(?:(?:LEFT|RIGHT|INNER|OUTER|CROSS|NATURAL)\s+)?(?:LATERAL\s+)?JOIN\s+(?:LATERAL\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\b`)
 	// Pattern to extract CTE names from WITH clauses
 	// Matches: WITH name AS, WITH RECURSIVE name AS, and comma-separated CTEs
 	patternCTENames = regexp.MustCompile(`(?i)\bWITH\s+(?:RECURSIVE\s+)?(\w+)\s+AS\s*\(|,\s*(\w+)\s+AS\s*\(`)

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -477,6 +477,22 @@ func TestJoinClausePatterns(t *testing.T) {
 	}
 }
 
+func TestConvertSQLToStoragePaths_BareJoinPreservesAliasSeparator(t *testing.T) {
+	h := &QueryHandler{
+		storage: &mockLocalBackend{basePath: "./data"},
+		pruner:  pruning.NewPartitionPruner(zerolog.Nop()),
+		logger:  zerolog.Nop(),
+	}
+
+	result := h.convertSQLToStoragePaths("SELECT * FROM a JOIN mydb.cpu ON 1=1")
+	if strings.Contains(result, "parquet'JOIN") {
+		t.Errorf("bare JOIN consumed the separator after the preceding table. Got: %s", result)
+	}
+	if !strings.Contains(result, " JOIN read_parquet('./data/mydb/cpu/**/*.parquet'") {
+		t.Errorf("bare JOIN was not rewritten correctly. Got: %s", result)
+	}
+}
+
 func TestValidateIdentifier(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### Summary

  Fixes SQL rewriting for bare JOIN clauses following a table or alias.

  The join-matching regex could consume the whitespace before a bare JOIN, producing invalid SQL such as tJOIN read_parquet(...). INNER JOIN was unaffected because
  its preceding whitespace was not part of the match.

### Changes

  - Require a join modifier before consuming modifier-adjacent whitespace.
  - Add a regression test covering a bare JOIN transformation.