### PR TITLE
fix(query): normalize decimals on the msgpack path and freeze the types contract

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -441,6 +441,24 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### msgpack query responses: decimal columns are now numbers, and the `types` array is a frozen contract
+
+Two related fixes to `/api/v1/query/msgpack`, ahead of that endpoint graduating out of experimental.
+
+**Decimal columns disagreed with their declared type.** DuckDB returns `SUM(integer)` as `decimal(38,0)` and `AVG` as `decimal(x,y)`. The Arrow IPC path normalizes those to `int64`/`float64`; the msgpack path did not, and its encoder has no decimal case — so decimal columns fell through to the string fallback. The response advertised `decimal(38, 0)` in `types` while transmitting the msgpack **string** `"3"`, and the same query returned a number on `/api/v1/query/arrow` but a string on `/api/v1/query/msgpack`. Decimals are now normalized on the msgpack path too: `SUM(int)` yields `int64`, scaled decimals yield `float64`, values are numeric, and the two binary formats agree for the same SQL.
+
+**The `types` array is now Arc's own contract rather than arrow-go debug output.** Type names previously came from `arrow.DataType.String()`, which upstream treats as debug output and reformats in patch releases — `list<item: int32>` gained `, nullable` in 2021, its hardcoded `item` became the element name a week later, and struct gained an (un-comma'd) ` nullable` in the arrow-go release Arc currently pins. A client binding to those strings would break on a routine dependency bump.
+
+Names are now derived from stable Arrow type IDs:
+
+- **Scalars are unchanged** — `int64`, `utf8`, `float64`, `bool`, `binary`, `date32` and friends keep their exact spelling, so existing clients see no difference.
+- **Parameterized types keep their information** in an Arc-owned format: `timestamp[us]` (the unit is load-bearing) and `decimal(p, s)`.
+- **Nested types collapse to a bare `list` / `struct` / `map`.** The encoder has no list or struct case, so those values already go out as strings; a bare token says "opaque" instead of promising element typing that is not delivered.
+- **Types the encoder renders as text report `string_encoded`** — `DATE64`, `TIME`, `INTERVAL`, `DURATION`, `FLOAT16`, and fixed-size binary have no typed encoder case, so their values are transmitted as msgpack strings. They previously reported precise names like `duration[ns]`, which is the same "numeric-looking name over a string payload" defect as the decimal bug above; the name now matches the wire.
+- **Unrecognized types emit an `unknown:` sentinel** and log once, so a client cannot accidentally bind to a spelling Arc does not control. DuckDB `ENUM` columns land here, since DuckDB exports them as Arrow dictionaries.
+
+The SHOW handlers, which emit the same `types` field from a second code path, now share one set of constants with the streaming path, so the two cannot drift. A golden test pins every string the contract can produce.
+
 ### Arc refuses to start when built without `-tags=duckdb_arrow`
 
 Arc's query fast path uses DuckDB's Arrow interface, which `duckdb-go/v2` places behind the `duckdb_arrow` build tag — the tag is upstream's, not Arc's, and `NewArrowFromConn` does not exist in the package without it. Arc mirrored that with tagged files and a `database/sql` fallback, so a binary built without the tag still compiled and still started.

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -3299,10 +3299,10 @@ func (h *QueryHandler) handleShowDatabases(c *fiber.Ctx, start time.Time) error 
 	hasTiering := h.tieringManager != nil
 	if hasTiering {
 		columns = []string{"database", "tier"}
-		types = []string{"utf8", "utf8"}
+		types = []string{wireTypeUTF8, wireTypeUTF8}
 	} else {
 		columns = []string{"database"}
-		types = []string{"utf8"}
+		types = []string{wireTypeUTF8}
 	}
 	data := make([][]interface{}, 0)
 
