### PR TITLE
feat(query): make DuckDB preserve_insertion_order configurable, default false

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -62,6 +62,23 @@ This is a **file-count** bound, not a byte bound — compacted output size track
 
 Out-of-range values fall back to the default with a startup warning rather than failing. **`1` is not usable** and is treated as out of range: compaction's adaptive retry rejects any batch below two files, so a batch size of one would fail every batch of every partition.
 
+## Insertion-order preservation is now configurable, and off by default
+
+Arc previously forced DuckDB's `preserve_insertion_order=true`, which makes queries **without** an `ORDER BY` return rows in file/insertion order — at the cost of order-preserving buffering in the engine. That setting is now configurable and defaults to **false**:
+
+```toml
+[database]
+preserve_insertion_order = false   # default; set true for pre-26.09.1 behavior
+```
+
+Env var: `ARC_DATABASE_PRESERVE_INSERTION_ORDER`.
+
+The default follows SQL semantics (row order without `ORDER BY` is unspecified) and DuckDB's guidance that disabling order preservation can reduce memory usage and unlock additional parallelism on large result materializations. On ClickBench-style aggregation suites — where nearly every query carries an explicit `ORDER BY` — measured throughput is unchanged; the setting matters for large un-ordered scans and exports.
+
+**Behavior change:** queries without an explicit `ORDER BY` may now return rows in any order, as SQL semantics allow. Queries with an `ORDER BY` are completely unaffected. If a dashboard or integration relies on implicit insertion order (e.g. `SELECT * FROM cpu LIMIT 10` expecting oldest-first), either add an explicit `ORDER BY time` (recommended) or set `preserve_insertion_order = true`.
+
+Internal write paths that rebuild parquet files keep the same ordering behavior as before this change: compaction with configured `sort_keys` sorts explicitly, while sort-keys-less compaction and DELETE file rewrites force order preservation on their own database session (session-scoped, so concurrent queries are unaffected).
+
 ## New: edge-to-cloud sync (manual)
 
 Arc runs at the edge today — a standalone binary with local storage in a vehicle, a factory cell, or a forward deployment — with no first-class way to ship that data to a central Arc. Backup is a full DR snapshot rather than incremental sync, and Parquet import re-ingests rows through the write path, which breaks the end-to-end checksum and double-counts on retry.

--- a/arc.toml
+++ b/arc.toml
@@ -31,6 +31,12 @@ format = "console"  # json or console
 # thread_count = 14       # Default: CPU cores
 enable_wal = true
 
