### PR TITLE
feat(query): opt-in Arrow IPC dictionary encoding and buffer compress…

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -100,6 +100,37 @@ The write path also profiles GC-bound at sustained 20M+ records/sec (interface b
 
 **Restoring the old behavior:** `use_dictionary = true` re-enables dictionaries for string columns only (a middle ground measured at +12% over the old default with tag columns still dictionary-compressed); adding `numeric_dictionary = true` restores the exact pre-26.09.1 all-columns encoding.
 
+## Arrow IPC egress: opt-in dictionary encoding and buffer compression
+
+The Arrow IPC query endpoint (`/api/v1/query/arrow`) can now halve its wire
+size, opted in per request:
+
+- `x-arc-arrow-dictionary: true` — low-cardinality string columns (symbols,
+  hostnames, sides) are dictionary-encoded in the stream: the dictionary is
+  re-sent only when it grows and each row carries a 4-byte index instead of
+  the repeated string. Column selection is adaptive (first-batch cardinality
+  analysis); high-cardinality strings (URLs, IDs) stay plain. The affected
+  columns arrive as standard Arrow dictionary arrays — verified readable by
+  pyarrow, polars, and pandas. One caveat: column selection is decided on
+  the first batch, so a query ordered BY a medium-cardinality string column
+  can qualify a column whose dictionary then grows large over the stream —
+  Arc logs a warning when that happens; omit the header for such shapes.
+- `x-arc-arrow-compression: zstd` (or `lz4`) — standard Arrow IPC buffer
+  compression, decompressed natively by Arrow clients.
+
+Measured on a 500M-row trades table (5 columns, 8 parallel readers, M3 Max):
+**39.0 → 19.4 bytes/row (−50%) with both enabled** — 19.5GB → 9.7GB on the
+wire for the same result set.
+
+**When to use it:** these encodings trade server/client CPU for wire bytes.
+On loopback or very fast links, leave them off (the extra encode/decode work
+lowers rows/sec). On network-constrained links they win decisively — at
+1Gbps, transmitting the 500M-row result takes 156s plain vs 78s with
+dictionary+zstd, roughly 2× faster end-to-end. Rule of thumb: enable both
+for remote analytical clients pulling large result sets; leave off for
+same-host consumers. Existing clients are completely unaffected — without
+the headers, the stream is byte-identical to before.
+
 ## Insertion-order preservation is now configurable, and off by default
 
 Arc previously forced DuckDB's `preserve_insertion_order=true`, which makes queries **without** an `ORDER BY` return rows in file/insertion order — at the cost of order-preserving buffering in the engine. That setting is now configurable and defaults to **false**:

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -60,6 +60,28 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		})
 	}
 