@@ -3402,7 +3402,7 @@ func (h *QueryHandler) handleShowTables(c *fiber.Ctx, start time.Time, database 
 	// types parallel to columns: SHOW TABLES emits two text columns,
 	// a text path, an int file count, and a float size. Declared
 	// explicitly rather than inferred from row content.
-	types := []string{"utf8", "utf8", "utf8", "int64", "float64"}
+	types := []string{wireTypeUTF8, wireTypeUTF8, wireTypeUTF8, wireTypeInt64, wireTypeFloat64}
 	data := make([][]interface{}, 0)
 
 	ctx := context.Background()

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -451,7 +451,12 @@ type decimalCastInfo struct {
 func normalizeDecimalSchema(schema *arrow.Schema) *decimalCastInfo {
 	hasDecimal := false
 	for i := 0; i < schema.NumFields(); i++ {
-		if _, ok := schema.Field(i).Type.(*arrow.Decimal128Type); ok {
+		// Match the arrow.DecimalType interface, not *arrow.Decimal128Type:
+		// arrow-go also has Decimal32/64/256, and a decimal that slips
+		// through here is neither normalized nor encodable (the msgpack
+		// encoder has no decimal case), so it would go out as a string
+		// under a numeric-looking type name.
+		if _, ok := schema.Field(i).Type.(arrow.DecimalType); ok {
 			hasDecimal = true
 			break
 		}
@@ -464,8 +469,8 @@ func normalizeDecimalSchema(schema *arrow.Schema) *decimalCastInfo {
 	fields := make([]arrow.Field, schema.NumFields())
 	for i := 0; i < schema.NumFields(); i++ {
 		f := schema.Field(i)
-		if dt, ok := f.Type.(*arrow.Decimal128Type); ok {
-			if dt.Scale == 0 {
+		if dt, ok := f.Type.(arrow.DecimalType); ok {
+			if dt.GetScale() == 0 {
 				targets[i] = arrow.PrimitiveTypes.Int64
 			} else {
 				targets[i] = arrow.PrimitiveTypes.Float64

--- a/internal/api/query_msgpack.go
+++ b/internal/api/query_msgpack.go
@@ -147,7 +147,24 @@ func executeArrowMsgPackQuery(
 	// row stream can produce partial JSON-valid output, so the
 	// failure mode is less harmful there.
 	schema := reader.Schema()
-	batches, rowCount, drainErr := drainArrowBatches(ctx, reader, governanceMaxRows)
+
+	// Normalize decimal columns exactly as the Arrow IPC path does
+	// (see normalizeDecimalSchema): DuckDB returns SUM(integer) as
+	// decimal(38,0) and AVG as decimal(x,y). Without this the msgpack
+	// encoder has no *array.Decimal128 case, so decimal columns fall
+	// through to encodeFallbackColumn and go out as msgpack *strings*
+	// while the "types" array advertises decimal(38, 0) — the wire
+	// contract disagreeing with the bytes on the wire. Casting here
+	// keeps types and values consistent and makes msgpack agree with
+	// /api/v1/query/arrow for the same SQL.
+	// castInfo is nil when there are no decimal columns (zero overhead
+	// on the common path).
+	castInfo := normalizeDecimalSchema(schema)
+	if castInfo != nil {
+		schema = castInfo.schema
+	}
+
+	batches, rowCount, drainErr := drainArrowBatches(ctx, reader, governanceMaxRows, castInfo)
 	// reader and conn are no longer needed after the drain — release
 	// them before either the error or the streaming branch.
 	reader.Release()
@@ -265,10 +282,25 @@ func executeArrowMsgPackQuery(
 
 // drainArrowBatches reads all batches from the Arrow reader into a
 // retained slice. governanceMaxRows (when > 0) trims the trailing batch
-// to fit. Returns the batches, total row count, and an error if ctx
-// fires or the reader surfaces a deferred error. Callers MUST Release()
-// the returned batches when done.
-func drainArrowBatches(ctx context.Context, reader array.RecordReader, governanceMaxRows int) ([]arrow.Record, int, error) {
+// to fit. castInfo (when non-nil) rewrites decimal columns to int64 /
+// float64 as each batch is retained, so the buffered batches match the
+// normalized schema the encoder advertises. Returns the batches, total
+// row count, and an error if ctx fires, the reader surfaces a deferred
+// error, or a decimal cast fails. Callers MUST Release() the returned
+// batches when done.
+func drainArrowBatches(ctx context.Context, reader array.RecordReader, governanceMaxRows int, castInfo *decimalCastInfo) ([]arrow.Record, int, error) {
+	// retain prepares one batch for buffering: cast decimals when
+	// castInfo is set (castDecimalBatch returns an already-owned record,
+	// so no extra Retain), otherwise take a reference on the reader's
+	// batch, which is only valid until the next Next() call.
+	retain := func(batch arrow.Record) (arrow.Record, error) {
+		if castInfo == nil {
+			batch.Retain()
+			return batch, nil
+		}
+		return castDecimalBatch(batch, castInfo)
+	}
+
 	rowCap := 0
 	if governanceMaxRows > 0 {
 		rowCap = governanceMaxRows
@@ -295,13 +327,25 @@ func drainArrowBatches(ctx context.Context, reader array.RecordReader, governanc
 			if rowCount+n > rowCap {
 				keep := rowCap - rowCount
 				trimmed := batch.NewSlice(0, int64(keep))
-				batches = append(batches, trimmed)
+				// NewSlice returns an owned record; retain() either
+				// takes a second reference (castInfo == nil) or builds
+				// a new casted record. Either way the slice itself must
+				// be released once we no longer need it directly.
+				kept, err := retain(trimmed)
+				trimmed.Release()
+				if err != nil {
+					return batches, rowCount, fmt.Errorf("decimal cast failed at row %d: %w", rowCount, err)
+				}
+				batches = append(batches, kept)
 				rowCount = rowCap
 				break
 			}
 		}
-		batch.Retain()
-		batches = append(batches, batch)
+		kept, err := retain(batch)
+		if err != nil {
+			return batches, rowCount, fmt.Errorf("decimal cast failed at row %d: %w", rowCount, err)
+		}
+		batches = append(batches, kept)
 		rowCount += n
 	}
 	if err := reader.Err(); err != nil {
@@ -316,7 +360,7 @@ func drainArrowBatches(ctx context.Context, reader array.RecordReader, governanc
 //	map(7 or 8) {
 //	  "success":           bool
 //	  "columns":           [string...]            // column names
-//	  "types":             [string...]            // arrow type names, parallel to columns
+//	  "types":             [string...]            // Arc wire type names, parallel to columns
 //	  "data":              [[v...], [v...], ...]  // numCols arrays, each with N values
 //	  "row_count":         uint
 //	  "execution_time_ms": uint                   (milliseconds)
@@ -402,10 +446,11 @@ func streamMsgPackFromBatches(
 		}
 	}
 
-	// "types": [arrow-type-name...] — clients use this to interpret
+	// "types": [arc-wire-type-name...] — clients use this to interpret
 	// each column's elements (int64 vs uint64 vs string vs timestamp
-	// ext type vs binary). Names come from arrow.DataType.String()
-	// which is stable across the arrow-go library.
+	// ext type vs binary). Names come from arrowTypeName, which is Arc's
+	// own contract keyed on Arrow type IDs; see query_msgpack_types.go
+	// for why arrow.DataType.String() must not be used here.
 	if err := enc.EncodeString("types"); err != nil {
 		return 0, err
 	}
@@ -413,7 +458,7 @@ func streamMsgPackFromBatches(
 		return 0, err
 	}
 	for _, f := range fields {
-		if err := enc.EncodeString(f.Type.String()); err != nil {
+		if err := enc.EncodeString(arrowTypeName(f.Type)); err != nil {
 			return 0, err
 		}
 	}

--- a/internal/api/query_msgpack_decimal_test.go
+++ b/internal/api/query_msgpack_decimal_test.go
@@ -1,0 +1,161 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// TestMsgPackDecimal_TypesMatchValues is the regression test for the
+// contract bug found in plan review: the msgpack "types" array advertised
+// decimal(38, 0) while the encoder — which has no *array.Decimal128 case —
+// sent the column through encodeFallbackColumn as msgpack *strings*.
+//
+// DuckDB returns SUM(integer) as decimal(38,0) and AVG as decimal(x,y), so
+// this hit ordinary analytical queries, not exotic ones. The Arrow IPC path
+// already normalized decimals (normalizeDecimalSchema); the msgpack path
+// did not, so the two binary formats also disagreed with each other for the
+// same SQL.
+//
+// Reverting the normalizeDecimalSchema call in executeQueryArrowMsgPack (or
+// in msgpackStreamToBytes, which mirrors it) fails this test: types come
+// back as "decimal(38, 0)"/"decimal(10, 2)" and the values decode as
+// strings rather than numbers.
+func TestMsgPackDecimal_TypesMatchValues(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		// SUM(int) shape: scale 0 → int64
+		{Name: "total", Type: &arrow.Decimal128Type{Precision: 38, Scale: 0}},
+		// AVG / DECIMAL(10,2) shape: scale > 0 → float64
+		{Name: "price", Type: &arrow.Decimal128Type{Precision: 10, Scale: 2}},
+	}, nil)
+
+	totalB := array.NewDecimal128Builder(alloc, &arrow.Decimal128Type{Precision: 38, Scale: 0})
+	defer totalB.Release()
+	totalB.Append(decimal128.FromI64(3))
+	totalB.Append(decimal128.FromI64(-7))
+
+	priceB := array.NewDecimal128Builder(alloc, &arrow.Decimal128Type{Precision: 10, Scale: 2})
+	defer priceB.Release()
+	// Unscaled 123 at scale 2 == 1.23
+	priceB.Append(decimal128.FromI64(123))
+	priceB.Append(decimal128.FromI64(4550))
+
+	totalArr := totalB.NewArray()
+	defer totalArr.Release()
+	priceArr := priceB.NewArray()
+	defer priceArr.Release()
+
+	batch := array.NewRecord(schema, []arrow.Array{totalArr, priceArr}, 2)
+	defer batch.Release()
+
+	reader := newSimpleRecordReader(schema, []arrow.Record{batch})
+	data, rowCount := msgpackStreamToBytes(reader, 0)
+	if rowCount != 2 {
+		t.Fatalf("rowCount = %d, want 2", rowCount)
+	}
+
+	result := decodeMsgpack(t, data)
+
+	// 1. The advertised types must be the normalized ones, not decimal.
+	types, ok := result["types"].([]interface{})
+	if !ok {
+		t.Fatalf("expected 'types' array, got %T", result["types"])
+	}
+	if len(types) != 2 {
+		t.Fatalf("len(types) = %d, want 2", len(types))
+	}
+	if got := types[0]; got != "int64" {
+		t.Errorf("types[0] = %v, want \"int64\" (scale-0 decimal must normalize to int64)", got)
+	}
+	if got := types[1]; got != "float64" {
+		t.Errorf("types[1] = %v, want \"float64\" (scaled decimal must normalize to float64)", got)
+	}
+
+	// 2. The values must actually BE those types on the wire — this is
+	//    the half that was broken. Strings here mean the contract lies.
+	cols := colsOf(t, result)
+
+	for i, v := range cols[0] {
+		if _, isStr := v.(string); isStr {
+			t.Fatalf("total[%d] decoded as string %q — decimal values must be numeric on the wire", i, v)
+		}
+	}
+	if got := toInt64(t, cols[0][0]); got != 3 {
+		t.Errorf("total[0] = %d, want 3", got)
+	}
+	if got := toInt64(t, cols[0][1]); got != -7 {
+		t.Errorf("total[1] = %d, want -7", got)
+	}
+
+	for i, v := range cols[1] {
+		if _, isStr := v.(string); isStr {
+			t.Fatalf("price[%d] decoded as string %q — decimal values must be numeric on the wire", i, v)
+		}
+	}
+	if got := toFloat64(t, cols[1][0]); got < 1.2299 || got > 1.2301 {
+		t.Errorf("price[0] = %v, want ~1.23 (unscaled 123 at scale 2)", got)
+	}
+	if got := toFloat64(t, cols[1][1]); got < 45.4999 || got > 45.5001 {
+		t.Errorf("price[1] = %v, want ~45.50 (unscaled 4550 at scale 2)", got)
+	}
+}
+
+// TestMsgPackDecimal_NoDecimalIsZeroOverhead guards the fast path: a schema
+// with no decimal columns must produce a nil castInfo so the drain skips
+// casting entirely.
+func TestMsgPackDecimal_NoDecimalIsZeroOverhead(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "host", Type: arrow.BinaryTypes.String},
+	}, nil)
+	if info := normalizeDecimalSchema(schema); info != nil {
+		t.Errorf("normalizeDecimalSchema returned non-nil for a decimal-free schema; the drain would cast needlessly")
+	}
+}
+
+func toInt64(t *testing.T, v interface{}) int64 {
+	t.Helper()
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int8:
+		return int64(n)
+	case int16:
+		return int64(n)
+	case int32:
+		return int64(n)
+	case int:
+		return int64(n)
+	case uint64:
+		return int64(n)
+	case uint8:
+		return int64(n)
+	case uint16:
+		return int64(n)
+	case uint32:
+		return int64(n)
+	default:
+		t.Fatalf("expected an integer, got %T (%v)", v, v)
+		return 0
+	}
+}
+
+func toFloat64(t *testing.T, v interface{}) float64 {
+	t.Helper()
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	default:
+		t.Fatalf("expected a float, got %T (%v)", v, v)
+		return 0
+	}
+}

--- a/internal/api/query_msgpack_response.go
+++ b/internal/api/query_msgpack_response.go
@@ -65,9 +65,11 @@ func respondError(c *fiber.Ctx, status int, errMsg, timestamp string, start time
 // passes through unchanged.
 //
 // types is parallel to columns and carries the wire-level type name
-// per column (matching the streaming hot path's arrow.DataType.String()
-// output for the comparable Arrow type). Passed explicitly by the
-// caller rather than inferred from cell content, because:
+// per column. Callers pass the shared wireType* constants (wiretypes.go),
+// which are the same values arrowTypeName produces on the streaming hot
+// path — one source, so the two emitters of this field cannot drift.
+// Passed explicitly by the caller rather than inferred from cell content,
+// because:
 //
 //  1. SHOW handlers know the schema by construction — the row-major
 //     []interface{} representation is for JSON convenience, not type

--- a/internal/api/query_msgpack_test.go
+++ b/internal/api/query_msgpack_test.go
@@ -40,7 +40,13 @@ func msgpackStreamToBytes(
 	start := time.Now()
 	ctx := context.Background()
 	schema := reader.Schema()
-	batches, rowCount, drainErr := drainArrowBatches(ctx, reader, governanceMaxRows)
+	// Mirror production: normalize decimals before the drain so the
+	// buffered batches match the schema the encoder advertises.
+	castInfo := normalizeDecimalSchema(schema)
+	if castInfo != nil {
+		schema = castInfo.schema
+	}
+	batches, rowCount, drainErr := drainArrowBatches(ctx, reader, governanceMaxRows, castInfo)
 	defer func() {
 		for _, b := range batches {
 			b.Release()
@@ -125,7 +131,9 @@ func TestStreamArrowMsgPack_BasicTypes(t *testing.T) {
 	if len(typeNames) != 5 {
 		t.Fatalf("expected 5 type names, got %d", len(typeNames))
 	}
-	// Spot-check a few type names — the streamer emits arrow.DataType.String().
+	// Spot-check a few type names — the streamer emits arrowTypeName's
+	// Arc-owned wire names (see query_msgpack_types.go), not Arrow's
+	// String() output.
 	if typeNames[0].(string) != "int64" {
 		t.Errorf("expected types[0]='int64', got %v", typeNames[0])
 	}

--- a/internal/api/query_msgpack_types.go
+++ b/internal/api/query_msgpack_types.go
@@ -1,0 +1,169 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/rs/zerolog/log"
+)
+
+// arrowTypeName maps an Arrow data type to the name Arc publishes in the
+// msgpack response's "types" array.
+//
+// This is Arc's wire contract, deliberately NOT arrow.DataType.String().
+// That method is Go debug output and upstream changes its format in patch
+// releases: `list<item: int32>` gained `, nullable` in 2021 (ARROW-8452),
+// the hardcoded `item` became the element's name a week later (ARROW-8453),
+// and struct gained an (un-comma'd) ` nullable` in arrow-go 1a28af3 — which
+// shipped in v18.6.0, the version this module pins. Upstream classes these
+// as bug fixes because String() was never meant to be a contract. Clients
+// binding to it would break on a routine dependency bump.
+//
+// Dispatch is on arrow.Type IDs instead. Those are the Arrow wire-format
+// enum: a renumbering is invisible here (Go resolves the constant names at
+// compile time) and a removal is a compile error rather than silent drift.
+//
+// Rules:
+//   - Scalars keep the exact spelling they have always had, so no existing
+//     client changes.
+//   - Parameterized types keep their information — decimal precision/scale
+//     and timestamp unit are semantically load-bearing — but the format
+//     string is Arc's, so upstream cannot move it.
+//   - Nested types collapse to a bare token. encodeColumn has no List or
+//     Struct case, so nested values already go out as ValueStr strings; a
+//     bare `list` honestly says "opaque, rendered as string" where
+//     `list<int32>` would promise element typing the encoder never delivers.
+//   - Anything unrecognized gets an `unknown:` sentinel rather than raw
+//     String(), so a client cannot accidentally bind to a spelling Arc does
+//     not control. The query still succeeds — a new Arrow type must never
+//     fail a request.
+//
+// Keep in sync with the golden test in query_msgpack_types_test.go, which
+// pins every string this function can return.
+func arrowTypeName(dt arrow.DataType) string {
+	// A nil type cannot come from a well-formed Arrow schema, but the
+	// design rule is that a type name must never fail a query — so
+	// degrade to the sentinel rather than panicking on dt.ID().
+	if dt == nil {
+		return wireTypeUnknownPrefix + "nil"
+	}
+	switch dt.ID() {
+	case arrow.BOOL:
+		return wireTypeBool
+	case arrow.INT8:
+		return wireTypeInt8
+	case arrow.INT16:
+		return wireTypeInt16
+	case arrow.INT32:
+		return wireTypeInt32
+	case arrow.INT64:
+		return wireTypeInt64
+	case arrow.UINT8:
+		return wireTypeUint8
+	case arrow.UINT16:
+		return wireTypeUint16
+	case arrow.UINT32:
+		return wireTypeUint32
+	case arrow.UINT64:
+		return wireTypeUint64
+	case arrow.FLOAT32:
+		return wireTypeFloat32
+	case arrow.FLOAT64:
+		return wireTypeFloat64
+	case arrow.STRING:
+		return wireTypeUTF8
+	case arrow.LARGE_STRING:
+		return "large_utf8"
+	case arrow.BINARY:
+		return wireTypeBinary
+	case arrow.LARGE_BINARY:
+		return "large_binary"
+	case arrow.DATE32:
+		return "date32"
+	case arrow.TIMESTAMP:
+		// Unit is load-bearing: a client must distinguish us from ns to
+		// scale the integer correctly. Timezone is deliberately omitted —
+		// Arc normalizes to UTC.
+		if t, ok := dt.(*arrow.TimestampType); ok {
+			return "timestamp[" + arrowTimeUnitName(t.Unit) + "]"
+		}
+		return "timestamp[us]"
+	case arrow.DECIMAL32, arrow.DECIMAL64, arrow.DECIMAL128, arrow.DECIMAL256:
+		// Reachable only if a decimal escapes normalizeDecimalSchema
+		// (which rewrites every arrow.DecimalType to int64/float64 before
+		// this runs). All four widths are listed so a decimal can never
+		// fall to the unknown: sentinel — that would be the same
+		// types-disagree-with-values bug this contract exists to prevent.
+		if t, ok := dt.(arrow.DecimalType); ok {
+			return fmt.Sprintf("decimal(%d, %d)", t.GetPrecision(), t.GetScale())
+		}
+		return "decimal"
+	case arrow.DATE64, arrow.TIME32, arrow.TIME64, arrow.DURATION,
+		arrow.INTERVAL_MONTHS, arrow.INTERVAL_DAY_TIME, arrow.INTERVAL_MONTH_DAY_NANO,
+		arrow.FLOAT16, arrow.FIXED_SIZE_BINARY:
+		// encodeColumn has no case for any of these, so their values go
+		// out as encodeFallbackColumn strings (e.g. a DURATION renders as
+		// "1h0m0s"). Naming them `duration[ns]` or `date64` would repeat
+		// the mistake this contract exists to fix — a precise numeric-
+		// looking name over a string payload. Same rule as the nested
+		// types below: the name describes what is actually on the wire.
+		// If an encoder case is added later, the type graduates to its
+		// own name and that is a deliberate contract change.
+		return wireTypeStringEncoded
+	case arrow.LIST, arrow.LARGE_LIST, arrow.FIXED_SIZE_LIST:
+		return wireTypeList
+	case arrow.STRUCT:
+		return wireTypeStruct
+	case arrow.MAP:
+		return wireTypeMap
+	case arrow.NULL:
+		return wireTypeNull
+	default:
+		return unknownArrowTypeName(dt)
+	}
+}
+
+// arrowTimeUnitName spells an Arrow time unit. Arc owns these four strings
+// rather than using arrow.TimeUnit.String() for the same reason
+// arrowTypeName exists.
+func arrowTimeUnitName(u arrow.TimeUnit) string {
+	switch u {
+	case arrow.Second:
+		return "s"
+	case arrow.Millisecond:
+		return "ms"
+	case arrow.Microsecond:
+		return "us"
+	case arrow.Nanosecond:
+		return "ns"
+	default:
+		return "us"
+	}
+}
+
+// unknownArrowTypeLogged bounds the log volume for unmapped types: one
+// line per distinct Arrow type ID for the process lifetime, not one per
+// query (a wide result set would otherwise log per column, per request).
+var unknownArrowTypeLogged sync.Map
+
+// unknownArrowTypeName renders an unmapped type behind an `unknown:`
+// prefix so no client mistakes it for a stable Arc type name, and logs it
+// once so the gap is noticed and mapped in a later release.
+//
+// DuckDB ENUM columns land here: DuckDB's Arrow export maps them to
+// dictionary<...>, and Arc does not normalize that. Their values already
+// go out as encodeFallbackColumn strings, so the sentinel is honest about
+// what is on the wire.
+func unknownArrowTypeName(dt arrow.DataType) string {
+	if _, seen := unknownArrowTypeLogged.LoadOrStore(dt.ID(), struct{}{}); !seen {
+		log.Warn().
+			Str("component", "query-handler").
+			Str("arrow_type", dt.String()).
+			Int("arrow_type_id", int(dt.ID())).
+			Msg("msgpack response: Arrow type has no Arc wire-type name; emitting unknown: sentinel")
+	}
+	return wireTypeUnknownPrefix + dt.String()
+}

--- a/internal/api/query_msgpack_types_test.go
+++ b/internal/api/query_msgpack_types_test.go
@@ -1,0 +1,253 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// TestArrowTypeName_Golden pins every string arrowTypeName can return.
+//
+// This is the durable artifact of the wire-contract freeze: these strings
+// are published to clients, so a change here is a breaking change and must
+// be a deliberate edit to this table, not a side effect of bumping
+// arrow-go. See query_msgpack_types.go for the three historical cases where
+// arrow.DataType.String() changed format in a patch release.
+func TestArrowTypeName_Golden(t *testing.T) {
+	tests := []struct {
+		name string
+		dt   arrow.DataType
+		want string
+	}{
+		// Scalars — these spellings match what Arc shipped before the
+		// freeze, so no existing client sees a change.
+		{"bool", arrow.FixedWidthTypes.Boolean, "bool"},
+		{"int8", arrow.PrimitiveTypes.Int8, "int8"},
+		{"int16", arrow.PrimitiveTypes.Int16, "int16"},
+		{"int32", arrow.PrimitiveTypes.Int32, "int32"},
+		{"int64", arrow.PrimitiveTypes.Int64, "int64"},
+		{"uint8", arrow.PrimitiveTypes.Uint8, "uint8"},
+		{"uint16", arrow.PrimitiveTypes.Uint16, "uint16"},
+		{"uint32", arrow.PrimitiveTypes.Uint32, "uint32"},
+		{"uint64", arrow.PrimitiveTypes.Uint64, "uint64"},
+		{"float32", arrow.PrimitiveTypes.Float32, "float32"},
+		{"float64", arrow.PrimitiveTypes.Float64, "float64"},
+		{"utf8", arrow.BinaryTypes.String, "utf8"},
+		{"large_utf8", arrow.BinaryTypes.LargeString, "large_utf8"},
+		{"binary", arrow.BinaryTypes.Binary, "binary"},
+		{"large_binary", arrow.BinaryTypes.LargeBinary, "large_binary"},
+		{"date32", arrow.FixedWidthTypes.Date32, "date32"},
+		{"null", arrow.Null, "null"},
+
+		// Parameterized — the unit and precision/scale are load-bearing,
+		// so they survive, but in a format string Arc owns.
+		{"timestamp_us", arrow.FixedWidthTypes.Timestamp_us, "timestamp[us]"},
+		{"timestamp_ns", arrow.FixedWidthTypes.Timestamp_ns, "timestamp[ns]"},
+		{"timestamp_ms", arrow.FixedWidthTypes.Timestamp_ms, "timestamp[ms]"},
+		{"timestamp_s", arrow.FixedWidthTypes.Timestamp_s, "timestamp[s]"},
+		{"timestamp_tz", &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "America/Denver"}, "timestamp[us]"},
+		// All four decimal widths must be named — a decimal that reached
+		// the unknown: sentinel would be the types-lie-about-values bug
+		// again, in miniature.
+		{"decimal128", &arrow.Decimal128Type{Precision: 10, Scale: 2}, "decimal(10, 2)"},
+		{"decimal128_hugeint", &arrow.Decimal128Type{Precision: 38, Scale: 0}, "decimal(38, 0)"},
+		{"decimal256", &arrow.Decimal256Type{Precision: 40, Scale: 4}, "decimal(40, 4)"},
+		{"decimal32", &arrow.Decimal32Type{Precision: 8, Scale: 2}, "decimal(8, 2)"},
+		{"decimal64", &arrow.Decimal64Type{Precision: 16, Scale: 2}, "decimal(16, 2)"},
+
+		// Recognized types the encoder has no typed case for: their
+		// values go out as ValueStr strings, so the name says so rather
+		// than advertising a numeric payload.
+		{"date64", arrow.FixedWidthTypes.Date64, "string_encoded"},
+		{"time32_s", arrow.FixedWidthTypes.Time32s, "string_encoded"},
+		{"time64_ns", arrow.FixedWidthTypes.Time64ns, "string_encoded"},
+		{"duration_ns", arrow.FixedWidthTypes.Duration_ns, "string_encoded"},
+		{"month_interval", arrow.FixedWidthTypes.MonthInterval, "string_encoded"},
+		{"day_time_interval", arrow.FixedWidthTypes.DayTimeInterval, "string_encoded"},
+		{"month_day_nano", arrow.FixedWidthTypes.MonthDayNanoInterval, "string_encoded"},
+		{"float16", arrow.FixedWidthTypes.Float16, "string_encoded"},
+		{"fixed_size_binary", &arrow.FixedSizeBinaryType{ByteWidth: 16}, "string_encoded"},
+
+		// Nested — deliberately collapsed to a bare token. encodeColumn
+		// has no List/Struct case, so the values go out as strings; the
+		// token says "opaque" instead of promising element typing.
+		{"list", arrow.ListOf(arrow.PrimitiveTypes.Int32), "list"},
+		{"large_list", arrow.LargeListOf(arrow.PrimitiveTypes.Int32), "list"},
+		{"fixed_size_list", arrow.FixedSizeListOf(2, arrow.PrimitiveTypes.Int32), "list"},
+		{"struct", arrow.StructOf(arrow.Field{Name: "a", Type: arrow.PrimitiveTypes.Int32, Nullable: true}), "struct"},
+		{"map", arrow.MapOf(arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int32), "map"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := arrowTypeName(tt.dt); got != tt.want {
+				t.Errorf("arrowTypeName(%s) = %q, want %q (this is a WIRE CONTRACT change — update clients, not just this test)", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestArrowTypeName_NestedIsNotArrowString is the regression guard for the
+// bug that motivated this work: nested types must NOT carry through
+// arrow.DataType.String(), whose format upstream changes in patch releases.
+//
+// Reverting arrowTypeName's LIST/STRUCT cases to f.Type.String() fails this
+// test — the assertions below are exactly the debug spellings that leaked
+// before the freeze.
+func TestArrowTypeName_NestedIsNotArrowString(t *testing.T) {
+	list := arrow.ListOf(arrow.PrimitiveTypes.Int32)
+	strct := arrow.StructOf(arrow.Field{Name: "a", Type: arrow.PrimitiveTypes.Int32, Nullable: true})
+
+	// Guard the premise: if upstream ever makes String() match our token,
+	// this test would pass for the wrong reason.
+	if list.String() == "list" || strct.String() == "struct" {
+		t.Fatalf("premise broken: arrow String() now matches the Arc token (list=%q struct=%q)", list.String(), strct.String())
+	}
+
+	for _, tc := range []struct {
+		name string
+		dt   arrow.DataType
+		want string
+	}{
+		{"list", list, "list"},
+		{"struct", strct, "struct"},
+	} {
+		got := arrowTypeName(tc.dt)
+		if got != tc.want {
+			t.Errorf("arrowTypeName(%s) = %q, want %q", tc.name, got, tc.want)
+		}
+		if got == tc.dt.String() {
+			t.Errorf("arrowTypeName(%s) returned arrow's String() output %q — the wire contract must not be arrow-go debug output", tc.name, got)
+		}
+		if strings.ContainsAny(got, "<>:") {
+			t.Errorf("arrowTypeName(%s) = %q contains structural punctuation; nested types must be a bare token", tc.name, got)
+		}
+	}
+}
+
+// TestArrowTypeName_NilIsSentinelNotPanic guards the design rule that a
+// type name must never fail a query.
+func TestArrowTypeName_NilIsSentinelNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("arrowTypeName(nil) panicked: %v", r)
+		}
+	}()
+	if got := arrowTypeName(nil); !strings.HasPrefix(got, "unknown:") {
+		t.Errorf("arrowTypeName(nil) = %q, want an unknown: sentinel", got)
+	}
+}
+
+// TestArrowTypeName_NoTypedNameWithoutEncoderCase is the structural guard
+// for the class of bug this contract exists to prevent: a column must
+// never be advertised with a precise, typed-looking name while its values
+// are transmitted as msgpack strings.
+//
+// encodeColumn (query_msgpack.go) has typed cases only for the Arrow types
+// listed here. Every other type must resolve to "string_encoded", a bare
+// nested token, or the unknown: sentinel — all of which tell a client the
+// payload is opaque. If someone adds a typed name without a matching
+// encoder case, this fails.
+func TestArrowTypeName_NoTypedNameWithoutEncoderCase(t *testing.T) {
+	// Types encodeColumn handles with a typed (non-string) encoding.
+	typedOK := map[string]bool{
+		"int8": true, "int16": true, "int32": true, "int64": true,
+		"uint8": true, "uint16": true, "uint32": true, "uint64": true,
+		"float32": true, "float64": true, "bool": true,
+		"timestamp[s]": true, "timestamp[ms]": true, "timestamp[us]": true, "timestamp[ns]": true,
+		"date32": true,
+		// String-family types are genuinely strings on the wire, so a
+		// string-shaped name is honest for them.
+		"utf8": true, "large_utf8": true, "binary": true, "large_binary": true,
+		// null carries no values at all.
+		"null": true,
+	}
+	// Names that self-describe as opaque.
+	opaque := func(s string) bool {
+		return s == "string_encoded" || s == "list" || s == "struct" || s == "map" ||
+			strings.HasPrefix(s, "unknown:") || strings.HasPrefix(s, "decimal(")
+	}
+
+	// Every Arrow type Arc could plausibly meet.
+	all := []arrow.DataType{
+		arrow.FixedWidthTypes.Boolean, arrow.PrimitiveTypes.Int8, arrow.PrimitiveTypes.Int16,
+		arrow.PrimitiveTypes.Int32, arrow.PrimitiveTypes.Int64, arrow.PrimitiveTypes.Uint8,
+		arrow.PrimitiveTypes.Uint16, arrow.PrimitiveTypes.Uint32, arrow.PrimitiveTypes.Uint64,
+		arrow.PrimitiveTypes.Float32, arrow.PrimitiveTypes.Float64, arrow.FixedWidthTypes.Float16,
+		arrow.BinaryTypes.String, arrow.BinaryTypes.LargeString, arrow.BinaryTypes.Binary,
+		arrow.BinaryTypes.LargeBinary, &arrow.FixedSizeBinaryType{ByteWidth: 16},
+		arrow.FixedWidthTypes.Date32, arrow.FixedWidthTypes.Date64,
+		arrow.FixedWidthTypes.Timestamp_us, arrow.FixedWidthTypes.Timestamp_ns,
+		arrow.FixedWidthTypes.Time32s, arrow.FixedWidthTypes.Time64ns,
+		arrow.FixedWidthTypes.Duration_ns, arrow.FixedWidthTypes.MonthInterval,
+		arrow.FixedWidthTypes.DayTimeInterval, arrow.FixedWidthTypes.MonthDayNanoInterval,
+		&arrow.Decimal128Type{Precision: 38, Scale: 0}, &arrow.Decimal256Type{Precision: 40, Scale: 4},
+		&arrow.Decimal32Type{Precision: 8, Scale: 2}, &arrow.Decimal64Type{Precision: 16, Scale: 2},
+		arrow.ListOf(arrow.PrimitiveTypes.Int32),
+		arrow.StructOf(arrow.Field{Name: "a", Type: arrow.PrimitiveTypes.Int32}),
+		arrow.MapOf(arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int32),
+		arrow.Null,
+		&arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.BinaryTypes.String},
+	}
+
+	for _, dt := range all {
+		name := arrowTypeName(dt)
+		if !typedOK[name] && !opaque(name) {
+			t.Errorf("arrowTypeName(%s) = %q: a typed-looking name with no encodeColumn case — "+
+				"values would ship as strings under a numeric-looking type. Use string_encoded, "+
+				"or add the encoder case.", dt, name)
+		}
+	}
+}
+
+// TestArrowTypeName_UnknownSentinel covers the fallback path. This is the
+// one place arrow.DataType.String() still runs, so it is the residual
+// exposure to an upstream format change — pinned here deliberately.
+//
+// DuckDB ENUM columns reach this path: DuckDB's Arrow export maps ENUM to
+// dictionary<...> and Arc does not normalize it.
+func TestArrowTypeName_UnknownSentinel(t *testing.T) {
+	dict := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int8,
+		ValueType: arrow.BinaryTypes.String,
+	}
+
+	got := arrowTypeName(dict)
+
+	if !strings.HasPrefix(got, "unknown:") {
+		t.Errorf("arrowTypeName(dictionary) = %q, want an %q-prefixed sentinel so clients cannot bind to an unowned spelling", got, "unknown:")
+	}
+	if got == dict.String() {
+		t.Errorf("arrowTypeName(dictionary) = %q — the raw String() must not be emitted unprefixed", got)
+	}
+	// The suffix is arrow-go's debug text by design (it is diagnostic, not
+	// contractual); the prefix is what makes that safe.
+	if !strings.Contains(got, dict.String()) {
+		t.Errorf("arrowTypeName(dictionary) = %q, want it to carry %q for diagnosis", got, dict.String())
+	}
+}
+
+// TestArrowTypeName_MatchesSHOWLiterals proves the two independent emitters
+// of the "types" array agree. The SHOW handlers (query.go) cannot import
+// Arrow — query.go builds without the duckdb_arrow tag — so both sides
+// reference the shared constants in wiretypes.go instead. This asserts the
+// constants really are what arrowTypeName produces for the same logical
+// type, which is the property that makes the sharing meaningful.
+func TestArrowTypeName_MatchesSHOWLiterals(t *testing.T) {
+	cases := []struct {
+		constant string
+		dt       arrow.DataType
+	}{
+		{wireTypeUTF8, arrow.BinaryTypes.String},
+		{wireTypeInt64, arrow.PrimitiveTypes.Int64},
+		{wireTypeFloat64, arrow.PrimitiveTypes.Float64},
+	}
+	for _, c := range cases {
+		if got := arrowTypeName(c.dt); got != c.constant {
+			t.Errorf("SHOW handlers emit %q but the streaming path emits %q for the same logical type", c.constant, got)
+		}
+	}
+}

--- a/internal/api/wiretypes.go
+++ b/internal/api/wiretypes.go
@@ -1,0 +1,54 @@
+package api
+
+// Arc's msgpack wire-type names.
+//
+// These are the strings the msgpack response's "types" array carries, and
+// they are a published contract: BI drivers and other clients switch on
+// them to decode each column. They live here, in an untagged file with no
+// Arrow dependency, because two independent code paths emit them and must
+// not drift apart:
+//
+//   - the streaming query path, via arrowTypeName (query_msgpack_types.go,
+//     build-tagged duckdb_arrow) — derives the name from the Arrow schema
+//   - the SHOW handlers (query.go), which know their schema by construction
+//     and cannot import Arrow, since query.go builds without the tag
+//
+// Defining the strings once and having both paths reference them makes
+// divergence a compile-time impossibility rather than something a test has
+// to notice after the fact.
+//
+// Any change here is a wire-contract change. See query_msgpack_types.go for
+// why these are Arc's own names rather than arrow.DataType.String().
+const (
+	wireTypeBool    = "bool"
+	wireTypeInt8    = "int8"
+	wireTypeInt16   = "int16"
+	wireTypeInt32   = "int32"
+	wireTypeInt64   = "int64"
+	wireTypeUint8   = "uint8"
+	wireTypeUint16  = "uint16"
+	wireTypeUint32  = "uint32"
+	wireTypeUint64  = "uint64"
+	wireTypeFloat32 = "float32"
+	wireTypeFloat64 = "float64"
+	wireTypeUTF8    = "utf8"
+	wireTypeBinary  = "binary"
+	wireTypeStruct  = "struct"
+	wireTypeList    = "list"
+	wireTypeMap     = "map"
+	wireTypeNull    = "null"
+
+	// wireTypeStringEncoded is the honest name for a column whose Arrow
+	// type Arc recognizes but whose values the msgpack encoder has no
+	// typed case for, so they are rendered with ValueStr and transmitted
+	// as msgpack strings (DATE64, TIME32/64, DURATION, the INTERVALs,
+	// FLOAT16, FIXED_SIZE_BINARY). Naming these by their logical Arrow
+	// type would advertise a numeric payload over a string one — the
+	// exact defect this contract was introduced to eliminate.
+	wireTypeStringEncoded = "string_encoded"
+
+	// wireTypeUnknownPrefix marks a type Arc has no published name for.
+	// Prefixed rather than bare so a client cannot mistake the trailing
+	// debug text for a stable Arc type name.
+	wireTypeUnknownPrefix = "unknown:"
+)


### PR DESCRIPTION
Prerequisite for graduating `/api/v1/query/msgpack` out of experimental. Two related fixes.

## 1. The `types` array disagreed with the bytes on the wire

DuckDB returns `SUM(integer)` as `decimal(38,0)` and `AVG` as `decimal(x,y)`. The Arrow IPC path normalizes those (`normalizeDecimalSchema`); the msgpack path did not, and `encodeColumn` has no decimal case — so decimals fell through to `encodeFallbackColumn` and shipped as msgpack **strings** while `types` advertised `decimal(38, 0)`.

Verified against the running binary, `SELECT SUM(CAST(1 AS INTEGER)) s, 1.23::DECIMAL(10,2) d FROM range(3)`:

| Endpoint | `s` declared | `s` on the wire | `d` declared | `d` on the wire |
|---|---|---|---|---|
| `/api/v1/query/arrow` | `int64` | `3` (number) | `double` | `1.23` (number) |
| `/api/v1/query/msgpack` (before) | `decimal(38, 0)` | `'3'` (**string**) | `decimal(10, 2)` | `'1.23'` (**string**) |
| `/api/v1/query/msgpack` (after) | `int64` | `3` (number) | `float64` | `1.23` (number) |

`SUM(int_col)` is an ordinary analytical query, so this was common, not exotic. Freezing the contract without fixing it would have made a lie permanent.

## 2. Type names were arrow-go debug output

Names came from `arrow.DataType.String()`, which upstream treats as debug output and reformats in patch releases:

| When | Commit | Change |
|---|---|---|
| 2021-10-12 | `c066597` | `list<item: int32>` → `list<item: int32, nullable>` |
| 2021-10-18 | `aa41adf` | hardcoded `item` → dynamic `elem.Name` |
| **2026-03-10** | **`1a28af3`** | **`struct<a: int32>` → `struct<a: int32 nullable>`** |

The last one is tagged **v18.6.0** — the version `go.mod` pins. The format changed five months ago in a routine dependency bump. The upstream PR body even notes *"the String() representation for data types is user facing."*

Names now derive from stable `arrow.Type` IDs:

- **Scalars unchanged** — `int64`, `utf8`, `float64`, `bool`, `binary`, `date32` keep their exact spelling; no existing client sees a difference.
- **Parameterized types keep their information** in an Arc-owned format: `timestamp[us]`, `decimal(p, s)`.
- **`string_encoded`** for recognized types with no typed encoder case (`DATE64`, `TIME32/64`, `DURATION`, the `INTERVAL`s, `FLOAT16`, fixed-size binary). These previously reported precise names like `duration[ns]` over a string payload — the same defect as the decimal bug.
- **Nested types** collapse to `list` / `struct` / `map`.
- **Unrecognized types** get an `unknown:` sentinel and log once. DuckDB `ENUM` lands here (exported as an Arrow dictionary).

`normalizeDecimalSchema` now matches the `arrow.DecimalType` interface rather than `*arrow.Decimal128Type`, so Decimal32/64/256 cannot slip past it — that would have reproduced the same bug.

The SHOW handlers (`query.go`, untagged, cannot import Arrow) and the streaming path now share one set of constants in `wiretypes.go`, so the two emitters of this field cannot drift.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, tagged, msgpack query | **Yes** — `query_msgpack.go:416` per column per query | `f.Type` non-nil for every field from `reader.Schema()`; `arrowTypeName` also nil-guards and returns a sentinel rather than panicking |
| JSON or Arrow query | **No** — JSON envelope has no `types` field (`query.go:678-687`); Arrow carries a binary schema | N/A |
| SHOW DATABASES / SHOW TABLES via msgpack | **Yes** — second emitter, `query_msgpack_response.go:154`, fed by `query.go:3302/3305/3405` | Both sites now reference the shared `wireType*` constants |
| Decimal-producing query (`SUM(int)`) via msgpack | **Yes** — the case previously broken | `decimal(x,0)`→`int64`, `decimal(x,y)`→`float64`, matching Arrow IPC and the encoded values |
| Governance row cap (`governanceMaxRows > 0`) | **Yes** — trimmed trailing batch is cast via the same path | Leak-tested with `memory.NewCheckedAllocator`; refcounts correct for both `castInfo == nil` and `!= nil` |
| ENUM / dictionary column via msgpack | **Yes** — `x-arc-arrow-dictionary` is read only at `query_arrow.go:68` and cannot reach msgpack, but DuckDB exports ENUM as a dictionary natively | Hits the `unknown:` sentinel; values already ship as fallback strings, so the name matches the wire |
| Untagged build | **No** — `//go:build duckdb_arrow`; msgpack 501s before encoding, and an untagged binary refuses to start (#598) | N/A |

**New config keys: none.**

## Test plan

- [x] Golden test pins every string the contract can produce (37 cases)
- [x] Structural test fails if any type gains a typed-looking name without a matching `encodeColumn` case
- [x] Decimal regression test: types **and** values, both halves of the bug
- [x] **Verified every new test FAILS pre-fix** (revert-run-restore) — decimal test failed with `types[0] = decimal(38, 0)` and `total[0] decoded as string "3"`; nested test failed with the real `list<item: int32, nullable>` / `struct<a: int32 nullable>` spellings
- [x] Leak-tested the cast path with `memory.NewCheckedAllocator`: plain drain, decimal cast, governance-trimmed, trimmed+cast — no leaks, no double-release
- [x] Binary run: decimals numeric and matching Arrow; INTERVAL/TIME report `string_encoded`; real trades queries unchanged
- [x] Full `internal/api` suite, `-race`, `gofmt`, `go vet` clean in **both** build modes
- [x] Release notes updated

## Note

`string_encoded` is a new name, so a client reading `duration[ns]` today sees a change. The endpoint is experimental and the old name was actively misleading, which is what makes this the right moment.