### PR TITLE
feat(ingest): disable Parquet dictionary encoding at ingest by default (+26% write throughput)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arc
 
-[![Ingestion](https://img.shields.io/badge/ingestion-20M%2B%20rec%2Fs-brightgreen)](https://github.com/basekick-labs/arc)
+[![Ingestion](https://img.shields.io/badge/ingestion-26M%2B%20rec%2Fs-brightgreen)](https://github.com/basekick-labs/arc)
 [![Query](https://img.shields.io/badge/query-8.42M%20rows%2Fs-blue)](https://github.com/basekick-labs/arc)
 [![Go](https://img.shields.io/badge/go-1.26+-00ADD8?logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
@@ -10,7 +10,7 @@
 [![Discord](https://img.shields.io/badge/discord-join-7289da?logo=discord)](https://discord.gg/nxnWfUxsdm)
 [![GitHub](https://img.shields.io/github/stars/basekick-labs/arc?style=social)](https://github.com/basekick-labs/arc)
 
-Open, SQL-native time-series database for telemetry you need to keep. Arc ingests 20M+ records/sec, stores data as standard Parquet on infrastructure you own, and lets you query recent and historical data together. InfluxDB Line Protocol and Telegraf compatible. Single binary. AGPL-3.0.
+Open, SQL-native time-series database for telemetry you need to keep. Arc ingests 26M+ records/sec, stores data as standard Parquet on infrastructure you own, and lets you query recent and historical data together. InfluxDB Line Protocol and Telegraf compatible. Single binary. AGPL-3.0.
 
 > **Prefer a UI?** [**Arc Launchpad**](https://github.com/Basekick-Labs/launchpad) is a self-hosted web console for the Arc instances you run — SQL console, schema explorer, logs, monitoring, and management for tokens, retention, alerts, continuous queries, and MQTT ingestion. Deploy it alongside Arc with Docker Compose. [Docs](https://docs.basekick.net/launchpad).
 
@@ -104,18 +104,20 @@ See Arc in action: [https://basekick.net/demos](https://basekick.net/demos)
 Benchmarked on Apple MacBook Pro M3 Max (14 cores, 36GB RAM, 1TB NVMe).
 Test config: 12 concurrent workers, 1000-record batches, columnar data.
 
-### Ingestion (June 2026)
+### Ingestion (August 2026)
 
 | Protocol | Throughput | p50 Latency | p99 Latency |
 |----------|------------|-------------|-------------|
-| MessagePack Columnar | **20.9M rec/s** | 0.43ms | 2.67ms |
-| MessagePack + Zstd | 17.2M rec/s | 0.58ms | 2.49ms |
-| MessagePack + GZIP | 16.9M rec/s | 0.59ms | 2.55ms |
-| Line Protocol | 5.4M rec/s | 1.83ms | 7.24ms |
+| MessagePack Columnar | **26.1M rec/s** | 0.37ms | 1.78ms |
+| MessagePack + Zstd | 20.2M rec/s | 0.49ms | 1.94ms |
+| MessagePack + GZIP | 19.7M rec/s | 0.51ms | 1.98ms |
+| Line Protocol | 4.6M rec/s | 2.29ms | 6.92ms |
 
-All rows measured over a 60-second sustained run. The radix flush-sort and single-hour
-allocation fixes in 26.06.2 lifted MessagePack Columnar from 19.9M to 20.9M and flattened
-its decay curve; the Zstd/GZIP rows benefit from the same flush-path work.
+All rows measured over a 60-second sustained run — the MessagePack Columnar row moved
+**1,563,468,000 records in 60 seconds**. Measured on a development build; these
+improvements ship in **26.09.1**, which stops dictionary-encoding Parquet at ingest
+time (compaction re-encodes files anyway, so ingest now spends that CPU on
+throughput — see the 26.09.1 release notes).
 
 ### Compaction
 

--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -62,6 +62,24 @@ This is a **file-count** bound, not a byte bound — compacted output size track
 
 Out-of-range values fall back to the default with a startup warning rather than failing. **`1` is not usable** and is treated as out of range: compaction's adaptive retry rejects any batch below two files, so a batch size of one would fail every batch of every partition.
 
+## Faster ingest: Parquet dictionary encoding at write time is now off by default
+
+Sustained msgpack ingest throughput improves **~26%** (20.65M → 26.1M records/sec — 1.56 billion records in a 60-second run — on the IOT sustained-load benchmark, Apple M3 Max, 12 workers) by no longer dictionary-encoding Parquet columns at ingest time:
+
+```toml
+[ingest]
+use_dictionary = false        # default; was true
+numeric_dictionary = false    # default (only relevant with use_dictionary = true)
+```
+
+Env vars: `ARC_INGEST_USE_DICTIONARY`, `ARC_INGEST_NUMERIC_DICTIONARY`.
+
+**Why this is safe:** ingest files are transient staging — hourly and daily compaction rewrite them through DuckDB, which re-encodes every column with its own adaptive dictionary/compression choices regardless of how the source files were encoded. Dictionary-encoding at ingest paid a hash-table insert plus an interface allocation for every value (~8–10% of write CPU in profiles) to compress files that were about to be rewritten anyway. Long-term storage efficiency is unchanged; the tradeoff is a temporarily larger uncompacted hot partition (up to ~2× for highly repetitive data) until the next compaction pass.
+
+The write path also profiles GC-bound at sustained 20M+ records/sec (interface boxing across the decode → buffer → flush pipeline); operators chasing peak sustained throughput on memory-rich hosts can additionally set `GOGC=200-300` (measured +7% and flat RPS over time, at roughly double the resident memory). A typed-column ingest pipeline that removes the boxing entirely is planned follow-up work.
+
+**Restoring the old behavior:** `use_dictionary = true` re-enables dictionaries for string columns only (a middle ground measured at +12% over the old default with tag columns still dictionary-compressed); adding `numeric_dictionary = true` restores the exact pre-26.09.1 all-columns encoding.
+
 ## Insertion-order preservation is now configurable, and off by default
 
 Arc previously forced DuckDB's `preserve_insertion_order=true`, which makes queries **without** an `ORDER BY` return rows in file/insertion order — at the cost of order-preserving buffering in the engine. That setting is now configurable and defaults to **false**:

--- a/arc.toml
+++ b/arc.toml
@@ -64,6 +64,16 @@ max_buffer_age_ms = 100   # Max buffer age before flush
 sort_keys = []
 default_sort_keys = ""
 
+# Parquet dictionary encoding at ingest. Off by default: ingest files are
+# transient (hourly/daily compaction rewrites them via DuckDB, which applies
+# its own adaptive encoding), and ingest-time dictionaries cost significant
+# write CPU. Set use_dictionary = true to dictionary-encode string columns
+# (smaller uncompacted hot partition, ~12% write throughput cost); add
+# numeric_dictionary = true to also cover numeric/timestamp columns
+# (pre-26.09.1 behavior).
+# use_dictionary = false
+# numeric_dictionary = false
+
 # -----------------------------------------------------------------------------
 # Compaction
 # -----------------------------------------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,7 +108,8 @@ type IngestConfig struct {
 	MaxBufferSize         int      // Max records before flush
 	MaxBufferAgeMS        int      // Max age in milliseconds before flush
 	Compression           string   // Parquet compression: snappy, gzip, zstd
-	UseDictionary         bool     // Use dictionary encoding
+	UseDictionary         bool     // Dictionary-encode string/binary columns at ingest (default false: compaction re-encodes anyway; see setDefaults)
+	NumericDictionary     bool     // With UseDictionary, also dictionary-encode numeric/timestamp columns (pre-26.09.1 behavior; costs hashing+boxing per value)
 	WriteStatistics       bool     // Write Parquet statistics
 	DataPageVersion       string   // Parquet data page version: 1.0 or 2.0
 	FlushWorkers          int      // Number of workers for async flush (default: 2x CPU, min 8, max 64)
@@ -742,6 +743,7 @@ func Load() (*Config, error) {
 			MaxBufferAgeMS:        v.GetInt("ingest.max_buffer_age_ms"),
 			Compression:           v.GetString("ingest.compression"),
 			UseDictionary:         v.GetBool("ingest.use_dictionary"),
+			NumericDictionary:     v.GetBool("ingest.numeric_dictionary"),
 			WriteStatistics:       v.GetBool("ingest.write_statistics"),
 			DataPageVersion:       v.GetString("ingest.data_page_version"),
 			FlushWorkers:          v.GetInt("ingest.flush_workers"),
@@ -1354,7 +1356,15 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("ingest.max_buffer_size", 50000)
 	v.SetDefault("ingest.max_buffer_age_ms", 5000)
 	v.SetDefault("ingest.compression", "snappy")
-	v.SetDefault("ingest.use_dictionary", true)
+	// Dictionary encoding OFF at ingest by default: ingest files are
+	// transient — hourly/daily compaction rewrites them via DuckDB COPY,
+	// which re-encodes with its own adaptive dictionary/compression choices
+	// regardless of source encoding. Ingest-time dictionaries cost a hash
+	// insert + interface boxing per value (~measured 20.6→26.0M rec/s when
+	// disabled) to compress files that are about to be rewritten anyway.
+	// The tradeoff is a temporarily larger uncompacted hot partition.
+	v.SetDefault("ingest.use_dictionary", false)
+	v.SetDefault("ingest.numeric_dictionary", false) // only relevant with use_dictionary=true; see IngestConfig
 	v.SetDefault("ingest.write_statistics", true)
 	v.SetDefault("ingest.data_page_version", "2.0")
 	v.SetDefault("ingest.flush_workers", getDefaultFlushWorkers())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,6 +133,22 @@ func TestLoad_DefaultsFromSystem(t *testing.T) {
 		t.Errorf("Database.MemoryLimit = %s, want %s", cfg.Database.MemoryLimit, expectedMem)
 	}
 
+	// Ingest dictionary defaults (26.09.1): no dictionary encoding at ingest —
+	// compaction re-encodes via DuckDB anyway. A silent revert of either
+	// SetDefault would ship unnoticed otherwise: every ingest test constructs
+	// IngestConfig by hand and the bool zero values coincide with these.
+	if cfg.Ingest.UseDictionary {
+		t.Error("Ingest.UseDictionary default = true, want false (26.09.1 default flip)")
+	}
+	if cfg.Ingest.NumericDictionary {
+		t.Error("Ingest.NumericDictionary default = true, want false")
+	}
+
+	// preserve_insertion_order (26.09.1): SQL-standard unordered results.
+	if cfg.Database.PreserveInsertionOrder {
+		t.Error("Database.PreserveInsertionOrder default = true, want false (26.09.1 default flip)")
+	}
+
 	// Verify ingest defaults are applied
 	expectedFlushWorkers := getDefaultFlushWorkers()
 	if cfg.Ingest.FlushWorkers != expectedFlushWorkers {

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -192,14 +192,23 @@ func (c *schemaLRUCache) evictLRU() {
 
 // ArrowWriter handles Arrow schema inference and Parquet writing
 type ArrowWriter struct {
-	compression     compress.Compression
-	useDictionary   bool
-	writeStatistics bool
-	dataPageVersion string
+	compression       compress.Compression
+	useDictionary     bool
+	numericDictionary bool
+	writeStatistics   bool
+	dataPageVersion   string
 
-	// Pre-built Parquet writer properties (immutable after construction)
+	// Pre-built Parquet writer properties (immutable after construction).
+	// Used directly for the all-columns-alike configurations (the
+	// use_dictionary=false default, and use_dictionary+numeric_dictionary
+	// both true) and for all-string schemas; the strings-only tier
+	// (use_dictionary=true alone) builds per-schema properties in
+	// writerPropsFor instead.
 	writerProps *parquet.WriterProperties
-	arrowProps  pqarrow.ArrowWriterProperties
+	// baseWriterOpts are the schema-independent options writerPropsFor
+	// extends with per-column dictionary overrides.
+	baseWriterOpts []parquet.WriterProperty
+	arrowProps     pqarrow.ArrowWriterProperties
 
 	// LRU Schema cache (measurement -> schema) with bounded size
 	schemaCache *schemaLRUCache
@@ -238,15 +247,56 @@ func NewArrowWriter(cfg *config.IngestConfig, logger zerolog.Logger) *ArrowWrite
 	}
 
 	return &ArrowWriter{
-		compression:     comp,
-		useDictionary:   cfg.UseDictionary,
-		writeStatistics: cfg.WriteStatistics,
-		dataPageVersion: cfg.DataPageVersion,
-		writerProps:     parquet.NewWriterProperties(writerOpts...),
-		arrowProps:      pqarrow.NewArrowWriterProperties(pqarrow.WithStoreSchema()),
-		schemaCache:     newSchemaLRUCache(schemaCacheCapacity),
-		logger:          logger.With().Str("component", "arrow-writer").Logger(),
+		compression:       comp,
+		useDictionary:     cfg.UseDictionary,
+		numericDictionary: cfg.NumericDictionary,
+		writeStatistics:   cfg.WriteStatistics,
+		dataPageVersion:   cfg.DataPageVersion,
+		writerProps:       parquet.NewWriterProperties(writerOpts...),
+		baseWriterOpts:    writerOpts,
+		arrowProps:        pqarrow.NewArrowWriterProperties(pqarrow.WithStoreSchema()),
+		schemaCache:       newSchemaLRUCache(schemaCacheCapacity),
+		logger:            logger.With().Str("component", "arrow-writer").Logger(),
 	}
+}
+
+// writerPropsFor returns Parquet writer properties for one schema. String and
+// binary columns keep the configured dictionary setting — dictionaries
+// compress repeated tag values extremely well. All other columns (numeric,
+// boolean, timestamp, decimal) get dictionary encoding disabled unless
+// ingest.numeric_dictionary is set: metric values are mostly
+// high-cardinality, so the dictionary path pays a hash-table insert plus an
+// interface boxing per value (~8-10% of write CPU on the sustained-ingest
+// benchmark) and then typically falls back to plain encoding anyway.
+// (Booleans are listed for completeness; the parquet writer never
+// dictionary-encodes the Boolean physical type, so their override is a
+// no-op either way.)
+//
+// Building properties per flush is deliberate: flushes happen tens of times
+// per second at most, and the alternative — caching per schema — would need
+// eviction tied to the schema LRU for no measurable gain.
+func (w *ArrowWriter) writerPropsFor(schema *arrow.Schema) *parquet.WriterProperties {
+	if !w.useDictionary || w.numericDictionary {
+		return w.writerProps
+	}
+	var opts []parquet.WriterProperty
+	for _, f := range schema.Fields() {
+		switch f.Type.ID() {
+		case arrow.STRING, arrow.LARGE_STRING, arrow.BINARY, arrow.LARGE_BINARY:
+			// keep the dictionary default
+		default:
+			if opts == nil {
+				opts = make([]parquet.WriterProperty, 0, len(w.baseWriterOpts)+len(schema.Fields()))
+				opts = append(opts, w.baseWriterOpts...)
+			}
+			opts = append(opts, parquet.WithDictionaryFor(f.Name, false))
+		}
+	}
+	if opts == nil {
+		// No non-string columns — the prebuilt props are already correct.
+		return w.writerProps
+	}
+	return parquet.NewWriterProperties(opts...)
 }
 
 // =============================================================================
@@ -671,11 +721,12 @@ func (w *ArrowWriter) writeRecordToParquet(schema *arrow.Schema, arrays []arrow.
 	// Write to Parquet
 	var buf bytes.Buffer
 
-	// Use pre-built writer properties (constructed once at startup, immutable)
+	// Schema-aware writer properties (see writerPropsFor for the
+	// per-configuration dictionary tiers).
 	writer, err := pqarrow.NewFileWriter(
 		schema,
 		&buf,
-		w.writerProps,
+		w.writerPropsFor(schema),
 		w.arrowProps,
 	)
 	if err != nil {

--- a/internal/ingest/arrow_writer_dictionary_test.go
+++ b/internal/ingest/arrow_writer_dictionary_test.go
@@ -1,0 +1,103 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/rs/zerolog"
+)
+
+// columnUsesDictionary reports whether the named column's first row-group
+// chunk was written with a dictionary encoding.
+func columnUsesDictionary(t *testing.T, data []byte, colName string) bool {
+	t.Helper()
+	rdr, err := file.NewParquetReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("open parquet: %v", err)
+	}
+	defer rdr.Close()
+
+	rg := rdr.MetaData().RowGroup(0)
+	for i := 0; i < rg.NumColumns(); i++ {
+		col, err := rg.ColumnChunk(i)
+		if err != nil {
+			t.Fatalf("column chunk %d: %v", i, err)
+		}
+		if col.PathInSchema().String() != colName {
+			continue
+		}
+		for _, enc := range col.Encodings() {
+			if enc == parquet.Encodings.RLEDict || enc == parquet.Encodings.PlainDict {
+				return true
+			}
+		}
+		return false
+	}
+	t.Fatalf("column %q not found in parquet metadata", colName)
+	return false
+}
+
+func writeIOTBatch(t *testing.T, cfg *config.IngestConfig) []byte {
+	t.Helper()
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	writer := NewArrowWriter(cfg, logger)
+	columns := map[string]interface{}{
+		"time":  []int64{1000000, 2000000, 3000000},
+		"value": []float64{1.5, 2.5, 3.5},
+		"host":  []string{"h1", "h2", "h1"},
+	}
+	data, err := writer.WriteParquetColumnar(context.Background(), "cpu", columns, nil, nil, false, nil)
+	if err != nil {
+		t.Fatalf("WriteParquetColumnar: %v", err)
+	}
+	return data
+}
+
+// TestDictionaryPerColumnType verifies the use_dictionary=true middle tier:
+// string columns dictionary-encoded, numeric columns plain. (The shipped
+// default is use_dictionary=false — no dictionaries at all — covered by
+// TestDictionaryFullyDisabled and the config-defaults test.)
+func TestDictionaryPerColumnType(t *testing.T) {
+	data := writeIOTBatch(t, &config.IngestConfig{Compression: "snappy", UseDictionary: true})
+
+	if !columnUsesDictionary(t, data, "host") {
+		t.Error("host (string) should be dictionary-encoded with use_dictionary=true")
+	}
+	if columnUsesDictionary(t, data, "value") {
+		t.Error("value (float64) should NOT be dictionary-encoded with use_dictionary=true alone")
+	}
+	if columnUsesDictionary(t, data, "time") {
+		t.Error("time (int64) should NOT be dictionary-encoded with use_dictionary=true alone")
+	}
+}
+
+// TestDictionaryNumericOptIn verifies ingest.numeric_dictionary restores
+// dictionary encoding on numeric columns (pre-26.09.1 behavior).
+func TestDictionaryNumericOptIn(t *testing.T) {
+	data := writeIOTBatch(t, &config.IngestConfig{Compression: "snappy", UseDictionary: true, NumericDictionary: true})
+
+	if !columnUsesDictionary(t, data, "host") {
+		t.Error("host (string) should be dictionary-encoded")
+	}
+	if !columnUsesDictionary(t, data, "value") {
+		t.Error("value (float64) should be dictionary-encoded with numeric_dictionary=true")
+	}
+}
+
+// TestDictionaryFullyDisabled verifies use_dictionary=false turns dictionary
+// encoding off for every column, including strings.
+func TestDictionaryFullyDisabled(t *testing.T) {
+	data := writeIOTBatch(t, &config.IngestConfig{Compression: "snappy", UseDictionary: false})
+
+	if columnUsesDictionary(t, data, "host") {
+		t.Error("host should not be dictionary-encoded with use_dictionary=false")
+	}
+	if columnUsesDictionary(t, data, "value") {
+		t.Error("value should not be dictionary-encoded with use_dictionary=false")
+	}
+}


### PR DESCRIPTION
## Summary

- **`ingest.use_dictionary` now defaults to `false`** — Arc no longer dictionary-encodes Parquet columns at ingest time. Rationale: ingest files are transient staging — hourly/daily compaction rewrites them through DuckDB COPY, which re-encodes every column adaptively regardless of source encoding, so ingest-time dictionaries spent ~8–10% of write CPU (memo-table hashing + one interface allocation per value, confirmed by CPU profiles) compressing files that were about to be rewritten. Long-term storage efficiency is compaction's job and is unchanged; the uncompacted hot partition is temporarily larger (~2× worst case) until the next compaction pass.
- **Measured**: sustained msgpack columnar ingest 20.65M → 26.1M records/sec (+26%, 1.56B records in a 60-second run, Apple M3 Max, 12 workers); p99 2.81ms → 1.78ms. Official rerun also refreshed the README table for all four protocol rows (gzip 19.7M, zstd 20.2M, line protocol 4.6M).
- **Three encoding tiers**, all verified live via `parquet_metadata()` on files written through the running binary:
  - default: all columns PLAIN
  - `use_dictionary=true`: string/binary columns dictionary-encoded (new per-schema `writerPropsFor`), numeric/timestamp PLAIN — measured +12% over the old default with tag columns still dictionary-compressed
  - `use_dictionary=true` + new key `ingest.numeric_dictionary=true`: exact pre-26.09.1 all-columns encoding
- Release notes document `GOGC=200-300` as ops guidance (+7%, flat RPS over the run, ~2× RSS) — the observed RPS decay over sustained runs is GC pressure, not thermal. A typed-column ingest pipeline (removing `[]interface{}` boxing across decode→flush) is noted as follow-up.
- Env vars: `ARC_INGEST_USE_DICTIONARY`, `ARC_INGEST_NUMERIC_DICTIONARY`. Matching docs.basekick.net update ships separately.

## Test plan

- [x] Configuration matrix written and traced (default / strings-only / all-dict / all-string schema / all ingest formats via the single `writeRecordToParquet` site / compaction+delete unaffected)
- [x] Single deep adversarial review: no Blockers/High; verified slice-aliasing safety of per-schema props under concurrent flush workers, dotted-field-name column-path matching in arrow-go, stats-with-PLAIN interaction; its 3 Medium findings (number drift, untested viper default, test wording) fixed
- [x] New tests: per-column encoding split, numeric opt-in, fully-disabled; config-defaults test now pins `use_dictionary=false`, `numeric_dictionary=false` (and `preserve_insertion_order=false`) so a silent `SetDefault` revert cannot ship
- [x] `go build`, `go vet`, `gofmt` clean; `internal/ingest` + `internal/config` suites green
- [x] Binary run at default AND both non-default combinations — encodings inspected via `parquet_metadata()`, data queried back through the API
- [x] 60-second sustained benches: baseline 20.65M, strings-only 23.08M, no-dict 25.96M/26.20M (mine) and 26.06M (official rerun), zero errors, identical row counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)