+# Allow DuckDB to reorder results of queries WITHOUT an ORDER BY (queries
+# with ORDER BY are unaffected); can reduce memory usage on large un-ordered
+# scans and exports. Set true to restore pre-26.09.1 behavior where
+# un-ordered SELECTs return rows in file/insertion order.
+# preserve_insertion_order = false
+
 # -----------------------------------------------------------------------------
 # Storage
 # -----------------------------------------------------------------------------

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -235,11 +235,12 @@ func main() {
 		Int("machine_cpus", runtime.NumCPU()).
 		Msg("Initializing DuckDB with database config")
 	dbConfig := &database.Config{
-		MaxConnections: cfg.Database.MaxConnections,
-		MemoryLimit:    cfg.Database.MemoryLimit,
-		ThreadCount:    cfg.Database.ThreadCount,
-		EnableWAL:      cfg.Database.EnableWAL,
-		TempDirectory:  cfg.Database.TempDirectory,
+		MaxConnections:         cfg.Database.MaxConnections,
+		MemoryLimit:            cfg.Database.MemoryLimit,
+		ThreadCount:            cfg.Database.ThreadCount,
+		EnableWAL:              cfg.Database.EnableWAL,
+		TempDirectory:          cfg.Database.TempDirectory,
+		PreserveInsertionOrder: cfg.Database.PreserveInsertionOrder,
 		// S3 configuration for httpfs extension (enables DuckDB to query S3 directly)
 		S3Region:    cfg.Storage.S3Region,
 		S3AccessKey: cfg.Storage.S3AccessKey,

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -743,7 +743,10 @@ func (h *DeleteHandler) rewriteLocalFile(ctx context.Context, filePath, _, where
 
 	tempFile := filepath.Join(tempDir, filepath.Base(filePath)+".new")
 
-	// Write filtered data to temp file using DuckDB COPY
+	// Write filtered data to temp file using DuckDB COPY. Run with
+	// preserve_insertion_order forced on so the rewritten file keeps the
+	// source's row order (typically time-sorted) even when the
+	// database-wide setting is false.
 	copyQuery := fmt.Sprintf(`
 		COPY (
 			SELECT * FROM read_parquet('%s') WHERE NOT (%s)
@@ -754,7 +757,7 @@ func (h *DeleteHandler) rewriteLocalFile(ctx context.Context, filePath, _, where
 			ROW_GROUP_SIZE %d
 		)`, escapeDuckDBPath(filePath), whereClause, escapeDuckDBPath(tempFile), parquetRowGroupSize)
 
-	if _, err := db.ExecContext(ctx, copyQuery); err != nil {
+	if err := database.ExecPreservingInsertionOrder(ctx, db, copyQuery); err != nil {
 		os.Remove(tempFile)
 		return 0, fmt.Errorf("failed to write filtered data: %w", err)
 	}
@@ -816,7 +819,10 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 	tempFile.Close()
 	defer os.Remove(tempPath)
 
-	// DuckDB reads from S3 and writes to local temp file
+	// DuckDB reads from S3 and writes to local temp file. Run with
+	// preserve_insertion_order forced on so the rewritten file keeps the
+	// source's row order (typically time-sorted) even when the
+	// database-wide setting is false.
 	copyQuery := fmt.Sprintf(`
 		COPY (
 			SELECT * FROM read_parquet('%s') WHERE NOT (%s)
@@ -827,7 +833,7 @@ func (h *DeleteHandler) rewriteS3File(ctx context.Context, s3Path, relativePath,
 			ROW_GROUP_SIZE %d
 		)`, escapeDuckDBPath(s3Path), whereClause, escapeDuckDBPath(tempPath), parquetRowGroupSize)
 
-	if _, err := db.ExecContext(ctx, copyQuery); err != nil {
+	if err := database.ExecPreservingInsertionOrder(ctx, db, copyQuery); err != nil {
 		return 0, nil, fmt.Errorf("failed to write filtered data: %w", err)
 	}
 

--- a/internal/compaction/job.go
+++ b/internal/compaction/job.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/basekick-labs/arc/internal/database"
 	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/rs/zerolog"
@@ -729,6 +730,26 @@ func (j *Job) compactFiles(ctx context.Context, files []downloadedFile, tempDir 
 		}
 		conn.Close()
 	}()
+	// Without configured sort keys the compaction SQL has no ORDER BY, so the
+	// merged output's row order comes from the scan itself. Force
+	// preserve_insertion_order on this pinned session so the output keeps
+	// per-source-file row order (typically time-sorted) even when the
+	// database-wide setting is false. Registered after the Close defer above,
+	// so the restore runs before the connection returns to the pool.
+	//
+	// In the shipping configuration this is a no-op: compaction runs in a
+	// subprocess whose raw DuckDB never goes through configureDatabase, so
+	// its preserve_insertion_order sits at DuckDB's default (true). The
+	// force is what keeps ordering correct if compaction is ever moved
+	// in-process onto the configured database (a refactor duckdb.go
+	// explicitly anticipates).
+	if orderByClause == "" {
+		restore, err := database.ForcePreserveInsertionOrder(ctx, conn)
+		if err != nil {
+			return "", fmt.Errorf("failed to force preserve_insertion_order for compaction: %w", err)
+		}
+		defer restore()
+	}
 	for _, stmt := range stmts {
 		if _, err := conn.ExecContext(ctx, stmt); err != nil {
 			return "", fmt.Errorf("failed to execute compaction query: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,14 @@ type DatabaseConfig struct {
 	// binary. Empty disables the loader. Arc Enterprise only — gated by
 	// licenseClient.CanUseArcx() before this value reaches the DB layer.
 	ArcxExtensionPath string
+	// PreserveInsertionOrder controls DuckDB's preserve_insertion_order
+	// setting. false (the default) lets DuckDB reorder results of queries
+	// without an ORDER BY, which can reduce memory usage and unlock
+	// parallelism on large un-ordered materializations. Queries with an
+	// explicit ORDER BY are unaffected either way. Set true to restore
+	// pre-26.09.1 behavior where un-ordered SELECTs return rows in
+	// file/insertion order.
+	PreserveInsertionOrder bool
 }
 
 type StorageConfig struct {
@@ -697,12 +705,13 @@ func Load() (*Config, error) {
 			TLSKeyFile:      v.GetString("server.tls_key_file"),
 		},
 		Database: DatabaseConfig{
-			MaxConnections:    v.GetInt("database.max_connections"),
-			MemoryLimit:       v.GetString("database.memory_limit"),
-			ThreadCount:       v.GetInt("database.thread_count"),
-			EnableWAL:         v.GetBool("database.enable_wal"),
-			TempDirectory:     v.GetString("database.temp_directory"),
-			ArcxExtensionPath: v.GetString("database.arcx_extension_path"),
+			MaxConnections:         v.GetInt("database.max_connections"),
+			MemoryLimit:            v.GetString("database.memory_limit"),
+			ThreadCount:            v.GetInt("database.thread_count"),
+			EnableWAL:              v.GetBool("database.enable_wal"),
+			TempDirectory:          v.GetString("database.temp_directory"),
+			ArcxExtensionPath:      v.GetString("database.arcx_extension_path"),
+			PreserveInsertionOrder: v.GetBool("database.preserve_insertion_order"),
 		},
 		Storage: StorageConfig{
 			// Normalize once at load so the backend switch, the DuckDB
@@ -1325,8 +1334,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("database.memory_limit", getDefaultMemoryLimit())
 	v.SetDefault("database.thread_count", getDefaultThreadCount())
 	v.SetDefault("database.enable_wal", true)
-	v.SetDefault("database.temp_directory", "./.tmp") // DuckDB query spill files (overflow, sort, join). Orphans swept at startup.
-	v.SetDefault("database.arcx_extension_path", "")  // Enterprise-only; gated by licenseClient.CanUseArcx()
+	v.SetDefault("database.temp_directory", "./.tmp")        // DuckDB query spill files (overflow, sort, join). Orphans swept at startup.
+	v.SetDefault("database.arcx_extension_path", "")         // Enterprise-only; gated by licenseClient.CanUseArcx()
+	v.SetDefault("database.preserve_insertion_order", false) // false = SQL-standard unordered results; ORDER BY queries unaffected
 
 	// Storage defaults
 	v.SetDefault("storage.backend", "local")

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -203,6 +203,11 @@ type Config struct {
 	MemoryLimit    string
 	ThreadCount    int
 	EnableWAL      bool
+	// PreserveInsertionOrder maps to DuckDB's preserve_insertion_order.
+	// false allows DuckDB to reorder results of queries without an ORDER BY,
+	// enabling faster parallel scans/aggregations. Explicit ORDER BY clauses
+	// (including compaction's ORDER BY "time") are respected either way.
+	PreserveInsertionOrder bool
 	// TempDirectory is where DuckDB writes query spill files (HASH_GROUP_BY
 	// overflow, large sorts, joins). Empty leaves DuckDB's default
 	// (CWD-relative). Orphans from a crashed previous run are swept by
@@ -421,6 +426,70 @@ func loadArcxExtension(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 	return nil
 }
 
+// ForcePreserveInsertionOrder forces preserve_insertion_order=true for the
+// session of the pinned connection, so statements that rebuild parquet files
+// (DELETE rewrites, sort-keys-less compaction) keep the source's row order
+// even when the database-wide setting is false.
+//
+// Scope subtleties, verified against the pinned duckdb-go driver:
+//   - It MUST be `SET SESSION`: for this option a plain `SET` is
+//     GLOBAL-scoped and would flip the whole instance (slowing every
+//     concurrent query and racing two concurrent rewrites into unordered
+//     output).
+//   - The restore MUST be `RESET SESSION`, which clears the session override
+//     so the connection tracks the configured global again. A bare `RESET`
+//     would restore DuckDB's built-in default (true), stomping Arc's
+//     configured global; a `SET SESSION ...=false` would pin a session value
+//     that shadows any later change to the global.
+//   - The driver performs no session reset when a connection returns to the
+//     pool, so the caller MUST invoke the returned restore function (defer
+//     it) before releasing the connection. The restore uses
+//     context.WithoutCancel so a caller timeout that kills the statement
+//     cannot also skip the restore and leak the override into the pool.
+//
+// When the session value read here is already true the returned restore is a
+// no-op.
+func ForcePreserveInsertionOrder(ctx context.Context, conn *sql.Conn) (restore func(), err error) {
+	var prev bool
+	if err := conn.QueryRowContext(ctx, "SELECT current_setting('preserve_insertion_order')").Scan(&prev); err != nil {
+		return nil, fmt.Errorf("read preserve_insertion_order: %w", err)
+	}
+	if prev {
+		return func() {}, nil
+	}
+	if _, err := conn.ExecContext(ctx, "SET SESSION preserve_insertion_order=true"); err != nil {
+		return nil, fmt.Errorf("set preserve_insertion_order: %w", err)
+	}
+	return func() {
+		_, _ = conn.ExecContext(context.WithoutCancel(ctx), "RESET SESSION preserve_insertion_order")
+	}, nil
+}
+
+// ExecPreservingInsertionOrder runs a statement (typically a COPY that
+// rewrites a parquet file in place) on a dedicated connection with
+// preserve_insertion_order forced on for that session. See
+// ForcePreserveInsertionOrder for the ordering rationale. Callers are
+// infrequent maintenance paths (DELETE file rewrites), so the extra
+// roundtrips are irrelevant.
+func ExecPreservingInsertionOrder(ctx context.Context, db *sql.DB, query string) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection: %w", err)
+	}
+	defer conn.Close()
+
+	restore, err := ForcePreserveInsertionOrder(ctx, conn)
+	if err != nil {
+		return err
+	}
+	defer restore()
+
+	if _, err := conn.ExecContext(ctx, query); err != nil {
+		return err
+	}
+	return nil
+}
+
 // configureDatabase sets DuckDB configuration after connection
 func configureDatabase(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 	// Set memory limit to prevent unbounded memory growth
@@ -460,8 +529,13 @@ func configureDatabase(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 		logger.Warn().Err(err).Msg("Failed to enable parquet metadata cache (continuing without it)")
 	}
 
-	// Preserve insertion order for deterministic results (important for LIMIT queries)
-	if _, err := db.Exec("SET GLOBAL preserve_insertion_order=true"); err != nil {
+	// preserve_insertion_order=false (the default) lets DuckDB reorder
+	// results of queries without an ORDER BY, which per DuckDB guidance can
+	// reduce memory usage and unlock parallelism on large un-ordered
+	// materializations. Explicit ORDER BY is respected either way. Operators
+	// can set database.preserve_insertion_order=true to restore
+	// insertion-ordered results for un-ordered SELECTs.
+	if _, err := db.Exec(fmt.Sprintf("SET GLOBAL preserve_insertion_order=%t", cfg.PreserveInsertionOrder)); err != nil {
 		logger.Warn().Err(err).Msg("Failed to set preserve_insertion_order")
 	}
 

--- a/internal/database/preserve_order_test.go
+++ b/internal/database/preserve_order_test.go
@@ -1,0 +1,135 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// readPIO returns preserve_insertion_order as seen by the given connection.
+func readPIO(t *testing.T, ctx context.Context, conn *sql.Conn) bool {
+	t.Helper()
+	var v bool
+	if err := conn.QueryRowContext(ctx, "SELECT current_setting('preserve_insertion_order')").Scan(&v); err != nil {
+		t.Fatalf("read preserve_insertion_order: %v", err)
+	}
+	return v
+}
+
+// TestForcePreserveInsertionOrderSessionScoped verifies the override is
+// session-scoped: while connection A holds the forced override, connection B
+// on the same database instance must still see the configured global (false).
+// A global-scoped SET would leak to B — flipping the instance-wide setting
+// during DELETE rewrites and racing concurrent rewrites into unordered
+// output — so this is the discriminating assertion for the mechanism.
+func TestForcePreserveInsertionOrderSessionScoped(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, "SET GLOBAL preserve_insertion_order=false"); err != nil {
+		t.Fatalf("set global: %v", err)
+	}
+
+	connA, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("conn A: %v", err)
+	}
+	defer connA.Close()
+	connB, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("conn B: %v", err)
+	}
+	defer connB.Close()
+
+	restore, err := ForcePreserveInsertionOrder(ctx, connA)
+	if err != nil {
+		t.Fatalf("ForcePreserveInsertionOrder: %v", err)
+	}
+	if !readPIO(t, ctx, connA) {
+		t.Fatal("connection A does not see the forced override")
+	}
+	if readPIO(t, ctx, connB) {
+		t.Fatal("override leaked beyond the session: connection B sees preserve_insertion_order=true")
+	}
+
+	restore()
+	if readPIO(t, ctx, connA) {
+		t.Fatal("restore did not clear the session override on connection A")
+	}
+	if readPIO(t, ctx, connB) {
+		t.Fatal("restore corrupted the global: connection B sees preserve_insertion_order=true")
+	}
+}
+
+// TestExecPreservingInsertionOrder verifies the statement wrapper: the
+// statement runs under the override, errors propagate, no override survives
+// for later pool users, and a true global is left untouched (no-op path).
+func TestExecPreservingInsertionOrder(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+	// Single connection so a session override leaked by the helper (or by its
+	// statement-error path) would be visible to the follow-up queries below.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, "SET GLOBAL preserve_insertion_order=false"); err != nil {
+		t.Fatalf("set global: %v", err)
+	}
+
+	if err := ExecPreservingInsertionOrder(ctx, db, "CREATE TABLE t AS SELECT 1 AS x"); err != nil {
+		t.Fatalf("ExecPreservingInsertionOrder: %v", err)
+	}
+
+	var val bool
+	if err := db.QueryRowContext(ctx, "SELECT current_setting('preserve_insertion_order')").Scan(&val); err != nil {
+		t.Fatalf("read setting: %v", err)
+	}
+	if val {
+		t.Fatal("session override leaked into pool: preserve_insertion_order=true, want false")
+	}
+
+	// The table created through the helper must exist (statement really ran).
+	var n int
+	if err := db.QueryRowContext(ctx, "SELECT count(*) FROM t").Scan(&n); err != nil {
+		t.Fatalf("query table created via helper: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("unexpected row count %d", n)
+	}
+
+	// Statement errors must propagate, and the error path must not leak the
+	// override either (checked while the global is still false).
+	if err := ExecPreservingInsertionOrder(ctx, db, "SELECT * FROM missing_table"); err == nil {
+		t.Fatal("expected error for invalid statement, got nil")
+	}
+	if err := db.QueryRowContext(ctx, "SELECT current_setting('preserve_insertion_order')").Scan(&val); err != nil {
+		t.Fatalf("read setting: %v", err)
+	}
+	if val {
+		t.Fatal("statement-error path leaked the override: preserve_insertion_order=true, want false")
+	}
+
+	// With the global already true (operator set preserve_insertion_order=true),
+	// the helper must be a no-op: the session value stays true afterwards
+	// rather than being "restored" to false.
+	if _, err := db.ExecContext(ctx, "SET GLOBAL preserve_insertion_order=true"); err != nil {
+		t.Fatalf("set global true: %v", err)
+	}
+	if err := ExecPreservingInsertionOrder(ctx, db, "CREATE TABLE t2 AS SELECT 1 AS x"); err != nil {
+		t.Fatalf("ExecPreservingInsertionOrder with global true: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, "SELECT current_setting('preserve_insertion_order')").Scan(&val); err != nil {
+		t.Fatalf("read setting: %v", err)
+	}
+	if !val {
+		t.Fatal("helper flipped a true global to false: preserve_insertion_order=false, want true")
+	}
+}


### PR DESCRIPTION
## Summary

- New config key `database.preserve_insertion_order` (env `ARC_DATABASE_PRESERVE_INSERTION_ORDER`), **default `false`**: queries without an `ORDER BY` may return rows in any order (SQL-standard semantics); per DuckDB guidance this can reduce memory usage and unlock parallelism on large un-ordered materializations. Queries with an explicit `ORDER BY` are unaffected. Set `true` to restore pre-26.09.1 insertion-ordered results.
- Internal file-rewrite paths keep their pre-change row order regardless of the global: new `ForcePreserveInsertionOrder` / `ExecPreservingInsertionOrder` helpers force the setting on their own pinned session for DELETE file rewrites (local + S3) and sort-keys-less compaction. For this DuckDB option a plain `SET` is **GLOBAL-scoped** (verified on duckdb-go v2.10501.0), so the helpers use `SET SESSION` and restore via `RESET SESSION`; a two-connection regression test fails on the plain-`SET` form.
- Production compaction runs in a subprocess with a raw DuckDB (default `true`) and was never exposed; the in-job force is defensive for a future in-process refactor.
- Release notes + `arc.toml` documented; matching docs.basekick.net update ships separately (`docs/preserve-insertion-order-key`).

**Not a performance change:** interleaved ABAB ClickBench runs (100M rows, 43 queries, Apple M3 Max) measured no difference between `true`/`false` — nearly every ClickBench query carries a top-level `ORDER BY`, which DuckDB honors regardless. An earlier apparent −12.5% was a cold-page-cache artifact and is documented (with the corrected protocol) in `docs/progress/2026-08-13-preserve-insertion-order.md` (untracked).

## Test plan

- [x] Configuration matrix written and traced (OSS default, non-default `true`, DELETE local/S3, compaction with/without `sort_keys`, cluster)
- [x] Single deep adversarial review completed; its Blocker (plain `SET` is global-scoped → instance-wide flip + concurrent-rewrite race) fixed with `SET SESSION`/`RESET SESSION` and regression-tested
- [x] New tests: `TestForcePreserveInsertionOrderSessionScoped` (two-connection scope check; fails pre-fix), `TestExecPreservingInsertionOrder` (leak-proofing incl. statement-error path, no-op at global `true`)
- [x] `go build`, `go vet`, `gofmt` clean on touched packages; `go test -race ./internal/database/... ./internal/compaction/...` green; `./internal/api/... ./internal/config/...` green
- [x] Binary run at **default** (`false`) and **non-default** (`true`, via env var) — `current_setting` verified through the query API in both
- [x] Live DELETE at default `false` on a 9,000-row time-sorted file: 90 rows deleted, rewritten file has **0 out-of-order rows**
- [x] Full 43-query ClickBench suite at both values: identical row counts on all queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)