+	// Opt-in stream encodings. Both change the bytes the client must be able
+	// to parse, so they are strictly request-driven — no config default:
+	//   x-arc-arrow-dictionary: true  → dictionary-encode low-cardinality
+	//     string columns (schema becomes dictionary<int32, utf8> for them)
+	//   x-arc-arrow-compression: zstd|lz4 → Arrow IPC buffer compression
+	dictEnabled := isTruthyHeader(c.Get("x-arc-arrow-dictionary"))
+	// strings.Clone is REQUIRED: c.Get aliases the fasthttp header buffer,
+	// and ToLower/TrimSpace return the ORIGINAL string when unchanged (e.g.
+	// "zstd"). ipcCompression is captured by the SetBodyStreamWriter closure
+	// and read after the handler returns — same aliasing class as the
+	// x-arc-database wrong-DB corruption bug.
+	ipcCompression := strings.Clone(strings.ToLower(strings.TrimSpace(c.Get("x-arc-arrow-compression"))))
+	switch ipcCompression {
+	case "", "zstd", "lz4":
+	default:
+		m.IncQueryErrors()
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"error":   "invalid x-arc-arrow-compression: must be zstd or lz4",
+		})
+	}
+
 	// Extract x-arc-database header for optimized query path
 	headerDB := c.Get("x-arc-database")
 	if err := validateHeaderDatabase(headerDB); err != nil {
@@ -217,7 +239,38 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 
 	streamCtx := ctx
 	fctx.SetBodyStreamWriter(func(w *bufio.Writer) {
-		ipcWriter := ipc.NewWriter(w, ipc.WithSchema(schema))
+		// This closure runs on a bare fasthttp goroutine: an unrecovered
+		// panic here kills the whole process (fiber's recover middleware
+		// only wraps the handler, which has already returned). Convert
+		// panics to a logged error; the connection dies mid-stream, which
+		// the client sees as a truncated Arrow stream.
+		defer func() {
+			if r := recover(); r != nil {
+				m.IncQueryErrors()
+				h.logger.Error().Interface("panic", r).
+					Msg("Arrow IPC stream writer panicked; stream truncated")
+			}
+		}()
+		// The IPC writer is created lazily on the first batch: when
+		// dictionary encoding is requested, the output schema depends on a
+		// cardinality analysis of that batch (see newArrowDictTransformer).
+		var ipcWriter *ipc.Writer
+		var dictXform *arrowDictTransformer
+		// Dictionary columns use REPLACEMENT dictionaries (arrow-go's
+		// default): the writer skips re-sending an unchanged dictionary and
+		// re-sends the full dictionary when it grows. Deliberately NOT
+		// WithDictionaryDeltas — polars cannot read delta batches (verified
+		// against polars 1.43; pyarrow reads both).
+		newIPCWriter := func(outSchema *arrow.Schema) *ipc.Writer {
+			opts := []ipc.Option{ipc.WithSchema(outSchema)}
+			switch ipcCompression {
+			case "zstd":
+				opts = append(opts, ipc.WithZstd())
+			case "lz4":
+				opts = append(opts, ipc.WithLZ4())
+			}
+			return ipc.NewWriter(w, opts...)
+		}
 
 		var totalRows int64
 		var streamErr error
@@ -261,7 +314,40 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 				batch = castedBatch
 			}
 
-			err := ipcWriter.Write(batch)
+			// First batch: decide dictionary columns (if requested) and
+			// create the writer with the final output schema.
+			if ipcWriter == nil {
+				outSchema := schema
+				if dictEnabled {
+					// Analysis runs on the (possibly decimal-casted) batch so
+					// the transformer's schema matches what it will receive.
+					dictXform = newArrowDictTransformer(batch, &h.logger)
+					if dictXform != nil {
+						outSchema = dictXform.schema
+					}
+				}
+				ipcWriter = newIPCWriter(outSchema)
+			}
+
+			writeBatch := batch
+			var encodedBatch arrow.Record
+			if dictXform != nil {
+				var encErr error
+				encodedBatch, encErr = dictXform.transform(batch)
+				if encErr != nil {
+					if castedBatch != nil {
+						castedBatch.Release()
+					}
+					streamErr = fmt.Errorf("failed to dictionary-encode batch at row %d: %w", totalRows, encErr)
+					break streamLoop
+				}
+				writeBatch = encodedBatch
+			}
+
+			err := ipcWriter.Write(writeBatch)
+			if encodedBatch != nil {
+				encodedBatch.Release()
+			}
 			if castedBatch != nil {
 				castedBatch.Release()
 			}
@@ -284,6 +370,16 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			if err := reader.Err(); err != nil {
 				streamErr = fmt.Errorf("arrow reader error after %d rows: %w", totalRows, err)
 			}
+		}
+
+		// Zero-batch result: no writer was created in the loop. Emit an
+		// empty stream with the base schema so clients still get a valid
+		// Arrow IPC response.
+		if ipcWriter == nil {
+			ipcWriter = newIPCWriter(schema)
+		}
+		if dictXform != nil {
+			defer dictXform.release()
 		}
 
 		if err := ipcWriter.Close(); err != nil {

--- a/internal/api/query_arrow_dict.go
+++ b/internal/api/query_arrow_dict.go
@@ -1,0 +1,209 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/rs/zerolog"
+)
+
+// Arrow IPC dictionary encoding for low-cardinality string columns (opt-in
+// via the x-arc-arrow-dictionary request header).
+//
+// DuckDB's Arrow export materializes VARCHAR columns as plain utf8 arrays, so
+// repeated tag-like values (symbols, hostnames, sides) are re-sent in full for
+// every row — measured 39 bytes/row on the trades egress benchmark vs 18.8
+// for engines that dictionary-encode the stream. This transformer re-encodes
+// qualifying string columns as dictionary<int32, utf8> with ONE persistent
+// dictionary builder per column for the whole stream. The IPC writer re-sends
+// a column's dictionary only when it has grown since the previous batch
+// (replacement dictionaries — NOT delta dictionaries: polars cannot read
+// delta batches, verified against polars 1.43; replacements are read
+// correctly by pyarrow, polars, and pandas). Once the dictionary stabilizes
+// it is transmitted no further, and every batch carries 4-byte indices
+// instead of repeated strings.
+//
+// Column selection is adaptive and decided ONCE on the first record batch
+// (the IPC schema is fixed for the stream): a string column qualifies when
+// its unique-value count in the first batch stays under both an absolute cap
+// and a fraction of the batch rows — high-cardinality columns (URLs, IDs)
+// would make dictionaries larger than the plain encoding and are left alone.
+//
+// COST HONESTY: if a qualifying column's cardinality explodes later in the
+// stream (typical shape: ORDER BY on a medium-cardinality column, whose
+// first batch shows few uniques), correctness is preserved but the persistent
+// dictionary grows without bound for the stream's lifetime, every batch
+// re-materializes and re-compares the full dictionary (O(batches × uniques)
+// CPU), and the client receives the cumulative dictionary. transform() logs
+// one warning per stream when growth blows past the qualification cap; the
+// release notes carry the operator-facing caveat.
+//
+// Only utf8 (String) columns are considered. LargeString is deliberately
+// EXCLUDED: arrow-go v18 has no LargeString dictionary builder — constructing
+// one panics — and the pinned duckdb-go never emits LargeString. The stream
+// closure also carries a recover() as insurance, since it runs on a bare
+// fasthttp goroutine where an unrecovered panic kills the process.
+
+// isTruthyHeader reports whether an opt-in header value is enabled.
+func isTruthyHeader(v string) bool {
+	return strings.EqualFold(v, "true") || v == "1"
+}
+
+// dictMaxCardinality is the absolute unique-count cap for a column to
+// qualify on the first batch.
+const dictMaxCardinality = 4096
+
+// dictMinRows is the minimum first-batch row count to bother analyzing —
+// tiny result sets gain nothing from dictionary encoding.
+const dictMinRows = 256
+
+// dictGrowthWarnCap: transform() logs one warning per stream when any
+// column's persistent dictionary exceeds this size — the signal that a
+// column qualified on an unrepresentative first batch (see COST HONESTY
+// above).
+const dictGrowthWarnCap = 16 * dictMaxCardinality
+
+// arrowDictTransformer rewrites qualifying string columns of each record
+// batch into dictionary arrays with stream-persistent dictionaries.
+type arrowDictTransformer struct {
+	schema     *arrow.Schema
+	builders   map[int]array.DictionaryBuilder // column index -> persistent builder
+	logger     *zerolog.Logger
+	growthWarn bool
+}
+
+// newArrowDictTransformer analyzes the first batch and returns a transformer
+// for qualifying string columns, or nil if no column qualifies (stream is
+// then written untouched). logger may be nil (tests).
+func newArrowDictTransformer(first arrow.Record, logger *zerolog.Logger) *arrowDictTransformer {
+	rows := int(first.NumRows())
+	if rows < dictMinRows {
+		return nil
+	}
+	// A column qualifies when its uniques fit the absolute cap AND repeat
+	// enough to pay for the dictionary (uniques <= rows/4).
+	limit := rows / 4
+	if limit > dictMaxCardinality {
+		limit = dictMaxCardinality
+	}
+
+	schema := first.Schema()
+	var dictCols map[int]array.DictionaryBuilder
+
+	for i := 0; i < int(first.NumCols()); i++ {
+		f := schema.Field(i)
+		var uniques int
+		switch col := first.Column(i).(type) {
+		case *array.String:
+			uniques = countUniqueStrings(col, limit)
+		default:
+			// LargeString deliberately excluded — no dictionary builder for
+			// it in arrow-go v18 (constructing one panics). See file header.
+			continue
+		}
+		if uniques < 0 {
+			continue // exceeded limit — leave plain
+		}
+		if dictCols == nil {
+			dictCols = make(map[int]array.DictionaryBuilder)
+		}
+		dt := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: f.Type}
+		dictCols[i] = array.NewDictionaryBuilder(memory.DefaultAllocator, dt)
+	}
+
+	if dictCols == nil {
+		return nil
+	}
+
+	fields := make([]arrow.Field, schema.NumFields())
+	for i := 0; i < schema.NumFields(); i++ {
+		f := schema.Field(i)
+		if _, ok := dictCols[i]; ok {
+			f = arrow.Field{
+				Name:     f.Name,
+				Type:     &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: f.Type},
+				Nullable: f.Nullable,
+				Metadata: f.Metadata,
+			}
+		}
+		fields[i] = f
+	}
+	md := schema.Metadata()
+	return &arrowDictTransformer{
+		schema:   arrow.NewSchema(fields, &md),
+		builders: dictCols,
+		logger:   logger,
+	}
+}
+
+// transform returns a new record with the qualifying string columns
+// dictionary-encoded. The caller owns the returned record and must Release
+// it after writing.
+func (t *arrowDictTransformer) transform(batch arrow.Record) (arrow.Record, error) {
+	cols := make([]arrow.Array, batch.NumCols())
+	var toRelease []arrow.Array
+
+	for i := 0; i < int(batch.NumCols()); i++ {
+		b, ok := t.builders[i]
+		if !ok {
+			cols[i] = batch.Column(i)
+			continue
+		}
+		if err := b.AppendArray(batch.Column(i)); err != nil {
+			for _, a := range toRelease {
+				a.Release()
+			}
+			return nil, fmt.Errorf("dictionary-encode column %d: %w", i, err)
+		}
+		arr := b.NewDictionaryArray()
+		cols[i] = arr
+		toRelease = append(toRelease, arr)
+
+		// One warning per stream when a column's dictionary blows past the
+		// qualification cap — the first batch was unrepresentative and this
+		// stream is now paying the growth cost described in the file header.
+		if !t.growthWarn && t.logger != nil && arr.Dictionary().Len() > dictGrowthWarnCap {
+			t.growthWarn = true
+			t.logger.Warn().
+				Str("column", t.schema.Field(i).Name).
+				Int("dictionary_size", arr.Dictionary().Len()).
+				Int("qualify_cap", dictMaxCardinality).
+				Msg("Arrow dictionary column grew far beyond its first-batch cardinality; consider omitting x-arc-arrow-dictionary for this query shape")
+		}
+	}
+
+	rec := array.NewRecord(t.schema, cols, batch.NumRows())
+	for _, a := range toRelease {
+		a.Release()
+	}
+	return rec, nil
+}
+
+// release frees the persistent builders. Call once when the stream ends.
+func (t *arrowDictTransformer) release() {
+	for _, b := range t.builders {
+		b.Release()
+	}
+}
+
+// countUniqueStrings returns the unique count, or -1 as soon as it exceeds
+// limit (early abort keeps first-batch analysis cheap for high-cardinality
+// columns).
+func countUniqueStrings(col *array.String, limit int) int {
+	seen := make(map[string]struct{}, limit+1)
+	for i := 0; i < col.Len(); i++ {
+		if col.IsNull(i) {
+			continue
+		}
+		seen[col.Value(i)] = struct{}{}
+		if len(seen) > limit {
+			return -1
+		}
+	}
+	return len(seen)
+}

