### PR TITLE
fix(compaction): skip partitions without a time column; stop retrying deterministic SQL errors

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -448,6 +448,19 @@ The consequences depended on where the stale offset happened to land, which in p
 
 The lookahead now uses the match offset the regex already provides, so it always reads the string actually being rewritten. Table-valued functions and database-qualified names are still skipped, including when whitespace separates the name from the paren.
 
+### Compaction skips partitions without a `time` column instead of failing every cycle
+
+Every compaction query normalizes the `time` column via a `SELECT * REPLACE (...)` expression (and sorts by `time` by default). A partition whose Parquet files have no `time` column at all — data loaded by external tools rather than Arc's ingest path, which always writes one — could never satisfy either, so every cycle failed with `Binder Error: Column "time" in REPLACE list not found in FROM clause`, forever.
+
+Worse, the adaptive batch splitter treated that deterministic error as potentially memory-related and walked its full retry ladder (30 → 15 → 7 → 3 files), re-downloading the batch at every rung — turning one impossible partition into up to eight failed jobs with gigabytes of wasted I/O, every cycle.
+
+Two fixes ship together:
+
+- Compaction now probes the unified schema up front (a footer-only `DESCRIBE`, no data scan) and, when **no** input file has a `time` column, completes as a zero-work skip: a single warning (`Skipping compaction: no 'time' column in any input file`), sources left in place, counted as completed rather than failed. Partitions where only *some* files have `time` compact normally — the missing values are backfilled as `NULL`.
+- Deterministic DuckDB SQL failures (`Binder Error`, `Catalog Error`, `Parser Error`) are now classified as non-recoverable, so the batch splitter no longer retries errors that fail identically at any batch size. DuckDB's own out-of-memory errors remain recoverable — retrying with a smaller batch is exactly the right response, and they are now recognized on the subprocess result path too, not just in stderr.
+
+Zero-work completions (skips, and the existing "all files already compacted" path) also no longer invalidate the parquet-metadata and query caches — nothing changed on storage, and dropping those caches forced a cold re-read on every in-flight query. In cluster mode they now clean up their pending completion manifest instead of leaving one orphaned file per cycle for the startup sweep.
+
 ### Compaction no longer treats a storage failure as "no manifests exist" ([#314](https://github.com/Basekick-Labs/arc/issues/314))
 
 `ListManifests` discarded every error from the storage backend and returned an empty list, with no log line. "No manifests exist" and "we could not find out" are opposite instructions to the caller: an empty manifest set means nothing is being compacted and the candidate may proceed, while a failed lookup means the files in flight cannot be identified.

