### PR TITLE
feat(health): surface per-tier storage credential state in /health and /ready (#603)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -441,6 +441,29 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### `/health` now reports storage credential state — a dead read path can no longer hide behind green probes ([#603](https://github.com/Basekick-Labs/arc/issues/603))
+
+The incident that motivated this: a reader ran ~21 hours READY 1/1 with `/health` green while every S3-backed query failed on expired credentials — the only failure signal lived in query responses, invisible to probes, monitoring, and orchestration.
+
+`/health` now carries a `storage` field describing every configured tier — hot always; cold once its configuration succeeded (a cold tier whose secret creation failed is absent from the payload rather than falsely green):
+
+```json
+"storage": {
+  "hot":  {"backend": "s3", "credentials": "sdk_managed", "state": "ok",
+           "expires_at": "2026-08-18T20:24:18Z", "source": "CredentialsEndpointProvider",
+           "last_refresh": "2026-08-18T20:12:26Z"},
+  "cold": {"backend": "azure", "credentials": "unmanaged_chain", "state": "unknown"}
+}
+```
+
+States: `ok`, `degraded` (refreshes failing, credentials still valid), `expired` (the incident case — red within a minute of expiry), `fallback` (no resolvable credentials; running on DuckDB's chain), `unknown` (Arc has no visibility — see below). The state is computed from the credential refresher's in-memory records at read time: **`/health` never probes S3 or Azure**, so there is nothing to flap and no per-probe storage traffic. Pre-expiry alerting belongs on `expires_at`, not on a state change — a healthy IMDS or Pod Identity session routinely waits for server-side rotation near its end and stays `ok` while doing so.
+
+Honesty notes: an Azure connection string embedding a **SAS token** reports `credentials: sas, state: unknown` — SAS tokens expire and Arc cannot see when, and calling that "ok" would recreate exactly the incident above. Azure **managed identity** likewise reports `unmanaged_chain / unknown`: those credentials are resolved once by DuckDB and never refreshed — the same class #600 fixed for S3, tracked as a probable live bug in [#605](https://github.com/Basekick-Labs/arc/issues/605). Local storage reports `local / none / ok`.
+
+**Opt-in readiness gating**: `server.storage_credentials_fail_ready = true` (default **false**) makes `/ready` return 503 while any tier's credential state is `expired`, so Kubernetes recycles the pod — a restart re-resolves credentials. Only `expired` drains a node; `fallback`/`unknown`/`degraded` never do (those deployments may be healthy or credential-less by design). Intended for reader pools: Arc logs a startup warning when it is enabled on a cluster writer, whose ingest keeps working through credential expiry. Startup and shutdown readiness gating are unaffected — the knob can only remove readiness, never grant it.
+
+The field is served unauthenticated like the rest of `/health` and `/metrics`: it contains no bucket or container names, endpoints, prefixes, paths, or key material.
+
 ### S3 queries no longer fail with `ExpiredToken` an hour after startup on EKS/IRSA ([#600](https://github.com/Basekick-Labs/arc/issues/600))
 
 On EKS with IRSA — where pods authenticate to S3 through a projected service-account token instead of static keys — Arc's query path stopped being able to read S3 roughly **one hour after each process start**. Every S3-backed query failed with `ExpiredToken`, while ingest and `/health` kept working normally, so Kubernetes probes never noticed and only a pod restart recovered it.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1691,6 +1691,14 @@ func main() {
 
 	server := api.NewServer(serverConfig, logger.Get("server"))
 
+	// #603: surface per-tier storage credential state in /health (and /ready
+	// when the knob is set). In-memory reads from the credential refresher —
+	// never a live S3/Azure probe from the probe path.
+	server.SetStorageStatus(db.StorageCredentialStatus, cfg.Server.StorageCredentialsFailReady)
+	if cfg.Server.StorageCredentialsFailReady && cfg.Cluster.Enabled && cfg.Cluster.Role == string(cluster.RoleWriter) {
+		log.Warn().Msg("server.storage_credentials_fail_ready is set on a writer: expired S3 credentials will drain this node from the LB even though ingest is unaffected by credential expiry; intended for reader pools")
+	}
+
 	// Register base routes
 	server.RegisterRoutes()
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/database"
 	"github.com/basekick-labs/arc/internal/fips"
 	"github.com/basekick-labs/arc/internal/logger"
 	"github.com/basekick-labs/arc/internal/metrics"
@@ -45,6 +46,22 @@ type Server struct {
 	// so the LB drains this node before Stop() actually closes the
 	// listener. See docs/progress/2026-05-26-multi-writer-pattern2.md.
 	ready atomic.Bool
+
+	// storageStatus supplies the /health "storage" payload (#603): per-tier
+	// backend + credential state from the DuckDB credential refresher
+	// machinery. Wired by main.go after database.New; nil until then (the
+	// listener only opens after wiring, but the guard keeps tests and future
+	// reorderings safe). In-memory reads only — /health never probes S3.
+	storageStatus func() map[string]database.StorageTierStatus
+
+	// storageCredsFailReady: when true (server.storage_credentials_fail_ready,
+	// default false), /ready returns 503 while any tier's credential state is
+	// "expired". Applied AND-ed after the ready flag — it can only remove
+	// readiness, never grant it, so WAL-recovery gating and shutdown drain are
+	// untouched. Only "expired" fails ready: "fallback"/"unknown"/"degraded"
+	// deployments may be healthy or permanently credential-less by design and
+	// must not flap the LB.
+	storageCredsFailReady bool
 }
 
 // ServerConfig holds server configuration
@@ -203,15 +220,44 @@ func (s *Server) RegisterLogsRoute(authManager *auth.AuthManager) {
 	s.app.Get("/api/v1/logs", withAdminAuth(authManager), s.logsHandler)
 }
 
-// healthHandler returns server health status
+// SetStorageStatus wires the per-tier storage credential status source
+// (database.DuckDB.StorageCredentialStatus) into /health and, when
+// server.storage_credentials_fail_ready is set, /ready. failReady gates the
+// readiness behavior.
+func (s *Server) SetStorageStatus(fn func() map[string]database.StorageTierStatus, failReady bool) {
+	s.storageStatus = fn
+	s.storageCredsFailReady = failReady
+}
+
+// healthHandler returns server health status.
+//
+// The "storage" field is served UNAUTHENTICATED by design, like the rest of
+// /health and like /metrics (see the PublicRoutes rationale in main.go): it
+// contains no bucket/container names, endpoints, prefixes, paths, or key
+// material — only tier names, backend types, credential modes, sanitized
+// provider labels, expiry timestamps and error counts. That is what probes
+// and Prometheus need, and they do not authenticate. Field-incident context:
+// a reader served green /health for ~21h while every S3 query failed on
+// expired credentials (#603).
+//
+// "status" stays "ok" regardless of credential state: /health is LIVENESS.
+// Killing a pod over expired credentials would loop it through restarts that
+// mask the problem; traffic routing on credential state is /ready's job
+// (opt-in knob).
 func (s *Server) healthHandler(c *fiber.Ctx) error {
 	uptime := time.Since(startTime)
-	return c.JSON(fiber.Map{
+	payload := fiber.Map{
 		"status":     "ok",
 		"time":       time.Now().UTC().Format(time.RFC3339),
 		"uptime":     uptime.String(),
 		"uptime_sec": uptime.Seconds(),
-	})
+	}
+	if s.storageStatus != nil {
+		if st := s.storageStatus(); len(st) > 0 {
+			payload["storage"] = st
+		}
+	}
+	return c.JSON(payload)
 }
 
 // readyHandler returns server readiness status for load-balancer health
@@ -242,6 +288,25 @@ func (s *Server) readyHandler(c *fiber.Ctx) error {
 			"time":   time.Now().UTC().Format(time.RFC3339),
 			"reason": "server is starting up or shutting down; load balancer should not route traffic here",
 		})
+	}
+
+	// Opt-in (#603): drain this node while storage credentials are expired.
+	// Checked after the ready flag — this can only remove readiness. Only
+	// "expired" qualifies; see SetStorageStatus.
+	if s.storageCredsFailReady && s.storageStatus != nil {
+		st := s.storageStatus()
+		// Deterministic order so incident logs are stable when both tiers are
+		// expired.
+		for _, tier := range []string{"hot", "cold"} {
+			if ts, ok := st[tier]; ok && ts.State == database.CredStateExpired {
+				return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+					"status": "not_ready",
+					"time":   time.Now().UTC().Format(time.RFC3339),
+					"reason": "storage_credentials_expired",
+					"tier":   tier,
+				})
+			}
+		}
 	}
 
 	uptime := time.Since(startTime).Seconds()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,10 +1,15 @@
 package api
 
 import (
+	"encoding/json"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/database"
 
 	"github.com/rs/zerolog"
 )