--- a/internal/api/query_arrow_dict_test.go
+++ b/internal/api/query_arrow_dict_test.go
@@ -1,0 +1,283 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// buildTestRecord creates a record with a low-cardinality string column, a
+// high-cardinality string column, an int column, and scattered nulls.
+func buildTestRecord(t *testing.T, rows int, batchIdx int) arrow.Record {
+	t.Helper()
+	mem := memory.DefaultAllocator
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "symbol", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "url", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "v", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+	}, nil)
+
+	sb := array.NewStringBuilder(mem)
+	ub := array.NewStringBuilder(mem)
+	vb := array.NewInt64Builder(mem)
+	defer sb.Release()
+	defer ub.Release()
+	defer vb.Release()
+
+	symbols := []string{"AAPL", "MSFT", "GOOG", "AMZN", "NVDA"}
+	for i := 0; i < rows; i++ {
+		if i%97 == 0 {
+			sb.AppendNull()
+		} else {
+			// batchIdx shifts the distribution so later batches introduce
+			// dictionary values unseen in the first batch (delta path).
+			sb.Append(symbols[(i+batchIdx)%len(symbols)])
+		}
+		ub.Append(fmt.Sprintf("https://example.com/%d/%d", batchIdx, i)) // all unique
+		vb.Append(int64(i))
+	}
+
+	sArr := sb.NewArray()
+	uArr := ub.NewArray()
+	vArr := vb.NewArray()
+	defer sArr.Release()
+	defer uArr.Release()
+	defer vArr.Release()
+	return array.NewRecord(schema, []arrow.Array{sArr, uArr, vArr}, int64(rows))
+}
+
+// TestArrowDictTransformerRoundTrip encodes multiple batches through the
+// transformer + IPC writer with deltas and reads them back, asserting the
+// decoded values are identical to the originals, the low-cardinality column
+// became dictionary-typed, and the high-cardinality column stayed plain.
+func TestArrowDictTransformerRoundTrip(t *testing.T) {
+	const rows = 1000
+	const batches = 3
+
+	originals := make([]arrow.Record, batches)
+	for b := 0; b < batches; b++ {
+		originals[b] = buildTestRecord(t, rows, b)
+		defer originals[b].Release()
+	}
+
+	xform := newArrowDictTransformer(originals[0], nil)
+	if xform == nil {
+		t.Fatal("expected transformer (symbol column qualifies)")
+	}
+	defer xform.release()
+
+	// Schema expectations: symbol dictionary-encoded, url and v untouched.
+	if _, ok := xform.schema.Field(0).Type.(*arrow.DictionaryType); !ok {
+		t.Fatalf("symbol should be dictionary-typed, got %s", xform.schema.Field(0).Type)
+	}
+	if xform.schema.Field(1).Type.ID() != arrow.STRING {
+		t.Fatalf("url (all-unique) should stay plain, got %s", xform.schema.Field(1).Type)
+	}
+	if xform.schema.Field(2).Type.ID() != arrow.INT64 {
+		t.Fatalf("v should stay int64, got %s", xform.schema.Field(2).Type)
+	}
+
+	var buf bytes.Buffer
+	w := ipc.NewWriter(&buf, ipc.WithSchema(xform.schema))
+	for b := 0; b < batches; b++ {
+		enc, err := xform.transform(originals[b])
+		if err != nil {
+			t.Fatalf("transform batch %d: %v", b, err)
+		}
+		if err := w.Write(enc); err != nil {
+			enc.Release()
+			t.Fatalf("ipc write batch %d: %v", b, err)
+		}
+		enc.Release()
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("ipc close: %v", err)
+	}
+
+	// Read back and compare values.
+	r, err := ipc.NewReader(&buf)
+	if err != nil {
+		t.Fatalf("ipc reader: %v", err)
+	}
+	defer r.Release()
+
+	for b := 0; b < batches; b++ {
+		if !r.Next() {
+			t.Fatalf("missing batch %d on read-back: %v", b, r.Err())
+		}
+		got := r.Record()
+		orig := originals[b]
+		if got.NumRows() != orig.NumRows() {
+			t.Fatalf("batch %d rows %d != %d", b, got.NumRows(), orig.NumRows())
+		}
+
+		dict, ok := got.Column(0).(*array.Dictionary)
+		if !ok {
+			t.Fatalf("batch %d symbol not a dictionary array: %T", b, got.Column(0))
+		}
+		dictVals := dict.Dictionary().(*array.String)
+		origSym := orig.Column(0).(*array.String)
+		for i := 0; i < int(got.NumRows()); i++ {
+			if origSym.IsNull(i) != dict.IsNull(i) {
+				t.Fatalf("batch %d row %d null mismatch", b, i)
+			}
+			if origSym.IsNull(i) {
+				continue
+			}
+			if gotV := dictVals.Value(dict.GetValueIndex(i)); gotV != origSym.Value(i) {
+				t.Fatalf("batch %d row %d symbol %q != %q", b, i, gotV, origSym.Value(i))
+			}
+		}
+
+		gotURL := got.Column(1).(*array.String)
+		origURL := orig.Column(1).(*array.String)
+		for i := 0; i < int(got.NumRows()); i++ {
+			if gotURL.Value(i) != origURL.Value(i) {
+				t.Fatalf("batch %d row %d url mismatch", b, i)
+			}
+		}
+	}
+	if r.Next() {
+		t.Fatal("unexpected extra batch")
+	}
+}
+
+// TestArrowDictTransformerSkipsSmallAndHighCardinality pins the adaptive
+// gates: tiny first batches and high-cardinality-only schemas produce no
+// transformer.
+func TestArrowDictTransformerSkips(t *testing.T) {
+	small := buildTestRecord(t, dictMinRows-1, 0)
+	defer small.Release()
+	if newArrowDictTransformer(small, nil) != nil {
+		t.Fatal("tiny first batch must not enable dictionary encoding")
+	}
+
+	mem := memory.DefaultAllocator
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "url", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+	ub := array.NewStringBuilder(mem)
+	defer ub.Release()
+	for i := 0; i < 1000; i++ {
+		ub.Append(fmt.Sprintf("unique-%d", i))
+	}
+	uArr := ub.NewArray()
+	defer uArr.Release()
+	rec := array.NewRecord(schema, []arrow.Array{uArr}, 1000)
+	defer rec.Release()
+	if newArrowDictTransformer(rec, nil) != nil {
+		t.Fatal("all-unique string column must not enable dictionary encoding")
+	}
+}
+
+// TestArrowDictTransformerIgnoresLargeString is the B1 regression guard:
+// arrow-go v18 has NO LargeString dictionary builder — constructing one
+// panics, and a panic in the fasthttp stream goroutine kills the process.
+// A low-cardinality LargeString column must therefore be left plain.
+func TestArrowDictTransformerIgnoresLargeString(t *testing.T) {
+	mem := memory.DefaultAllocator
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "sym", Type: arrow.BinaryTypes.LargeString, Nullable: true},
+	}, nil)
+	lb := array.NewLargeStringBuilder(mem)
+	defer lb.Release()
+	for i := 0; i < 1000; i++ {
+		lb.Append([]string{"a", "b", "c"}[i%3]) // low cardinality — would qualify if supported
+	}
+	lArr := lb.NewArray()
+	defer lArr.Release()
+	rec := array.NewRecord(schema, []arrow.Array{lArr}, 1000)
+	defer rec.Release()
+
+	if newArrowDictTransformer(rec, nil) != nil {
+		t.Fatal("LargeString columns must not be dictionary-encoded (no builder support in arrow-go)")
+	}
+}
+
+// TestArrowDictTransformerAllNullFirstBatch covers the empty-first-dictionary
+// edge: a qualifying column whose first batch is entirely null produces an
+// empty dictionary, and later batches grow it — the dictionary-emission path
+// the main round-trip doesn't touch.
+func TestArrowDictTransformerAllNullFirstBatch(t *testing.T) {
+	mem := memory.DefaultAllocator
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "sym", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	buildBatch := func(vals []string, nulls bool) arrow.Record {
+		sb := array.NewStringBuilder(mem)
+		defer sb.Release()
+		for i := 0; i < 500; i++ {
+			if nulls {
+				sb.AppendNull()
+			} else {
+				sb.Append(vals[i%len(vals)])
+			}
+		}
+		arr := sb.NewArray()
+		defer arr.Release()
+		return array.NewRecord(schema, []arrow.Array{arr}, 500)
+	}
+
+	first := buildBatch(nil, true)
+	defer first.Release()
+	second := buildBatch([]string{"x", "y"}, false)
+	defer second.Release()
+
+	xform := newArrowDictTransformer(first, nil)
+	if xform == nil {
+		t.Fatal("all-null column should qualify (0 uniques)")
+	}
+	defer xform.release()
+
+	var buf bytes.Buffer
+	w := ipc.NewWriter(&buf, ipc.WithSchema(xform.schema))
+	for _, rec := range []arrow.Record{first, second} {
+		enc, err := xform.transform(rec)
+		if err != nil {
+			t.Fatalf("transform: %v", err)
+		}
+		if err := w.Write(enc); err != nil {
+			enc.Release()
+			t.Fatalf("write: %v", err)
+		}
+		enc.Release()
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	r, err := ipc.NewReader(&buf)
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	defer r.Release()
+
+	if !r.Next() {
+		t.Fatalf("missing batch 1: %v", r.Err())
+	}
+	b1 := r.Record().Column(0).(*array.Dictionary)
+	for i := 0; i < 500; i++ {
+		if !b1.IsNull(i) {
+			t.Fatalf("batch 1 row %d should be null", i)
+		}
+	}
+	if !r.Next() {
+		t.Fatalf("missing batch 2: %v", r.Err())
+	}
+	b2 := r.Record().Column(0).(*array.Dictionary)
+	vals := b2.Dictionary().(*array.String)
+	want := []string{"x", "y"}
+	for i := 0; i < 500; i++ {
+		if got := vals.Value(b2.GetValueIndex(i)); got != want[i%2] {
+			t.Fatalf("batch 2 row %d: %q != %q", i, got, want[i%2])
+		}
+	}
+}


### PR DESCRIPTION
…ion (-50% wire bytes)

Two per-request opt-in encodings on /api/v1/query/arrow; without the headers the stream is byte-identical to before (live-verified):

- x-arc-arrow-dictionary: true — adaptively dictionary-encode low-cardinality string columns. DuckDB's Arrow export materializes VARCHAR as plain utf8, so repeated tag-like values were re-sent in full per row. Column selection runs once on the first batch (unique-count cap 4096 and <= rows/4; high-cardinality columns stay plain); one persistent dictionary builder per column for the stream, with REPLACEMENT dictionaries (deliberately not deltas: polars cannot read delta batches — verified against polars 1.43; replacement streams verified readable by pyarrow, polars, and pandas). LargeString is excluded: arrow-go v18 has no LargeString dictionary builder and constructing one panics.
- x-arc-arrow-compression: zstd|lz4 — standard Arrow IPC buffer compression; invalid values 400 before query execution.

Measured (500M-row trades table, 5 cols, 8 parallel readers, M3 Max, loopback): 39.0 -> 32.2 B/row dictionary-only, 27.7 zstd-only, 19.4 (-50%) combined — 19.5GB -> 9.7GB for the same result set, matching QuestDB's published 18.8 B/row wire efficiency. These trade CPU for wire bytes: on loopback throughput drops (28.3M -> 17.6M rows/s combined), on a 1Gbps link the same result moves ~2x faster end-to-end. Release notes carry the when-to-use guidance.

The stream loop now creates the IPC writer lazily (the dictionary schema depends on first-batch analysis); zero-batch results still emit a valid empty stream, and default-path output is option- and byte-identical. The stream closure gained a recover(): it runs on a bare fasthttp goroutine where an unrecovered panic previously killed the process. A one-per-stream warning fires if a qualified column's dictionary grows far beyond the qualification cap (first batch unrepresentative, e.g. ORDER BY on a medium-cardinality column). ipcCompression is strings.Clone'd — c.Get aliases the fasthttp header buffer and the value is read after the handler returns.