--- a/internal/compaction/dedup.go
+++ b/internal/compaction/dedup.go
@@ -258,6 +258,28 @@ func buildCompactionQuery(fileListSQL, orderByClause, outputFile string, tagColu
 //     exactly make_timestamptz's unit; it yields a UTC-anchored TIMESTAMPTZ.
 const timeNormalizeReplace = `COALESCE(TRY_CAST("time" AS TIMESTAMPTZ), make_timestamptz(TRY_CAST("time" AS BIGINT))) AS "time"`
 
+// parquetFilesHaveTimeColumn reports whether the unified schema of the given
+// Parquet files contains a "time" column. DESCRIBE over read_parquet reads
+// footers only (no data scan), and union_by_name gives exactly the schema the
+// compaction COPY will see — so "true" here guarantees the REPLACE("time")
+// normalization and the default ORDER BY "time" can bind. When only SOME files
+// have the column, union_by_name backfills the others with NULLs and the query
+// still binds; the probe is false only when NO file has it (e.g. a dataset
+// loaded outside Arc's ingest path, which always writes "time").
+// fileListSQL is a DuckDB array literal or single quoted path, as built by
+// Job.compactFiles.
+func parquetFilesHaveTimeColumn(ctx context.Context, db *sql.DB, fileListSQL string) (bool, error) {
+	query := fmt.Sprintf(
+		`SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM read_parquet(%s, union_by_name=true)) WHERE column_name = 'time'`,
+		fileListSQL,
+	)
+	var n int64
+	if err := db.QueryRowContext(ctx, query).Scan(&n); err != nil {
+		return false, fmt.Errorf("failed to probe parquet schema for time column: %w", err)
+	}
+	return n > 0, nil
+}
+
 // countParquetRows counts total rows across Parquet files using metadata (no data scan).
 // fileListSQL is a DuckDB array literal like "['file1.parquet', 'file2.parquet']".
 func countParquetRows(ctx context.Context, db *sql.DB, fileListSQL string) (int64, error) {

--- a/internal/compaction/job.go
+++ b/internal/compaction/job.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,12 @@ import (
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/rs/zerolog"
 )
+
+// errNoTimeColumn is returned by compactFiles when no input file has a "time"
+// column. Job.Run treats it as a clean skip (complete with zero files, sources
+// left in place), not a failure — the partition is outside Arc's data model and
+// retrying can never succeed.
+var errNoTimeColumn = errors.New("no 'time' column in any input file")
 
 // escapeSQLString escapes single quotes for safe use in DuckDB SQL string literals.
 // This prevents SQL injection when interpolating configuration values.
@@ -296,6 +303,7 @@ func (j *Job) Run(ctx context.Context) error {
 
 	if len(downloadedFiles) == 0 {
 		j.logger.Info().Msg("All files already compacted, skipping")
+		j.discardCompletionManifest()
 		return j.complete()
 	}
 
@@ -311,6 +319,24 @@ func (j *Job) Run(ctx context.Context) error {
 	// This allows GC to reclaim memory from the file metadata before upload/delete phases.
 	downloadedFiles = nil
 
+	if errors.Is(err, errNoTimeColumn) {
+		// Not compactable, ever: no input file has a "time" column, so neither
+		// the REPLACE("time") normalization nor the default ORDER BY "time" can
+		// bind. Complete as a zero-file skip (compactedFiles is empty, so
+		// nothing is uploaded or deleted) rather than failing — a failure here
+		// would repeat every cycle and, pre-classification-fix, walked the
+		// whole adaptive retry ladder on a deterministic error.
+		j.logger.Warn().
+			Str("database", j.Database).
+			Str("partition", j.PartitionPath).
+			Msg("Skipping compaction: no 'time' column in any input file (data was not written by Arc ingest); leaving source files in place")
+		// Zero the download-phase byte count: nothing was compacted, and a
+		// non-zero BytesBefore with BytesAfter 0 would log as a 100%
+		// compression ratio and count toward the manager's total_bytes_saved.
+		j.BytesBefore = 0
+		j.discardCompletionManifest()
+		return j.complete()
+	}
 	if err != nil {
 		return j.fail(fmt.Errorf("failed to compact files: %w", err))
 	}
@@ -655,6 +681,20 @@ func (j *Job) compactFiles(ctx context.Context, files []downloadedFile, tempDir 
 		fileListSQL += "]"
 	}
 
+	// A partition whose files have no "time" column at all can never compact:
+	// the REPLACE("time") normalization in buildCompactionQuery and the default
+	// ORDER BY "time" both fail to bind, deterministically, at any batch size.
+	// Probe the unified schema up front (footer-only read) and skip cleanly
+	// instead of surfacing a Binder Error every cycle. A probe FAILURE is not a
+	// skip — proceed and let the compaction query produce the authoritative
+	// error, so a transient read problem doesn't silently strand a partition.
+	hasTime, err := parquetFilesHaveTimeColumn(ctx, db, fileListSQL)
+	if err != nil {
+		j.logger.Warn().Err(err).Msg("Failed to probe parquet schema for time column; attempting compaction anyway")
+	} else if !hasTime {
+		return "", errNoTimeColumn
+	}
+
 	// Build ORDER BY clause from sort keys
 	// This ensures compacted files maintain the same sort order as ingested files
 	orderByClause := buildOrderByClause(j.SortKeys)
@@ -957,6 +997,23 @@ func (j *Job) writeSourcesDeletedManifest() error {
 		Int("deleted_sources", len(prev.DeletedSources)).
 		Msg("Phase 4 completion manifest: sources_deleted")
 	return nil
+}
+
+// discardCompletionManifest removes the Phase 4 writing_output completion
+// manifest for a job that completes WITHOUT producing output (a no-time-column
+// skip, or all files already compacted). Run() writes that manifest before the
+// outcome is known; a zero-work completion never advances it to
+// output_written, so the watcher will never consume it — and a partition that
+// skips every cycle would otherwise accumulate one orphaned manifest file per
+// cycle, only swept at restart. Idempotent and a no-op in OSS mode.
+func (j *Job) discardCompletionManifest() {
+	if !j.clusterMode() {
+		return
+	}
+	path := filepath.Join(j.CompletionDir, j.JobID+".json")
+	if err := deleteCompletionManifest(path); err != nil {
+		j.logger.Warn().Err(err).Str("path", path).Msg("Failed to remove completion manifest for zero-work job; orphan sweep will collect it")
+	}
 }
 
 // cleanupTemp removes the temporary directory

--- a/internal/compaction/job_notimecolumn_test.go
+++ b/internal/compaction/job_notimecolumn_test.go
@@ -1,0 +1,181 @@
+//go:build duckdb_arrow
+
+package compaction
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	_ "github.com/duckdb/duckdb-go/v2" // duckdb driver
+)
+
+// writeFixtureParquet writes a single-row parquet file whose columns come from
+// the given SELECT list. Paths go through ToSlash because they are interpolated
+// into DuckDB SQL.
+func writeFixtureParquet(t *testing.T, ctx context.Context, db *sql.DB, path, selectList string) {
+	t.Helper()
+	q := fmt.Sprintf(`COPY (SELECT %s) TO '%s' (FORMAT PARQUET)`, selectList, escapeSQLPath(filepath.ToSlash(path)))
+	if _, err := db.ExecContext(ctx, q); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}
+
+// TestParquetFilesHaveTimeColumn exercises the schema probe that gates the
+// time-normalizing REPLACE (and the ORDER BY "time" default) in compaction.
+func TestParquetFilesHaveTimeColumn(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	noTime1 := filepath.Join(dir, "notime1.parquet")
+	noTime2 := filepath.Join(dir, "notime2.parquet")
+	withTime := filepath.Join(dir, "withtime.parquet")
+	writeFixtureParquet(t, ctx, db, noTime1, `'AAPL' AS symbol, 1.5 AS price, 1723600000000000::BIGINT AS timestamp`)
+	writeFixtureParquet(t, ctx, db, noTime2, `'MSFT' AS symbol, 2.5 AS price, 1723600001000000::BIGINT AS timestamp`)
+	writeFixtureParquet(t, ctx, db, withTime, `now() AS time, 'h1' AS host, 1.0 AS value`)
+
+	list := func(paths ...string) string {
+		out := "["
+		for i, p := range paths {
+			if i > 0 {
+				out += ", "
+			}
+			out += fmt.Sprintf("'%s'", escapeSQLPath(filepath.ToSlash(p)))
+		}
+		return out + "]"
+	}
+
+	tests := []struct {
+		name    string
+		files   string
+		hasTime bool
+	}{
+		{"no file has time", list(noTime1, noTime2), false},
+		{"all files have time", list(withTime), true},
+		// union_by_name backfills the missing column with NULLs, so a mixed
+		// partition binds and must NOT be skipped.
+		{"mixed: one file has time", list(noTime1, withTime), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parquetFilesHaveTimeColumn(ctx, db, tt.files)
+			if err != nil {
+				t.Fatalf("parquetFilesHaveTimeColumn: %v", err)
+			}
+			if got != tt.hasTime {
+				t.Errorf("parquetFilesHaveTimeColumn = %v, want %v", got, tt.hasTime)
+			}
+		})
+	}
+}
+
+// TestCompactFiles_SkipsPartitionWithoutTimeColumn is the end-to-end regression
+// for the trades partition: files whose unified schema has no "time" column can
+// never satisfy the REPLACE("time") normalization (nor the default ORDER BY
+// "time"), so compactFiles must return errNoTimeColumn — a clean skip — instead
+// of a Binder Error that the retry ladder then amplifies. Pre-fix, this test
+// fails with: "Binder Error: Column \"time\" in REPLACE list not found in FROM
+// clause".
+func TestCompactFiles_SkipsPartitionWithoutTimeColumn(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	f1 := filepath.Join(dir, "trades_1.parquet")
+	f2 := filepath.Join(dir, "trades_2.parquet")
+	writeFixtureParquet(t, ctx, db, f1, `'AAPL' AS symbol, 'buy' AS side, 1.5 AS price, 2.0 AS amount, 1723600000000000::BIGINT AS timestamp`)
+	writeFixtureParquet(t, ctx, db, f2, `'MSFT' AS symbol, 'sell' AS side, 2.5 AS price, 3.0 AS amount, 1723600001000000::BIGINT AS timestamp`)
+
+	job := NewJob(&JobConfig{
+		Measurement:   "trades",
+		PartitionPath: "trades/trades/2026/08/01",
+		Database:      "trades",
+		Tier:          "daily",
+		TempDirectory: dir,
+		Logger:        zerolog.Nop(),
+		DB:            db,
+	})
+
+	files := []downloadedFile{
+		{storageKey: "trades/trades/2026/08/01/00/trades_1.parquet", localPath: f1, size: fileSize(t, f1)},
+		{storageKey: "trades/trades/2026/08/01/01/trades_2.parquet", localPath: f2, size: fileSize(t, f2)},
+	}
+
+	_, err = job.compactFiles(ctx, files, dir)
+	if !errors.Is(err, errNoTimeColumn) {
+		t.Fatalf("compactFiles error = %v, want errNoTimeColumn", err)
+	}
+	if len(job.compactedFiles) != 0 {
+		t.Errorf("compactedFiles = %v, want empty (skip must not mark files deletable)", job.compactedFiles)
+	}
+	if job.FilesCompacted != 0 {
+		t.Errorf("FilesCompacted = %d, want 0", job.FilesCompacted)
+	}
+}
+
+// TestCompactFiles_TimeColumnPresentStillCompacts is the positive control: a
+// normal partition (time column present) must be unaffected by the probe.
+func TestCompactFiles_TimeColumnPresentStillCompacts(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	f1 := filepath.Join(dir, "cpu_1.parquet")
+	f2 := filepath.Join(dir, "cpu_2.parquet")
+	writeFixtureParquet(t, ctx, db, f1, `TIMESTAMPTZ '2026-08-01 00:00:00Z' AS time, 'h1' AS host, 1.0 AS value`)
+	writeFixtureParquet(t, ctx, db, f2, `TIMESTAMPTZ '2026-08-01 00:00:01Z' AS time, 'h2' AS host, 2.0 AS value`)
+
+	job := NewJob(&JobConfig{
+		Measurement:   "cpu",
+		PartitionPath: "production/cpu/2026/08/01/00",
+		Database:      "production",
+		Tier:          "hourly",
+		TempDirectory: dir,
+		Logger:        zerolog.Nop(),
+		DB:            db,
+	})
+
+	files := []downloadedFile{
+		{storageKey: "production/cpu/2026/08/01/00/cpu_1.parquet", localPath: f1, size: fileSize(t, f1)},
+		{storageKey: "production/cpu/2026/08/01/00/cpu_2.parquet", localPath: f2, size: fileSize(t, f2)},
+	}
+
+	out, err := job.compactFiles(ctx, files, dir)
+	if err != nil {
+		t.Fatalf("compactFiles: %v", err)
+	}
+	if _, statErr := os.Stat(out); statErr != nil {
+		t.Fatalf("compacted output missing: %v", statErr)
+	}
+	if job.FilesCompacted != 2 {
+		t.Errorf("FilesCompacted = %d, want 2", job.FilesCompacted)
+	}
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Size()
+}

--- a/internal/compaction/manager.go
+++ b/internal/compaction/manager.go
@@ -328,11 +328,16 @@ func (m *Manager) CompactPartition(ctx context.Context, candidate Candidate) err
 		}
 	}
 
