### PR TITLE
fix(wal): restore crash durability and replay correctness (#590, #594)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -100,6 +100,37 @@ The write path also profiles GC-bound at sustained 20M+ records/sec (interface b
 
 **Restoring the old behavior:** `use_dictionary = true` re-enables dictionaries for string columns only (a middle ground measured at +12% over the old default with tag columns still dictionary-compressed); adding `numeric_dictionary = true` restores the exact pre-26.09.1 all-columns encoding.
 
+## WAL reliability improvements ([#594](https://github.com/Basekick-Labs/arc/issues/594), [#590](https://github.com/Basekick-Labs/arc/issues/590))
+
+This release includes a set of fixes that make WAL-based crash recovery
+significantly more robust. If you run with `wal.enabled = true` (off by
+default), we recommend picking up 26.09.1.
+
+**#594 — startup recovery could interfere with the active WAL file.** WAL
+recovery at startup scanned the WAL directory after the writer had already
+created its current file and could clean that file up as an empty leftover,
+which prevented WAL entries written during the session from being available
+for crash recovery later. Startup recovery now excludes the active file
+(the periodic recovery path already did), and the periodic path gained a
+minimum-file-age guard against the same interaction during file rotation.
+
+**#590 — replayed data now behaves exactly like live-ingested data.** WAL
+crash replay and cluster WAL replication feed the original client bytes back
+through ingestion, and previously skipped some of the live decode path's
+post-processing. Now aligned:
+
+- Timestamp units are normalized on replay, so clients sending second- or
+  millisecond-precision timestamps recover into the correct time partitions.
+- Clients that omit the `time` column have timestamps regenerated on replay
+  (stamped at replay time rather than original ingest time — an inherent
+  semantic for omitted timestamps).
+- Strings are UTF-8-sanitized on replay, matching live ingest.
+
+Additionally, a single problematic WAL entry no longer stops replay of the
+remaining entries in its file (the failure is counted in recovery stats).
+These improvements also apply to Enterprise cluster WAL replication, which
+shares the same ingestion path on replica nodes.
+
 ## JSON and msgpack query responses honor Accept-Encoding (zstd/gzip)
 
 `/api/v1/query` and `/api/v1/query/msgpack` now compress responses when the

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -768,7 +768,26 @@ func main() {
 		recoveryCallback := createWALRecoveryCallback(arrowBuffer, logger.Get("wal-recovery"))
 		columnarCallback := createColumnarRecoveryCallback(arrowBuffer, logger.Get("wal-recovery"))
 
+		// SkipActiveFile is REQUIRED (#594): the WAL writer was created
+		// above and has already rotated in its active (header-only) file.
+		// Without the skip, recovery treats that file as an empty leftover
+		// and DELETES it — the writer then appends to an unlinked inode for
+		// the whole session and the WAL provides no crash durability. The
+		// periodic flush-failure recovery below always passed this; the
+		// startup call was the one that forgot.
+		startupActiveFile := ""
+		if walWriter != nil {
+			startupActiveFile = walWriter.CurrentFile()
+		}
+		// NOTE: no MinFileAge here — startup recovery runs exactly once,
+		// before any ingest, so there is no rotation race (the active file
+		// is fully identified by SkipActiveFile), and a just-crashed
+		// server's WAL file may legitimately be seconds old. Skipping it
+		// would strand its data until the next restart. The age guard is
+		// for the PERIODIC flush-failure recovery below, where ingest (and
+		// therefore rotation) is live during the scan.
 		recoveryStats, err := walRecovery.RecoverWithOptions(context.Background(), recoveryCallback, &wal.RecoveryOptions{
+			SkipActiveFile:   startupActiveFile,
 			BatchSize:        cfg.WAL.RecoveryBatchSize,
 			ColumnarCallback: columnarCallback,
 		})
@@ -840,6 +859,7 @@ func main() {
 						}
 						stats, err := recovery.RecoverWithOptions(context.Background(), recoveryCallback, &wal.RecoveryOptions{
 							SkipActiveFile:   activeFile,
+							MinFileAge:       5 * time.Second,
 							BatchSize:        cfg.WAL.RecoveryBatchSize,
 							ColumnarCallback: columnarCallback,
 						})

--- a/internal/ingest/arrow_writer.go
+++ b/internal/ingest/arrow_writer.go
@@ -1427,6 +1427,52 @@ func (b *ArrowBuffer) WriteColumnarRecord(ctx context.Context, database string, 
 // loss. This matches the pre-existing arc:tags WAL behavior; propagating the
 // markers through the WAL is a separate, larger change (WAL schema).
 func (b *ArrowBuffer) WriteColumnarDirectNoWAL(ctx context.Context, database, measurement string, columns map[string][]interface{}) error {
+	// #590: both callers (WAL crash replay, cluster WAL replication) feed
+	// RAW client payloads that never went through the live decode path's
+	// post-processing. Apply it here so replayed data behaves exactly like
+	// live-ingested data:
+	//   - missing/empty time column → generate now-µs (the live path did
+	//     this at original ingest; the WAL stores the client's original
+	//     bytes WITHOUT the generated column, and without it the flush
+	//     wrote nothing — silent data loss)
+	//   - normalize timestamp units to µs (a seconds-precision client's
+	//     entries otherwise land in 1970-era partitions via groupByHour)
+	//   - sanitize strings to valid UTF-8 (invalid UTF-8 breaks DuckDB)
+	// All three are idempotent for already-processed data.
+	//
+	// Structural validation mirrors decodeColumnar: today's inputs are
+	// leader-validated (the WAL stores only payloads that passed the live
+	// decode; replication is HMAC-authenticated), but a checksum-passing
+	// corrupt entry with mismatched column lengths must not flow into the
+	// typed conversion unchecked.
+	numRecords := -1
+	for colName, col := range columns {
+		if numRecords == -1 {
+			numRecords = len(col)
+		} else if len(col) != numRecords {
+			return fmt.Errorf("replayed columnar entry for %s: column length mismatch (expected %d, got %d for '%s')", measurement, numRecords, len(col), colName)
+		}
+	}
+	if numRecords <= 0 {
+		return fmt.Errorf("replayed columnar entry for %s: empty columns", measurement)
+	}
+	if _, ok := columns["time"]; !ok {
+		b.logger.Warn().
+			Str("measurement", measurement).
+			Int("row_count", numRecords).
+			Msg("Replayed data missing 'time' column - generating UTC timestamps")
+		nowMicros := time.Now().UTC().UnixMicro()
+		generated := make([]interface{}, numRecords)
+		for i := range generated {
+			generated[i] = nowMicros
+		}
+		columns["time"] = generated
+	}
+	if err := normalizeTimestampColumns(columns); err != nil {
+		return fmt.Errorf("normalize replayed timestamps for %s: %w", measurement, err)
+	}
+	sanitizeColumnarStrings(columns)
+
 	record := &models.ColumnarRecord{
 		Measurement: measurement,
 		Columns:     columns,

--- a/internal/ingest/msgpack.go
+++ b/internal/ingest/msgpack.go
@@ -461,6 +461,15 @@ func (d *MessagePackDecoder) extractCompactFields(f interface{}) map[string]inte
 // Modifies values in-place to avoid allocating a new []interface{} slice
 // This reduces GC pressure significantly under high load (6M+ RPS)
 func (d *MessagePackDecoder) normalizeTimestamps(columns map[string][]interface{}) error {
+	return normalizeTimestampColumns(columns)
+}
+
+// normalizeTimestampColumns is the package-level implementation, shared with
+// the WAL-replay/replication path (WriteColumnarDirectNoWAL, #590): raw WAL
+// payloads are original client bytes that never went through the live decode
+// path, so replay must apply identical normalization. Idempotent for values
+// already in microseconds (multiplier 1).
+func normalizeTimestampColumns(columns map[string][]interface{}) error {
 	timeCol, exists := columns["time"]
 	if !exists || len(timeCol) == 0 {
 		return nil
@@ -569,6 +578,12 @@ func toInt64Timestamp(v interface{}) (int64, bool) {
 // This prevents DuckDB query failures caused by non-UTF-8 data in Parquet files.
 // Returns count of sanitized fields for logging.
 func (d *MessagePackDecoder) sanitizeStringColumns(columns map[string][]interface{}) int {
+	return sanitizeColumnarStrings(columns)
+}
+
+// sanitizeColumnarStrings is the package-level implementation, shared with
+// the WAL-replay/replication path (#590).
+func sanitizeColumnarStrings(columns map[string][]interface{}) int {
 	sanitizedCount := 0
 	for _, colData := range columns {
 		for i, val := range colData {

--- a/internal/ingest/msgpack_typed_test.go
+++ b/internal/ingest/msgpack_typed_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Basekick-Labs/msgpack/v6"
@@ -330,8 +331,17 @@ func TestTypedDecodeRejectEquivalence(t *testing.T) {
 			if typedErr == nil {
 				t.Fatalf("typed-enabled decode accepted %s that generic path rejects", tc.name)
 			}
-			if typedErr.Error() != boxedErr.Error() {
-				t.Errorf("error text diverged:\n typed: %v\n boxed: %v", typedErr, boxedErr)
+			// Exact-text equality is wrong for errors that embed a column
+			// name chosen by map-iteration order (length_mismatch reports
+			// whichever column the validation loop visited first — two
+			// independent Decode calls can legitimately name different
+			// columns). Compare the deterministic prefix instead.
+			te, be := typedErr.Error(), boxedErr.Error()
+			if te != be {
+				common := "columnar format: array length mismatch"
+				if !(strings.Contains(te, common) && strings.Contains(be, common)) {
+					t.Errorf("error text diverged:\n typed: %v\n boxed: %v", typedErr, boxedErr)
+				}
 			}
 		})
 	}

--- a/internal/ingest/wal_replay_normalization_test.go
+++ b/internal/ingest/wal_replay_normalization_test.go
@@ -1,0 +1,135 @@
+package ingest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// newReplayTestBuffer returns a buffer flushing to tmpDir.
+func newReplayTestBuffer(t *testing.T, tmpDir string) *ArrowBuffer {
+	t.Helper()
+	cfg := &config.IngestConfig{
+		MaxBufferSize:  1000000,
+		MaxBufferAgeMS: 60000,
+		FlushWorkers:   2,
+		FlushQueueSize: 10,
+		ShardCount:     4,
+		Compression:    "snappy",
+	}
+	localStorage, err := storage.NewLocalBackend(tmpDir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	t.Cleanup(func() { localStorage.Close() })
+	return NewArrowBuffer(cfg, localStorage, zerolog.Nop())
+}
+
+func parquetPaths(t *testing.T, tmpDir string) []string {
+	t.Helper()
+	var paths []string
+	_ = filepath.Walk(tmpDir, func(p string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(p, ".parquet") {
+			rel, _ := filepath.Rel(tmpDir, p)
+			paths = append(paths, rel)
+		}
+		return nil
+	})
+	return paths
+}
+
+// TestNoWALReplayNormalizesSecondTimestamps is the #590 repro: WAL replay and
+// cluster replication feed RAW client payloads into WriteColumnarDirectNoWAL,
+// which historically skipped the live decode path's timestamp normalization.
+// A client legitimately sending SECOND-precision timestamps (accepted and
+// normalized on the live path) would replay into 1970-era partitions
+// (seconds interpreted as microseconds by groupByHour).
+//
+// 1700000000 seconds = 2023-11-14. The partition path is the assertion.
+func TestNoWALReplayNormalizesSecondTimestamps(t *testing.T) {
+	tmpDir := t.TempDir()
+	buf := newReplayTestBuffer(t, tmpDir)
+
+	columns := map[string][]interface{}{
+		"time": {int64(1700000000), int64(1700000001)}, // seconds precision
+		"v":    {1.5, 2.5},
+	}
+	if err := buf.WriteColumnarDirectNoWAL(context.Background(), "replaydb", "m1", columns); err != nil {
+		t.Fatalf("WriteColumnarDirectNoWAL: %v", err)
+	}
+	if err := buf.Close(); err != nil { // Close flushes pending buffers
+		t.Fatalf("close: %v", err)
+	}
+
+	paths := parquetPaths(t, tmpDir)
+	if len(paths) == 0 {
+		t.Fatal("no parquet files written")
+	}
+	for _, p := range paths {
+		if strings.Contains(p, "1970") {
+			t.Fatalf("replayed data landed in 1970 partition (#590): %s", p)
+		}
+		if !strings.Contains(p, string(filepath.Separator)+"2023"+string(filepath.Separator)) {
+			t.Fatalf("expected 2023 partition for 1700000000s, got: %s", p)
+		}
+	}
+}
+
+// TestNoWALReplayGeneratesMissingTime: a raw payload whose client omitted
+// the time column (the live path generated timestamps at ingest, but the WAL
+// stores the ORIGINAL bytes without them) must not break replay — timestamps
+// are generated like the live path does.
+func TestNoWALReplayGeneratesMissingTime(t *testing.T) {
+	tmpDir := t.TempDir()
+	buf := newReplayTestBuffer(t, tmpDir)
+
+	columns := map[string][]interface{}{
+		"v":    {int64(1), int64(2), int64(3)},
+		"host": {"a", "b", "c"},
+	}
+	if err := buf.WriteColumnarDirectNoWAL(context.Background(), "replaydb", "m2", columns); err != nil {
+		t.Fatalf("WriteColumnarDirectNoWAL: %v", err)
+	}
+	if err := buf.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	paths := parquetPaths(t, tmpDir)
+	if len(paths) == 0 {
+		t.Fatal("no parquet files written for missing-time payload")
+	}
+	for _, p := range paths {
+		if strings.Contains(p, "1970") {
+			t.Fatalf("missing-time payload landed in 1970 partition: %s", p)
+		}
+	}
+}
+
+// TestNoWALReplaySanitizesStrings: replayed raw payloads must get the same
+// UTF-8 sanitization the live path applies (invalid UTF-8 in parquet breaks
+// DuckDB queries).
+func TestNoWALReplaySanitizesStrings(t *testing.T) {
+	tmpDir := t.TempDir()
+	buf := newReplayTestBuffer(t, tmpDir)
+
+	columns := map[string][]interface{}{
+		"time": {int64(1700000000000000)},
+		"host": {"bad\xff\xfeutf8"},
+	}
+	if err := buf.WriteColumnarDirectNoWAL(context.Background(), "replaydb", "m3", columns); err != nil {
+		t.Fatalf("WriteColumnarDirectNoWAL: %v", err)
+	}
+	// The write mutates columns in place exactly like the live path;
+	// sanitized means valid UTF-8 now.
+	s := columns["host"][0].(string)
+	if strings.Contains(s, "\xff") {
+		t.Fatalf("string column not sanitized on replay path: %q", s)
+	}
+	_ = buf.Close()
+}

--- a/internal/wal/recovery.go
+++ b/internal/wal/recovery.go
@@ -40,6 +40,16 @@ type RecoveryOptions struct {
 
 	// ColumnarCallback handles columnar WAL entries from the zero-copy write path
 	ColumnarCallback ColumnarRecoveryCallback
+
+	// MinFileAge, when > 0, skips WAL files modified more recently than this.
+	// Defense against the #594 class beyond the SkipActiveFile name match:
+	// the periodic recovery reads CurrentFile() and then scans — a rotation
+	// landing between those instants would put the NEW active (header-only)
+	// file in the scan, and deleting it re-creates the unlinked-inode data
+	// loss. Production call sites pass a few seconds; a genuinely
+	// recoverable young file is picked up by the next pass. Zero disables
+	// the guard (tests recover freshly-written files).
+	MinFileAge time.Duration
 }
 
 // Recovery manages WAL recovery operations
@@ -104,6 +114,15 @@ func (r *Recovery) RecoverWithOptions(ctx context.Context, callback RecoveryCall
 			continue
 		}
 
+		// See RecoveryOptions.MinFileAge (#594 rotation-race defense).
+		if opts.MinFileAge > 0 {
+			if info, statErr := os.Stat(walFile); statErr == nil && time.Since(info.ModTime()) < opts.MinFileAge {
+				r.logger.Debug().Str("file", filepath.Base(walFile)).Msg("Skipping too-recent WAL file (possible fresh rotation)")
+				stats.SkippedFiles++
+				continue
+			}
+		}
+
 		r.logger.Info().Str("file", filepath.Base(walFile)).Msg("Recovering WAL file")
 
 		reader := NewReader(walFile, r.logger)
@@ -123,9 +142,22 @@ func (r *Recovery) RecoverWithOptions(ctx context.Context, callback RecoveryCall
 			if entry.ColumnarData != nil && opts.ColumnarCallback != nil {
 				// Columnar entry from zero-copy AppendRaw path
 				if err := opts.ColumnarCallback(ctx, entry.ColumnarData.Database, entry.ColumnarData.Measurement, entry.ColumnarData.Columns); err != nil {
-					r.logger.Error().Err(err).Msg("Failed to replay columnar WAL entry")
+					// #590: continue with the remaining entries instead of
+					// abandoning the rest of the file — one poisoned entry
+					// (e.g. a payload the write path rejects) must not
+					// discard every durable entry after it. The file is not
+					// deleted by THIS recovery pass (allEntriesSucceeded=
+					// false); note the periodic WAL maintenance will still
+					// purge it once it passes safeAge, so the failed entry
+					// is not durably retried — the win here is only that
+					// the healthy entries after it get replayed now.
+					r.logger.Error().Err(err).
+						Str("database", entry.ColumnarData.Database).
+						Str("measurement", entry.ColumnarData.Measurement).
+						Msg("Failed to replay columnar WAL entry; continuing with remaining entries")
 					allEntriesSucceeded = false
-					break
+					stats.CorruptedEntries++
+					continue
 				}
 				fileRecoveredBatches++
 				// Count rows from first column length
@@ -156,6 +188,13 @@ func (r *Recovery) RecoverWithOptions(ctx context.Context, callback RecoveryCall
 					}
 				} else {
 					if err := callback(ctx, entry.Records); err != nil {
+						// Deliberate asymmetry with the columnar branch's
+						// continue: row-format callbacks apply records one
+						// by one, so a mid-entry failure leaves an unknown
+						// prefix applied — continuing to the next entry
+						// would need per-record granularity to be
+						// meaningful. Row entries are the rare non-msgpack
+						// fallback; keep the conservative break here.
 						r.logger.Error().Err(err).Msg("Failed to replay WAL entry")
 						allEntriesSucceeded = false
 						break

--- a/internal/wal/recovery_continue_test.go
+++ b/internal/wal/recovery_continue_test.go
@@ -1,0 +1,75 @@
+package wal
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/rs/zerolog"
+)
+
+// TestColumnarReplayContinuesPastFailedEntry (#590): a single columnar entry
+// whose replay callback fails must NOT abandon the remaining entries in the
+// WAL file — every durable entry after the poisoned one must still be
+// attempted, and the failure must be counted.
+func TestColumnarReplayContinuesPastFailedEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writer, err := NewWriter(&WriterConfig{
+		WALDir:       tmpDir,
+		SyncMode:     SyncModeFsync,
+		MaxSizeBytes: 100 * 1024 * 1024,
+		Logger:       zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		payload, merr := msgpack.Marshal(map[string]interface{}{
+			"m": fmt.Sprintf("m%d", i),
+			"columns": map[string]interface{}{
+				"time": []interface{}{int64(1700000000000000 + i)},
+				"v":    []interface{}{int64(i)},
+			},
+		})
+		if merr != nil {
+			t.Fatalf("marshal: %v", merr)
+		}
+		if aerr := writer.AppendRawWithMeta("db", payload); aerr != nil {
+			t.Fatalf("append %d: %v", i, aerr)
+		}
+	}
+	// Give the async writer goroutine time to drain, then close (flushes).
+	time.Sleep(200 * time.Millisecond)
+	if cerr := writer.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+
+	var attempted []string
+	columnarCallback := func(ctx context.Context, database, measurement string, columns map[string][]interface{}) error {
+		attempted = append(attempted, measurement)
+		if measurement == "m0" {
+			return fmt.Errorf("simulated poisoned entry")
+		}
+		return nil
+	}
+	rowCallback := func(ctx context.Context, records []map[string]interface{}) error { return nil }
+
+	recovery := NewRecovery(tmpDir, zerolog.Nop())
+	stats, err := recovery.RecoverWithOptions(context.Background(), rowCallback, &RecoveryOptions{
+		ColumnarCallback: columnarCallback,
+	})
+	if err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+
+	if len(attempted) != 3 {
+		t.Fatalf("expected all 3 entries attempted after one failure, got %d: %v", len(attempted), attempted)
+	}
+	if stats.CorruptedEntries != 1 {
+		t.Fatalf("expected 1 failed entry counted, got %d", stats.CorruptedEntries)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #590, closes #594. Two WAL bugs — the second discovered while live-verifying the first's fix, and it's the severe one.

- **#594**: startup WAL recovery ran without `SkipActiveFile`. The writer creates its active (header-only) file first; recovery then scanned the directory, deleted that file as an "empty leftover", and the writer spent the whole session appending to the unlinked inode — `data/wal/` empty during operation, nothing to replay after a crash. **Fix**: startup recovery excludes the active file (the periodic flush-failure path already did); `RecoveryOptions.MinFileAge` added and used by the periodic path to close the same class under concurrent rotation (deliberately *not* at startup, where a just-crashed server's seconds-old file must be recovered and no rotation race exists — traced in review).
- **#590**: `WriteColumnarDirectNoWAL` (WAL crash replay + Enterprise cluster WAL replication both feed it *original client bytes*) skipped the live decode path's post-processing. Now applied at that single chokepoint: timestamp unit normalization (seconds/ms clients no longer replay into 1970 partitions), missing-`time` generation (previously those payloads produced **no parquet at all** on replay — silent data loss; timestamps now stamped at replay time, documented), UTF-8 sanitization, and column-length validation (checksum-passing corrupt entries can't reach typed conversion).
- One poisoned columnar entry no longer abandons the rest of its WAL file — replay continues, failure counted in `CorruptedEntries`, file retained by that pass. Row-format branch keeps its conservative `break` (per-record application makes continue meaningless there; documented at the site).

## Test plan

- [x] Four repro tests, each **verified failing pre-fix**: seconds-precision replay landing in a `1970/01/01/00/` partition; missing-time replay producing zero parquet; unsanitized strings; only 1-of-3 entries attempted after a poisoned entry
- [x] Live end-to-end, twice: WAL-enabled server (`fsync`), seconds-precision + missing-`time` writes, `kill -9`, restart — WAL file **present on disk during operation** (first time; previously always empty), all entries replayed, seconds data queryable in its correct 2023 window, missing-time data queryable at replay time
- [x] Configuration matrix traced (WAL off default → no new code reached; WAL on; all timestamp units; poisoned entries; cluster replication; flush-failure periodic recovery unchanged)
- [x] Deep adversarial review: **GO, zero Blockers/High** — confirmed `walRecovery != nil ⇒ walWriter != nil` structurally (NewWriter failure is Fatal before recovery is constructed), `CurrentFile()` stability during the startup scan (no rotation possible before ingest starts), no replica double-normalization (WAL stores original client bytes), and purge-path safety; its five Medium findings addressed in this diff
- [x] `go build`, `go vet`, `gofmt` clean; full `internal/ingest` + `internal/wal` suites green (`-count=1`); also fixes a map-iteration-order flaky assertion in the #591 equivalence tests
- [x] Release notes: WAL reliability section (calm framing) + the replay-time-timestamp semantic for omitted `time`

🤖 Generated with [Claude Code](https://claude.com/claude-code)