### PR TITLE
feat(query): Azure managed-identity credential refresher (#605)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -441,6 +441,18 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### Azure managed-identity credentials on the query path now refresh — and no longer die an hour in ([#605](https://github.com/Basekick-Labs/arc/issues/605))
+
+The same class as the S3/IRSA bug above, on the other cloud: DuckDB's azure `CREDENTIAL_CHAIN` secret materializes an AAD token **once** at secret creation and never refreshes it, while AAD access tokens live about an hour — so on `storage.backend = azure` with managed identity or a service-principal environment, query reads died roughly an hour after each process start, with ingest unaffected.
+
+Arc now resolves AAD tokens itself through `azidentity`'s `DefaultAzureCredential` — the same chain ingest uses, so query identity equals ingest identity — and hands DuckDB `PROVIDER ACCESS_TOKEN` secrets, re-issued before each expiry by the same refresher machinery that manages the AWS sources. Near the end of a token's life MSAL serves its cache for up to ~5 minutes; the refresher's rotation-wait handles that, exactly as it does for IMDS and Pod Identity. Verified end-to-end against live Azure Blob Storage with real hour-long AAD tokens, through a full rotation.
+
+Also in this change:
+
+- **`storage.azure_endpoint` now reaches the query path.** It was silently ignored there — every azure secret targeted `blob.core.windows.net`, so sovereign-cloud endpoints only worked for writes. Full-URL values are normalized to DuckDB's host-suffix form; path-style endpoints (Azurite) don't fit that model and are logged and skipped. The sovereign token *audience* remains a known, ingest-shared limitation.
+- **SAS deployments never start a refresher.** `storage.azure_sas_token` is now visible to the credential routing: a deliberately-scoped SAS reports `sas / unknown` in `/health` and keeps its existing behavior — a managed refresher would have acquired a broader identity than the operator intended. (The query path has never consumed the SAS itself; its DuckDB secret is chain-shaped. That pre-existing asymmetry is unchanged and now at least visible.)
+- Deployments with no resolvable Azure credentials degrade to the previous chain secret with a demoted background retry, like S3.
+
 ### `/health` now reports storage credential state — a dead read path can no longer hide behind green probes ([#603](https://github.com/Basekick-Labs/arc/issues/603))
 
 The incident that motivated this: a reader ran ~21 hours READY 1/1 with `/health` green while every S3-backed query failed on expired credentials — the only failure signal lived in query responses, invisible to probes, monitoring, and orchestration.
@@ -452,13 +464,13 @@ The incident that motivated this: a reader ran ~21 hours READY 1/1 with `/health
   "hot":  {"backend": "s3", "credentials": "sdk_managed", "state": "ok",
            "expires_at": "2026-08-18T20:24:18Z", "source": "CredentialsEndpointProvider",
            "last_refresh": "2026-08-18T20:12:26Z"},
-  "cold": {"backend": "azure", "credentials": "unmanaged_chain", "state": "unknown"}
+  "cold": {"backend": "azure", "credentials": "sas", "state": "unknown"}
 }
 ```
 
 States: `ok`, `degraded` (refreshes failing, credentials still valid), `expired` (the incident case — red within a minute of expiry), `fallback` (no resolvable credentials; running on DuckDB's chain), `unknown` (Arc has no visibility — see below). The state is computed from the credential refresher's in-memory records at read time: **`/health` never probes S3 or Azure**, so there is nothing to flap and no per-probe storage traffic. Pre-expiry alerting belongs on `expires_at`, not on a state change — a healthy IMDS or Pod Identity session routinely waits for server-side rotation near its end and stays `ok` while doing so.
 
-Honesty notes: an Azure connection string embedding a **SAS token** reports `credentials: sas, state: unknown` — SAS tokens expire and Arc cannot see when, and calling that "ok" would recreate exactly the incident above. Azure **managed identity** likewise reports `unmanaged_chain / unknown`: those credentials are resolved once by DuckDB and never refreshed — the same class #600 fixed for S3, tracked as a probable live bug in [#605](https://github.com/Basekick-Labs/arc/issues/605). Local storage reports `local / none / ok`.
+Honesty notes: an Azure **SAS token** (configured directly or embedded in a connection string) reports `credentials: sas, state: unknown` — SAS tokens expire and Arc cannot see when, and calling that "ok" would recreate exactly the incident above. Azure **managed identity** reports full refresher state (`sdk_managed`), since [#605](https://github.com/Basekick-Labs/arc/issues/605) above brought it under Arc's credential management. Local storage reports `local / none / ok`.
 
 **Opt-in readiness gating**: `server.storage_credentials_fail_ready = true` (default **false**) makes `/ready` return 503 while any tier's credential state is `expired`, so Kubernetes recycles the pod — a restart re-resolves credentials. Only `expired` drains a node; `fallback`/`unknown`/`degraded` never do (those deployments may be healthy or credential-less by design). Intended for reader pools: Arc logs a startup warning when it is enabled on a cluster writer, whose ingest keeps working through credential expiry. Startup and shutdown readiness gating are unaffected — the knob can only remove readiness, never grant it.
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -273,6 +273,7 @@ func main() {
 		AzureAccountName:      cfg.Storage.AzureAccountName,
 		AzureAccountKey:       cfg.Storage.AzureAccountKey,
 		AzureConnectionString: cfg.Storage.AzureConnectionString,
+		AzureSASToken:         cfg.Storage.AzureSASToken,
 		AzureEndpoint:         cfg.Storage.AzureEndpoint,
 		AzureContainer:        cfg.Storage.AzureContainer,
 		// Primary-backend signal for Azure (mirrors S3IsPrimaryBackend): only an
@@ -3200,7 +3201,9 @@ func main() {
 				ConnectionString: cold.AzureConnectionString,
 				AccountName:      cold.AzureAccountName,
 				AccountKey:       cold.AzureAccountKey,
+				SASToken:         cold.AzureSASToken,
 				Container:        cold.AzureContainer,
+				Endpoint:         cold.AzureEndpoint,
 			}); err != nil {
 				log.Warn().Err(err).Msg("Failed to configure DuckDB with cold tier Azure credentials")
 			} else {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -270,7 +270,7 @@ func TestHealthStorageField(t *testing.T) {
 		s.SetStorageStatus(func() map[string]database.StorageTierStatus {
 			return map[string]database.StorageTierStatus{
 				"hot":  {Backend: "s3", Credentials: "sdk_managed", State: "ok", ExpiresAt: &exp, Source: "WebIdentityCredentials"},
-				"cold": {Backend: "azure", Credentials: "unmanaged_chain", State: "unknown"},
+				"cold": {Backend: "azure", Credentials: "sas", State: "unknown"},
 			}
 		}, false)
 		_, body := mkReq(s, "/health")

--- a/internal/database/azurerefresh.go
+++ b/internal/database/azurerefresh.go
@@ -1,0 +1,100 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/rs/zerolog"
+)
+
+// Azure side of Arc's credential management for DuckDB (#605); shared core in
+// credrefresh.go, S3 sibling (and the incident history that shaped all of
+// this) in s3refresh.go.
+//
+// Azure managed-identity credentials had the same resolve-once class as #600:
+// DuckDB's azure CREDENTIAL_CHAIN secret materializes an AAD token once at
+// CREATE SECRET time and never refreshes, while AAD access tokens live ~60-90
+// minutes (SP) — so query reads died about an hour in, exactly like IRSA did.
+// Arc now resolves tokens itself via azidentity (the same
+// DefaultAzureCredential chain ingest uses — identity symmetry, like S3) and
+// emits PROVIDER ACCESS_TOKEN secrets, re-issued before expiry (probed
+// against the bundled engine: the provider exists, ACCESS_TOKEN is redacted
+// in duckdb_secrets(), chain→access_token replacement takes effect).
+
+// azureStorageScope is the AAD resource scope for Azure Storage in the public
+// cloud — the same value the ingest path's azblob client requests. Sovereign
+// AUDIENCE selection is a pre-existing, ingest-shared limitation (documented);
+// sovereign AUTHORITY is covered by azidentity's AZURE_AUTHORITY_HOST env.
+const azureStorageScope = "https://storage.azure.com/.default"
+
+// azureDemotionHint is what a never-succeeded Azure refresher's demotion Warn
+// tells the operator (see credentialRefresher.planError).
+const azureDemotionHint = "no resolvable Azure credentials; running on DuckDB's credential chain — configure an account key/connection string, or fix the managed identity / service principal environment"
+
+// azureTokenCredential is the seam between the Azure resolver and azidentity,
+// so tests can inject deterministic credentials.
+type azureTokenCredential interface {
+	GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error)
+}
+
+// newAzureCredProvider builds the azidentity default chain (env service
+// principal, workload identity, managed identity, az CLI). Package-level so
+// tests can substitute a fake.
+var newAzureCredProvider = func() (azureTokenCredential, error) {
+	return azidentity.NewDefaultAzureCredential(nil)
+}
+
+// azureResolver implements credentialResolver for Azure secrets.
+//
+// invalidate is a documented NO-OP here: azidentity/MSAL expose no public
+// cache invalidation. MSAL serves its cached token until an internal 5-minute
+// hard buffer before expiry (plus proactive refresh_on where the server sends
+// one), so proactive resolves inside our 10-minute margin legitimately return
+// the SAME token for up to ~5 minutes — the core's non-advancing flat-poll is
+// the mechanism that bridges that gap, and it was built for exactly this
+// shape (#601). One observability note: MSAL swallows managed-identity
+// proactive-refresh failures (serves cache), so a broken AAD surfaces as
+// "degraded" only inside the final ~5 minutes (#605 review M3).
+type azureResolver struct {
+	db     *sql.DB
+	params azureSecretParams // template; accessToken filled per emission
+	cred   azureTokenCredential
+}
+
+func (a *azureResolver) Resolve(ctx context.Context, invalidate bool) (credMaterial, error) {
+	_ = invalidate // no azidentity equivalent; see type comment
+	tok, err := a.cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{azureStorageScope}})
+	if err != nil {
+		return credMaterial{}, fmt.Errorf("resolve Azure credentials: %w", err)
+	}
+	return credMaterial{
+		canExpire:    true, // AAD access tokens always expire
+		expires:      tok.ExpiresOn,
+		source:       "DefaultAzureCredential",
+		secretValues: []string{tok.Token},
+		payload:      tok,
+	}, nil
+}
+
+func (a *azureResolver) Emit(ctx context.Context, m credMaterial) error {
+	tok := m.payload.(azcore.AccessToken)
+	p := a.params
+	p.accessToken = tok.Token
+	secretSQL, err := buildAzureSecretSQL(p)
+	if err != nil {
+		return err
+	}
+	_, err = a.db.ExecContext(ctx, secretSQL)
+	return err
+}
+
+// startAzureCredentialRefresher wires an Azure resolver into the shared core.
+func startAzureCredentialRefresher(db *sql.DB, params azureSecretParams, cred azureTokenCredential, logger zerolog.Logger, onFirstFailure func(error)) *credentialRefresher {
+	return startCredentialRefresher(
+		&azureResolver{db: db, params: params, cred: cred},
+		params.name, logger, azureDemotionHint, onFirstFailure)
+}

--- a/internal/database/azurerefresh_test.go
+++ b/internal/database/azurerefresh_test.go
@@ -1,0 +1,272 @@
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/rs/zerolog"
+)
+
+// fakeAzureCred is a deterministic azureTokenCredential.
+type fakeAzureCred struct {
+	tok   azcore.AccessToken
+	err   error
+	calls atomic.Int64
+}
+
+func (f *fakeAzureCred) GetToken(ctx context.Context, o policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	f.calls.Add(1)
+	if f.err != nil {
+		return azcore.AccessToken{}, f.err
+	}
+	return f.tok, nil
+}
+
+// TestBuildAzureSecretSQL_AccessToken pins the refresher emission shape (#605):
+// PROVIDER ACCESS_TOKEN + ACCOUNT_NAME (+ ENDPOINT when configured), escaping,
+// and the mutual-exclusion/template rules.
+func TestBuildAzureSecretSQL_AccessToken(t *testing.T) {
+	got, err := buildAzureSecretSQL(azureSecretParams{
+		name: arcAzurePrimarySecretName, accountName: "myacct",
+		accessToken: "eyJ0token'with'quotes", scope: "azure://cont/",
+		endpoint: "blob.core.usgovcloudapi.net",
+	})
+	if err != nil {
+		t.Fatalf("buildAzureSecretSQL: %v", err)
+	}
+	mustContain(t, got, "PROVIDER ACCESS_TOKEN")
+	mustContain(t, got, "ACCESS_TOKEN 'eyJ0token''with''quotes'")
+	mustContain(t, got, "ACCOUNT_NAME 'myacct'")
+	mustContain(t, got, "ENDPOINT 'blob.core.usgovcloudapi.net'")
+	mustContain(t, got, "SCOPE 'azure://cont/'")
+
+	if _, err := buildAzureSecretSQL(azureSecretParams{name: "x", accessToken: "t"}); err == nil {
+		t.Error("access token without account name must error")
+	}
+	if _, err := buildAzureSecretSQL(azureSecretParams{name: "x", accountName: "a", accessToken: "t", accountKey: "k"}); err == nil {
+		t.Error("access token + static credentials must error")
+	}
+}
+
+// TestAzureAccessTokenSecretExecutesAndRedacts runs the refresher-shaped azure
+// secret against real DuckDB: accepted, and ACCESS_TOKEN redacted in
+// duckdb_secrets() — the manager is readable by any authenticated query user.
+func TestAzureAccessTokenSecretExecutesAndRedacts(t *testing.T) {
+	db := openTestDuckDBWithHTTPFS(t)
+	if _, err := db.Exec("INSTALL azure"); err != nil {
+		t.Skipf("azure extension unavailable (offline?): %v", err)
+	}
+	if _, err := db.Exec("LOAD azure"); err != nil {
+		t.Skipf("azure extension unavailable (offline?): %v", err)
+	}
+	const token = "SUPERSECRETBEARERxyz"
+	stmt, err := buildAzureSecretSQL(azureSecretParams{
+		name: arcAzurePrimarySecretName, accountName: "myacct", accessToken: token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(stmt); err != nil {
+		t.Fatalf("DuckDB rejected access_token secret: %v\nSQL:\n%s", err, stmt)
+	}
+	var secretString string
+	if err := db.QueryRow("SELECT secret_string FROM duckdb_secrets() WHERE name = ?", arcAzurePrimarySecretName).Scan(&secretString); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(secretString, "SUPERSECRETBEARER") {
+		t.Fatalf("token visible in duckdb_secrets(): %s", secretString)
+	}
+	mustContain(t, secretString, "access_token=redacted")
+}
+
+// TestAzureEndpointSuffix pins the full-URL→suffix normalization (#605 M4).
+func TestAzureEndpointSuffix(t *testing.T) {
+	cases := []struct {
+		in, acct, want string
+		ok             bool
+	}{
+		{"", "a", "", true},
+		{"https://myacct.blob.core.windows.net", "myacct", "blob.core.windows.net", true},
+		{"https://myacct.blob.core.usgovcloudapi.net", "myacct", "blob.core.usgovcloudapi.net", true},
+		{"blob.core.windows.net", "myacct", "blob.core.windows.net", true},
+		{"http://127.0.0.1:10000/devstoreaccount1", "devstoreaccount1", "", false}, // Azurite path-style
+	}
+	for _, tc := range cases {
+		got, ok := azureEndpointSuffix(tc.in, tc.acct)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("azureEndpointSuffix(%q,%q) = %q,%v want %q,%v", tc.in, tc.acct, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestAzureResolverThroughCore exercises the azure resolver via the shared
+// core against real DuckDB: first fill emits, a same-token resolve is
+// non-advancing (Emit skipped), an advanced token re-emits.
+func TestAzureResolverThroughCore(t *testing.T) {
+	db := openTestDuckDBWithHTTPFS(t)
+	if _, err := db.Exec("INSTALL azure; LOAD azure"); err != nil {
+		t.Skipf("azure extension unavailable: %v", err)
+	}
+	now := time.Now()
+	fake := &fakeAzureCred{tok: azcore.AccessToken{Token: "tok1", ExpiresOn: now.Add(time.Hour)}}
+	r := &credentialRefresher{
+		resolver: &azureResolver{db: db, cred: fake,
+			params: azureSecretParams{name: "az_core_test", accountName: "acct"}},
+		logger: zerolog.Nop(),
+	}
+	if _, err := r.refreshOnce(context.Background(), false); err != nil {
+		t.Fatalf("first fill: %v", err)
+	}
+	if _, err := r.refreshOnce(context.Background(), true); err != errNonAdvancingExpiry {
+		t.Fatalf("same token must be non-advancing, got %v", err)
+	}
+	fake.tok = azcore.AccessToken{Token: "tok2", ExpiresOn: now.Add(2 * time.Hour)}
+	if _, err := r.refreshOnce(context.Background(), true); err != nil {
+		t.Fatalf("advanced token: %v", err)
+	}
+	var provider string
+	if err := db.QueryRow("SELECT provider FROM duckdb_secrets() WHERE name='az_core_test'").Scan(&provider); err != nil {
+		t.Fatal(err)
+	}
+	if provider != "access_token" {
+		t.Fatalf("provider = %q", provider)
+	}
+}
+
+// TestNewStartsAzureRefresherWhenManaged pins the hot-tier wiring (#605): an
+// Azure primary with no static credentials must start the refresher, whose
+// synchronous first resolve emits the access_token secret before New returns —
+// and /health must report it sdk_managed/ok.
+func TestNewStartsAzureRefresherWhenManaged(t *testing.T) {
+	hermeticAWSEnv(t)
+	orig := newAzureCredProvider
+	fake := &fakeAzureCred{tok: azcore.AccessToken{Token: "hotTok", ExpiresOn: time.Now().Add(time.Hour)}}
+	newAzureCredProvider = func() (azureTokenCredential, error) { return fake, nil }
+	t.Cleanup(func() { newAzureCredProvider = orig })
+
+	tmp := t.TempDir()
+	db, err := New(&Config{
+		MaxConnections: 2, MemoryLimit: "256MB", TempDirectory: tmp,
+		LocalStorageRoot:      filepath.Join(tmp, "d"),
+		AzureIsPrimaryBackend: true, AzureAccountName: "hotacct", AzureContainer: "cont",
+	}, zerolog.Nop())
+	if err != nil {
+		if strings.Contains(err.Error(), "azure") || strings.Contains(err.Error(), "httpfs") {
+			t.Skipf("extension unavailable: %v", err)
+		}
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+
+	var provider string
+	if err := db.DB().QueryRow("SELECT provider FROM duckdb_secrets() WHERE name = ?", arcAzurePrimarySecretName).Scan(&provider); err != nil {
+		t.Fatalf("primary azure secret not registered: %v", err)
+	}
+	if provider != "access_token" {
+		t.Fatalf("provider = %q, want access_token (refresher-managed)", provider)
+	}
+	hot := db.StorageCredentialStatus()["hot"]
+	if hot.Backend != "azure" || hot.Credentials != s3ModeSDKManaged || hot.State != CredStateOK || hot.ExpiresAt == nil {
+		t.Fatalf("hot = %+v", hot)
+	}
+	if fake.calls.Load() == 0 {
+		t.Fatal("injected azure credential never used")
+	}
+}
+
+// TestAzureSASNeverStartsRefresher (#605 review M6): a SAS-scoped deployment
+// must keep today's chain secret and report sas/unknown — a managed refresher
+// would acquire a BROADER identity than the operator deliberately scoped.
+func TestAzureSASNeverStartsRefresher(t *testing.T) {
+	hermeticAWSEnv(t)
+	orig := newAzureCredProvider
+	newAzureCredProvider = func() (azureTokenCredential, error) {
+		t.Fatal("SAS deployment must never construct an azure credential provider")
+		return nil, nil
+	}
+	t.Cleanup(func() { newAzureCredProvider = orig })
+
+	tmp := t.TempDir()
+	db, err := New(&Config{
+		MaxConnections: 2, MemoryLimit: "256MB", TempDirectory: tmp,
+		LocalStorageRoot:      filepath.Join(tmp, "d"),
+		AzureIsPrimaryBackend: true, AzureAccountName: "sasacct",
+		AzureSASToken: "sv=2024&sig=xyz",
+	}, zerolog.Nop())
+	if err != nil {
+		if strings.Contains(err.Error(), "azure") || strings.Contains(err.Error(), "httpfs") {
+			t.Skipf("extension unavailable: %v", err)
+		}
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	hot := db.StorageCredentialStatus()["hot"]
+	if hot.Credentials != credModeSAS || hot.State != CredStateUnknown {
+		t.Fatalf("SAS hot = %+v, want sas/unknown", hot)
+	}
+	if db.s3Refreshers[arcAzurePrimarySecretName] != nil {
+		t.Fatal("SAS deployment must not register a refresher")
+	}
+}
+
+// TestConfigureAzureColdManagedStartsRefresher pins cold-tier routing +
+// the record-after-success rule for azure (#603 H1 / #605).
+func TestConfigureAzureColdManagedStartsRefresher(t *testing.T) {
+	hermeticAWSEnv(t)
+	orig := newAzureCredProvider
+	fake := &fakeAzureCred{tok: azcore.AccessToken{Token: "coldTok", ExpiresOn: time.Now().Add(time.Hour)}}
+	newAzureCredProvider = func() (azureTokenCredential, error) { return fake, nil }
+	t.Cleanup(func() { newAzureCredProvider = orig })
+
+	tmp := t.TempDir()
+	db, err := New(&Config{
+		MaxConnections: 2, MemoryLimit: "256MB", TempDirectory: tmp,
+		LocalStorageRoot: filepath.Join(tmp, "d"),
+		// azure cold requires the extension pre-loaded at startup:
+		ColdAzureContainer: "coldcont",
+	}, zerolog.Nop())
+	if err != nil {
+		if strings.Contains(err.Error(), "azure") || strings.Contains(err.Error(), "httpfs") {
+			t.Skipf("extension unavailable: %v", err)
+		}
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.ConfigureAzure(&AzureConfig{AccountName: "coldacct", Container: "coldcont"}); err != nil {
+		t.Fatalf("ConfigureAzure: %v", err)
+	}
+	cold := db.StorageCredentialStatus()["cold"]
+	if cold.Backend != "azure" || cold.Credentials != s3ModeSDKManaged || cold.State != CredStateOK {
+		t.Fatalf("cold = %+v", cold)
+	}
+	var provider string
+	if err := db.DB().QueryRow("SELECT provider FROM duckdb_secrets() WHERE name = ?", arcAzureColdSecretName).Scan(&provider); err != nil {
+		t.Fatal(err)
+	}
+	if provider != "access_token" {
+		t.Fatalf("cold provider = %q", provider)
+	}
+
+	// Record-after-success: a failing ConfigureAzure must leave no cold entry.
+	db2, err := New(&Config{
+		MaxConnections: 2, MemoryLimit: "256MB", TempDirectory: t.TempDir(),
+		LocalStorageRoot: filepath.Join(t.TempDir(), "d"),
+	}, zerolog.Nop())
+	if err != nil {
+		t.Skipf("New: %v", err)
+	}
+	defer db2.Close()
+	if err := db2.ConfigureAzure(&AzureConfig{ /* no account name, no conn string */ }); err == nil {
+		t.Fatal("ConfigureAzure without identity must error")
+	}
+	if _, ok := db2.StorageCredentialStatus()["cold"]; ok {
+		t.Fatal("failed cold azure tier must be absent from /health")
+	}
+}

--- a/internal/database/credrefresh.go
+++ b/internal/database/credrefresh.go
@@ -1,0 +1,448 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// This file owns the storage-credential refresher CORE, shared by every
+// backend (S3: s3refresh.go, Azure: azurerefresh.go). It grew out of #600/#601
+// (S3/IRSA ExpiredToken — see s3refresh.go for that incident history) and was
+// generalized for #605 (Azure managed identity, same resolve-once class).
+//
+// Shape: a credentialResolver produces credential material and emits the
+// DuckDB secret; the core owns everything behavior-critical — scheduling, the
+// non-advancing detection (server-rotated sources return the same material
+// near session end; the core skips Emit and flat-polls), the control-byte
+// guard, retry/demotion severity, and the /health status snapshot (#603).
+// Keeping those in the core means a new backend cannot forget them.
+
+const (
+	// s3RefreshMargin is how long before credential expiry the refresher
+	// re-resolves. It must comfortably exceed the default query timeout (300s)
+	// so credentials stay valid for the lifetime of queries started just before
+	// a rotation. Queries longer than the margin may still see one retryable
+	// failure at rotation. (Named s3* for history; shared by all backends. For
+	// Azure, MSAL's internal 5-minute hard cache buffer sits inside this margin:
+	// polls between margin and buffer return the cached token — the
+	// non-advancing path — and a real acquisition happens inside the buffer.)
+	s3RefreshMargin = 10 * time.Minute
+	// s3RefreshMinDelay floors the delay between refreshes so pathologically
+	// short sessions cannot spin the loop.
+	s3RefreshMinDelay = time.Minute
+	// s3FirstResolveTimeout bounds the synchronous resolve during startup /
+	// ConfigureS3. An unreachable STS/AAD must degrade to the background retry
+	// loop, not stall startup — database.New failures are fatal in main.go.
+	s3FirstResolveTimeout = 10 * time.Second
+	// s3ResolveTimeout bounds each background resolve+emit.
+	s3ResolveTimeout = 30 * time.Second
+
+	s3RefreshBackoffMin = 30 * time.Second
+	s3RefreshBackoffMax = 5 * time.Minute
+	// s3RefreshBackoffMaxUnproven caps retries for a refresher that has NEVER
+	// succeeded and is running behind the fallback CREDENTIAL_CHAIN secret
+	// (e.g. anonymous MinIO with no resolvable credentials). Such a deployment
+	// is healthy; polling it every 5 minutes forever at Error level would
+	// produce ~288 spurious error lines/day. See planError.
+	s3RefreshBackoffMaxUnproven = 15 * time.Minute
+	// s3RefreshErrorsBeforeDemotion: a never-succeeded refresher logs its first
+	// failures at Error (a genuinely broken IMDS/STS/AAD at boot must be
+	// visible), then demotes to Debug with one Warn marking the transition.
+	s3RefreshErrorsBeforeDemotion = 3
+	// s3RefreshFinalWarnWindow: a non-advancing resolve (the upstream source
+	// has not rotated yet — normal for IMDS, Pod Identity and AAD, which
+	// rotate server-side on their own schedule) logs Debug while there is
+	// plenty of runway, escalating to Warn inside this window before the held
+	// credentials' expiry so an operator has reaction time.
+	s3RefreshFinalWarnWindow = 5 * time.Minute
+)
+
+// errNonAdvancingExpiry marks a resolve that succeeded but returned the same
+// session we already hold — the upstream source has not rotated yet. Not a
+// failure: the held credentials remain valid; the loop polls at a flat
+// s3RefreshMinDelay until the source rotates. Core-internal: resolvers never
+// see or produce it.
+var errNonAdvancingExpiry = errors.New("credential provider returned a non-advancing expiry (upstream not rotated yet)")
+
+// credMaterial is what a resolver hands the core per resolve.
+type credMaterial struct {
+	canExpire bool
+	expires   time.Time
+	source    string // sanitized provider label, for logs and /health
+	// secretValues is every credential string that will be interpolated into
+	// the CREATE SECRET statement; the CORE runs the control-byte guard over
+	// them so no backend can forget it (a NUL truncates DuckDB's parser string
+	// and its error echoes the credential prefix into logs).
+	secretValues []string
+	// payload carries backend-private material from Resolve to Emit.
+	payload any
+}
+
+// credentialResolver is the backend seam (#605 review M1): Resolve produces
+// material, Emit writes the DuckDB secret. The core decides IF Emit runs —
+// on a non-advancing resolve it does not (no pointless re-emission, no
+// misleading "refreshed" log). invalidate requests a real re-resolution:
+// the AWS SDK cache needs it (aws.CredentialsCache.Invalidate); azidentity
+// has no equivalent and its resolver documents it as a no-op.
+type credentialResolver interface {
+	Resolve(ctx context.Context, invalidate bool) (credMaterial, error)
+	Emit(ctx context.Context, m credMaterial) error
+}
+
+// credentialRefresher keeps one DuckDB storage secret stocked with fresh
+// credentials. One instance per managed secret; owned by the DuckDB struct,
+// which stops it on Close.
+type credentialRefresher struct {
+	resolver credentialResolver
+	logger   zerolog.Logger
+	cancel   context.CancelFunc
+	done     chan struct{}
+
+	// demotionHint names the backend-appropriate way to silence a
+	// never-succeeded retry loop (see planError).
+	demotionHint string
+
+	// lastExpiry drives the non-advancing check: every successful refresh must
+	// advance the expiry, else the upstream source has not rotated yet.
+	// Core-owned: resolvers never track expiry state.
+	lastExpiry time.Time
+
+	// Scheduling/severity state, owned by the loop goroutine (and the sync
+	// first resolve before the goroutine starts).
+	everSucceeded     bool
+	consecutiveErrors int
+
+	// lastRefresh / source describe the last successful emission; loop-owned
+	// like the fields above.
+	lastRefresh time.Time
+	source      string
+
+	// snap is the read side for /health (#603): an immutable snapshot swapped
+	// atomically at every outcome. status() reads ONLY this — never the
+	// loop-owned raw fields above. Publication of the refresher in the DuckDB
+	// registry (under refresherMu) is what orders the constructor's writes
+	// before any reader; the done channel plays no part in that.
+	snap atomic.Pointer[storageCredSnapshot]
+}
+
+// storageCredSnapshot is the raw material for state derivation. It stores
+// facts, not a state string: state is derived at READ time by deriveState so
+// an expiry crossing between refresher outcomes (up to ~refreshDelay apart)
+// becomes visible within one probe interval, not one refresh interval.
+type storageCredSnapshot struct {
+	everSucceeded     bool
+	canExpire         bool
+	consecutiveErrors int
+	lastExpiry        time.Time
+	lastRefresh       time.Time
+	source            string
+}
+
+// publishStatus snapshots the loop-owned fields. Called at every outcome —
+// the three constructor branches, the three plan* outcomes, and the loop's
+// non-expiring exit. Missing a site is not cosmetic: skipping the
+// constructor-success site would report "fallback" for ~refreshDelay on a
+// perfectly healthy refresher (#603 review F1).
+func (r *credentialRefresher) publishStatus(canExpire bool) {
+	r.snap.Store(&storageCredSnapshot{
+		everSucceeded:     r.everSucceeded,
+		canExpire:         canExpire,
+		consecutiveErrors: r.consecutiveErrors,
+		lastExpiry:        r.lastExpiry,
+		lastRefresh:       r.lastRefresh,
+		source:            r.source,
+	})
+}
+
+// Credential states surfaced via /health (#603). Exported: they are a
+// published API contract (release notes) and internal/api compares against
+// CredStateExpired for the readiness knob — a raw string there would let a
+// respelling here silently disable the knob (#603 review M3).
+const (
+	CredStateOK       = "ok"
+	CredStateDegraded = "degraded"
+	CredStateExpired  = "expired"
+	CredStateFallback = "fallback"
+	CredStateUnknown  = "unknown"
+)
+
+// deriveState maps a snapshot to a state at time `now`. Pure so the full grid
+// — including "expired", impossible to force against real STS/AAD in a test —
+// is unit-testable.
+//
+// Precedence (#603 review F4): fallback (never succeeded — cannot be expired,
+// lastExpiry is only ever set by a successful emit) > non-expiring ok >
+// expired (EVEN with a concurrent error streak: in the field incident both
+// held at once and expired is the actionable truth) > degraded > ok.
+// Non-advancing rotation-waits stay "ok" deliberately: they occur in the tail
+// of every healthy IMDS/Pod-Identity/AAD session; pre-expiry alerting belongs
+// to the payload's expires_at, not a state flap. Note: for Azure managed
+// identity, MSAL swallows proactive-refresh failures and serves the cached
+// token, so "degraded" can appear only inside the final ~5 minutes there
+// (vs ~10 for S3) — #605 review M3.
+func deriveState(snap *storageCredSnapshot, now time.Time) string {
+	switch {
+	case snap == nil || !snap.everSucceeded:
+		return CredStateFallback
+	case !snap.canExpire:
+		return CredStateOK
+	case !now.Before(snap.lastExpiry):
+		return CredStateExpired
+	case snap.consecutiveErrors > 0:
+		return CredStateDegraded
+	default:
+		return CredStateOK
+	}
+}
+
+// status returns this refresher's contribution to the /health payload.
+func (r *credentialRefresher) status(now time.Time) StorageTierStatus {
+	snap := r.snap.Load()
+	st := StorageTierStatus{State: deriveState(snap, now)}
+	if snap == nil {
+		return st
+	}
+	st.Source = snap.source
+	st.ConsecutiveErrors = snap.consecutiveErrors
+	if snap.canExpire && !snap.lastExpiry.IsZero() {
+		t := snap.lastExpiry.UTC()
+		st.ExpiresAt = &t
+	}
+	if !snap.lastRefresh.IsZero() {
+		t := snap.lastRefresh.UTC()
+		st.LastRefresh = &t
+	}
+	return st
+}
+
+// startCredentialRefresher performs one synchronous resolve+emit (bounded by
+// s3FirstResolveTimeout) and then maintains the secret in the background. It
+// never fails: an unreachable STS/AAD or an unprojected token degrades to the
+// caller's onFirstFailure hook and background retries — a transient credential
+// race must not turn into a startup failure.
+//
+// onFirstFailure, when non-nil, runs synchronously after a failed first
+// resolve and BEFORE the retry loop starts — so a caller-emitted fallback
+// secret is structurally guaranteed to land before the loop's first managed
+// emit can replace it (#601 review M1).
+func startCredentialRefresher(resolver credentialResolver, secretName string, logger zerolog.Logger, demotionHint string, onFirstFailure func(error)) *credentialRefresher {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &credentialRefresher{
+		resolver: resolver,
+		logger: logger.With().
+			Str("component", "storage-cred-refresher").
+			Str("secret", secretName).Logger(),
+		cancel:       cancel,
+		done:         make(chan struct{}),
+		demotionHint: demotionHint,
+	}
+
+	fctx, fcancel := context.WithTimeout(ctx, s3FirstResolveTimeout)
+	m, err := r.refreshOnce(fctx, false)
+	fcancel()
+
+	switch {
+	case err != nil:
+		r.publishStatus(true)
+		if onFirstFailure != nil {
+			onFirstFailure(err)
+		}
+		go r.loop(ctx, s3RefreshBackoffMin)
+	case !m.canExpire:
+		// Static credentials resolved through the chain — nothing to refresh.
+		r.everSucceeded = true
+		r.publishStatus(false)
+		r.logger.Info().Msg("resolved non-expiring credentials; refresh loop not needed")
+		close(r.done)
+	default:
+		r.everSucceeded = true
+		r.publishStatus(true)
+		go r.loop(ctx, refreshDelay(m.expires))
+	}
+	return r
+}
+
+// stop cancels the refresher and waits for the background goroutine to finish,
+// so no Exec can race the pool's Close.
+func (r *credentialRefresher) stop() {
+	r.cancel()
+	<-r.done
+}
+
+func (r *credentialRefresher) loop(ctx context.Context, initialDelay time.Duration) {
+	defer close(r.done)
+	timer := time.NewTimer(initialDelay)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		rctx, rcancel := context.WithTimeout(ctx, s3ResolveTimeout)
+		m, err := r.refreshOnce(rctx, true)
+		rcancel()
+
+		if ctx.Err() != nil {
+			// Shutdown, not a failure.
+			r.logger.Debug().Msg("credential refresh stopped")
+			return
+		}
+
+		var delay time.Duration
+		switch {
+		case err == nil && !m.canExpire:
+			// Publish before exiting or the stale ExpiresAt would eventually
+			// derive "expired" forever while queries work (#603 review F1).
+			r.everSucceeded = true
+			r.consecutiveErrors = 0
+			r.publishStatus(false)
+			r.logger.Info().Msg("credentials became non-expiring; refresh loop exiting")
+			return
+		case err == nil:
+			delay = r.planSuccess(m)
+		case errors.Is(err, errNonAdvancingExpiry):
+			delay = r.planNonAdvancing()
+		default:
+			delay = r.planError(err)
+		}
+		timer.Reset(delay)
+	}
+}
+
+// planSuccess, planNonAdvancing and planError decide the wait before the next
+// attempt and do the outcome's logging. They are separated from loop so the
+// scheduling/severity policy is unit-testable without real waits.
+
+func (r *credentialRefresher) planSuccess(m credMaterial) time.Duration {
+	r.everSucceeded = true
+	r.consecutiveErrors = 0
+	r.publishStatus(true)
+	return refreshDelay(m.expires)
+}
+
+// planNonAdvancing: the upstream source has not rotated yet. The held secret
+// stays valid; poll at the flat minimum until it rotates. Debug while there is
+// runway, Warn inside the final window. NOTE: this outcome is expected in the
+// tail of every IMDS / Pod Identity / AAD session — do not "fix" it back into
+// an error, and do not add backoff (a backoff step could straddle the
+// rotation).
+func (r *credentialRefresher) planNonAdvancing() time.Duration {
+	r.consecutiveErrors = 0
+	r.publishStatus(true)
+	remaining := time.Until(r.lastExpiry)
+	// Deliberate: if the source NEVER rotates and the held credentials expire,
+	// this keeps warning once a minute indefinitely. Queries are failing in
+	// that state; unlike the never-succeeded error loop (demoted — the
+	// deployment there is healthy on the fallback), this noise is proportionate.
+	ev := r.logger.Debug()
+	if remaining < s3RefreshFinalWarnWindow {
+		ev = r.logger.Warn()
+	}
+	ev.Dur("held_credentials_expire_in", remaining.Round(time.Second)).
+		Msg("credential source has not rotated yet; polling")
+	return s3RefreshMinDelay
+}
+
+// planError: a real resolve/emit failure. A refresher that has succeeded
+// before keeps loud Error + 30s→5m backoff — its credentials WILL die at
+// expiry. A refresher that has NEVER succeeded is running behind the fallback
+// CREDENTIAL_CHAIN secret (see startRefresher): the deployment may simply have
+// no resolvable credentials, so after s3RefreshErrorsBeforeDemotion failures
+// it demotes to Debug with a longer cap — one Warn (carrying demotionHint)
+// marks the demotion so the state is diagnosable from logs. It never gives
+// up: a host whose metadata service was down at boot is picked up by a later
+// retry.
+func (r *credentialRefresher) planError(err error) time.Duration {
+	r.consecutiveErrors++
+	r.publishStatus(true)
+	n := r.consecutiveErrors
+	backoffCap := s3RefreshBackoffMax
+	ev := r.logger.Error()
+	if !r.everSucceeded {
+		backoffCap = s3RefreshBackoffMaxUnproven
+		switch {
+		case n == s3RefreshErrorsBeforeDemotion+1:
+			ev = r.logger.Warn()
+			ev = ev.Str("hint", r.demotionHint)
+		case n > s3RefreshErrorsBeforeDemotion+1:
+			ev = r.logger.Debug()
+		}
+	}
+	delay := s3RefreshBackoffMin << (n - 1)
+	if delay > backoffCap || delay <= 0 {
+		delay = backoffCap
+	}
+	ev.Err(err).Dur("retry_in", delay).
+		Msg("storage credential refresh failed; existing secret remains in place")
+	return delay
+}
+
+// refreshOnce resolves credential material and — unless the source has not
+// rotated yet — emits the secret. Credential values are never logged.
+func (r *credentialRefresher) refreshOnce(ctx context.Context, invalidate bool) (credMaterial, error) {
+	m, err := r.resolver.Resolve(ctx, invalidate)
+	if err != nil {
+		return credMaterial{}, err
+	}
+	// Refuse credential material containing control bytes BEFORE it reaches
+	// SQL construction. escapeSQLString handles quotes, but a NUL truncates
+	// the C string inside DuckDB's parser, whose "unterminated quoted string"
+	// error echoes the credential prefix — which our callers log. Real
+	// AWS/AAD credentials are ASCII and never trip this; the guard exists so
+	// the no-credentials-in-logs guarantee doesn't rest on that assumption.
+	// Core-owned so no backend can forget it. Fixed error string on purpose.
+	for _, v := range m.secretValues {
+		if strings.ContainsFunc(v, func(c rune) bool { return c < 0x20 || c == 0x7f }) {
+			return credMaterial{}, fmt.Errorf("resolved credential material contains control bytes; refusing to emit secret")
+		}
+	}
+	if m.canExpire && !r.lastExpiry.IsZero() && !m.expires.After(r.lastExpiry) {
+		// Same session as we already hold. For server-rotated sources this is
+		// NORMAL near the end of a session — rotation happens on the server's
+		// schedule, not ours. Emit is SKIPPED: re-emitting identical material
+		// would only produce a misleading "refreshed" log line.
+		return credMaterial{}, errNonAdvancingExpiry
+	}
+	if err := r.resolver.Emit(ctx, m); err != nil {
+		return credMaterial{}, fmt.Errorf("emit storage secret: %w", err)
+	}
+	r.source = m.source
+	r.lastRefresh = time.Now().Truncate(time.Second)
+	if m.canExpire {
+		r.lastExpiry = m.expires
+		// Wording note: on EC2 the SDK caps reported Expires at now+1h even
+		// for ~6h IMDS sessions (ec2rolecreds), so hourly re-emits of the SAME
+		// material under an advancing cap are expected — hence "refreshed",
+		// not "new session".
+		r.logger.Info().Time("expires", m.expires.UTC()).
+			Str("source", m.source).
+			Msg("DuckDB storage secret refreshed")
+	} else {
+		r.logger.Info().Str("source", m.source).
+			Msg("DuckDB storage secret emitted (non-expiring credentials)")
+	}
+	return m, nil
+}
+
+// refreshDelay schedules the next refresh s3RefreshMargin before `expires`,
+// floored at s3RefreshMinDelay. `expires` is whatever the provider REPORTS —
+// for AWS that is the real session expiry (no ExpiryWindow configured; the
+// proactive resolve Invalidates the cache, which is what makes firing before
+// expiry actually produce a new session); for Azure it is the AAD token
+// expiry (MSAL serves cache until its 5-min internal buffer; the
+// non-advancing flat-poll bridges the gap).
+func refreshDelay(expires time.Time) time.Duration {
+	d := time.Until(expires) - s3RefreshMargin
+	if d < s3RefreshMinDelay {
+		d = s3RefreshMinDelay
+	}
+	return d
+}

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -40,10 +40,11 @@ type DuckDB struct {
 	config *Config
 
 	// s3Refreshers holds the credential refreshers for Arc-managed S3 secrets
-	// (primary and/or cold tier), keyed by secret name. Guarded by refresherMu;
+	// (primary and/or cold tier, S3 and Azure alike — see credrefresh.go),
+	// keyed by secret name. Guarded by refresherMu;
 	// Close stops and waits for each. See s3refresh.go and #600.
 	refresherMu  sync.Mutex
-	s3Refreshers map[string]*s3CredentialRefresher
+	s3Refreshers map[string]*credentialRefresher
 
 	// coldTier records the cold tier's backend + credential mode for the
 	// /health storage payload (#603). Set by ConfigureS3/ConfigureAzure at
@@ -56,7 +57,7 @@ type DuckDB struct {
 // whose secret was emitted directly (no refresher registry entry).
 type storageTierConfig struct {
 	backend     string // s3 | azure
-	credentials string // static_keys | sas | sdk_managed | unmanaged_chain
+	credentials string // static_keys | sas | sdk_managed | credential_chain
 	secretName  string // registry key when credentials == sdk_managed
 }
 
@@ -75,10 +76,9 @@ type StorageTierStatus struct {
 
 // Credential-mode labels for tiers without a refresher.
 const (
-	credModeNone           = "none"
-	credModeStaticKeys     = "static_keys"
-	credModeSAS            = "sas"
-	credModeUnmanagedChain = "unmanaged_chain"
+	credModeNone       = "none"
+	credModeStaticKeys = "static_keys"
+	credModeSAS        = "sas"
 )
 
 // azureCredentialsLabel classifies an Azure tier's credential source. A
@@ -86,7 +86,17 @@ const (
 // hours/days) — reporting it "static_keys/ok" would recreate the exact
 // green-dashboard-dead-reads incident #603 fixes, so SAS maps to
 // state "unknown" (#603 review F3). Arc has no visibility into SAS expiry.
-func azureCredentialsLabel(connectionString, accountKey string) (creds, state string) {
+// Precedence note (#605 review M3): a configured SAS wins the LABEL even when
+// a connection string or account key would win the emitted secret (emission
+// precedence is connectionString > accountKey; ingest is connString > SAS >
+// key). Deliberately conservative: a SAS in the config means the operator
+// scoped an identity, so the gate must never start a refresher and /health
+// must never over-promise — sas/unknown in mixed configs is the honest floor.
+func azureCredentialsLabel(connectionString, accountKey, sasToken string) (creds, state string) {
+	if sasToken != "" {
+		// Deliberately-scoped, expiring credential Arc cannot see into.
+		return credModeSAS, CredStateUnknown
+	}
 	if connectionString != "" {
 		lower := strings.ToLower(connectionString)
 		// ';sig=' cannot false-positive inside an AccountKey: base64 excludes
@@ -101,9 +111,8 @@ func azureCredentialsLabel(connectionString, accountKey string) (creds, state st
 	if accountKey != "" {
 		return credModeStaticKeys, CredStateOK
 	}
-	// Managed identity / az-login via DuckDB's chain: resolved once, never
-	// refreshed, no Arc visibility (#605 tracks the refresher gap).
-	return credModeUnmanagedChain, CredStateUnknown
+	// Managed identity / az-login: Arc-managed AAD token refresher (#605).
+	return s3ModeSDKManaged, CredStateOK
 }
 
 // StorageCredentialStatus builds the /health "storage" payload: one entry per
@@ -119,7 +128,7 @@ func (d *DuckDB) StorageCredentialStatus() map[string]StorageTierStatus {
 	now := time.Now()
 
 	d.refresherMu.Lock()
-	refreshers := make(map[string]*s3CredentialRefresher, len(d.s3Refreshers))
+	refreshers := make(map[string]*credentialRefresher, len(d.s3Refreshers))
 	for k, v := range d.s3Refreshers {
 		refreshers[k] = v
 	}
@@ -135,8 +144,9 @@ func (d *DuckDB) StorageCredentialStatus() map[string]StorageTierStatus {
 	case d.config.S3IsPrimaryBackend:
 		out["hot"] = d.s3TierStatus(primaryS3SecretParams(d.config), refreshers, now)
 	case d.config.AzureIsPrimaryBackend:
-		creds, state := azureCredentialsLabel(d.config.AzureConnectionString, d.config.AzureAccountKey)
-		out["hot"] = StorageTierStatus{Backend: "azure", Credentials: creds, State: state}
+		out["hot"] = d.azureTierStatus(
+			d.config.AzureConnectionString, d.config.AzureAccountKey, d.config.AzureSASToken,
+			arcAzurePrimarySecretName, refreshers, now)
 	default:
 		out["hot"] = StorageTierStatus{Backend: "local", Credentials: credModeNone, State: CredStateOK}
 	}
@@ -144,7 +154,7 @@ func (d *DuckDB) StorageCredentialStatus() map[string]StorageTierStatus {
 	if cold != nil {
 		st := StorageTierStatus{Backend: cold.backend, Credentials: cold.credentials, State: CredStateOK}
 		switch cold.credentials {
-		case credModeSAS, credModeUnmanagedChain:
+		case credModeSAS:
 			st.State = CredStateUnknown
 		case s3ModeSDKManaged:
 			if r := refreshers[cold.secretName]; r != nil {
@@ -161,9 +171,26 @@ func (d *DuckDB) StorageCredentialStatus() map[string]StorageTierStatus {
 	return out
 }
 
+// azureTierStatus describes an Azure tier from its credential shape + the
+// refresher registry (#605).
+func (d *DuckDB) azureTierStatus(connectionString, accountKey, sasToken, secretName string, refreshers map[string]*credentialRefresher, now time.Time) StorageTierStatus {
+	creds, state := azureCredentialsLabel(connectionString, accountKey, sasToken)
+	if creds != s3ModeSDKManaged {
+		return StorageTierStatus{Backend: "azure", Credentials: creds, State: state}
+	}
+	if r := refreshers[secretName]; r != nil {
+		st := r.status(now)
+		st.Backend, st.Credentials = "azure", s3ModeSDKManaged
+		return st
+	}
+	// sdk_managed route but no registry entry: azidentity construction failed
+	// and the CREDENTIAL_CHAIN fallback secret is serving.
+	return StorageTierStatus{Backend: "azure", Credentials: s3ModeCredentialChain, State: CredStateFallback}
+}
+
 // s3TierStatus describes an S3 tier from its secret params + the refresher
 // registry.
-func (d *DuckDB) s3TierStatus(params s3SecretParams, refreshers map[string]*s3CredentialRefresher, now time.Time) StorageTierStatus {
+func (d *DuckDB) s3TierStatus(params s3SecretParams, refreshers map[string]*credentialRefresher, now time.Time) StorageTierStatus {
 	if s3CredentialMode(params.accessKey, params.secretKey) == s3ModeStaticKeys {
 		return StorageTierStatus{Backend: "s3", Credentials: credModeStaticKeys, State: CredStateOK}
 	}
@@ -456,8 +483,15 @@ type Config struct {
 	// set, it is the primary auth method and AzureAccountName may be empty —
 	// mirrors the Go backend's first auth case (internal/storage/azure_blob.go).
 	AzureConnectionString string
-	AzureEndpoint         string // Custom endpoint (optional)
-	AzureContainer        string // Container name; used to build the allowed_directories prefix for the sandbox
+	// AzureSASToken (#605 review M6): plumbed so the credential gate can SEE a
+	// SAS deployment. A SAS excludes the managed refresher — starting one would
+	// acquire a BROADER identity than the operator's deliberately-scoped SAS —
+	// and labels the tier sas/unknown in /health. NOTE: the query path does not
+	// otherwise consume the SAS today (the DuckDB secret stays chain-shaped, a
+	// pre-existing identity mismatch with ingest; documented, unchanged here).
+	AzureSASToken  string
+	AzureEndpoint  string // Custom endpoint (optional); wired into azure secrets via azureEndpointSuffix (#605)
+	AzureContainer string // Container name; used to build the allowed_directories prefix for the sandbox
 	// AzureIsPrimaryBackend is true when storage.backend is "azure"/"azblob".
 	// Gates primary Azure secret creation on the backend actually being Azure,
 	// so a stray storage.azure_* value on a non-Azure-primary deployment does
@@ -562,7 +596,7 @@ func New(cfg *Config, logger zerolog.Logger) (*DuckDB, error) {
 		db:           db,
 		logger:       logger,
 		config:       cfg,
-		s3Refreshers: make(map[string]*s3CredentialRefresher),
+		s3Refreshers: make(map[string]*credentialRefresher),
 	}
 
 	// IRSA (web identity): the primary S3 secret is Arc-managed. configureS3Access
@@ -570,6 +604,18 @@ func New(cfg *Config, logger zerolog.Logger) (*DuckDB, error) {
 	// DuckDB struct owns its lifecycle (Close stops it). The first resolve+emit
 	// happens synchronously inside startRefresher, before New returns — i.e.
 	// before the server starts accepting queries.
+	if cfg.AzureIsPrimaryBackend {
+		if creds, _ := azureCredentialsLabel(cfg.AzureConnectionString, cfg.AzureAccountKey, cfg.AzureSASToken); creds == s3ModeSDKManaged {
+			// Azure managed identity / SP env (#605): configureAzureAccess
+			// deferred emission (and already warned about any path-style
+			// endpoint); the refresher owns the secret from here.
+			if err := d.startAzureRefresher(primaryAzureSecretParams(cfg)); err != nil {
+				db.Close()
+				return nil, fmt.Errorf("failed to configure azure credential refresher: %w", err)
+			}
+		}
+	}
+
 	if cfg.S3IsPrimaryBackend && s3CredentialMode(cfg.S3AccessKey, cfg.S3SecretKey) == s3ModeSDKManaged {
 		if err := d.startRefresher(primaryS3SecretParams(cfg)); err != nil {
 			// Template errors are deterministic misconfigurations — startup-fatal
@@ -1280,6 +1326,15 @@ type azureSecretParams struct {
 	connectionString string
 	accountName      string
 	accountKey       string // empty → PROVIDER CREDENTIAL_CHAIN (managed identity / env)
+	// accessToken selects PROVIDER ACCESS_TOKEN — an AAD bearer resolved by
+	// Arc's credential refresher (#605). Requires accountName; mutually
+	// exclusive with connectionString/accountKey (refresher-only field).
+	accessToken string
+	// endpoint is DuckDB's ENDPOINT parameter: a host SUFFIX (default
+	// blob.core.windows.net; the account name is prepended by the extension).
+	// Derived from Config.AzureEndpoint via azureEndpointSuffix — which was
+	// dead config on the query path before #605 (#605 review M4).
+	endpoint string
 }
 
 // buildAzureSecretSQL builds a `CREATE OR REPLACE SECRET <name> (TYPE AZURE, ...)`
@@ -1301,6 +1356,21 @@ func buildAzureSecretSQL(p azureSecretParams) (string, error) {
 	b.WriteString(p.name)
 	b.WriteString(" (\n\tTYPE AZURE")
 	switch {
+	case p.accessToken != "":
+		// Arc-managed AAD bearer (#605): the refresher resolves tokens via
+		// azidentity (the ingest chain) and re-emits before expiry — DuckDB's
+		// own chain resolves once and never refreshes, the #600 class.
+		if p.accountName == "" {
+			return "", fmt.Errorf("azure secret %q: access token requires account name", p.name)
+		}
+		if p.connectionString != "" || p.accountKey != "" {
+			return "", fmt.Errorf("azure secret %q: access token is mutually exclusive with static credentials", p.name)
+		}
+		b.WriteString(",\n\tPROVIDER ACCESS_TOKEN,\n\tACCESS_TOKEN '")
+		b.WriteString(escapeSQLString(p.accessToken))
+		b.WriteString("',\n\tACCOUNT_NAME '")
+		b.WriteString(escapeSQLString(p.accountName))
+		b.WriteString("'")
 	case p.connectionString != "":
 		// Operator-supplied connection string (embeds account name + key/SAS).
 		b.WriteString(",\n\tCONNECTION_STRING '")
@@ -1318,6 +1388,15 @@ func buildAzureSecretSQL(p azureSecretParams) (string, error) {
 		b.WriteString(escapeSQLString(p.accountName))
 		b.WriteString("'")
 	}
+	// ENDPOINT is suppressed for connection-string shapes: the string may embed
+	// its own BlobEndpoint, and ingest likewise ignores azure_endpoint whenever
+	// a connection string is set — emitting both risks a conflicting host
+	// (#605 review M4).
+	if p.endpoint != "" && p.connectionString == "" {
+		b.WriteString(",\n\tENDPOINT '")
+		b.WriteString(escapeSQLString(p.endpoint))
+		b.WriteString("'")
+	}
 	if p.scope != "" {
 		b.WriteString(",\n\tSCOPE '")
 		b.WriteString(escapeSQLString(p.scope))
@@ -1325,6 +1404,27 @@ func buildAzureSecretSQL(p azureSecretParams) (string, error) {
 	}
 	b.WriteString("\n)")
 	return b.String(), nil
+}
+
+// azureEndpointSuffix converts Arc's AzureEndpoint (a FULL URL for the Go SDK,
+// e.g. "https://myacct.blob.core.usgovcloudapi.net") into DuckDB's ENDPOINT
+// parameter (a host SUFFIX with the account prepended by the extension, e.g.
+// "blob.core.usgovcloudapi.net"). Empty in → empty out (extension default).
+// Path-style endpoints (Azurite's host:port/account) do not fit the suffix
+// model: reported unsupported so the caller can log-and-drop rather than emit
+// a broken host.
+func azureEndpointSuffix(endpoint, accountName string) (string, bool) {
+	if endpoint == "" {
+		return "", true
+	}
+	h := stripURLScheme(endpoint)
+	if strings.ContainsRune(h, '/') {
+		return "", false // path-style; unsupported by the suffix model
+	}
+	if accountName != "" {
+		h = strings.TrimPrefix(h, accountName+".")
+	}
+	return h, true
 }
 
 // azureScope builds the SCOPE prefix for an Azure secret from a container name,
@@ -1364,20 +1464,56 @@ func configureAzureAccess(db *sql.DB, cfg *Config, logger zerolog.Logger) error 
 	if err := ensureAzureLoaded(db, logger); err != nil {
 		return err
 	}
-	secretSQL, err := buildAzureSecretSQL(azureSecretParams{
-		name:             arcAzurePrimarySecretName,
-		scope:            azureScope(cfg.AzureContainer),
-		connectionString: cfg.AzureConnectionString,
-		accountName:      cfg.AzureAccountName,
-		accountKey:       cfg.AzureAccountKey,
-	})
+
+	if _, ok := azureEndpointSuffix(cfg.AzureEndpoint, cfg.AzureAccountName); !ok {
+		warnPathStyleAzureEndpoint(logger, cfg.AzureEndpoint)
+	}
+	creds, _ := azureCredentialsLabel(cfg.AzureConnectionString, cfg.AzureAccountKey, cfg.AzureSASToken)
+	if creds == s3ModeSDKManaged {
+		// Managed identity / SP env (#605): the secret is created and
+		// maintained by the Azure credential refresher, which New starts after
+		// configureDatabase returns (it needs the DuckDB struct for ownership).
+		// Must stay after ensureAzureLoaded: the refresher's post-lockdown
+		// CREATE SECRETs need the azure extension already loaded.
+		logger.Info().
+			Str("component", "database").
+			Str("secret", arcAzurePrimarySecretName).
+			Str("credential_mode", creds).
+			Msg("DuckDB azure secret deferred to credential refresher")
+		return nil
+	}
+
+	secretSQL, err := buildAzureSecretSQL(primaryAzureSecretParams(cfg))
 	if err != nil {
 		return err
 	}
 	if _, err := db.Exec(secretSQL); err != nil {
 		return fmt.Errorf("failed to create azure secret: %w", err)
 	}
+	logger.Info().
+		Str("component", "database").
+		Str("secret", arcAzurePrimarySecretName).
+		Str("credential_mode", creds).
+		Msg("DuckDB azure secret created")
 	return nil
+}
+
+// primaryAzureSecretParams builds the secret template for an Azure primary
+// tier; shared by configureAzureAccess (direct emission) and New (refresher
+// template) so the two can never diverge. A path-style endpoint yields the
+// default host (pre-#605 behavior — the key was dead config); BOTH hot callers
+// must pair this with warnPathStyleAzureEndpoint so the drop is never silent
+// (#605 review H1).
+func primaryAzureSecretParams(cfg *Config) azureSecretParams {
+	suffix, _ := azureEndpointSuffix(cfg.AzureEndpoint, cfg.AzureAccountName)
+	return azureSecretParams{
+		name:             arcAzurePrimarySecretName,
+		scope:            azureScope(cfg.AzureContainer),
+		connectionString: cfg.AzureConnectionString,
+		accountName:      cfg.AzureAccountName,
+		accountKey:       cfg.AzureAccountKey,
+		endpoint:         suffix,
+	}
 }
 
 // AzureConfig holds Azure configuration for a runtime (cold-tier) secret.
@@ -1387,7 +1523,12 @@ type AzureConfig struct {
 	ConnectionString string
 	AccountName      string
 	AccountKey       string
-	Container        string // scopes the secret to this container; empty = unscoped
+	// SASToken (#605 review M6): visible to the credential gate so a
+	// SAS-scoped deployment never starts a managed refresher (which would
+	// acquire a broader identity than the operator intended).
+	SASToken  string
+	Container string // scopes the secret to this container; empty = unscoped
+	Endpoint  string // full-URL Azure endpoint; normalized to DuckDB's suffix form
 }
 
 // ConfigureAzure provisions the cold-tier Azure secret at runtime, under a
@@ -1403,26 +1544,105 @@ func (d *DuckDB) ConfigureAzure(azcfg *AzureConfig) error {
 	if azcfg == nil {
 		return fmt.Errorf("ConfigureAzure: azcfg must not be nil")
 	}
-	secretSQL, err := buildAzureSecretSQL(azureSecretParams{
+	params := azureSecretParams{
 		name:             arcAzureColdSecretName,
 		scope:            azureScope(azcfg.Container),
 		connectionString: azcfg.ConnectionString,
 		accountName:      azcfg.AccountName,
 		accountKey:       azcfg.AccountKey,
-	})
-	if err != nil {
-		return err
 	}
-	if _, err := d.db.Exec(secretSQL); err != nil {
-		return fmt.Errorf("failed to create cold-tier azure secret: %w", err)
+	params.endpoint = d.azureEndpointForSecret(azcfg.Endpoint, azcfg.AccountName)
+
+	creds, _ := azureCredentialsLabel(azcfg.ConnectionString, azcfg.AccountKey, azcfg.SASToken)
+	if creds == s3ModeSDKManaged {
+		// Managed identity / SP env (#605): Arc-managed AAD token refresher.
+		// Template errors are deterministic misconfigurations and propagate.
+		if err := d.startAzureRefresher(params); err != nil {
+			return err
+		}
+	} else {
+		secretSQL, err := buildAzureSecretSQL(params)
+		if err != nil {
+			return err
+		}
+		if _, err := d.db.Exec(secretSQL); err != nil {
+			return fmt.Errorf("failed to create cold-tier azure secret: %w", err)
+		}
 	}
 
-	creds, _ := azureCredentialsLabel(azcfg.ConnectionString, azcfg.AccountKey)
+	// Record the tier only AFTER the secret/refresher is in place (#603 review
+	// H1: recording first would report a working tier whose secret was never
+	// created). On failure the tier is ABSENT from the payload.
 	d.refresherMu.Lock()
 	d.coldTier = &storageTierConfig{backend: "azure", credentials: creds, secretName: arcAzureColdSecretName}
 	d.refresherMu.Unlock()
 
-	d.logger.Info().Str("account", azcfg.AccountName).Str("container", azcfg.Container).Msg("DuckDB cold-tier Azure secret configured")
+	d.logger.Info().Str("account", azcfg.AccountName).Str("container", azcfg.Container).
+		Str("credential_mode", creds).Msg("DuckDB cold-tier Azure secret configured")
+	return nil
+}
+
+// azureEndpointForSecret normalizes a configured Azure endpoint into DuckDB's
+// suffix form, logging and dropping shapes the suffix model cannot express.
+func (d *DuckDB) azureEndpointForSecret(endpoint, accountName string) string {
+	suffix, ok := azureEndpointSuffix(endpoint, accountName)
+	if !ok {
+		warnPathStyleAzureEndpoint(d.logger, endpoint)
+		return ""
+	}
+	return suffix
+}
+
+// warnPathStyleAzureEndpoint is the single wording for the endpoint-drop Warn,
+// shared by the hot (configureAzureAccess / New) and cold (ConfigureAzure)
+// paths so no cell drops the endpoint silently (#605 review H1).
+func warnPathStyleAzureEndpoint(logger zerolog.Logger, endpoint string) {
+	logger.Warn().Str("endpoint", endpoint).
+		Msg("azure endpoint is path-style; DuckDB's ENDPOINT suffix model cannot express it — azure query secrets will use the default host (writes are unaffected)")
+}
+
+// startAzureRefresher mirrors startRefresher for the Azure backend: template
+// validation stays startup-fatal; azidentity construction failure or a failed
+// first resolve degrades to the CREDENTIAL_CHAIN fallback secret + retries.
+func (d *DuckDB) startAzureRefresher(params azureSecretParams) error {
+	probe := params
+	probe.accessToken = "VALIDATE"
+	if _, err := buildAzureSecretSQL(probe); err != nil {
+		return fmt.Errorf("invalid azure secret template for %q: %w", params.name, err)
+	}
+
+	emitFallback := func(reason error) {
+		fallback := params
+		fallback.accessToken, fallback.connectionString, fallback.accountKey = "", "", ""
+		sqlText, berr := buildAzureSecretSQL(fallback)
+		if berr != nil {
+			d.logger.Error().Err(berr).Str("secret", params.name).Msg("azure fallback secret build failed")
+			return
+		}
+		if _, xerr := d.db.Exec(sqlText); xerr != nil {
+			d.logger.Error().Err(xerr).Str("secret", params.name).
+				Str("resolve_error", reason.Error()).
+				Msg("azure fallback secret creation failed")
+			return
+		}
+		d.logger.Warn().Err(reason).
+			Str("secret", params.name).
+			Str("credential_mode", s3ModeCredentialChain).
+			Msg("Azure credentials not resolvable yet; emitted DuckDB credential-chain fallback secret (will not auto-refresh)")
+	}
+
+	cred, err := newAzureCredProvider()
+	if err != nil {
+		emitFallback(err)
+		return nil
+	}
+
+	d.refresherMu.Lock()
+	defer d.refresherMu.Unlock()
+	if old := d.s3Refreshers[params.name]; old != nil {
+		old.stop()
+	}
+	d.s3Refreshers[params.name] = startAzureCredentialRefresher(d.db, params, cred, d.logger, emitFallback)
 	return nil
 }
 

--- a/internal/database/s3refresh.go
+++ b/internal/database/s3refresh.go
@@ -3,18 +3,18 @@ package database
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
-	"sync/atomic"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/rs/zerolog"
 )
 
-// This file owns Arc-side S3 credential management for DuckDB (#600).
+// This file owns the S3 side of Arc's credential management for DuckDB
+// (#600/#601); the shared refresher core lives in credrefresh.go.
+//
+// Incident history, kept here on purpose:
 //
 // DuckDB's own credential resolution is a dead end for temporary credentials:
 // PROVIDER CREDENTIAL_CHAIN resolves once at CREATE SECRET time, and the 1.5.5
@@ -30,68 +30,33 @@ import (
 // across the whole pool (verified against the bundled engine: request signing
 // looks the secret up per request; a live process dead with ExpiredToken
 // recovers on the next query after re-emission, no restart).
+//
+// The first merge-gate run also taught the ExpiryWindow lesson now encoded in
+// newAWSCredProvider and the core's non-advancing machinery: a proactive
+// Retrieve before the cache considers credentials expired returns the SAME
+// session; only Invalidate() makes an early refresh real.
 
-const (
-	// s3RefreshMargin is how long before credential expiry the refresher
-	// re-resolves. It must comfortably exceed the default query timeout (300s)
-	// so credentials stay valid for the lifetime of queries started just before
-	// a rotation. Queries longer than the margin may still see one retryable
-	// ExpiredToken at rotation.
-	s3RefreshMargin = 10 * time.Minute
-	// s3RefreshMinDelay floors the delay between refreshes so pathologically
-	// short sessions cannot spin the loop.
-	s3RefreshMinDelay = time.Minute
-	// s3FirstResolveTimeout bounds the synchronous resolve during startup /
-	// ConfigureS3. STS unreachable (GovCloud endpoints, proxy misconfig) must
-	// degrade to the background retry loop, not stall startup — database.New
-	// failures are fatal in main.go.
-	s3FirstResolveTimeout = 10 * time.Second
-	// s3ResolveTimeout bounds each background resolve+emit.
-	s3ResolveTimeout = 30 * time.Second
+// s3DemotionHint is what a never-succeeded S3 refresher's demotion Warn tells
+// the operator (see credentialRefresher.planError).
+const s3DemotionHint = "no resolvable AWS credentials; running on DuckDB's credential chain — configure keys, or set AWS_EC2_METADATA_DISABLED=true to fast-fail the probe"
 
-	s3RefreshBackoffMin = 30 * time.Second
-	s3RefreshBackoffMax = 5 * time.Minute
-	// s3RefreshBackoffMaxUnproven caps retries for a refresher that has NEVER
-	// succeeded and is running behind the fallback CREDENTIAL_CHAIN secret
-	// (e.g. anonymous MinIO with no resolvable AWS credentials). Such a
-	// deployment is healthy; polling it every 5 minutes forever at Error level
-	// would produce ~288 spurious error lines/day. See planNext.
-	s3RefreshBackoffMaxUnproven = 15 * time.Minute
-	// s3RefreshErrorsBeforeDemotion: a never-succeeded refresher logs its first
-	// failures at Error (a genuinely broken IMDS/STS at boot must be visible),
-	// then demotes to Debug with one Warn marking the transition.
-	s3RefreshErrorsBeforeDemotion = 3
-	// s3RefreshFinalWarnWindow: a non-advancing resolve (the upstream source
-	// has not rotated yet — normal for IMDS and Pod Identity, which rotate
-	// server-side on their own schedule) logs Debug while there is plenty of
-	// runway, escalating to Warn inside this window before the held
-	// credentials' expiry so an operator has reaction time.
-	s3RefreshFinalWarnWindow = 5 * time.Minute
-)
-
-// errNonAdvancingExpiry marks a resolve that succeeded but returned the same
-// session we already hold — the upstream source has not rotated yet. Not a
-// failure: the held credentials remain valid; the loop polls at a flat
-// s3RefreshMinDelay until the source rotates.
-var errNonAdvancingExpiry = errors.New("credential provider returned a non-advancing expiry (upstream not rotated yet)")
-
-// awsCredentialsProvider is the seam between the refresher and the AWS SDK,
+// awsCredentialsProvider is the seam between the S3 resolver and the AWS SDK,
 // so tests can inject deterministic providers.
 type awsCredentialsProvider interface {
 	Retrieve(ctx context.Context) (aws.Credentials, error)
 }
 
 // newAWSCredProvider builds the SDK default credential chain (web identity /
-// IRSA, env, shared config, IMDS) for the refresher. Package-level so tests can
-// substitute a fake.
+// IRSA, env, shared config, IMDS, container credentials / Pod Identity) for
+// the refresher. Package-level so tests can substitute a fake.
 //
-// The returned provider is an aws.CredentialsCache. A PROACTIVE refresh (before
-// expiry) must call Invalidate() first: the cache serves cached credentials
-// until it considers them expired, so a plain Retrieve at Expires−margin
-// returns the SAME session and the refresh accomplishes nothing. (An
-// ExpiryWindow does NOT fix this — the SDK applies the window once at store
-// time, shifting the reported/stored Expires earlier, and still serves the
-// cache until that shifted instant. Verified live 2026-08-18: with
+// The returned provider is an aws.CredentialsCache. A PROACTIVE refresh
+// (before expiry) must call Invalidate() first: the cache serves cached
+// credentials until it considers them expired, so a plain Retrieve at
+// Expires−margin returns the SAME session and the refresh accomplishes
+// nothing. (An ExpiryWindow does NOT fix this — the SDK applies the window
+// once at store time, shifting the reported/stored Expires earlier, and still
+// serves the cache until that shifted instant. Verified live 2026-08-18: with
 // ExpiryWindow=11m a 1h session was reported as expires=+49m and the +39m
 // proactive Retrieve returned it unchanged, tripping the non-advancing guard
 // until the cache itself relented at +49m.)
@@ -109,355 +74,53 @@ var newAWSCredProvider = func(ctx context.Context, region string) (awsCredential
 	return cfg.Credentials, nil
 }
 
-// s3CredentialRefresher keeps one DuckDB S3 secret stocked with fresh session
-// credentials. One instance per managed secret (primary, cold); owned by the
-// DuckDB struct, which stops it on Close.
-type s3CredentialRefresher struct {
+// s3Resolver implements credentialResolver for S3 secrets: Resolve pulls from
+// the SDK chain (Invalidating its cache on proactive refreshes), Emit writes
+// the static KEY_ID/SECRET/SESSION_TOKEN secret.
+type s3Resolver struct {
 	db       *sql.DB
-	params   s3SecretParams // template; key/secret/session token filled per emission
+	params   s3SecretParams // template; credentials filled per emission
 	provider awsCredentialsProvider
-	logger   zerolog.Logger
-	cancel   context.CancelFunc
-	done     chan struct{}
-
-	// lastExpiry drives the non-advancing check: every successful refresh must
-	// advance the expiry, else the upstream source has not rotated yet.
-	lastExpiry time.Time
-
-	// Scheduling/severity state, owned by the loop goroutine (and the sync
-	// first resolve before the goroutine starts).
-	everSucceeded     bool
-	consecutiveErrors int
-
-	// lastRefresh / source describe the last successful emission; loop-owned
-	// like the fields above.
-	lastRefresh time.Time
-	source      string
-
-	// snap is the read side for /health (#603): an immutable snapshot swapped
-	// atomically by publishStatus at every outcome. status() reads ONLY this —
-	// never the loop-owned raw fields above. Publication of the refresher in
-	// the DuckDB registry (under refresherMu) is what orders the constructor's
-	// writes before any reader; the done channel plays no part in that.
-	snap atomic.Pointer[storageCredSnapshot]
 }
 
-// storageCredSnapshot is the raw material for state derivation. It stores
-// facts, not a state string: state is derived at READ time by deriveState so
-// an expiry crossing between refresher outcomes (up to ~refreshDelay apart)
-// becomes visible within one probe interval, not one refresh interval.
-type storageCredSnapshot struct {
-	everSucceeded     bool
-	canExpire         bool
-	consecutiveErrors int
-	lastExpiry        time.Time
-	lastRefresh       time.Time
-	source            string
-}
-
-// publishStatus snapshots the loop-owned fields. Called at every outcome —
-// the three constructor branches, the three plan* outcomes, and the loop's
-// non-expiring exit. Missing a site is not cosmetic: skipping the
-// constructor-success site would report "fallback" for ~refreshDelay on a
-// perfectly healthy refresher (#603 review F1).
-func (r *s3CredentialRefresher) publishStatus(canExpire bool) {
-	r.snap.Store(&storageCredSnapshot{
-		everSucceeded:     r.everSucceeded,
-		canExpire:         canExpire,
-		consecutiveErrors: r.consecutiveErrors,
-		lastExpiry:        r.lastExpiry,
-		lastRefresh:       r.lastRefresh,
-		source:            r.source,
-	})
-}
-
-// Credential states surfaced via /health (#603). Exported: they are a
-// published API contract (release notes) and internal/api compares against
-// CredStateExpired for the readiness knob — a raw string there would let a
-// respelling here silently disable the knob (#603 review M3).
-const (
-	CredStateOK       = "ok"
-	CredStateDegraded = "degraded"
-	CredStateExpired  = "expired"
-	CredStateFallback = "fallback"
-	CredStateUnknown  = "unknown"
-)
-
-// deriveState maps a snapshot to a state at time `now`. Pure so the full grid
-// — including "expired", impossible to force against real STS in a test — is
-// unit-testable.
-//
-// Precedence (#603 review F4): fallback (never succeeded — cannot be expired,
-// lastExpiry is only ever set by a successful emit) > non-expiring ok >
-// expired (EVEN with a concurrent error streak: in the field incident both
-// held at once and expired is the actionable truth) > degraded > ok.
-// Non-advancing rotation-waits stay "ok" deliberately: they occur in the tail
-// of every healthy IMDS/Pod-Identity session; pre-expiry alerting belongs to
-// the payload's expires_at, not a state flap.
-func deriveState(snap *storageCredSnapshot, now time.Time) string {
-	switch {
-	case snap == nil || !snap.everSucceeded:
-		return CredStateFallback
-	case !snap.canExpire:
-		return CredStateOK
-	case !now.Before(snap.lastExpiry):
-		return CredStateExpired
-	case snap.consecutiveErrors > 0:
-		return CredStateDegraded
-	default:
-		return CredStateOK
-	}
-}
-
-// status returns this refresher's contribution to the /health payload.
-func (r *s3CredentialRefresher) status(now time.Time) StorageTierStatus {
-	snap := r.snap.Load()
-	st := StorageTierStatus{State: deriveState(snap, now)}
-	if snap == nil {
-		return st
-	}
-	st.Source = snap.source
-	st.ConsecutiveErrors = snap.consecutiveErrors
-	if snap.canExpire && !snap.lastExpiry.IsZero() {
-		t := snap.lastExpiry.UTC()
-		st.ExpiresAt = &t
-	}
-	if !snap.lastRefresh.IsZero() {
-		t := snap.lastRefresh.UTC()
-		st.LastRefresh = &t
-	}
-	return st
-}
-
-// startS3CredentialRefresher performs one synchronous resolve+emit (bounded by
-// s3FirstResolveTimeout) and then maintains the secret in the background. It
-// never fails: an unreachable STS or an unprojected token degrades to a Warn
-// and background retries, matching the principle that a transient credential
-// race must not turn into a startup failure.
-// onFirstFailure, when non-nil, runs synchronously after a failed first
-// resolve and BEFORE the retry loop starts — so a caller-emitted fallback
-// secret is structurally guaranteed to land before the loop's first managed
-// emit can replace it (#601 review M1; without the hook that ordering rested
-// on the 30s initial backoff being longer than the fallback Exec).
-func startS3CredentialRefresher(db *sql.DB, params s3SecretParams, provider awsCredentialsProvider, logger zerolog.Logger, onFirstFailure func(error)) *s3CredentialRefresher {
-	ctx, cancel := context.WithCancel(context.Background())
-	r := &s3CredentialRefresher{
-		db:       db,
-		params:   params,
-		provider: provider,
-		logger: logger.With().
-			Str("component", "s3-cred-refresher").
-			Str("secret", params.name).Logger(),
-		cancel: cancel,
-		done:   make(chan struct{}),
-	}
-
-	fctx, fcancel := context.WithTimeout(ctx, s3FirstResolveTimeout)
-	creds, err := r.resolveAndEmit(fctx, false)
-	fcancel()
-
-	switch {
-	case err != nil:
-		r.publishStatus(true)
-		if onFirstFailure != nil {
-			onFirstFailure(err)
-		}
-		go r.loop(ctx, s3RefreshBackoffMin)
-	case !creds.CanExpire:
-		// Static credentials resolved through the chain — nothing to refresh.
-		r.everSucceeded = true
-		r.publishStatus(false)
-		r.logger.Info().Msg("resolved non-expiring S3 credentials; refresh loop not needed")
-		close(r.done)
-	default:
-		r.everSucceeded = true
-		r.publishStatus(true)
-		go r.loop(ctx, refreshDelay(creds.Expires))
-	}
-	return r
-}
-
-// stop cancels the refresher and waits for the background goroutine to finish,
-// so no Exec can race the pool's Close.
-func (r *s3CredentialRefresher) stop() {
-	r.cancel()
-	<-r.done
-}
-
-func (r *s3CredentialRefresher) loop(ctx context.Context, initialDelay time.Duration) {
-	defer close(r.done)
-	timer := time.NewTimer(initialDelay)
-	defer timer.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-		}
-
-		rctx, rcancel := context.WithTimeout(ctx, s3ResolveTimeout)
-		creds, err := r.resolveAndEmit(rctx, true)
-		rcancel()
-
-		if ctx.Err() != nil {
-			// Shutdown, not a failure.
-			r.logger.Debug().Msg("credential refresh stopped")
-			return
-		}
-
-		var delay time.Duration
-		switch {
-		case err == nil && !creds.CanExpire:
-			// Publish before exiting or the stale ExpiresAt would eventually
-			// derive "expired" forever while queries work (#603 review F1).
-			r.everSucceeded = true
-			r.consecutiveErrors = 0
-			r.publishStatus(false)
-			r.logger.Info().Msg("credentials became non-expiring; refresh loop exiting")
-			return
-		case err == nil:
-			delay = r.planSuccess(creds)
-		case errors.Is(err, errNonAdvancingExpiry):
-			delay = r.planNonAdvancing()
-		default:
-			delay = r.planError(err)
-		}
-		timer.Reset(delay)
-	}
-}
-
-// planSuccess, planNonAdvancing and planError decide the wait before the next
-// attempt and do the outcome's logging. They are separated from loop so the
-// scheduling/severity policy is unit-testable without real waits.
-
-func (r *s3CredentialRefresher) planSuccess(creds aws.Credentials) time.Duration {
-	r.everSucceeded = true
-	r.consecutiveErrors = 0
-	r.publishStatus(true)
-	return refreshDelay(creds.Expires)
-}
-
-// planNonAdvancing: the upstream source has not rotated yet. The held secret
-// stays valid; poll at the flat minimum until it rotates. Debug while there is
-// runway, Warn inside the final window. NOTE: this outcome is expected in the
-// tail of every IMDS / Pod Identity session — do not "fix" it back into an
-// error, and do not add backoff (a backoff step could straddle the rotation).
-func (r *s3CredentialRefresher) planNonAdvancing() time.Duration {
-	r.consecutiveErrors = 0
-	r.publishStatus(true)
-	remaining := time.Until(r.lastExpiry)
-	// Deliberate: if the source NEVER rotates and the held credentials expire,
-	// this keeps warning once a minute indefinitely. Queries are failing in
-	// that state; unlike the never-succeeded error loop (demoted — the
-	// deployment there is healthy on the fallback), this noise is proportionate.
-	ev := r.logger.Debug()
-	if remaining < s3RefreshFinalWarnWindow {
-		ev = r.logger.Warn()
-	}
-	ev.Dur("held_credentials_expire_in", remaining.Round(time.Second)).
-		Msg("credential source has not rotated yet; polling")
-	return s3RefreshMinDelay
-}
-
-// planError: a real resolve/emit failure. A refresher that has succeeded
-// before keeps loud Error + 30s→5m backoff — its credentials WILL die at
-// expiry. A refresher that has NEVER succeeded is running behind the fallback
-// CREDENTIAL_CHAIN secret (see startRefresher): the deployment may simply have
-// no resolvable AWS credentials (anonymous MinIO), so after
-// s3RefreshErrorsBeforeDemotion failures it demotes to Debug with a longer cap
-// — one Warn marks the demotion so the state is diagnosable from logs. It
-// never gives up: an EC2 host whose IMDS was down at boot is picked up by a
-// later retry.
-func (r *s3CredentialRefresher) planError(err error) time.Duration {
-	r.consecutiveErrors++
-	r.publishStatus(true)
-	n := r.consecutiveErrors
-	backoffCap := s3RefreshBackoffMax
-	ev := r.logger.Error()
-	if !r.everSucceeded {
-		backoffCap = s3RefreshBackoffMaxUnproven
-		switch {
-		case n == s3RefreshErrorsBeforeDemotion+1:
-			ev = r.logger.Warn()
-			ev = ev.Str("hint", "no resolvable AWS credentials; running on DuckDB's credential chain — configure keys, or set AWS_EC2_METADATA_DISABLED=true to fast-fail the probe")
-		case n > s3RefreshErrorsBeforeDemotion+1:
-			ev = r.logger.Debug()
-		}
-	}
-	delay := s3RefreshBackoffMin << (n - 1)
-	if delay > backoffCap || delay <= 0 {
-		delay = backoffCap
-	}
-	ev.Err(err).Dur("retry_in", delay).
-		Msg("S3 credential refresh failed; existing secret remains in place")
-	return delay
-}
-
-// resolveAndEmit retrieves credentials from the chain and re-emits the DuckDB
-// secret with them. Credential values are never logged.
-//
-// invalidate must be true for every PROACTIVE resolve (the scheduled refresh
-// and its retries): it drops the provider's cached session so Retrieve performs
-// a real STS exchange instead of returning the credentials we already hold.
-// The initial fill passes false — there is nothing cached yet, and on a
-// provider without Invalidate (tests) the assertion is simply skipped.
-func (r *s3CredentialRefresher) resolveAndEmit(ctx context.Context, invalidate bool) (aws.Credentials, error) {
+// Resolve retrieves credentials from the chain. invalidate must be true for
+// every PROACTIVE resolve (the scheduled refresh and its retries): it drops
+// the provider's cached session so Retrieve performs a real STS exchange
+// instead of returning the credentials we already hold. The initial fill
+// passes false — there is nothing cached yet, and on a provider without
+// Invalidate (tests) the assertion is simply skipped.
+func (s *s3Resolver) Resolve(ctx context.Context, invalidate bool) (credMaterial, error) {
 	if invalidate {
-		if inv, ok := r.provider.(interface{ Invalidate() }); ok {
+		if inv, ok := s.provider.(interface{ Invalidate() }); ok {
 			inv.Invalidate()
 		}
 	}
-	creds, err := r.provider.Retrieve(ctx)
+	creds, err := s.provider.Retrieve(ctx)
 	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("resolve AWS credentials: %w", err)
+		return credMaterial{}, fmt.Errorf("resolve AWS credentials: %w", err)
 	}
-	// Refuse credential material containing control bytes BEFORE it reaches SQL
-	// construction. escapeSQLString handles quotes, but a NUL truncates the C
-	// string inside DuckDB's parser, whose "unterminated quoted string" error
-	// echoes the credential prefix — which resolveAndEmit's callers log. Real
-	// AWS credentials are ASCII and never trip this; the check exists so the
-	// no-credentials-in-logs guarantee doesn't rest on that assumption. The
-	// error is a fixed string on purpose: never include the values.
-	for _, v := range []string{creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken} {
-		if strings.ContainsFunc(v, func(c rune) bool { return c < 0x20 || c == 0x7f }) {
-			return aws.Credentials{}, fmt.Errorf("resolved credential material contains control bytes; refusing to emit secret")
-		}
-	}
-	if creds.CanExpire && !r.lastExpiry.IsZero() && !creds.Expires.After(r.lastExpiry) {
-		// Same session as we already hold. For server-rotated sources (IMDS,
-		// Pod Identity) this is NORMAL near the end of a session — rotation
-		// happens on the server's schedule, not ours. The held secret stays
-		// valid; the caller polls until the source rotates.
-		return aws.Credentials{}, errNonAdvancingExpiry
-	}
+	return credMaterial{
+		canExpire:    creds.CanExpire,
+		expires:      creds.Expires,
+		source:       credSourceLabel(creds.Source),
+		secretValues: []string{creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken},
+		payload:      creds,
+	}, nil
+}
 
-	p := r.params
+// Emit writes the S3 secret with the resolved credentials.
+func (s *s3Resolver) Emit(ctx context.Context, m credMaterial) error {
+	creds := m.payload.(aws.Credentials)
+	p := s.params
 	p.accessKey = creds.AccessKeyID
 	p.secretKey = creds.SecretAccessKey
 	p.sessionToken = creds.SessionToken
 	secretSQL, err := buildS3SecretSQL(p)
 	if err != nil {
-		return aws.Credentials{}, err
+		return err
 	}
-	if _, err := r.db.ExecContext(ctx, secretSQL); err != nil {
-		return aws.Credentials{}, fmt.Errorf("emit S3 secret: %w", err)
-	}
-	r.source = credSourceLabel(creds.Source)
-	r.lastRefresh = time.Now().Truncate(time.Second)
-	if creds.CanExpire {
-		r.lastExpiry = creds.Expires
-		// Wording note: on EC2 the SDK caps reported Expires at now+1h even for
-		// ~6h IMDS sessions (ec2rolecreds), so hourly re-emits of the SAME
-		// material under an advancing cap are expected — hence "refreshed", not
-		// "new session".
-		r.logger.Info().Time("expires", creds.Expires.UTC()).
-			Str("source", credSourceLabel(creds.Source)).
-			Msg("DuckDB S3 secret refreshed")
-	} else {
-		r.logger.Info().Str("source", credSourceLabel(creds.Source)).
-			Msg("DuckDB S3 secret emitted (non-expiring credentials)")
-	}
-	return creds, nil
+	_, err = s.db.ExecContext(ctx, secretSQL)
+	return err
 }
 
 // credSourceLabel sanitizes aws.Credentials.Source for logging: the
@@ -475,15 +138,9 @@ func credSourceLabel(source string) string {
 	return source
 }
 
-// refreshDelay schedules the next refresh s3RefreshMargin before `expires`,
-// floored at s3RefreshMinDelay. With no ExpiryWindow configured (see
-// newAWSCredProvider) `expires` is the real STS session expiry, so the margin
-// is the true headroom; the proactive resolve Invalidates the cache first,
-// which is what makes firing before expiry actually produce a new session.
-func refreshDelay(expires time.Time) time.Duration {
-	d := time.Until(expires) - s3RefreshMargin
-	if d < s3RefreshMinDelay {
-		d = s3RefreshMinDelay
-	}
-	return d
+// startS3CredentialRefresher wires an S3 resolver into the shared core.
+func startS3CredentialRefresher(db *sql.DB, params s3SecretParams, provider awsCredentialsProvider, logger zerolog.Logger, onFirstFailure func(error)) *credentialRefresher {
+	return startCredentialRefresher(
+		&s3Resolver{db: db, params: params, provider: provider},
+		params.name, logger, s3DemotionHint, onFirstFailure)
 }

--- a/internal/database/s3refresh_test.go
+++ b/internal/database/s3refresh_test.go
@@ -81,11 +81,11 @@ func TestResolveAndEmitInvalidatesOnProactiveRefresh(t *testing.T) {
 		AccessKeyID: "K2", SecretAccessKey: "S2", SessionToken: "T2",
 		CanExpire: true, Expires: time.Now().Add(2 * time.Hour),
 	}
-	r := &s3CredentialRefresher{
-		db: db, provider: fake, logger: zerolog.Nop(),
-		params: s3SecretParams{name: "inv_test", region: "us-east-1", useSSL: true},
+	r := &credentialRefresher{
+		resolver: &s3Resolver{db: db, provider: fake, params: s3SecretParams{name: "inv_test", region: "us-east-1", useSSL: true}},
+		logger:   zerolog.Nop(),
 	}
-	if _, err := r.resolveAndEmit(context.Background(), false); err != nil {
+	if _, err := r.refreshOnce(context.Background(), false); err != nil {
 		t.Fatalf("initial fill: %v", err)
 	}
 	if fake.invalidations.Load() != 0 {
@@ -93,13 +93,13 @@ func TestResolveAndEmitInvalidatesOnProactiveRefresh(t *testing.T) {
 	}
 	// Without invalidation the provider keeps serving the current session, so a
 	// proactive resolve would be non-advancing; WITH it, the new session lands.
-	creds, err := r.resolveAndEmit(context.Background(), true)
+	m, err := r.refreshOnce(context.Background(), true)
 	if err != nil {
 		t.Fatalf("proactive refresh: %v", err)
 	}
-	if fake.invalidations.Load() != 1 || creds.SessionToken != "T2" {
+	if got := m.payload.(aws.Credentials).SessionToken; fake.invalidations.Load() != 1 || got != "T2" {
 		t.Fatalf("proactive refresh must invalidate then get the new session; invalidations=%d token=%q",
-			fake.invalidations.Load(), creds.SessionToken)
+			fake.invalidations.Load(), got)
 	}
 }
 
@@ -132,18 +132,18 @@ func TestResolveAndEmitFlagsNonAdvancingExpiry(t *testing.T) {
 		AccessKeyID: "K1", SecretAccessKey: "S", SessionToken: "T",
 		CanExpire: true, Expires: exp,
 	}}
-	r := &s3CredentialRefresher{
-		db: db, provider: fake, logger: zerolog.Nop(),
-		params: s3SecretParams{name: "adv_test", region: "us-east-1", useSSL: true},
+	r := &credentialRefresher{
+		resolver: &s3Resolver{db: db, provider: fake, params: s3SecretParams{name: "adv_test", region: "us-east-1", useSSL: true}},
+		logger:   zerolog.Nop(),
 	}
-	if _, err := r.resolveAndEmit(context.Background(), false); err != nil {
+	if _, err := r.refreshOnce(context.Background(), false); err != nil {
 		t.Fatalf("first emit: %v", err)
 	}
-	if _, err := r.resolveAndEmit(context.Background(), false); !errors.Is(err, errNonAdvancingExpiry) {
+	if _, err := r.refreshOnce(context.Background(), false); !errors.Is(err, errNonAdvancingExpiry) {
 		t.Fatalf("second emit with identical expiry must return errNonAdvancingExpiry, got: %v", err)
 	}
 	fake.creds.Expires = exp.Add(time.Hour)
-	if _, err := r.resolveAndEmit(context.Background(), false); err != nil {
+	if _, err := r.refreshOnce(context.Background(), false); err != nil {
 		t.Fatalf("emit with advanced expiry: %v", err)
 	}
 }
@@ -220,12 +220,12 @@ func TestSecretRotationReachesRequests(t *testing.T) {
 		AccessKeyID: "AKIAOLDKEY", SecretAccessKey: "s1", SessionToken: "t1",
 		CanExpire: true, Expires: time.Now().Add(time.Hour),
 	}}
-	r := &s3CredentialRefresher{
-		db: db, provider: fake, logger: zerolog.Nop(),
-		params: s3SecretParams{
+	r := &credentialRefresher{
+		resolver: &s3Resolver{db: db, provider: fake, params: s3SecretParams{
 			name: "rot_test", region: "us-east-1",
 			endpoint: endpoint, pathStyle: true, useSSL: false,
-		},
+		}},
+		logger: zerolog.Nop(),
 	}
 	// F8 sub-case: the FALLBACK-to-managed upgrade path replaces a
 	// CREDENTIAL_CHAIN secret with a static one. Emit the chain shape first
@@ -244,7 +244,7 @@ func TestSecretRotationReachesRequests(t *testing.T) {
 		t.Fatalf("chain fallback emit: %v", err)
 	}
 
-	if _, err := r.resolveAndEmit(context.Background(), false); err != nil {
+	if _, err := r.refreshOnce(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -259,7 +259,7 @@ func TestSecretRotationReachesRequests(t *testing.T) {
 		AccessKeyID: "AKIANEWKEY", SecretAccessKey: "s2", SessionToken: "t2",
 		CanExpire: true, Expires: time.Now().Add(2 * time.Hour),
 	}
-	if _, err := r.resolveAndEmit(context.Background(), false); err != nil {
+	if _, err := r.refreshOnce(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 	query()
@@ -362,11 +362,11 @@ func TestResolveAndEmitRejectsControlBytes(t *testing.T) {
 		AccessKeyID: "AKIA", SecretAccessKey: "s", SessionToken: "SUPERSECRET\x00trunc",
 		CanExpire: true, Expires: time.Now().Add(time.Hour),
 	}}
-	r := &s3CredentialRefresher{
-		db: db, provider: fake, logger: zerolog.Nop(),
-		params: s3SecretParams{name: "nul_test", region: "us-east-1", useSSL: true},
+	r := &credentialRefresher{
+		resolver: &s3Resolver{db: db, provider: fake, params: s3SecretParams{name: "nul_test", region: "us-east-1", useSSL: true}},
+		logger:   zerolog.Nop(),
 	}
-	_, err := r.resolveAndEmit(context.Background(), false)
+	_, err := r.refreshOnce(context.Background(), false)
 	if err == nil {
 		t.Fatal("control-byte credential must be rejected")
 	}
@@ -463,7 +463,7 @@ func TestNewAWSCredProviderPodIdentityStub(t *testing.T) {
 // TestPlanOutcomes pins the scheduling/severity state machine (#601 F2/F6)
 // without real waits.
 func TestPlanOutcomes(t *testing.T) {
-	r := &s3CredentialRefresher{logger: zerolog.Nop()}
+	r := &credentialRefresher{logger: zerolog.Nop()}
 
 	t.Run("non-advancing polls flat at MinDelay", func(t *testing.T) {
 		r.lastExpiry = time.Now().Add(30 * time.Minute)
@@ -473,7 +473,7 @@ func TestPlanOutcomes(t *testing.T) {
 	})
 
 	t.Run("never-succeeded errors demote after threshold with longer cap", func(t *testing.T) {
-		rr := &s3CredentialRefresher{logger: zerolog.Nop()} // everSucceeded=false
+		rr := &credentialRefresher{logger: zerolog.Nop()} // everSucceeded=false
 		var last time.Duration
 		for i := 0; i < 10; i++ {
 			last = rr.planError(fmt.Errorf("no creds"))
@@ -484,7 +484,7 @@ func TestPlanOutcomes(t *testing.T) {
 	})
 
 	t.Run("previously-succeeded errors keep the tight cap", func(t *testing.T) {
-		rr := &s3CredentialRefresher{logger: zerolog.Nop(), everSucceeded: true}
+		rr := &credentialRefresher{logger: zerolog.Nop(), everSucceeded: true}
 		var last time.Duration
 		for i := 0; i < 10; i++ {
 			last = rr.planError(fmt.Errorf("sts down"))
@@ -495,10 +495,10 @@ func TestPlanOutcomes(t *testing.T) {
 	})
 
 	t.Run("success resets the error streak", func(t *testing.T) {
-		rr := &s3CredentialRefresher{logger: zerolog.Nop()}
+		rr := &credentialRefresher{logger: zerolog.Nop()}
 		rr.planError(fmt.Errorf("x"))
 		rr.planError(fmt.Errorf("x"))
-		rr.planSuccess(aws.Credentials{CanExpire: true, Expires: time.Now().Add(time.Hour)})
+		rr.planSuccess(credMaterial{canExpire: true, expires: time.Now().Add(time.Hour)})
 		if rr.consecutiveErrors != 0 || !rr.everSucceeded {
 			t.Errorf("success must reset streak and mark proven: errors=%d proven=%v", rr.consecutiveErrors, rr.everSucceeded)
 		}
@@ -573,7 +573,7 @@ func TestPlanLogLevels(t *testing.T) {
 
 	t.Run("never-succeeded demotion: N errors, one warn, then debug", func(t *testing.T) {
 		var buf strings.Builder
-		r := &s3CredentialRefresher{logger: zerolog.New(&buf)}
+		r := &credentialRefresher{logger: zerolog.New(&buf), demotionHint: s3DemotionHint}
 		for i := 0; i < s3RefreshErrorsBeforeDemotion+3; i++ {
 			r.planError(fmt.Errorf("no creds"))
 		}
@@ -592,7 +592,7 @@ func TestPlanLogLevels(t *testing.T) {
 
 	t.Run("previously-succeeded failures stay at error", func(t *testing.T) {
 		var buf strings.Builder
-		r := &s3CredentialRefresher{logger: zerolog.New(&buf), everSucceeded: true}
+		r := &credentialRefresher{logger: zerolog.New(&buf), everSucceeded: true}
 		for i := 0; i < 6; i++ {
 			r.planError(fmt.Errorf("sts down"))
 		}
@@ -605,7 +605,7 @@ func TestPlanLogLevels(t *testing.T) {
 
 	t.Run("non-advancing: debug with runway, warn in final window", func(t *testing.T) {
 		var buf strings.Builder
-		r := &s3CredentialRefresher{logger: zerolog.New(&buf)}
+		r := &credentialRefresher{logger: zerolog.New(&buf)}
 		r.lastExpiry = time.Now().Add(30 * time.Minute)
 		r.planNonAdvancing()
 		r.lastExpiry = time.Now().Add(s3RefreshFinalWarnWindow - time.Minute)
@@ -688,7 +688,7 @@ func TestStatusPublishSites(t *testing.T) {
 	})
 
 	t.Run("planError publishes degraded; planSuccess recovers", func(t *testing.T) {
-		r := &s3CredentialRefresher{logger: zerolog.Nop()}
+		r := &credentialRefresher{logger: zerolog.Nop()}
 		r.everSucceeded = true
 		r.lastExpiry = now.Add(time.Hour)
 		r.publishStatus(true)
@@ -696,14 +696,14 @@ func TestStatusPublishSites(t *testing.T) {
 		if st := r.status(now); st.State != CredStateDegraded || st.ConsecutiveErrors != 1 {
 			t.Fatalf("post-error status = %+v", st)
 		}
-		r.planSuccess(aws.Credentials{CanExpire: true, Expires: now.Add(2 * time.Hour)})
+		r.planSuccess(credMaterial{canExpire: true, expires: now.Add(2 * time.Hour)})
 		if st := r.status(now); st.State != CredStateOK || st.ConsecutiveErrors != 0 {
 			t.Fatalf("post-recovery status = %+v", st)
 		}
 	})
 
 	t.Run("expired derives at READ time with no new outcome", func(t *testing.T) {
-		r := &s3CredentialRefresher{logger: zerolog.Nop()}
+		r := &credentialRefresher{logger: zerolog.Nop()}
 		r.everSucceeded = true
 		r.lastExpiry = now.Add(30 * time.Millisecond)
 		r.publishStatus(true)
@@ -721,18 +721,24 @@ func TestStatusPublishSites(t *testing.T) {
 // report static/ok.
 func TestAzureCredentialsLabel(t *testing.T) {
 	cases := []struct {
-		conn, key, wantCreds, wantState string
+		conn, key, sas, wantCreds, wantState string
 	}{
-		{"DefaultEndpointsProtocol=https;AccountName=a;AccountKey=abc==", "", credModeStaticKeys, CredStateOK},
-		{"BlobEndpoint=https://a.blob.core.windows.net;SharedAccessSignature=sv=2024&sig=xyz", "", credModeSAS, CredStateUnknown},
-		{"BlobEndpoint=https://a.blob.core.windows.net;sig=xyz", "", credModeSAS, CredStateUnknown},
-		{"", "accountkey==", credModeStaticKeys, CredStateOK},
-		{"", "", credModeUnmanagedChain, CredStateUnknown},
+		{"DefaultEndpointsProtocol=https;AccountName=a;AccountKey=abc==", "", "", credModeStaticKeys, CredStateOK},
+		{"BlobEndpoint=https://a.blob.core.windows.net;SharedAccessSignature=sv=2024&sig=xyz", "", "", credModeSAS, CredStateUnknown},
+		{"BlobEndpoint=https://a.blob.core.windows.net;sig=xyz", "", "", credModeSAS, CredStateUnknown},
+		{"BlobEndpoint=https://a.blob.core.windows.net?sv=2024&sig=xyz", "", "", credModeSAS, CredStateUnknown},
+		{"", "accountkey==", "", credModeStaticKeys, CredStateOK},
+		// A configured SAS token (#605 M6) must never route to the managed
+		// refresher — that would acquire a broader identity than the
+		// operator's deliberately-scoped SAS.
+		{"", "", "sv=2024&sig=xyz", credModeSAS, CredStateUnknown},
+		// Managed identity / SP env: Arc-managed refresher as of #605.
+		{"", "", "", s3ModeSDKManaged, CredStateOK},
 	}
 	for _, tc := range cases {
-		creds, state := azureCredentialsLabel(tc.conn, tc.key)
+		creds, state := azureCredentialsLabel(tc.conn, tc.key, tc.sas)
 		if creds != tc.wantCreds || state != tc.wantState {
-			t.Errorf("azureCredentialsLabel(%q,%q) = %s/%s, want %s/%s", tc.conn, tc.key, creds, state, tc.wantCreds, tc.wantState)
+			t.Errorf("azureCredentialsLabel(%q,%q,%q) = %s/%s, want %s/%s", tc.conn, tc.key, tc.sas, creds, state, tc.wantCreds, tc.wantState)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Closes #605**: Azure managed-identity / SP-env deployments lost DuckDB query reads ~1h after process start (the #600 class — AAD token materialized once at `CREATE SECRET`, never refreshed). Arc now resolves AAD tokens via `azidentity`'s `DefaultAzureCredential` (the ingest chain — identity symmetry) and emits `PROVIDER ACCESS_TOKEN` secrets, refreshed before expiry.
- **Refresher core extracted** (`credrefresh.go`) behind a two-method `Resolve`/`Emit` seam: the core owns scheduling, non-advance detection (Emit skipped), control-byte guard, retry demotion, and the `/health` snapshot — a new backend cannot forget them. `s3refresh.go` keeps its resolver + the #600/#601 incident history.
- azidentity/MSAL specifics pinned from module source and live: no cache invalidation exists; MSAL serves cache until a ~5-min pre-expiry buffer — the #601 non-advancing flat-poll is the bridging mechanism, by design.
- **`storage.azure_endpoint` was dead config on the query path** — now wired (sovereign clouds), full-URL→suffix normalized, path-style warned+skipped, suppressed on connection-string shapes.
- **SAS deployments never start a refresher** (`storage.azure_sas_token` now visible to the gate) — a managed refresher would acquire a broader identity than the operator scoped; reports `sas/unknown` in `/health`.
- `/health` azure managed tiers now report full refresher state (`sdk_managed`).

## Test plan

- [x] Probes against the bundled engine BEFORE design: `PROVIDER ACCESS_TOKEN` accepted (typo control), `ACCESS_TOKEN` redacted in `duckdb_secrets()`, chain secrets don't validate at CREATE, chain→access_token replacement works
- [x] Adversarial plan validation + deep review; all findings fixed (incl. H1 silent endpoint-drop, M4 ENDPOINT/conn-string conflict, SAS/label precedence documented)
- [x] 33/33 packages, `-race` clean; 7 new azure tests (emission+redaction, endpoint grid, resolver-through-core, hot/cold wiring, SAS-never-refreshes with fatal-in-provider guard, record-after-success); revert-verified gates
- [x] Refactor equivalence: reviewer traced every path old-vs-new (only log wording differs, all within the unreleased 26.09.1); **refactored S3 re-passed the full live rotation gate** (Pod Identity stub + real STS): `refreshes=2 polls=2 errors=0`, queries past real expiry
- [x] **Azure live gate on real Azure Blob Storage** (real SP, real 60-min AAD tokens): managed hot tier `sdk_managed/ok`, globbed `azure://` queries via the Arc-managed secret, full rotation — `VERDICT: query=OK state=ok refreshes=2 errors=0`, queries past the original token's expiry

Matching docs: `docs.basekick.net` branch `docs/605-azure-refresher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)