@@ -228,4 +233,122 @@ func TestHealthHandler_AlwaysOK(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("post-MarkNotReady /health status = %d; want 200 (liveness != readiness)", resp.StatusCode)
 	}
+}
+
+// TestHealthStorageField (#603): /health carries the per-tier storage
+// credential state when wired, and omits the field entirely when not (or when
+// empty) — static-key and pre-wiring deployments see the exact pre-#603
+// payload.
+func TestHealthStorageField(t *testing.T) {
+	now := time.Now().UTC()
+	mkReq := func(s *Server, path string) (*http.Response, map[string]any) {
+		t.Helper()
+		s.RegisterRoutes()
+		req := httptest.NewRequest("GET", path, nil)
+		resp, err := s.app.Test(req, 2000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		return resp, body
+	}
+
+	t.Run("absent when not wired", func(t *testing.T) {
+		s := NewServer(DefaultServerConfig(), zerolog.Nop())
+		_, body := mkReq(s, "/health")
+		if _, ok := body["storage"]; ok {
+			t.Fatal("storage field must be absent when no status source is wired")
+		}
+	})
+
+	t.Run("present with tiers when wired", func(t *testing.T) {
+		s := NewServer(DefaultServerConfig(), zerolog.Nop())
+		exp := now.Add(30 * time.Minute)
+		s.SetStorageStatus(func() map[string]database.StorageTierStatus {
+			return map[string]database.StorageTierStatus{
+				"hot":  {Backend: "s3", Credentials: "sdk_managed", State: "ok", ExpiresAt: &exp, Source: "WebIdentityCredentials"},
+				"cold": {Backend: "azure", Credentials: "unmanaged_chain", State: "unknown"},
+			}
+		}, false)
+		_, body := mkReq(s, "/health")
+		storage, ok := body["storage"].(map[string]any)
+		if !ok {
+			t.Fatalf("storage field missing: %v", body)
+		}
+		hot := storage["hot"].(map[string]any)
+		if hot["state"] != "ok" || hot["backend"] != "s3" || hot["expires_at"] == nil {
+			t.Fatalf("hot = %v", hot)
+		}
+		if cold := storage["cold"].(map[string]any); cold["state"] != "unknown" {
+			t.Fatalf("cold = %v", cold)
+		}
+		// Liveness stays ok regardless of credential state.
+		if body["status"] != "ok" {
+			t.Fatalf("/health status must stay ok, got %v", body["status"])
+		}
+	})
+}
+
+// TestReadyStorageCredentialsKnob (#603): the opt-in knob fails /ready ONLY on
+// state "expired" — fallback/unknown/degraded/local must not drain a node
+// (they may be healthy or permanently credential-less by design), and the knob
+// never overrides the not-ready startup/shutdown flag.
+func TestReadyStorageCredentialsKnob(t *testing.T) {
+	statusFn := func(state string) func() map[string]database.StorageTierStatus {
+		return func() map[string]database.StorageTierStatus {
+			return map[string]database.StorageTierStatus{
+				"hot": {Backend: "s3", Credentials: "sdk_managed", State: state},
+			}
+		}
+	}
+	get := func(s *Server) int {
+		t.Helper()
+		s.RegisterRoutes()
+		resp, err := s.app.Test(httptest.NewRequest("GET", "/ready", nil), 2000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resp.StatusCode
+	}
+
+	t.Run("knob on + expired -> 503", func(t *testing.T) {
+		s := NewServer(DefaultServerConfig(), zerolog.Nop())
+		s.MarkReady()
+		s.SetStorageStatus(statusFn("expired"), true)
+		if code := get(s); code != 503 {
+			t.Fatalf("code = %d, want 503", code)
+		}
+	})
+
+	t.Run("knob off + expired -> 200", func(t *testing.T) {
+		s := NewServer(DefaultServerConfig(), zerolog.Nop())
+		s.MarkReady()
+		s.SetStorageStatus(statusFn("expired"), false)
+		if code := get(s); code != 200 {
+			t.Fatalf("code = %d, want 200 (default-off knob)", code)
+		}
+	})
+
+	// The row that catches an accidental "any non-ok fails ready" bug.
+	for _, state := range []string{"ok", "degraded", "fallback", "unknown"} {
+		t.Run("knob on + "+state+" -> 200", func(t *testing.T) {
+			s := NewServer(DefaultServerConfig(), zerolog.Nop())
+			s.MarkReady()
+			s.SetStorageStatus(statusFn(state), true)
+			if code := get(s); code != 200 {
+				t.Fatalf("state %q: code = %d, want 200 (only expired fails ready)", state, code)
+			}
+		})
+	}
+
+	t.Run("knob cannot grant readiness before MarkReady", func(t *testing.T) {
+		s := NewServer(DefaultServerConfig(), zerolog.Nop())
+		s.SetStorageStatus(statusFn("ok"), true)
+		if code := get(s); code != 503 {
+			t.Fatalf("code = %d, want 503 (startup gating untouched)", code)
+		}
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,9 +51,13 @@ type ServerConfig struct {
 	Port            int
 	ReadTimeout     int
 	WriteTimeout    int
-	IdleTimeout     int   // Connection idle timeout in seconds
-	ShutdownTimeout int   // Graceful shutdown timeout in seconds
-	MaxPayloadSize  int64 // Maximum request payload size in bytes (applies to both compressed and decompressed)
+	IdleTimeout     int // Connection idle timeout in seconds
+	ShutdownTimeout int // Graceful shutdown timeout in seconds
+	// StorageCredentialsFailReady: /ready returns 503 while any storage tier's
+	// credential state is "expired" (#603). Default false — recycling on
+	// credential expiry is an operator policy; recommended for reader pools.
+	StorageCredentialsFailReady bool
+	MaxPayloadSize              int64 // Maximum request payload size in bytes (applies to both compressed and decompressed)
 	// TLS Configuration
 	TLSEnabled  bool   // Enable HTTPS/TLS
 	TLSCertFile string // Path to TLS certificate file (PEM format)
@@ -716,16 +720,17 @@ func Load() (*Config, error) {
 	// Build config from Viper (which includes defaults + env vars)
 	cfg := &Config{
 		Server: ServerConfig{
-			Host:            v.GetString("server.host"),
-			Port:            v.GetInt("server.port"),
-			ReadTimeout:     v.GetInt("server.read_timeout"),
-			WriteTimeout:    v.GetInt("server.write_timeout"),
-			IdleTimeout:     v.GetInt("server.idle_timeout"),
-			ShutdownTimeout: v.GetInt("server.shutdown_timeout"),
-			MaxPayloadSize:  maxPayloadSize,
-			TLSEnabled:      v.GetBool("server.tls_enabled"),
-			TLSCertFile:     v.GetString("server.tls_cert_file"),
-			TLSKeyFile:      v.GetString("server.tls_key_file"),
+			Host:                        v.GetString("server.host"),
+			Port:                        v.GetInt("server.port"),
+			ReadTimeout:                 v.GetInt("server.read_timeout"),
+			WriteTimeout:                v.GetInt("server.write_timeout"),
+			IdleTimeout:                 v.GetInt("server.idle_timeout"),
+			ShutdownTimeout:             v.GetInt("server.shutdown_timeout"),
+			StorageCredentialsFailReady: v.GetBool("server.storage_credentials_fail_ready"),
+			MaxPayloadSize:              maxPayloadSize,
+			TLSEnabled:                  v.GetBool("server.tls_enabled"),
+			TLSCertFile:                 v.GetString("server.tls_cert_file"),
+			TLSKeyFile:                  v.GetString("server.tls_key_file"),
 		},
 		Database: DatabaseConfig{
 			MaxConnections:         v.GetInt("database.max_connections"),
@@ -1368,6 +1373,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.host", "")
 	v.SetDefault("server.port", 8000)
 	v.SetDefault("server.read_timeout", 30)
+	v.SetDefault("server.storage_credentials_fail_ready", false)
 	v.SetDefault("server.write_timeout", 30)
 	v.SetDefault("server.idle_timeout", 120)
 	v.SetDefault("server.shutdown_timeout", 30)

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -44,6 +44,137 @@ type DuckDB struct {
 	// Close stops and waits for each. See s3refresh.go and #600.
 	refresherMu  sync.Mutex
 	s3Refreshers map[string]*s3CredentialRefresher
+
+	// coldTier records the cold tier's backend + credential mode for the
+	// /health storage payload (#603). Set by ConfigureS3/ConfigureAzure at
+	// startup (the hot tier is derived live from d.config and needs no
+	// record). Guarded by refresherMu.
+	coldTier *storageTierConfig
+}
+
+// storageTierConfig is what StorageCredentialStatus needs to describe a tier
+// whose secret was emitted directly (no refresher registry entry).
+type storageTierConfig struct {
+	backend     string // s3 | azure
+	credentials string // static_keys | sas | sdk_managed | unmanaged_chain
+	secretName  string // registry key when credentials == sdk_managed
+}
+
+// StorageTierStatus is one tier's entry in the /health "storage" payload
+// (#603). ExpiresAt/Source/LastRefresh are populated only for
+// refresher-managed credentials.
+type StorageTierStatus struct {
+	Backend           string     `json:"backend"`
+	Credentials       string     `json:"credentials"`
+	State             string     `json:"state"`
+	ExpiresAt         *time.Time `json:"expires_at,omitempty"`
+	Source            string     `json:"source,omitempty"`
+	LastRefresh       *time.Time `json:"last_refresh,omitempty"`
+	ConsecutiveErrors int        `json:"consecutive_errors,omitempty"`
+}
+
+// Credential-mode labels for tiers without a refresher.
+const (
+	credModeNone           = "none"
+	credModeStaticKeys     = "static_keys"
+	credModeSAS            = "sas"
+	credModeUnmanagedChain = "unmanaged_chain"
+)
+
+// azureCredentialsLabel classifies an Azure tier's credential source. A
+// connection string embedding a SharedAccessSignature EXPIRES (typically
+// hours/days) — reporting it "static_keys/ok" would recreate the exact
+// green-dashboard-dead-reads incident #603 fixes, so SAS maps to
+// state "unknown" (#603 review F3). Arc has no visibility into SAS expiry.
+func azureCredentialsLabel(connectionString, accountKey string) (creds, state string) {
+	if connectionString != "" {
+		lower := strings.ToLower(connectionString)
+		// ';sig=' cannot false-positive inside an AccountKey: base64 excludes
+		// ';'. The '?sig='/'&sig=' forms catch a SAS carried in BlobEndpoint
+		// query parameters.
+		if strings.Contains(lower, "sharedaccesssignature=") || strings.Contains(lower, ";sig=") ||
+			strings.Contains(lower, "?sig=") || strings.Contains(lower, "&sig=") {
+			return credModeSAS, CredStateUnknown
+		}
+		return credModeStaticKeys, CredStateOK
+	}
+	if accountKey != "" {
+		return credModeStaticKeys, CredStateOK
+	}
+	// Managed identity / az-login via DuckDB's chain: resolved once, never
+	// refreshed, no Arc visibility (#605 tracks the refresher gap).
+	return credModeUnmanagedChain, CredStateUnknown
+}
+
+// StorageCredentialStatus builds the /health "storage" payload: one entry per
+// configured tier (hot always; cold once its configuration succeeded), built
+// LIVE per call. Refresher pointers are copied under refresherMu and the mutex
+// is released before status() calls, keeping the critical section tiny. Note
+// what actually protects /health from blocking behind Close (which holds
+// refresherMu across stop(), bounded by s3ResolveTimeout): graceful-shutdown
+// ORDERING — HTTP drains (priority 10) before the database closes (priority
+// 90), so no probe can be in flight by then. A future non-HTTP caller running
+// through shutdown would still contend on the Lock below.
+func (d *DuckDB) StorageCredentialStatus() map[string]StorageTierStatus {
+	now := time.Now()
+
+	d.refresherMu.Lock()
+	refreshers := make(map[string]*s3CredentialRefresher, len(d.s3Refreshers))
+	for k, v := range d.s3Refreshers {
+		refreshers[k] = v
+	}
+	cold := d.coldTier
+	d.refresherMu.Unlock()
+
+	out := make(map[string]StorageTierStatus, 2)
+
+	// Hot tier: derived live from retained config. Note the legacy edge where
+	// S3 keys are set with backend=local: a primary S3 secret exists but reads
+	// serve from local storage, so hot honestly reports local/none.
+	switch {
+	case d.config.S3IsPrimaryBackend:
+		out["hot"] = d.s3TierStatus(primaryS3SecretParams(d.config), refreshers, now)
+	case d.config.AzureIsPrimaryBackend:
+		creds, state := azureCredentialsLabel(d.config.AzureConnectionString, d.config.AzureAccountKey)
+		out["hot"] = StorageTierStatus{Backend: "azure", Credentials: creds, State: state}
+	default:
+		out["hot"] = StorageTierStatus{Backend: "local", Credentials: credModeNone, State: CredStateOK}
+	}
+
+	if cold != nil {
+		st := StorageTierStatus{Backend: cold.backend, Credentials: cold.credentials, State: CredStateOK}
+		switch cold.credentials {
+		case credModeSAS, credModeUnmanagedChain:
+			st.State = CredStateUnknown
+		case s3ModeSDKManaged:
+			if r := refreshers[cold.secretName]; r != nil {
+				st = r.status(now)
+				st.Backend, st.Credentials = cold.backend, s3ModeSDKManaged
+			} else {
+				// Provider construction failed at configure time: running on
+				// the CREDENTIAL_CHAIN fallback with no refresher.
+				st.Credentials, st.State = s3ModeCredentialChain, CredStateFallback
+			}
+		}
+		out["cold"] = st
+	}
+	return out
+}
+
+// s3TierStatus describes an S3 tier from its secret params + the refresher
+// registry.
+func (d *DuckDB) s3TierStatus(params s3SecretParams, refreshers map[string]*s3CredentialRefresher, now time.Time) StorageTierStatus {
+	if s3CredentialMode(params.accessKey, params.secretKey) == s3ModeStaticKeys {
+		return StorageTierStatus{Backend: "s3", Credentials: credModeStaticKeys, State: CredStateOK}
+	}
+	if r := refreshers[params.name]; r != nil {
+		st := r.status(now)
+		st.Backend, st.Credentials = "s3", s3ModeSDKManaged
+		return st
+	}
+	// sdk_managed route but no registry entry: provider construction failed and
+	// the CREDENTIAL_CHAIN fallback secret is serving (see startRefresher).
+	return StorageTierStatus{Backend: "s3", Credentials: s3ModeCredentialChain, State: CredStateFallback}
 }
 
 // escapeSQLString escapes single quotes for safe use in DuckDB SQL strings.
@@ -1064,7 +1195,12 @@ func (d *DuckDB) ConfigureS3(s3cfg *S3Config) error {
 		pathStyle: s3cfg.PathStyle,
 		useSSL:    s3cfg.UseSSL,
 	}
+	coldCreds := credModeStaticKeys
 	if s3CredentialMode(s3cfg.AccessKey, s3cfg.SecretKey) == s3ModeSDKManaged {
+		coldCreds = s3ModeSDKManaged
+	}
+
+	if coldCreds == s3ModeSDKManaged {
 		// No static keys: the cold-tier secret is Arc-managed too (#600/#601).
 		// startRefresher stop-and-replaces any previous refresher for this name;
 		// template errors are deterministic misconfigurations and propagate.
@@ -1080,6 +1216,15 @@ func (d *DuckDB) ConfigureS3(s3cfg *S3Config) error {
 			return fmt.Errorf("failed to create S3 secret: %w", err)
 		}
 	}
+
+	// Record the tier only AFTER the secret/refresher is in place: recording
+	// first would make /health affirmatively report a working cold tier whose
+	// secret was never created — the exact green-but-dead shape #603 exists to
+	// kill (#603 review H1). On failure the tier is ABSENT from the payload,
+	// matching ConfigureAzure; the caller logs the error.
+	d.refresherMu.Lock()
+	d.coldTier = &storageTierConfig{backend: "s3", credentials: coldCreds, secretName: arcS3ColdSecretName}
+	d.refresherMu.Unlock()
 
 	// credential_mode matters most here: on a local-primary + S3-cold deployment
 	// configureS3Access never runs, so this is the ONLY place an operator can see
@@ -1271,6 +1416,12 @@ func (d *DuckDB) ConfigureAzure(azcfg *AzureConfig) error {
 	if _, err := d.db.Exec(secretSQL); err != nil {
 		return fmt.Errorf("failed to create cold-tier azure secret: %w", err)
 	}
+
+	creds, _ := azureCredentialsLabel(azcfg.ConnectionString, azcfg.AccountKey)
+	d.refresherMu.Lock()
+	d.coldTier = &storageTierConfig{backend: "azure", credentials: creds, secretName: arcAzureColdSecretName}
+	d.refresherMu.Unlock()
+
 	d.logger.Info().Str("account", azcfg.AccountName).Str("container", azcfg.Container).Msg("DuckDB cold-tier Azure secret configured")
 	return nil
 }

--- a/internal/database/s3refresh.go
+++ b/internal/database/s3refresh.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -127,6 +128,105 @@ type s3CredentialRefresher struct {
 	// first resolve before the goroutine starts).
 	everSucceeded     bool
 	consecutiveErrors int
+
+	// lastRefresh / source describe the last successful emission; loop-owned
+	// like the fields above.
+	lastRefresh time.Time
+	source      string
+
+	// snap is the read side for /health (#603): an immutable snapshot swapped
+	// atomically by publishStatus at every outcome. status() reads ONLY this —
+	// never the loop-owned raw fields above. Publication of the refresher in
+	// the DuckDB registry (under refresherMu) is what orders the constructor's
+	// writes before any reader; the done channel plays no part in that.
+	snap atomic.Pointer[storageCredSnapshot]
+}
+
+// storageCredSnapshot is the raw material for state derivation. It stores
+// facts, not a state string: state is derived at READ time by deriveState so
+// an expiry crossing between refresher outcomes (up to ~refreshDelay apart)
+// becomes visible within one probe interval, not one refresh interval.
+type storageCredSnapshot struct {
+	everSucceeded     bool
+	canExpire         bool
+	consecutiveErrors int
+	lastExpiry        time.Time
+	lastRefresh       time.Time
+	source            string
+}
+
+// publishStatus snapshots the loop-owned fields. Called at every outcome —
+// the three constructor branches, the three plan* outcomes, and the loop's
+// non-expiring exit. Missing a site is not cosmetic: skipping the
+// constructor-success site would report "fallback" for ~refreshDelay on a
+// perfectly healthy refresher (#603 review F1).
+func (r *s3CredentialRefresher) publishStatus(canExpire bool) {
+	r.snap.Store(&storageCredSnapshot{
+		everSucceeded:     r.everSucceeded,
+		canExpire:         canExpire,
+		consecutiveErrors: r.consecutiveErrors,
+		lastExpiry:        r.lastExpiry,
+		lastRefresh:       r.lastRefresh,
+		source:            r.source,
+	})
+}
+
+// Credential states surfaced via /health (#603). Exported: they are a
+// published API contract (release notes) and internal/api compares against
+// CredStateExpired for the readiness knob — a raw string there would let a
+// respelling here silently disable the knob (#603 review M3).
+const (
+	CredStateOK       = "ok"
+	CredStateDegraded = "degraded"
+	CredStateExpired  = "expired"
+	CredStateFallback = "fallback"
+	CredStateUnknown  = "unknown"
+)
+
+// deriveState maps a snapshot to a state at time `now`. Pure so the full grid
+// — including "expired", impossible to force against real STS in a test — is
+// unit-testable.
+//
+// Precedence (#603 review F4): fallback (never succeeded — cannot be expired,
+// lastExpiry is only ever set by a successful emit) > non-expiring ok >
+// expired (EVEN with a concurrent error streak: in the field incident both
+// held at once and expired is the actionable truth) > degraded > ok.
+// Non-advancing rotation-waits stay "ok" deliberately: they occur in the tail
+// of every healthy IMDS/Pod-Identity session; pre-expiry alerting belongs to
+// the payload's expires_at, not a state flap.
+func deriveState(snap *storageCredSnapshot, now time.Time) string {
+	switch {
+	case snap == nil || !snap.everSucceeded:
+		return CredStateFallback
+	case !snap.canExpire:
+		return CredStateOK
+	case !now.Before(snap.lastExpiry):
+		return CredStateExpired
+	case snap.consecutiveErrors > 0:
+		return CredStateDegraded
+	default:
+		return CredStateOK
+	}
+}
+
+// status returns this refresher's contribution to the /health payload.
+func (r *s3CredentialRefresher) status(now time.Time) StorageTierStatus {
+	snap := r.snap.Load()
+	st := StorageTierStatus{State: deriveState(snap, now)}
+	if snap == nil {
+		return st
+	}
+	st.Source = snap.source
+	st.ConsecutiveErrors = snap.consecutiveErrors
+	if snap.canExpire && !snap.lastExpiry.IsZero() {
+		t := snap.lastExpiry.UTC()
+		st.ExpiresAt = &t
+	}
+	if !snap.lastRefresh.IsZero() {
+		t := snap.lastRefresh.UTC()
+		st.LastRefresh = &t
+	}
+	return st
 }
 
 // startS3CredentialRefresher performs one synchronous resolve+emit (bounded by
@@ -158,6 +258,7 @@ func startS3CredentialRefresher(db *sql.DB, params s3SecretParams, provider awsC
 
 	switch {
 	case err != nil:
+		r.publishStatus(true)
 		if onFirstFailure != nil {
 			onFirstFailure(err)
 		}
@@ -165,10 +266,12 @@ func startS3CredentialRefresher(db *sql.DB, params s3SecretParams, provider awsC
 	case !creds.CanExpire:
 		// Static credentials resolved through the chain — nothing to refresh.
 		r.everSucceeded = true
+		r.publishStatus(false)
 		r.logger.Info().Msg("resolved non-expiring S3 credentials; refresh loop not needed")
 		close(r.done)
 	default:
 		r.everSucceeded = true
+		r.publishStatus(true)
 		go r.loop(ctx, refreshDelay(creds.Expires))
 	}
 	return r
@@ -205,6 +308,11 @@ func (r *s3CredentialRefresher) loop(ctx context.Context, initialDelay time.Dura
 		var delay time.Duration
 		switch {
 		case err == nil && !creds.CanExpire:
+			// Publish before exiting or the stale ExpiresAt would eventually
+			// derive "expired" forever while queries work (#603 review F1).
+			r.everSucceeded = true
+			r.consecutiveErrors = 0
+			r.publishStatus(false)
 			r.logger.Info().Msg("credentials became non-expiring; refresh loop exiting")
 			return
 		case err == nil:
@@ -225,6 +333,7 @@ func (r *s3CredentialRefresher) loop(ctx context.Context, initialDelay time.Dura
 func (r *s3CredentialRefresher) planSuccess(creds aws.Credentials) time.Duration {
 	r.everSucceeded = true
 	r.consecutiveErrors = 0
+	r.publishStatus(true)
 	return refreshDelay(creds.Expires)
 }
 
@@ -235,6 +344,7 @@ func (r *s3CredentialRefresher) planSuccess(creds aws.Credentials) time.Duration
 // error, and do not add backoff (a backoff step could straddle the rotation).
 func (r *s3CredentialRefresher) planNonAdvancing() time.Duration {
 	r.consecutiveErrors = 0
+	r.publishStatus(true)
 	remaining := time.Until(r.lastExpiry)
 	// Deliberate: if the source NEVER rotates and the held credentials expire,
 	// this keeps warning once a minute indefinitely. Queries are failing in
@@ -260,6 +370,7 @@ func (r *s3CredentialRefresher) planNonAdvancing() time.Duration {
 // later retry.
 func (r *s3CredentialRefresher) planError(err error) time.Duration {
 	r.consecutiveErrors++
+	r.publishStatus(true)
 	n := r.consecutiveErrors
 	backoffCap := s3RefreshBackoffMax
 	ev := r.logger.Error()
@@ -331,6 +442,8 @@ func (r *s3CredentialRefresher) resolveAndEmit(ctx context.Context, invalidate b
 	if _, err := r.db.ExecContext(ctx, secretSQL); err != nil {
 		return aws.Credentials{}, fmt.Errorf("emit S3 secret: %w", err)
 	}
+	r.source = credSourceLabel(creds.Source)
+	r.lastRefresh = time.Now().Truncate(time.Second)
 	if creds.CanExpire {
 		r.lastExpiry = creds.Expires
 		// Wording note: on EC2 the SDK caps reported Expires at now+1h even for

--- a/internal/database/s3refresh_test.go
+++ b/internal/database/s3refresh_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -615,4 +616,214 @@ func TestPlanLogLevels(t *testing.T) {
 			t.Fatalf("levels = %v, want %v", got, want)
 		}
 	})
+}
+
+// TestDeriveState covers the full state grid — the pure function is the only
+// practical coverage for "expired" (unforceable against real STS) and pins the
+// precedence: fallback > non-expiring ok > expired-even-with-errors > degraded.
+func TestDeriveState(t *testing.T) {
+	now := time.Now()
+	past, future := now.Add(-time.Minute), now.Add(time.Hour)
+	cases := []struct {
+		name string
+		snap *storageCredSnapshot
+		want string
+	}{
+		{"nil snapshot", nil, CredStateFallback},
+		{"never succeeded", &storageCredSnapshot{everSucceeded: false, consecutiveErrors: 9}, CredStateFallback},
+		{"non-expiring", &storageCredSnapshot{everSucceeded: true, canExpire: false}, CredStateOK},
+		{"healthy", &storageCredSnapshot{everSucceeded: true, canExpire: true, lastExpiry: future}, CredStateOK},
+		{"failing but valid", &storageCredSnapshot{everSucceeded: true, canExpire: true, lastExpiry: future, consecutiveErrors: 2}, CredStateDegraded},
+		{"expired", &storageCredSnapshot{everSucceeded: true, canExpire: true, lastExpiry: past}, CredStateExpired},
+		// The field incident: refreshes failing AND creds dead — expired wins.
+		{"expired with error streak", &storageCredSnapshot{everSucceeded: true, canExpire: true, lastExpiry: past, consecutiveErrors: 7}, CredStateExpired},
+	}
+	for _, tc := range cases {
+		if got := deriveState(tc.snap, now); got != tc.want {
+			t.Errorf("%s: deriveState = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestStatusPublishSites pins that every refresher outcome publishes a
+// snapshot status() can see — most importantly the constructor-success site,
+// whose omission would report "fallback" for ~refreshDelay on a healthy
+// refresher (#603 review F1).
+func TestStatusPublishSites(t *testing.T) {
+	db := openTestDuckDBWithHTTPFS(t)
+	now := time.Now()
+
+	t.Run("constructor success publishes ok with expiry+source", func(t *testing.T) {
+		fake := &fakeCredProvider{creds: aws.Credentials{
+			AccessKeyID: "K", SecretAccessKey: "S", SessionToken: "T", Source: "WebIdentityCredentials",
+			CanExpire: true, Expires: now.Add(time.Hour),
+		}}
+		r := startS3CredentialRefresher(db, s3SecretParams{name: "st_ok", region: "r", useSSL: true}, fake, zerolog.Nop(), nil)
+		defer r.stop()
+		st := r.status(now)
+		if st.State != CredStateOK || st.ExpiresAt == nil || st.Source != "WebIdentityCredentials" {
+			t.Fatalf("constructor success status = %+v", st)
+		}
+	})
+
+	t.Run("constructor failure publishes fallback", func(t *testing.T) {
+		fake := &fakeCredProvider{err: fmt.Errorf("nope")}
+		r := startS3CredentialRefresher(db, s3SecretParams{name: "st_fb", region: "r", useSSL: true}, fake, zerolog.Nop(), nil)
+		defer r.stop()
+		if st := r.status(now); st.State != CredStateFallback {
+			t.Fatalf("constructor failure status = %+v", st)
+		}
+	})
+
+	t.Run("emit-once publishes non-expiring ok", func(t *testing.T) {
+		fake := &fakeCredProvider{creds: aws.Credentials{
+			AccessKeyID: "K", SecretAccessKey: "S", Source: "EnvConfigCredentials", CanExpire: false,
+		}}
+		r := startS3CredentialRefresher(db, s3SecretParams{name: "st_once", region: "r", useSSL: true}, fake, zerolog.Nop(), nil)
+		r.stop()
+		st := r.status(now)
+		if st.State != CredStateOK || st.ExpiresAt != nil {
+			t.Fatalf("emit-once status = %+v", st)
+		}
+	})
+
+	t.Run("planError publishes degraded; planSuccess recovers", func(t *testing.T) {
+		r := &s3CredentialRefresher{logger: zerolog.Nop()}
+		r.everSucceeded = true
+		r.lastExpiry = now.Add(time.Hour)
+		r.publishStatus(true)
+		r.planError(fmt.Errorf("sts down"))
+		if st := r.status(now); st.State != CredStateDegraded || st.ConsecutiveErrors != 1 {
+			t.Fatalf("post-error status = %+v", st)
+		}
+		r.planSuccess(aws.Credentials{CanExpire: true, Expires: now.Add(2 * time.Hour)})
+		if st := r.status(now); st.State != CredStateOK || st.ConsecutiveErrors != 0 {
+			t.Fatalf("post-recovery status = %+v", st)
+		}
+	})
+
+	t.Run("expired derives at READ time with no new outcome", func(t *testing.T) {
+		r := &s3CredentialRefresher{logger: zerolog.Nop()}
+		r.everSucceeded = true
+		r.lastExpiry = now.Add(30 * time.Millisecond)
+		r.publishStatus(true)
+		if st := r.status(now); st.State != CredStateOK {
+			t.Fatalf("pre-expiry: %+v", st)
+		}
+		if st := r.status(now.Add(time.Minute)); st.State != CredStateExpired {
+			t.Fatalf("post-expiry (same snapshot!): %+v", st)
+		}
+	})
+}
+
+// TestAzureCredentialsLabel pins the SAS honesty rule (#603 review F3): a
+// connection string embedding a SharedAccessSignature EXPIRES and must not
+// report static/ok.
+func TestAzureCredentialsLabel(t *testing.T) {
+	cases := []struct {
+		conn, key, wantCreds, wantState string
+	}{
+		{"DefaultEndpointsProtocol=https;AccountName=a;AccountKey=abc==", "", credModeStaticKeys, CredStateOK},
+		{"BlobEndpoint=https://a.blob.core.windows.net;SharedAccessSignature=sv=2024&sig=xyz", "", credModeSAS, CredStateUnknown},
+		{"BlobEndpoint=https://a.blob.core.windows.net;sig=xyz", "", credModeSAS, CredStateUnknown},
+		{"", "accountkey==", credModeStaticKeys, CredStateOK},
+		{"", "", credModeUnmanagedChain, CredStateUnknown},
+	}
+	for _, tc := range cases {
+		creds, state := azureCredentialsLabel(tc.conn, tc.key)
+		if creds != tc.wantCreds || state != tc.wantState {
+			t.Errorf("azureCredentialsLabel(%q,%q) = %s/%s, want %s/%s", tc.conn, tc.key, creds, state, tc.wantCreds, tc.wantState)
+		}
+	}
+}
+
+// TestStorageCredentialStatusTiers pins the per-tier aggregation across the
+// matrix cells.
+func TestStorageCredentialStatusTiers(t *testing.T) {
+	hermeticAWSEnv(t)
+
+	t.Run("local hot only", func(t *testing.T) {
+		tmp := t.TempDir()
+		db, err := New(&Config{MaxConnections: 2, MemoryLimit: "256MB", TempDirectory: tmp, LocalStorageRoot: filepath.Join(tmp, "d")}, zerolog.Nop())
+		if err != nil {
+			t.Skipf("New: %v", err)
+		}
+		defer db.Close()
+		st := db.StorageCredentialStatus()
+		if len(st) != 1 || st["hot"].Backend != "local" || st["hot"].State != CredStateOK {
+			t.Fatalf("local-only status = %+v", st)
+		}
+	})
+
+	t.Run("s3 hot managed + s3 cold managed", func(t *testing.T) {
+		orig := newAWSCredProvider
+		newAWSCredProvider = func(ctx context.Context, region string) (awsCredentialsProvider, error) {
+			return &fakeCredProvider{creds: aws.Credentials{
+				AccessKeyID: "K", SecretAccessKey: "S", SessionToken: "T", Source: "CredentialsEndpointProvider",
+				CanExpire: true, Expires: time.Now().Add(time.Hour),
+			}}, nil
+		}
+		t.Cleanup(func() { newAWSCredProvider = orig })
+
+		tmp := t.TempDir()
+		db, err := New(&Config{
+			MaxConnections: 2, MemoryLimit: "256MB", TempDirectory: tmp,
+			S3IsPrimaryBackend: true, S3Bucket: "hotb", S3Region: "us-east-1", S3UseSSL: true,
+		}, zerolog.Nop())
+		if err != nil {
+			t.Skipf("New: %v", err)
+		}
+		defer db.Close()
+		if err := db.ConfigureS3(&S3Config{Region: "us-east-1", Bucket: "coldb"}); err != nil {
+			t.Fatalf("ConfigureS3: %v", err)
+		}
+		st := db.StorageCredentialStatus()
+		hot, cold := st["hot"], st["cold"]
+		if hot.Backend != "s3" || hot.Credentials != s3ModeSDKManaged || hot.State != CredStateOK || hot.ExpiresAt == nil {
+			t.Fatalf("hot = %+v", hot)
+		}
+		if cold.Backend != "s3" || cold.Credentials != s3ModeSDKManaged || cold.State != CredStateOK {
+			t.Fatalf("cold = %+v", cold)
+		}
+	})
+
+	t.Run("s3 static hot", func(t *testing.T) {
+		tmp := t.TempDir()
+		db, err := New(&Config{
+			MaxConnections: 2, MemoryLimit: "256MB", TempDirectory: tmp,
+			S3IsPrimaryBackend: true, S3Bucket: "b", S3Region: "us-east-1", S3UseSSL: true,
+			S3AccessKey: "AKIA", S3SecretKey: "sk",
+		}, zerolog.Nop())
+		if err != nil {
+			t.Skipf("New: %v", err)
+		}
+		defer db.Close()
+		hot := db.StorageCredentialStatus()["hot"]
+		if hot.Credentials != credModeStaticKeys || hot.State != CredStateOK || hot.ExpiresAt != nil {
+			t.Fatalf("static hot = %+v", hot)
+		}
+	})
+}
+
+// TestColdTierAbsentWhenConfigurationFails (#603 review H1): a cold tier whose
+// secret creation failed must be ABSENT from /health — recording it before
+// emission would affirmatively report a working tier with no secret, the exact
+// green-but-dead shape this feature exists to kill.
+func TestColdTierAbsentWhenConfigurationFails(t *testing.T) {
+	hermeticAWSEnv(t)
+	tmp := t.TempDir()
+	db, err := New(&Config{MaxConnections: 2, MemoryLimit: "256MB", TempDirectory: tmp, LocalStorageRoot: filepath.Join(tmp, "d")}, zerolog.Nop())
+	if err != nil {
+		t.Skipf("New: %v", err)
+	}
+	defer db.Close()
+
+	// Half-configured key pair: buildS3SecretSQL rejects it, ConfigureS3 errors.
+	if err := db.ConfigureS3(&S3Config{Region: "us-east-1", Bucket: "coldb", AccessKey: "AKIA"}); err == nil {
+		t.Fatal("half-configured cold tier must error")
+	}
+	st := db.StorageCredentialStatus()
+	if _, ok := st["cold"]; ok {
+		t.Fatalf("failed cold tier must be absent from /health, got %+v", st["cold"])
+	}
 }


### PR DESCRIPTION
## Summary

- **Closes #603**: `/health` gains a `storage` field with per-tier credential state (`ok`/`degraded`/`expired`/`fallback`/`unknown`, plus backend, credential mode, `expires_at`, sanitized source, `last_refresh`) — the field incident (reader READY 1/1 + green `/health` for ~21h while every S3 query failed on expired creds) becomes a red field within a minute of expiry.
- Built from the #601 refresher's in-memory records via an atomic snapshot published at all 7 outcome sites; **state derived at read time** by a pure function (unit-testable "expired", no clock seams). **Never probes S3/Azure from the probe path** — nothing to flap, no per-probe storage traffic.
- Honesty rules: Azure SAS connection strings → `sas/unknown` (SAS expires invisibly; `ok` would recreate the incident); Azure managed identity → `unmanaged_chain/unknown` (#605, probable live #600-class bug); failed cold-tier configuration → tier **absent**, not falsely green; local → `local/none/ok`.
- Opt-in `server.storage_credentials_fail_ready` (default **false**): `/ready` 503s while any tier is `expired` so K8s recycles the pod. Only `expired` drains; AND-ed after the ready flag; startup Warn on cluster writers.
- Field is unauthenticated like `/health`+`/metrics` (decision comment mirrors the PublicRoutes rationale): no bucket names, endpoints, prefixes, paths, or key material.

## Test plan

- [x] 33/33 packages, `-race` clean on database+api
- [x] Adversarial plan validation + deep review; all findings fixed (incl. H1: cold tier recorded before emission success — revert-verified regression test; exported state consts so the api knob can't drift; SAS query-param sniff)
- [x] Pure `deriveState` grid (incl. expired-with-error-streak precedence), publish-site coverage (constructor sites revert-verified), knob grid (only `expired` fails ready; knob can't grant readiness pre-MarkReady)
- [x] Binary runs: local (`hot: local/none/ok`), keyless-unresolvable + **knob=true non-default** (fallback stays ready)
- [x] **Live rig (real Pod Identity credentials)**: `/health` shows `ok` + real expiry + `CredentialsEndpointProvider` source
- [x] Matrix: 12 rows traced by reviewer, all confirmed

Matching docs: `docs.basekick.net` branch `docs/603-health-storage-state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)