-	// Update metrics
-	shouldInvalidateCache := err == nil && result.Success
+	// Update metrics. Cache invalidation is gated on FilesCompacted > 0, not
+	// just success: a zero-file completion (all files already compacted, or a
+	// no-time-column skip) changed nothing on storage, and dropping the parquet
+	// metadata + query caches for it would cost every in-flight query a cold
+	// re-read — every cycle, for a partition that skips every cycle.
+	jobSucceeded := err == nil && result.Success
+	shouldInvalidateCache := jobSucceeded && result.FilesCompacted > 0
 
 	m.mu.Lock()
-	if shouldInvalidateCache {
+	if jobSucceeded {
 		m.totalJobsCompleted++
 		m.totalFilesCompacted += result.FilesCompacted
 		m.totalBytesSaved += (result.BytesBefore - result.BytesAfter)

--- a/internal/compaction/subprocess.go
+++ b/internal/compaction/subprocess.go
@@ -371,15 +371,27 @@ func createStorageBackendFromConfig(config *SubprocessJobConfig, logger zerolog.
 	}
 }
 
+// sqlErrorMarkers are deterministic DuckDB SQL failure classes: a query that
+// fails to bind, resolve, or parse fails identically at any batch size, so the
+// adaptive splitter must not walk its retry ladder on them.
+var sqlErrorMarkers = []string{"binder error", "catalog error", "parser error"}
+
+// memoryErrorMarkers indicate memory pressure; retrying with a smaller batch
+// is exactly the right response.
+var memoryErrorMarkers = []string{"out of memory", "cannot allocate", "memory allocation failed"}
+
 // ClassifySubprocessError determines if a subprocess error is recoverable via retry.
 // Returns (recoverable, reason) where reason describes the error type.
 //
 // Recoverable errors (should retry with smaller batch):
 //   - Segmentation faults (memory corruption, often from memory pressure)
 //   - SIGKILL (exit code 137, usually OOM killer)
-//   - Explicit memory errors in stderr
+//   - Explicit memory errors in the error string or stderr (including DuckDB's
+//     own "Out of Memory Error", which arrives via the subprocess JSON result)
 //
 // Non-recoverable errors (should not retry):
+//   - Deterministic DuckDB SQL errors (Binder/Catalog/Parser Error) — these
+//     fail identically at any batch size
 //   - Permission denied
 //   - File not found
 //   - Access denied
@@ -389,7 +401,15 @@ func ClassifySubprocessError(err error, stderr string) (recoverable bool, reason
 	}
 
 	errStr := err.Error()
+	errLower := strings.ToLower(errStr)
 	stderrLower := strings.ToLower(stderr)
+
+	// Process-level evidence first: a real, actionable SQL error always arrives
+	// via the subprocess JSON result (exit 0, success=false), so it can never
+	// co-occur with a signal or OOM exit code. A crashed subprocess, however,
+	// embeds its whole stderr in the error string — including warn lines that
+	// may quote SQL error text — so a signal/exit-code match must win over the
+	// string markers below or a crash-after-warn would misclassify as permanent.
 
 	// Check for signals (segfault, killed)
 	if strings.Contains(errStr, "signal:") {
@@ -413,11 +433,21 @@ func ClassifySubprocessError(err error, stderr string) (recoverable bool, reason
 		}
 	}
 
-	// Check stderr for memory-related errors
-	if strings.Contains(stderrLower, "out of memory") ||
-		strings.Contains(stderrLower, "cannot allocate") ||
-		strings.Contains(stderrLower, "memory allocation failed") {
-		return true, "memory_error"
+	// Deterministic DuckDB SQL errors — permanent at any batch size, so the
+	// splitter's retry ladder (each rung re-downloads the whole batch) is pure
+	// waste. These arrive via the JSON result path, so they appear in err
+	// rather than stderr; check both.
+	for _, marker := range sqlErrorMarkers {
+		if strings.Contains(errLower, marker) || strings.Contains(stderrLower, marker) {
+			return false, "sql_error"
+		}
+	}
+
+	// Check for memory-related errors in either stream.
+	for _, marker := range memoryErrorMarkers {
+		if strings.Contains(errLower, marker) || strings.Contains(stderrLower, marker) {
+			return true, "memory_error"
+		}
 	}
 
 	// Non-recoverable errors - don't waste time retrying

--- a/internal/compaction/subprocess_test.go
+++ b/internal/compaction/subprocess_test.go
@@ -92,6 +92,62 @@ func TestClassifySubprocessError(t *testing.T) {
 			wantReason:      "unknown",
 		},
 		{
+			// Regression: the trades partition (#no-time-column) failed with a
+			// Binder Error via the subprocess JSON result (exit 0, success=false),
+			// so the error text is in err, not stderr. Pre-fix this classified as
+			// "unknown → recoverable" and the adaptive splitter walked the whole
+			// 30→15→7→3 ladder re-downloading files on a deterministic failure.
+			name:            "duckdb binder error in err - not recoverable",
+			err:             errors.New(`failed to compact files: failed to execute compaction query: Binder Error: Column "time" in REPLACE list not found in FROM clause`),
+			stderr:          "",
+			wantRecoverable: false,
+			wantReason:      "sql_error",
+		},
+		{
+			name:            "duckdb catalog error in err - not recoverable",
+			err:             errors.New("failed to execute compaction query: Catalog Error: Table with name x does not exist"),
+			stderr:          "",
+			wantRecoverable: false,
+			wantReason:      "sql_error",
+		},
+		{
+			name:            "duckdb parser error in err - not recoverable",
+			err:             errors.New("failed to execute compaction query: Parser Error: syntax error at or near \"FROM\""),
+			stderr:          "",
+			wantRecoverable: false,
+			wantReason:      "sql_error",
+		},
+		{
+			name:            "duckdb binder error in stderr - not recoverable",
+			err:             errors.New("subprocess failed: exit status 1"),
+			stderr:          `{"level":"error","error":"Binder Error: Column \"time\" in REPLACE list not found in FROM clause"}`,
+			wantRecoverable: false,
+			wantReason:      "sql_error",
+		},
+		{
+			// DuckDB's own OOM surfaces through the same JSON-result path as the
+			// binder error. It must STAY recoverable (retrying a smaller batch is
+			// exactly the right response) and must not be caught by the sql_error
+			// class.
+			name:            "duckdb out of memory in err - recoverable",
+			err:             errors.New("failed to execute compaction query: Out of Memory Error: could not allocate block"),
+			stderr:          "",
+			wantRecoverable: true,
+			wantReason:      "memory_error",
+		},
+		{
+			// A crashed subprocess embeds its whole stderr in the error string,
+			// and that stderr may quote SQL error text in warn lines logged
+			// before the crash. Process-level evidence (signal, OOM exit code)
+			// must win: the crash is memory-dependent and retryable even though
+			// an sql_error marker is present.
+			name:            "crash evidence wins over sql marker in embedded stderr",
+			err:             errors.New(`subprocess failed: signal: killed (stderr: {"level":"warn","message":"probe failed: Binder Error: something"})`),
+			stderr:          `{"level":"warn","message":"probe failed: Binder Error: something"}`,
+			wantRecoverable: true,
+			wantReason:      "killed",
+		},
+		{
 			name:            "case insensitive stderr matching",
 			err:             errors.New("failed"),
 			stderr:          "PERMISSION DENIED",


### PR DESCRIPTION
## Summary

- **Partitions whose Parquet files have no `time` column** (data loaded by external tools, not Arc ingest — e.g. a benchmark dataset with `symbol, side, price, amount, timestamp`) failed compaction with `Binder Error: Column "time" in REPLACE list not found in FROM clause` every cycle, forever. Compaction now probes the unified schema up front (footer-only `DESCRIBE`, no data scan) and completes as a clean zero-work skip: one warning, sources left in place, counted as completed. Mixed partitions (only some files have `time`) compact normally — `union_by_name` backfills `NULL`.
- **Deterministic DuckDB SQL errors (`Binder`/`Catalog`/`Parser Error`) are now non-recoverable** in `ClassifySubprocessError`. Previously they classified as "unknown → recoverable" and the adaptive splitter walked its full ladder (30→15→7→3 files), re-downloading the batch at every rung — turning one impossible partition into up to 8 failed jobs with gigabytes of wasted I/O per cycle. Process-level crash evidence (signals, exit 137/139) is checked **first**, so a crash whose embedded stderr quotes SQL error text still retries. DuckDB's own `Out of Memory Error` (which arrives via the subprocess JSON result, not stderr) is now recognized and stays recoverable.
- **Zero-work completions** (the new skip + the existing "all files already compacted" path) no longer invalidate the parquet-metadata/query caches, no longer inflate `total_bytes_saved`, and in cluster mode delete their pending `writing_output` completion manifest instead of leaking one orphaned file per cycle.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions |
|---|---|---|
| OSS standalone, compaction on (default) | YES — probe in subprocess `compactFiles`, classification in parent `compactFilesAdaptively`, metrics gate in `CompactPartition` | `db` nil-checked before probe; `result` non-nil when `err==nil` (RunJobInSubprocess contract) |
| OSS, compaction disabled | No — manager never constructed; no main.go changes | n/a |
| Cluster mode + no-time partition | YES — skip deletes the `writing_output` manifest `Run()` wrote (path matches `writeCompletionManifest`; delete is idempotent; watcher ignores `writing_output`) | traced |
| Dedup branch (arc:tags) + no time column | Probe runs before tag-metadata reads → skip precedes dedup | traced |
| Mixed partition | Probe true → normal compaction (covered by test) | traced |
| S3/Azure | Probe runs on downloaded local temp paths — backend-agnostic | traced |
| New config keys | none added | n/a |

## Internal review

Single deep reviewer confirmed the matrix row-by-row; no Blockers/High. Both actionable Medium findings addressed in this diff (classification ordering: crash evidence before SQL markers, + doc-comment update). Verified no current Binder error is batch-size-dependent (the #493 phantom-VARCHAR bind was eliminated by the dedup temp-table materialization), so permanent classification strands nothing a split-retry could rescue.

## Test plan

- [x] 6 new `ClassifySubprocessError` cases — 5 verified failing pre-fix; crash-wins-over-marker case covers the review finding
- [x] 3 DuckDB-backed tests (`-tags duckdb_arrow`): probe (none/all/mixed), end-to-end skip via `compactFiles` (verified pre-fix behavior reproduces the exact production Binder Error), positive control
- [x] `go test -race -tags duckdb_arrow ./internal/compaction/` green; `go vet` and `gofmt` clean on touched files
- [x] Live binary run (OSS standalone, local backend): no-time partition skips with one warning + all 14 source files intact; normal 12-file partition compacts to 1 file in the same cycle; `total_failed: 0`, `total_bytes_saved: 0` for the skip
- [x] Release notes updated (26.09.1); docs.basekick.net troubleshooting section shipped separately

## Follow-ups (out of scope)

- Skipped partitions still re-download their batch every cycle before probing (footers are remote); a partition-keyed negative cache in the tier scanner (cf. #345) is the natural next step
- PR 2: bound compaction subprocess memory (`compaction.memory_limit`, `threads`, explicit `temp_directory`)
- Pre-existing `gofmt` drift in `internal/compaction/scheduler.go` / `watcher.go` (untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)