### PR TITLE
feat(compaction): bound subprocess memory and threads (compaction.memory_limit, compaction.threads)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -47,6 +47,24 @@ Env vars follow the usual pattern, e.g. `ARC_ICEBERG_ENABLED=true`.
 
 **Backups cover the catalog wherever it lives.** Backup copies the Iceberg warehouse metadata alongside the Parquet data, and now also the Iceberg SQL catalog itself when `iceberg.catalog_db_path` points somewhere other than the shared database. The catalog holds every table's schema and snapshot pointers, so a backup without it restores data whose tables no longer resolve. Restores of older backups that predate this are unaffected — a missing catalog copy is skipped, not an error.
 
+## New: compaction subprocess resource bounds (`compaction.memory_limit`, `compaction.threads`)
+
+Compaction runs each job in an isolated subprocess so DuckDB's memory is fully returned on exit — but the *peak* was under-constrained. Each subprocess inherited the full `database.memory_limit`, and with the default `max_concurrent = 2`, compaction alone could reach **2× the configured limit on top of the main process's own DuckDB** — the RSS spike operators saw during backfill catch-up, when months of partitions become candidates in a single cycle. Each subprocess also used DuckDB's default of *all* CPU cores, competing with ingest and query work (and sort/scan buffers scale with threads, so this compounded the memory peak).
+
+Two new keys bound this:
+
+```toml
+[compaction]
+memory_limit = ""   # per-subprocess DuckDB memory limit; "" (default) = auto
+threads = 0         # per-subprocess DuckDB threads; 0 (default) = auto
+```
+
+Env vars: `ARC_COMPACTION_MEMORY_LIMIT`, `ARC_COMPACTION_THREADS`.
+
+**Auto defaults:** `memory_limit` derives as `database.memory_limit / max_concurrent`, so all concurrent compaction jobs together stay within roughly one `database.memory_limit` regardless of concurrency (an operator running `database.memory_limit = "8GB"` with default concurrency now gets 4GB per subprocess instead of 8GB each). `threads` defaults to half the CPU cores, minimum 1 — the two default subprocesses together use about one machine's worth of cores. Accepts absolute sizes with a unit (`"8GB"`, `"512MB"`, `"0.5GB"`); percent and unit-less forms are rejected at startup because DuckDB's `SET memory_limit` does not support them, as are other invalid values. The effective values are logged at startup (`subprocess_memory_limit`, `subprocess_threads`) and by each subprocess as it applies them.
+
+Compaction subprocesses also now spill to a managed location: a `duckdb-spill/` directory inside the job's own temp directory (under `compaction.temp_directory`), instead of DuckDB's default `.tmp` relative to the server's working directory. Spill files are covered by the existing job cleanup and crash sweeps, so they can never outlive the job — and they land on the volume you sized for compaction, not wherever Arc was started from.
+
 ## New: tunable compaction batch size
 
 Compaction splits a large partition into batches, each becoming an independent job with its own output file. That batch size was a hardcoded constant (30 files); it is now configurable:

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1162,8 +1162,14 @@ func main() {
 			LockManager:      lockManager,
 			MaxConcurrent:    cfg.Compaction.MaxConcurrent,
 			MaxFilesPerBatch: cfg.Compaction.MaxFilesPerBatch,
-			MemoryLimit:      cfg.Database.MemoryLimit, // Use same limit as main DuckDB
-			CompletionDir:    completionDir,            // Phase 4: empty in OSS, set in cluster mode
+			// Per-subprocess DuckDB bounds. Config resolves the "auto"
+			// sentinels at load time: memory_limit defaults to
+			// database.memory_limit / max_concurrent (so compaction's
+			// worst case stays ~one database.memory_limit total, not
+			// max_concurrent times it), threads to half the cores.
+			MemoryLimit:   cfg.Compaction.MemoryLimit,
+			Threads:       cfg.Compaction.Threads,
+			CompletionDir: completionDir, // Phase 4: empty in OSS, set in cluster mode
 			// Pass the SAME absolute-resolved value the DB-layer sandbox
 			// allowlist references — dbConfig.CompactionTempDirectory has
 			// already been through resolveAbsPath. Using the raw

--- a/internal/compaction/manager.go
+++ b/internal/compaction/manager.go
@@ -33,7 +33,8 @@ type Manager struct {
 	MaxFilesPerBatch int
 	MaxConcurrent    int
 	TempDirectory    string // Temp directory for compaction files
-	MemoryLimit      string // DuckDB memory limit for subprocess (e.g., "8GB")
+	MemoryLimit      string // DuckDB memory limit for EACH subprocess (e.g., "8GB")
+	Threads          int    // DuckDB thread count for EACH subprocess (0 = DuckDB default: all cores)
 	// Phase 4: local-disk directory where compaction subprocesses write
 	// completion manifests for the parent-side CompletionWatcher to pick
 	// up. Empty means "OSS mode, no completion-manifest handoff". Set by
@@ -82,7 +83,8 @@ type ManagerConfig struct {
 	MaxFilesPerBatch int
 	MaxConcurrent    int
 	TempDirectory    string              // Temp directory for compaction files
-	MemoryLimit      string              // DuckDB memory limit for subprocess (e.g., "8GB")
+	MemoryLimit      string              // DuckDB memory limit for EACH subprocess (e.g., "8GB")
+	Threads          int                 // DuckDB thread count for EACH subprocess (0 = DuckDB default: all cores)
 	CompletionDir    string              // Phase 4: local-disk completion-manifest dir (empty = OSS mode)
 	SortKeysConfig   map[string][]string // Per-measurement sort keys from ingest config
 	DefaultSortKeys  []string            // Default sort keys from ingest config
@@ -133,6 +135,7 @@ func NewManager(cfg *ManagerConfig) *Manager {
 		MaxConcurrent:    cfg.MaxConcurrent,
 		TempDirectory:    cfg.TempDirectory,
 		MemoryLimit:      cfg.MemoryLimit,
+		Threads:          cfg.Threads,
 		CompletionDir:    cfg.CompletionDir,
 		SortKeysConfig:   sortKeysConfig,
 		DefaultSortKeys:  defaultSortKeys,
@@ -160,9 +163,16 @@ func NewManager(cfg *ManagerConfig) *Manager {
 		}
 		m.logger.Info().
 			Strs("tiers", enabledTiers).
+			Str("subprocess_memory_limit", m.MemoryLimit).
+			Int("subprocess_threads", m.Threads).
+			Int("max_concurrent", m.MaxConcurrent).
 			Msg("Compaction manager initialized with tiers")
 	} else {
-		m.logger.Info().Msg("Compaction manager initialized (no tiers)")
+		m.logger.Info().
+			Str("subprocess_memory_limit", m.MemoryLimit).
+			Int("subprocess_threads", m.Threads).
+			Int("max_concurrent", m.MaxConcurrent).
+			Msg("Compaction manager initialized (no tiers)")
 	}
 
 	return m
@@ -279,6 +289,7 @@ func (m *Manager) CompactPartition(ctx context.Context, candidate Candidate) err
 		BatchNumber:   candidate.BatchNumber,
 		TempDirectory: m.TempDirectory,
 		MemoryLimit:   m.MemoryLimit,
+		Threads:       m.Threads,
 		SortKeys:      m.GetSortKeys(candidate.Measurement),
 		StorageType:   m.StorageBackend.Type(),
 		StorageConfig: m.StorageBackend.ConfigJSON(),

--- a/internal/compaction/subprocess.go
+++ b/internal/compaction/subprocess.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"runtime/pprof"
 	"strings"
@@ -38,6 +39,11 @@ type SubprocessJobConfig struct {
 	BatchNumber int      `json:"batch_number,omitempty"`
 	SortKeys    []string `json:"sort_keys"`    // Sort keys for ORDER BY in compaction
 	MemoryLimit string   `json:"memory_limit"` // DuckDB memory limit (e.g., "8GB")
+	// Threads is the DuckDB thread count for this subprocess. 0 means leave
+	// DuckDB at its default (all cores) — the parent normally sends the
+	// resolved compaction.threads value, so 0 only occurs for callers that
+	// predate the field.
+	Threads int `json:"threads,omitempty"`
 
 	// Storage configuration
 	StorageType   string `json:"storage_type"`   // "local" or "s3"
@@ -108,13 +114,44 @@ func RunSubprocessJob(config *SubprocessJobConfig) (*SubprocessJobResult, error)
 	}
 	defer db.Close()
 
-	// Set DuckDB memory limit from config.
-	// This prevents OOM on servers without swap by forcing DuckDB to spill to disk.
+	// Set DuckDB memory limit from config. Exceeding it makes DuckDB spill to
+	// its temp_directory (configured below) instead of OOMing the process.
 	if config.MemoryLimit != "" {
 		if _, err := db.Exec(fmt.Sprintf("SET memory_limit='%s'", escapeSQLString(config.MemoryLimit))); err != nil {
 			logger.Warn().Err(err).Str("limit", config.MemoryLimit).Msg("Failed to set DuckDB memory limit")
 		} else {
 			logger.Info().Str("limit", config.MemoryLimit).Msg("DuckDB memory limit configured")
+		}
+	}
+
+	// Cap DuckDB threads. Without this every subprocess uses all cores, so
+	// concurrent compaction jobs compete with the parent's ingest/query work —
+	// and sort/scan buffers scale with threads, so this also bounds memory.
+	if config.Threads > 0 {
+		if _, err := db.Exec(fmt.Sprintf("SET threads=%d", config.Threads)); err != nil {
+			logger.Warn().Err(err).Int("threads", config.Threads).Msg("Failed to set DuckDB thread count")
+		} else {
+			logger.Info().Int("threads", config.Threads).Msg("DuckDB thread count configured")
+		}
+	}
+
+	// Point DuckDB's spill directory inside this job's own temp dir. An
+	// in-memory DuckDB defaults temp_directory to ".tmp" relative to the
+	// PARENT's cwd — unmanaged by compaction's cleanup and wrong if the
+	// operator moved compaction.temp_directory to a bigger volume. The job dir
+	// ({TempDirectory}/{JobID}) is already covered by both the subprocess's
+	// deferred cleanup and the parent's crash sweep (CompactPartition's
+	// partition-prefix walk), so spill files can never outlive the job.
+	// JobID is always set by the parent (CompactPartition); skip on the
+	// defensive empty case and keep DuckDB's default.
+	if config.JobID != "" {
+		spillDir := filepath.Join(config.TempDirectory, config.JobID, "duckdb-spill")
+		if err := os.MkdirAll(spillDir, 0700); err != nil {
+			logger.Warn().Err(err).Str("dir", spillDir).Msg("Failed to create DuckDB spill directory; keeping DuckDB default")
+		} else if _, err := db.Exec(fmt.Sprintf("SET temp_directory='%s'", escapeSQLString(spillDir))); err != nil {
+			logger.Warn().Err(err).Str("dir", spillDir).Msg("Failed to set DuckDB spill directory")
+		} else {
+			logger.Info().Str("dir", spillDir).Msg("DuckDB spill directory configured")
 		}
 	}
 

--- a/internal/config/compaction_limits_test.go
+++ b/internal/config/compaction_limits_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestDeriveCompactionMemoryLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		dbLimit       string
+		maxConcurrent int
+		want          string
+		// skipRegexCheck marks fallback outputs that intentionally return the
+		// (invalid) input verbatim rather than a derivable limit.
+		skipRegexCheck bool
+	}{
+		{name: "even GB division", dbLimit: "8GB", maxConcurrent: 2, want: "4GB"},
+		{name: "odd GB division keeps decimals", dbLimit: "7GB", maxConcurrent: 2, want: "3.5GB"},
+		{name: "floors to 2 decimals, never rounds total up", dbLimit: "14GB", maxConcurrent: 3, want: "4.66GB"},
+		{name: "MB unit preserved", dbLimit: "512MB", maxConcurrent: 2, want: "256MB"},
+		{name: "decimal input", dbLimit: "2.5GB", maxConcurrent: 2, want: "1.25GB"},
+		{name: "sub-GB decimal result", dbLimit: "0.5GB", maxConcurrent: 2, want: "0.25GB"},
+		{name: "explicit B unit works", dbLimit: "100000B", maxConcurrent: 2, want: "50000B"},
+		{name: "max_concurrent 1 returns input verbatim", dbLimit: "8GB", maxConcurrent: 1, want: "8GB"},
+		{name: "max_concurrent 0 treated as default 2", dbLimit: "8GB", maxConcurrent: 0, want: "4GB"},
+		{name: "empty input returns empty (nothing to derive)", dbLimit: "", maxConcurrent: 2, want: ""},
+		{name: "whitespace tolerated like the validation regex", dbLimit: "8 GB", maxConcurrent: 2, want: "4GB"},
+		// DuckDB's SET memory_limit rejects percent and unit-less forms, and
+		// either as database.memory_limit aborts startup at the main DB's loud
+		// SET — derive nothing rather than smuggle an un-SETtable value
+		// downstream to the subprocess's warn-only SET.
+		{name: "percent input derives nothing", dbLimit: "80%", maxConcurrent: 2, want: ""},
+		{name: "unit-less input derives nothing", dbLimit: "1000000", maxConcurrent: 2, want: ""},
+		{name: "percent with max_concurrent 1 still derives nothing", dbLimit: "80%", maxConcurrent: 1, want: ""},
+		// Defensive fallbacks — unreachable through Load (dbLimit is already
+		// regex-validated there); return the input verbatim, i.e. the
+		// pre-derivation behavior of one full database limit per subprocess.
+		{name: "unparseable input returned verbatim (defensive)", dbLimit: "lots", maxConcurrent: 2, want: "lots", skipRegexCheck: true},
+		{name: "near-zero result falls back to input", dbLimit: "0.01GB", maxConcurrent: 2, want: "0.01GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveCompactionMemoryLimit(tt.dbLimit, tt.maxConcurrent)
+			if got != tt.want {
+				t.Errorf("deriveCompactionMemoryLimit(%q, %d) = %q, want %q", tt.dbLimit, tt.maxConcurrent, got, tt.want)
+			}
+			// Whatever we derive must itself pass the memory_limit validation
+			// regex — the derived value is later handed to DuckDB SET.
+			if got != "" && !tt.skipRegexCheck && !memoryLimitRe.MatchString(got) {
+				t.Errorf("derived value %q does not match memoryLimitRe", got)
+			}
+		})
+	}
+}
+
+// TestValidateCompactionMemoryLimit covers the forms DuckDB's SET
+// memory_limit accepts vs rejects. Unlike database.memory_limit (whose failed
+// SET aborts startup loudly), the compaction subprocess only warns on a failed
+// SET — so validation must reject anything DuckDB would refuse, or the
+// subprocess runs silently unbounded.
+func TestValidateCompactionMemoryLimit(t *testing.T) {
+	valid := []string{"", "2GB", "512MB", "0.5GB", "8 GB", "100000B", "1.5TB", "4KB"}
+	for _, v := range valid {
+		if err := validateCompactionMemoryLimit(v); err != nil {
+			t.Errorf("validateCompactionMemoryLimit(%q) = %v, want nil", v, err)
+		}
+	}
+	invalid := []string{"40%", "80 %", "1000000", "0.5", "bogus", "GB", "-1GB"}
+	for _, v := range invalid {
+		if err := validateCompactionMemoryLimit(v); err == nil {
+			t.Errorf("validateCompactionMemoryLimit(%q) = nil, want error", v)
+		}
+	}
+}
+
+func TestGetDefaultCompactionThreads(t *testing.T) {
+	got := getDefaultCompactionThreads()
+	if got < 1 {
+		t.Errorf("getDefaultCompactionThreads() = %d, want >= 1", got)
+	}
+	if want := runtime.NumCPU() / 2; want >= 1 && got != want {
+		t.Errorf("getDefaultCompactionThreads() = %d, want %d (half of %d cores)", got, want, runtime.NumCPU())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -155,6 +157,26 @@ type CompactionConfig struct {
 	DailySkipFileAgeCheckDays int    // Skip file creation time check for partitions older than N days (default: 7)
 	MaxConcurrent             int    // Max concurrent compaction jobs (default: 2)
 	TempDirectory             string // Temporary directory for compaction files (default: ./data/compaction)
+
+	// MemoryLimit is the DuckDB memory limit applied to EACH compaction
+	// subprocess. Empty (the default) means auto-derive: database.memory_limit
+	// divided by max_concurrent, so worst-case compaction memory stays at
+	// roughly one database.memory_limit regardless of concurrency. Before this
+	// key existed, each subprocess inherited the FULL database.memory_limit —
+	// with the default max_concurrent of 2, compaction alone could reach 2x
+	// the configured limit on top of the main process's DuckDB, which is
+	// exactly the RSS spike operators saw during backfill catch-up cycles.
+	// Accepts absolute sizes ("8GB", "512MB"). Percent forms are rejected:
+	// DuckDB's SET memory_limit does not support them, and the subprocess
+	// only warns on a failed SET, which would leave it silently unbounded.
+	MemoryLimit string
+
+	// Threads is the DuckDB thread count for EACH compaction subprocess.
+	// 0 (the default) means auto: half the CPU cores, minimum 1. Before this
+	// key existed, each subprocess used DuckDB's default of ALL cores, so two
+	// concurrent jobs could saturate the machine and starve ingest. Sort and
+	// scan buffers scale with threads, so this also bounds memory.
+	Threads int
 
 	// MaxFilesPerBatch bounds how many files a single compaction job feeds to
 	// one DuckDB read_parquet() call; larger partitions are split into that
@@ -813,6 +835,8 @@ func Load() (*Config, error) {
 			MaxConcurrent:               v.GetInt("compaction.max_concurrent"),
 			MaxFilesPerBatch:            v.GetInt("compaction.max_files_per_batch"),
 			TempDirectory:               v.GetString("compaction.temp_directory"),
+			MemoryLimit:                 v.GetString("compaction.memory_limit"),
+			Threads:                     v.GetInt("compaction.threads"),
 			CompletionWatcherIntervalMS: v.GetInt("compaction.completion_watcher_interval_ms"),
 			CompletionDir:               v.GetString("compaction.completion_dir"),
 			CompletionOrphanTimeoutMS:   v.GetInt("compaction.completion_orphan_timeout_ms"),
@@ -1010,6 +1034,29 @@ func Load() (*Config, error) {
 
 	if cfg.Database.MemoryLimit != "" && !memoryLimitRe.MatchString(cfg.Database.MemoryLimit) {
 		return nil, fmt.Errorf("invalid database.memory_limit value: %q", cfg.Database.MemoryLimit)
+	}
+	if err := validateCompactionMemoryLimit(cfg.Compaction.MemoryLimit); err != nil {
+		return nil, err
+	}
+	if cfg.Compaction.Threads < 0 {
+		return nil, fmt.Errorf("invalid compaction.threads value: %d (must be >= 0; 0 = auto)", cfg.Compaction.Threads)
+	}
+	// A negative max_concurrent would reach make(chan struct{}, m.MaxConcurrent)
+	// in the compaction manager's cycle loop and panic the process at the first
+	// scheduled cycle — NewManager only defaults the ZERO value. Fail fast here
+	// instead; 0 remains "use the default of 2".
+	if cfg.Compaction.MaxConcurrent < 0 {
+		return nil, fmt.Errorf("invalid compaction.max_concurrent value: %d (must be >= 0; 0 = default)", cfg.Compaction.MaxConcurrent)
+	}
+
+	// Resolve the "auto" sentinels AFTER validation so everything downstream
+	// (main.go wiring, the compaction manager, the subprocess) sees concrete
+	// effective values and the startup config log shows what will actually run.
+	if cfg.Compaction.MemoryLimit == "" {
+		cfg.Compaction.MemoryLimit = deriveCompactionMemoryLimit(cfg.Database.MemoryLimit, cfg.Compaction.MaxConcurrent)
+	}
+	if cfg.Compaction.Threads == 0 {
+		cfg.Compaction.Threads = getDefaultCompactionThreads()
 	}
 
 	// Trim storage identifiers in-place before validating. These build DuckDB
@@ -1434,6 +1481,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("compaction.max_concurrent", 2)                   // 2 concurrent jobs
 	v.SetDefault("compaction.max_files_per_batch", 30)             // 30 files per DuckDB read_parquet() call; valid range [2, 500]
 	v.SetDefault("compaction.temp_directory", "./data/compaction") // Temp directory for compaction files
+	v.SetDefault("compaction.memory_limit", "")                    // "" = auto: database.memory_limit / max_concurrent (see CompactionConfig.MemoryLimit)
+	v.SetDefault("compaction.threads", 0)                          // 0 = auto: half the CPU cores, min 1 (see CompactionConfig.Threads)
 	// Phase 4: completion-manifest watcher tunables
 	v.SetDefault("compaction.completion_watcher_interval_ms", 1000) // 1s poll rate
 	v.SetDefault("compaction.completion_dir", "")                   // "" = derive from temp_directory
@@ -1688,6 +1737,99 @@ func getDefaultMaxConnections() int {
 		return 64 // Cap at 64 to avoid excessive resource usage
 	}
 	return maxConns
+}
+
+// memoryLimitValueRe splits a validated memory-limit string into its numeric
+// value and unit. Same shape as memoryLimitRe, with capture groups.
+var memoryLimitValueRe = regexp.MustCompile(`^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB|%)?$`)
+
+// validateCompactionMemoryLimit rejects compaction.memory_limit values that
+// DuckDB's SET memory_limit would refuse: percent forms and unit-less numbers
+// (both of which memoryLimitRe allows, because database.memory_limit shares
+// that regex). The distinction matters here and not for database.memory_limit
+// because the main database's failed SET aborts startup loudly, while the
+// compaction subprocess only WARNS on a failed SET — an un-SETtable value
+// would silently leave every subprocess unbounded, defeating the limit
+// entirely. Empty is valid ("auto"). Verified against DuckDB: absolute sizes
+// with a B/KB/MB/GB/TB unit work (decimals and internal whitespace included);
+// "%" and bare numbers are parser errors.
+func validateCompactionMemoryLimit(limit string) error {
+	if limit == "" {
+		return nil
+	}
+	if !memoryLimitRe.MatchString(limit) {
+		return fmt.Errorf("invalid compaction.memory_limit value: %q", limit)
+	}
+	m := memoryLimitValueRe.FindStringSubmatch(strings.TrimSpace(limit))
+	if m == nil || m[2] == "" || m[2] == "%" {
+		return fmt.Errorf("invalid compaction.memory_limit value: %q (DuckDB requires an absolute size with a unit, e.g. \"2GB\" or \"512MB\"; percent and unit-less forms are not supported)", limit)
+	}
+	return nil
+}
+
+// deriveCompactionMemoryLimit computes the auto value for
+// compaction.memory_limit: database.memory_limit divided by the effective
+// max_concurrent, so all concurrent compaction subprocesses together stay
+// within roughly one database.memory_limit. The unit is preserved; the value
+// is floored to 2 decimals so the division never rounds the total up. Falls
+// back to dbLimit unchanged when it cannot parse (dbLimit is already
+// regex-validated, so this is defensive) or when division would produce a
+// nonsensical near-zero limit.
+//
+// An empty dbLimit (operator explicitly disabled the database limit, letting
+// DuckDB default to 80% of RAM) returns "" — there is nothing to derive from,
+// and the subprocess skips the SET entirely, matching pre-existing behavior.
+// A percent or unit-less dbLimit also returns "": DuckDB's SET memory_limit
+// rejects both forms, so such a config aborts startup at the main database's
+// loud SET before compaction ever runs — deriving from it would only smuggle
+// an un-SETtable value past validateCompactionMemoryLimit (which checks the
+// operator-set value BEFORE this derivation fills it in).
+//
+// The remaining fallbacks (unparseable input, near-zero result) return
+// dbLimit verbatim — i.e. the pre-derivation behavior of one full database
+// limit per subprocess. Both are unreachable through Load, which has already
+// regex-validated dbLimit; they exist only so a future caller can't get an
+// empty limit out of a non-empty input by accident.
+func deriveCompactionMemoryLimit(dbLimit string, maxConcurrent int) string {
+	if dbLimit == "" {
+		return ""
+	}
+	m := memoryLimitValueRe.FindStringSubmatch(strings.TrimSpace(dbLimit))
+	if m == nil {
+		return dbLimit
+	}
+	if m[2] == "" || m[2] == "%" {
+		return ""
+	}
+	// Load has already rejected negative max_concurrent; 0 means the default
+	// of 2, matching compaction.NewManager.
+	if maxConcurrent <= 0 {
+		maxConcurrent = 2
+	}
+	if maxConcurrent == 1 {
+		return dbLimit
+	}
+	value, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return dbLimit
+	}
+	derived := math.Floor(value/float64(maxConcurrent)*100) / 100
+	if derived <= 0 {
+		return dbLimit
+	}
+	return strconv.FormatFloat(derived, 'f', -1, 64) + m[2]
+}
+
+// getDefaultCompactionThreads is the auto value for compaction.threads: half
+// the CPU cores, minimum 1. With the default max_concurrent of 2, the two
+// subprocesses together use about as many threads as the machine has cores,
+// leaving headroom for the main process's ingest and query work.
+func getDefaultCompactionThreads() int {
+	threads := runtime.NumCPU() / 2
+	if threads < 1 {
+		threads = 1
+	}
+	return threads
 }
 
 func getDefaultMemoryLimit() string {


### PR DESCRIPTION
## Summary

Follow-up to #596 (second of the two compaction PRs). Each compaction subprocess previously inherited the **full** `database.memory_limit` and DuckDB's default thread count (all cores) — with default `max_concurrent = 2`, compaction alone could reach 2× the configured memory limit on top of the main process's DuckDB. This is the RSS spike operators see during backfill catch-up, when months of partitions become candidates in one cycle.

- **`compaction.memory_limit`** (default `""` = auto): per-subprocess DuckDB memory limit, derived as `database.memory_limit / effective max_concurrent` (floored to 2 decimals so the total never rounds up; unit preserved). All concurrent jobs together stay within ~one `database.memory_limit`.
- **`compaction.threads`** (default `0` = auto): per-subprocess DuckDB threads, half the CPU cores, minimum 1 — the default two subprocesses together use about one machine's worth of cores, and sort/scan buffers scale with threads so this also bounds memory.
- **Managed spill**: subprocesses `SET temp_directory` to `{TempDirectory}/{JobID}/duckdb-spill` instead of DuckDB's default `.tmp` relative to the parent's cwd. Spill files are covered by the job's deferred cleanup, the parent's crash sweep, and startup `CleanupOrphanedTempDirs`, so they cannot outlive the job.
- **Fail-fast validation**: percent and unit-less memory limits are rejected at startup — DuckDB's `SET memory_limit` refuses both, and unlike the main database (loud SET failure aborts startup) the subprocess only *warns* on a failed SET, which would leave it silently unbounded. Negative `compaction.threads` and negative `compaction.max_concurrent` are also rejected (the latter previously reached `make(chan struct{}, n)` and panicked the process at the first scheduled cycle).

## Configuration matrix (every new key exercised at non-default values, live)

| Configuration | Result |
|---|---|
| All defaults (OSS) | memory derived = `database.memory_limit / 2`, threads = cores/2 — traced |
| `memory_limit="1GB"`, `threads=2` | subprocess SET both + spill dir created; 12→1 compaction succeeded — **live** |
| `database.memory_limit="8GB"`, compaction auto | subprocess SET `4GB` — **live** |
| `max_concurrent=1` | derived = full `8GB` — **live** |
| `memory_limit="0.5GB"` (decimal edge) | accepted, applied — **live** |
| `memory_limit="bogus"` / `"40%"` / `"1000000"` (unit-less) | startup exit 1, clear error — **live** |
| `threads=-1` / `max_concurrent=-1` | startup exit 1, clear error — **live** |
| `database.memory_limit=""` explicit | derives `""`, subprocess skips SET (pre-existing behavior), threads still capped — traced |
| Cluster mode | `Threads` travels via `SubprocessJobConfig` JSON; JobID always parent-set → spill dir active — traced |

## Internal review

Single deep reviewer confirmed all matrix rows (including empirical DuckDB checks of which SET forms are accepted) and found 1 High + 2 Medium, all fixed in this diff and re-verified live:
- **H1**: unit-less values passed the shared `memoryLimitRe` but DuckDB rejects them at SET → subprocess silently unbounded. Now rejected at startup, with the fix's own edges tested (`0.5GB`, `8 GB`, `100000B` all valid).
- **M1**: negative `max_concurrent` panic (pre-existing) — now validated.
- **M2**: derivation fallback semantics documented.

## Test plan

- [x] `TestDeriveCompactionMemoryLimit` (16 cases: units, decimals, flooring, percent/unit-less refusal, defensive fallbacks) + `TestValidateCompactionMemoryLimit` (accept/reject sets) + `TestGetDefaultCompactionThreads`
- [x] `go test -race -tags duckdb_arrow ./internal/compaction/`, `go test ./internal/config/`, `go vet`, `gofmt` clean on touched files
- [x] 8 live binary runs (table above)
- [x] Release notes section in 26.09.1; docs.basekick.net configuration subsection shipped separately