### PR TITLE
fix(startup): refuse to start when built without -tags=duckdb_arrow

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -441,6 +441,23 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### Arc refuses to start when built without `-tags=duckdb_arrow`
+
+Arc's query fast path uses DuckDB's Arrow interface, which `duckdb-go/v2` places behind the `duckdb_arrow` build tag — the tag is upstream's, not Arc's, and `NewArrowFromConn` does not exist in the package without it. Arc mirrored that with tagged files and a `database/sql` fallback, so a binary built without the tag still compiled and still started.
+
+That binary was not a lighter variant, it was a strictly worse one. On a 2M-row query, `/api/v1/query` served the fallback at **1425ms against 637ms** for the same query on a tagged build — byte-identical responses, 2.2× the latency. `/api/v1/query/arrow` was worse than unavailable: the route is never registered, so the request fell through to the `GET /api/v1/query/:measurement` pattern and returned `405 Method Not Allowed`, which a client cannot distinguish from using the wrong verb. `/api/v1/query/msgpack` returned `501`.
+
+Every artifact Arc ships already sets the tag — `make build`, the Dockerfile, and all release targets including FIPS — so no released binary was ever affected. The untagged build was reachable only by someone running a bare `go build ./cmd/arc`, who would then be silently served half-speed queries and a misleading `405`.
+
+Arc now checks the tag at startup and refuses to run without it, alongside the existing FIPS fail-closed check:
+
+```
+Arc was built without -tags=duckdb_arrow; refusing to start.
+The Arrow query path is required: rebuild with `make build`.
+```
+
+The untagged tree still compiles, so `go build ./...` and editor tooling are unaffected — the failure moved from silent runtime degradation to an explicit startup error. The `compact` subcommand is unaffected; it does not use the query path.
+
 ### `LEFT`/`RIGHT`/`FULL OUTER`/`NATURAL` joins are no longer rewritten to inner joins ([#586](https://github.com/Basekick-Labs/arc/issues/586))
 
 Arc rewrites table references into `read_parquet(...)` calls before handing the query to DuckDB. The join rewriter matched the join operator but replaced it with a hardcoded bare `JOIN`, discarding whatever modifier the query actually used. `LEFT JOIN metrics` became `JOIN read_parquet(…)`.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -106,6 +106,19 @@ func main() {
 		log.Fatal().Msg("FIPS build started without the Go Cryptographic Module in FIPS mode (GODEBUG=fips140 disabled); refusing to start. Remove any GODEBUG=fips140=off override.")
 	}
 
+	// Fail closed: every artifact Arc ships (Makefile, Dockerfile, and all
+	// release-build.yml targets) is compiled with -tags=duckdb_arrow. The tag
+	// is a pass-through requirement of duckdb-go/v2, which puts its Arrow
+	// interface — NewArrowFromConn, the whole query fast path — behind the
+	// same tag. A binary built without it is not a lighter variant, it is a
+	// strictly worse one: /api/v1/query serves the database/sql fallback at
+	// roughly half the throughput, /api/v1/query/arrow is unrouted (405), and
+	// /api/v1/query/msgpack returns 501. Refuse to start rather than serve a
+	// silently degraded configuration nobody intends to run.
+	if !database.ArrowEnabled {
+		log.Fatal().Msg("Arc was built without -tags=duckdb_arrow; refusing to start. The Arrow query path is required: rebuild with `make build` (or `go build -tags=duckdb_arrow ./cmd/arc`).")
+	}
+
 	// Validate Enterprise License early (before component initialization)
 	// This allows us to apply core limits to DuckDB and ingestion workers
 	var licenseClient *license.Client


### PR DESCRIPTION
## Summary

- Arc now **refuses to start** if built without `-tags=duckdb_arrow`, instead of running in a silently degraded mode.
- The tag is a **pass-through requirement of `duckdb-go/v2`**, which puts its Arrow interface (`NewArrowFromConn`) behind `//go:build duckdb_arrow`. It is not Arc's tag to remove — the upstream symbol does not exist without it.
- An untagged binary was not a lighter variant, it was strictly worse:
  - `/api/v1/query` served the `database/sql` fallback at **1425ms vs 637ms** on a 2M-row query (byte-identical responses, 2.2x latency)
  - `/api/v1/query/arrow` returned **405 Method Not Allowed** — the route is never registered, so the request falls through to the `GET /api/v1/query/:measurement` pattern, which a client cannot distinguish from using the wrong verb
  - `/api/v1/query/msgpack` returned **501**
- **No released binary was ever affected** — `make build`, the Dockerfile, and all five `release-build.yml` targets (including FIPS) already set the tag. The untagged build was reachable only via a bare `go build ./cmd/arc`.
- The untagged tree still **compiles**, so `go build ./...`, `go vet`, and editor tooling are unaffected. The failure moved from silent runtime degradation to an explicit startup error.
- The `compact` subcommand is unaffected — it returns before the check and has no Arrow dependency.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, tagged | Yes — `main.go:118` evaluates; `ArrowEnabled=true` via `duckdb_arrow.go:19-21` `init()`. No Fatal. | No deref. `ArrowEnabled` is a package-level `bool` (`duckdb.go:20`), never nil. |
| OSS standalone, **untagged** (non-default build) | Yes — `ArrowEnabled=false` → `log.Fatal`, exit 1. Verified by running it. | Same; bool only. Runs before any subsystem init. |
| Cluster / compaction / license / auth (any combo) | Yes, identically — check precedes `licenseClient` (:122), `authManager`, `clusterCoordinator`, `compactionManager`. | N/A by construction — placed before every subsystem, so no independently-enabled-subsystem interaction is possible (the #445 class). |
| FIPS build (`duckdb_arrow,fips`) | Yes — runs right after the existing FIPS fail-closed (`main.go:105`). Both tags set in `Makefile:15`. | Ordering intentional: FIPS posture first, Arrow second. Neither depends on the other. |
| `compact` subcommand | No — returns at `main.go:78-81` before the check. | Intentional; verified `internal/compaction/` has zero references to the Arrow API. |

**New config keys: none.** The diff reads a build-tag artifact, not a config key, so the non-default-value check does not apply.

## Test plan

- [x] `go build ./cmd/... ./internal/...` succeeds **both** tagged and untagged
- [x] `go vet ./cmd/arc/` clean in both build modes
- [x] `gofmt -l cmd/arc/main.go` empty (the 11 files listed under `./internal` are pre-existing drift, confirmed by stash-and-rerun)
- [x] Untagged binary: exits **1** with an actionable message
- [x] Tagged binary: starts and serves JSON / msgpack / Arrow all **200**
- [x] `internal/api/query_msgpack_no_tag_test.go` still passes (library test, never calls `main()`)
- [x] No CI path breaks — all five `release-build.yml` matrix targets set the tag; `scripts/test-decimal128.sh:53` already passes it
- [x] 405-vs-404 claim independently reproduced with a minimal Fiber app
- [x] Release notes updated in the same change set

🤖 Generated with [Claude Code](https://claude.com/claude-code)