### PR TITLE
feat(license): boot resilience — bounded retry, failure taxonomy, cached-license fallback

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -441,6 +441,23 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### License-server outages no longer crash-loop Enterprise clusters ([field report])
+
+Every pod boot used to make one blocking license check against `enterprise.basekick.net` with no retry and no memory: any transient failure — a deploy-window ingress 404, DNS, an egress blip — dropped the pod to OSS mode, and for enterprise-required configurations (shared-storage multi-writer) that is a **fatal exit**. One customer watched a writer accumulate 27 restarts during a brief license-server deploy. License-server availability was, in effect, a hard runtime dependency of every pod restart.
+
+Boot now works like this:
+
+1. **Bounded retry** — up to three attempts with jittered backoff, the whole phase capped at 45 seconds, so a black-holed endpoint can't stretch startup past probe budgets.
+2. **Failure classification** — a *definitive* answer (the server spoke the license protocol and said no: revoked, suspended, expired, unknown key) still lands in OSS mode immediately, no retries. Only *non-definitive* failures — unreachable, 5xx, rate-limited, or a 4xx **without** the protocol's JSON body (an ingress error page, exactly the field incident) — proceed to:
+3. **The cached license** — after every successful activation or verification, Arc persists the server's signed response (`license_cache.json`, `0600`, next to the auth DB). When the server can't answer, the cache is re-verified from scratch — RSA signature against the pinned key, license key must match the configured key, machine binding must match **this** machine, and expiry is enforced — and if it holds, the pod boots **fully licensed until the license's own expiry**, with a prominent warning and background re-verification continuing. A cache file copied to another machine fails the binding check (the fingerprint is hostname/hardware-derived — this stops casual copying, the same bar as online activation, not a determined cloner); removing or changing `license.key` stops the cache being consulted at all; **no new grace period exists** — the cache is honored to `expires_at`, never past it. One accepted property, stated plainly: a license revoked *during* an outage keeps working from cache until the server is reachable again or the license expires — revocation was only ever enforceable online, and a definitive server answer always wins the moment one arrives.
+
+Two more fixes in the same change:
+
+- **A latent crash-loop nobody had reported yet**: the license server reaps activations that haven't been heard from in 72 hours, but the "heard from" signal was only ever sent by a heartbeat call Arc never made — so any machine with a stable fingerprint was silently revoked 72 hours after activating, and its next restart crash-looped. Arc now re-activates on that condition (a deliberately revoked *license* still refuses definitively), and the license server counts successful verifications as liveness.
+- The Helm chart's Arc pods gain a **startupProbe** (5 minutes of grace): the liveness probe used to be able to kill a legitimately slow boot — license retries plus multi-writer WAL recovery — at about 60 seconds, before the HTTP listener even bound.
+
+Air-gapped, fully offline license files (no server dependency at all) are the follow-up currently in flight.
+
 ### Azure managed-identity credentials on the query path now refresh — and no longer die an hour in ([#605](https://github.com/Basekick-Labs/arc/issues/605))
 
 The same class as the S3/IRSA bug above, on the other cloud: DuckDB's azure `CREDENTIAL_CHAIN` secret materializes an AAD token **once** at secret creation and never refreshes it, while AAD access tokens live about an hour — so on `storage.backend = azure` with managed identity or a service-principal environment, query reads died roughly an hour after each process start, with ingest unaffected.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -131,13 +131,21 @@ func main() {
 		var err error
 		licenseClient, err = license.NewClient(&license.ClientConfig{
 			LicenseKey: cfg.License.Key,
-			Logger:     logger.Get("license"),
+			// Cache lives next to the auth DB (per-pod volume): boot survives a
+			// transient license-server outage on the last verified license,
+			// honored until ITS OWN expiry. Deliberately inside the Key != ""
+			// branch — removing the key must also stop cache consultation.
+			CacheDir: filepath.Dir(cfg.Auth.DBPath),
+			Logger:   logger.Get("license"),
 		})
 		if err != nil {
 			log.Warn().Err(err).Msg("Failed to initialize license client - enterprise features disabled")
 		} else {
-			// Activate or verify license at startup
-			lic, err := licenseClient.ActivateOrVerify(context.Background())
+			// Activate or verify at startup: bounded retries, then — for
+			// transient failures only — the signature-verified cache. A
+			// definitive server rejection still lands in OSS mode; a
+			// deploy-window ingress 404 no longer crash-loops the cluster.
+			lic, src, err := licenseClient.ActivateOrVerifyResilient(context.Background())
 			if err != nil {
 				log.Warn().
 					Err(err).
@@ -145,14 +153,21 @@ func main() {
 					Msg("License activation/verification failed - enterprise features disabled")
 				licenseClient = nil
 			} else {
-				log.Info().
-					Str("tier", string(lic.Tier)).
-					Str("status", lic.Status).
-					Int("days_remaining", lic.DaysRemaining).
-					Int("max_cores", lic.MaxCores).
-					Time("expires_at", lic.ExpiresAt).
-					Strs("features", lic.Features).
-					Msg("Enterprise license verified successfully")
+				if src == license.SourceCache {
+					log.Warn().
+						Str("tier", string(lic.Tier)).
+						Time("expires_at", lic.ExpiresAt).
+						Msg("license server unreachable; running on the cached verified license until it expires or the server recovers (background re-verification continues)")
+				} else {
+					log.Info().
+						Str("tier", string(lic.Tier)).
+						Str("status", lic.Status).
+						Int("days_remaining", lic.DaysRemaining).
+						Int("max_cores", lic.MaxCores).
+						Time("expires_at", lic.ExpiresAt).
+						Strs("features", lic.Features).
+						Msg("Enterprise license verified successfully")
+				}
 
 				// Apply core limits from license to config
 				// This ensures DuckDB and ingestion workers respect the license

--- a/helm/arc-enterprise/templates/compactor-statefulset.yaml
+++ b/helm/arc-enterprise/templates/compactor-statefulset.yaml
@@ -60,6 +60,19 @@ spec:
               mountPath: /etc/arc/tls
               readOnly: true
             {{- end }}
+          startupProbe:
+            # Boot can legitimately take minutes: the license phase retries a
+            # transient license-server outage (bounded 45s) and multi-writer
+            # WAL recovery replays before the listener binds — during which
+            # /health is connection-refused. Without this gate the liveness
+            # probe (kill at ~60s) would murder booting pods, converting a
+            # slow boot into a crash-loop. 30 * 10s = 5 minutes of grace;
+            # liveness takes over only after the first success.
+            httpGet:
+              path: /health
+              port: 8000
+            failureThreshold: {{ .Values.compactor.startupProbeFailureThreshold | default 30 }}
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health

--- a/helm/arc-enterprise/templates/reader-statefulset.yaml
+++ b/helm/arc-enterprise/templates/reader-statefulset.yaml
@@ -69,6 +69,19 @@ spec:
               mountPath: /etc/arc/tls
               readOnly: true
             {{- end }}
+          startupProbe:
+            # Boot can legitimately take minutes: the license phase retries a
+            # transient license-server outage (bounded 45s) and multi-writer
+            # WAL recovery replays before the listener binds — during which
+            # /health is connection-refused. Without this gate the liveness
+            # probe (kill at ~60s) would murder booting pods, converting a
+            # slow boot into a crash-loop. 30 * 10s = 5 minutes of grace;
+            # liveness takes over only after the first success.
+            httpGet:
+              path: /health
+              port: 8000
+            failureThreshold: {{ .Values.reader.startupProbeFailureThreshold | default 30 }}
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health

--- a/helm/arc-enterprise/templates/writer-statefulset.yaml
+++ b/helm/arc-enterprise/templates/writer-statefulset.yaml
@@ -66,6 +66,19 @@ spec:
               mountPath: /etc/arc/tls
               readOnly: true
             {{- end }}
+          startupProbe:
+            # Boot can legitimately take minutes: the license phase retries a
+            # transient license-server outage (bounded 45s) and multi-writer
+            # WAL recovery replays before the listener binds — during which
+            # /health is connection-refused. Without this gate the liveness
+            # probe (kill at ~60s) would murder booting pods, converting a
+            # slow boot into a crash-loop. 30 * 10s = 5 minutes of grace;
+            # liveness takes over only after the first success.
+            httpGet:
+              path: /health
+              port: 8000
+            failureThreshold: {{ .Values.writer.startupProbeFailureThreshold | default 30 }}
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health

--- a/helm/arc-enterprise/values.yaml
+++ b/helm/arc-enterprise/values.yaml
@@ -163,6 +163,11 @@ minio:
 # Writer nodes — ingest data, flush to storage, run Raft leader election
 # -----------------------------------------------------------------------------
 writer:
+  # startupProbe allowance: failureThreshold x 10s of boot grace before the
+  # liveness probe arms. Raise for large WAL replays (writer) — a threshold
+  # crossed mid-recovery kill-loops the pod, the exact failure the probe
+  # prevents. Default 30 (5 minutes).
+  startupProbeFailureThreshold: 30
   replicas: 1                      # 3 enables failover; 2 has no failure tolerance (Raft quorum=2 stalls on single-pod loss)
   resources:
     requests: { cpu: 500m, memory: 1Gi }
@@ -184,6 +189,11 @@ writer:
 # Reader nodes — serve queries
 # -----------------------------------------------------------------------------
 reader:
+  # startupProbe allowance: failureThreshold x 10s of boot grace before the
+  # liveness probe arms. Raise for large WAL replays (writer) — a threshold
+  # crossed mid-recovery kill-loops the pod, the exact failure the probe
+  # prevents. Default 30 (5 minutes).
+  startupProbeFailureThreshold: 30
   replicas: 2                      # scale horizontally for query throughput
   resources:
     requests: { cpu: 500m, memory: 1Gi }
@@ -202,6 +212,11 @@ reader:
 # Compactor — runs background Parquet compaction
 # -----------------------------------------------------------------------------
 compactor:
+  # startupProbe allowance: failureThreshold x 10s of boot grace before the
+  # liveness probe arms. Raise for large WAL replays (writer) — a threshold
+  # crossed mid-recovery kill-loops the pod, the exact failure the probe
+  # prevents. Default 30 (5 minutes).
+  startupProbeFailureThreshold: 30
   enabled: true
   replicas: 1                      # exactly one active compactor — failover handles replacement
   resources:

--- a/internal/license/cache.go
+++ b/internal/license/cache.go
@@ -1,0 +1,227 @@
+package license
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// License cache + resilient boot (#license-boot-resilience).
+//
+// Field incident: every pod boot made one blocking ActivateOrVerify with no
+// retry and no cache; a deploy-window ingress 404 on the license server
+// crash-looped a customer's cluster (27 restarts) because OSS fallback is
+// FATAL for enterprise-required configs (shared-storage multi-writer).
+//
+// The cache is the exact signed server response pair — tamper-evident by
+// signature, nothing secret beyond what the license already is. Loading it is
+// gated HARD (see LoadCachedLicense): without the fingerprint requirement, a
+// copied cache file would license any number of machines until expiry
+// (VerifyLicenseFile alone checks signature+parse only, and bindFingerprint
+// accepts an EMPTY fingerprint as unbound — a legitimate cache can never be
+// unbound, because Arc always sends a non-empty fingerprint for the server to
+// sign).
+
+// cacheFileName sits in the auth-DB directory (per-pod volume in the Helm
+// chart — no cross-pod file races).
+const cacheFileName = "license_cache.json"
+
+// Boot retry budget. ONE phase deadline bounds the whole retry loop —
+// per-attempt arithmetic lies when the server is black-holed (three full
+// 30s HTTP timeouts = 103s, past the ~60s liveness kill line). The Helm
+// chart's startupProbe (shipped with this change) covers the phase.
+// Vars, not consts, purely so tests can compress time; production never
+// mutates them.
+var (
+	bootRetryPhaseBudget = 45 * time.Second
+	bootRetryAttempts    = 3
+	bootRetryBackoffUnit = time.Second
+)
+
+// bootRetryBackoff returns the pause before attempt i (1-based, no pause
+// before the first), with ±20% jitter so a restart storm doesn't synchronize
+// against the server's rate limiter (100 req/min/IP, and cluster egress is
+// typically NAT'd to one IP).
+func bootRetryBackoff(attempt int) time.Duration {
+	if attempt <= 1 {
+		return 0
+	}
+	base := bootRetryBackoffUnit << (attempt - 1) // 2s, 4s at the 1s unit
+	jitter := time.Duration(rand.Int63n(int64(base)/2)) - time.Duration(int64(base)/4)
+	return base + jitter
+}
+
+// cachedPair is the on-disk shape: byte-identical to the server's activation/
+// verify response payload, so one verifier serves the online response, this
+// cache, and (deliverable B) the offline license file.
+type cachedPair struct {
+	LicenseFile      string `json:"license_file"`
+	LicenseSignature string `json:"license_signature"`
+}
+
+// cachePath returns "" when caching is disabled (no dir configured — tests,
+// or library callers).
+func (c *Client) cachePath() string {
+	if c.cacheDir == "" {
+		return ""
+	}
+	return filepath.Join(c.cacheDir, cacheFileName)
+}
+
+// saveCache persists the verified pair after a successful Activate/Verify.
+// Best-effort: a cache write failure never fails the activation that produced
+// it. 0600 — it is a bearer of enterprise entitlements for THIS machine.
+func (c *Client) saveCache(licenseFile, licenseSignature string) {
+	path := c.cachePath()
+	if path == "" {
+		return
+	}
+	// Never persist an UNBOUND pair: LoadCachedLicense's gate 3 could never
+	// load it, so it would only overwrite a previously usable bound cache.
+	// Server-bug-only today (the server always signs the fingerprint Arc
+	// sent), and it keeps deliverable B's unbound site files structurally out
+	// of the cache slot.
+	if signed, err := VerifyLicenseFile(licenseFile, licenseSignature); err != nil || signed.MachineFingerprint == "" {
+		c.logger.Warn().Msg("refusing to cache an unbound or unverifiable license pair")
+		return
+	}
+	data, err := json.Marshal(cachedPair{LicenseFile: licenseFile, LicenseSignature: licenseSignature})
+	if err != nil {
+		c.logger.Warn().Err(err).Msg("license cache marshal failed")
+		return
+	}
+	// The license phase runs BEFORE main.go creates the auth-DB directory, so
+	// a first-ever boot would otherwise fail its first cache write and only
+	// persist at the next periodic verify (4h later) — leaving a restart
+	// inside that window unprotected. 0700 matches the auth-DB dir's own mode.
+	if err := os.MkdirAll(c.cacheDir, 0o700); err != nil {
+		c.logger.Warn().Err(err).Msg("license cache dir create failed")
+		return
+	}
+	// Fixed tmp name is safe: cache writers are strictly serialized (boot
+	// completes before StartPeriodicValidation; no other Verify callers).
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		c.logger.Warn().Err(err).Msg("license cache write failed")
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		c.logger.Warn().Err(err).Msg("license cache rename failed")
+		return
+	}
+	c.logger.Debug().Str("path", path).Msg("license cache updated")
+}
+
+// deleteCache removes the cache (best-effort), used when its contents cannot
+// belong to the configured key.
+func (c *Client) deleteCache() {
+	if path := c.cachePath(); path != "" {
+		_ = os.Remove(path)
+	}
+}
+
+// LoadCachedLicense loads and re-verifies the cached pair. ALL of the
+// following must hold, or the cache is rejected (and on a key mismatch,
+// deleted):
+//
+//  1. signature verifies against the pinned public key;
+//  2. the signed license key equals the CONFIGURED key — a stale cache from a
+//     replaced/downgraded license must not resurrect old entitlements;
+//  3. the signed fingerprint is NON-EMPTY and equals this machine's — see the
+//     file comment; empty-accepting bindFingerprint is NOT sufficient here;
+//  4. not expired (the cache is honored until the license's OWN expires_at,
+//     never longer — no new grace is introduced).
+func (c *Client) LoadCachedLicense() (*License, error) {
+	path := c.cachePath()
+	if path == "" {
+		return nil, fmt.Errorf("license cache disabled")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("license cache unavailable: %w", err)
+	}
+	var pair cachedPair
+	if err := json.Unmarshal(data, &pair); err != nil {
+		return nil, fmt.Errorf("license cache corrupt: %w", err)
+	}
+	signed, err := VerifyLicenseFile(pair.LicenseFile, pair.LicenseSignature)
+	if err != nil {
+		return nil, fmt.Errorf("license cache failed verification: %w", err)
+	}
+	if signed.LicenseKey != c.licenseKey {
+		c.deleteCache()
+		return nil, fmt.Errorf("license cache is for a different license key; deleted")
+	}
+	if signed.MachineFingerprint == "" || signed.MachineFingerprint != c.fingerprint {
+		return nil, fmt.Errorf("license cache is not bound to this machine")
+	}
+	now := time.Now().UTC()
+	if !now.Before(signed.ExpiresAt) {
+		return nil, fmt.Errorf("cached license expired at %s", signed.ExpiresAt.UTC().Format(time.RFC3339))
+	}
+
+	lic := signed.ToRuntimeLicense(now)
+	c.mu.Lock()
+	c.license = lic
+	c.mu.Unlock()
+	return lic, nil
+}
+
+// LicenseSource says where the boot license came from, for operator-facing
+// logging.
+type LicenseSource string
+
+const (
+	SourceServer LicenseSource = "server"
+	SourceCache  LicenseSource = "cache"
+)
+
+// ActivateOrVerifyResilient is the boot entry point: bounded retries against
+// the server, then — for TRANSIENT failures only — the verified cache.
+//
+//   - The whole retry phase shares one deadline (bootRetryPhaseBudget); a
+//     black-holed server cannot stretch it to attempts × HTTP-timeout.
+//   - A DEFINITIVE rejection (the server spoke the protocol and said no)
+//     returns immediately and never consults the cache: revocation stays
+//     effective whenever the server is reachable.
+//   - Cache fallback proceeds FULLY LICENSED until the license's own
+//     expires_at; the caller logs it loudly and the periodic re-verify keeps
+//     trying the server (first success rewrites the cache).
+func (c *Client) ActivateOrVerifyResilient(ctx context.Context) (*License, LicenseSource, error) {
+	phaseCtx, cancel := context.WithTimeout(ctx, bootRetryPhaseBudget)
+	defer cancel()
+
+	var lastErr error
+	for attempt := 1; attempt <= bootRetryAttempts; attempt++ {
+		if attempt > 1 {
+			select {
+			case <-phaseCtx.Done():
+			case <-time.After(bootRetryBackoff(attempt)):
+			}
+			if phaseCtx.Err() != nil {
+				break // phase budget exhausted
+			}
+		}
+		lic, err := c.ActivateOrVerify(phaseCtx)
+		if err == nil {
+			return lic, SourceServer, nil
+		}
+		lastErr = err
+		if FailureClassOf(err) == ClassDefinitive {
+			return nil, SourceServer, err
+		}
+		c.logger.Warn().Err(err).Int("attempt", attempt).Int("max_attempts", bootRetryAttempts).
+			Msg("license server unreachable or answered non-definitively; will retry")
+	}
+
+	lic, cacheErr := c.LoadCachedLicense()
+	if cacheErr != nil {
+		c.logger.Warn().Err(cacheErr).Msg("license cache not usable")
+		return nil, SourceServer, fmt.Errorf("license server unreachable and no usable cache: %w", lastErr)
+	}
+	return lic, SourceCache, nil
+}

--- a/internal/license/client.go
+++ b/internal/license/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,7 +35,11 @@ const (
 // ClientConfig holds configuration for the license client
 type ClientConfig struct {
 	LicenseKey string
-	Logger     zerolog.Logger
+	// CacheDir, when non-empty, enables the on-disk license cache
+	// (license_cache.json) used for boot resilience when the license server
+	// is unreachable. See cache.go.
+	CacheDir string
+	Logger   zerolog.Logger
 }
 
 // Client handles license validation with the enterprise server
@@ -42,6 +47,7 @@ type Client struct {
 	serverURL   string
 	licenseKey  string
 	fingerprint string
+	cacheDir    string
 	httpClient  *http.Client
 	license     *License
 	mu          sync.RWMutex
@@ -97,6 +103,7 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 	c := &Client{
 		serverURL:   LicenseServerURL,
 		licenseKey:  cfg.LicenseKey,
+		cacheDir:    cfg.CacheDir,
 		fingerprint: fingerprint,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
@@ -178,7 +185,7 @@ func (c *Client) Activate(ctx context.Context) (*License, error) {
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("License activation request failed")
-		return nil, fmt.Errorf("license activation request failed: %w", err)
+		return nil, transientErr("license activation request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -187,7 +194,8 @@ func (c *Client) Activate(ctx context.Context) (*License, error) {
 	}
 	var activateResp ActivateResponse
 	if err := readBoundedJSON(resp, &activateResp); err != nil {
-		return nil, fmt.Errorf("failed to decode activation response: %w", err)
+		// Malformed 200 = proxy default backend, not a protocol answer.
+		return nil, transientErr("failed to decode activation response: %w", err)
 	}
 
 	if !activateResp.Success {
@@ -196,7 +204,8 @@ func (c *Client) Activate(ctx context.Context) (*License, error) {
 			errMsg = "license activation failed"
 		}
 		c.logger.Warn().Str("error", errMsg).Msg("License activation failed")
-		return nil, fmt.Errorf("license activation failed: %s", errMsg)
+		// 200 envelope rejection: the server spoke the protocol and said no.
+		return nil, definitiveErr("license activation failed: %s", errMsg)
 	}
 
 	// Verify the detached signature against the raw license_file
@@ -207,11 +216,13 @@ func (c *Client) Activate(ctx context.Context) (*License, error) {
 	signed, err := VerifyLicenseFile(activateResp.LicenseFile, activateResp.LicenseSignature)
 	if err != nil {
 		c.logger.Warn().Err(err).Msg("License activation: signature verification failed")
-		return nil, fmt.Errorf("license activation failed: %w", err)
+		// Protocol violation (or MITM): transient — the cache re-verifies
+		// independently, so preferring it cannot be worse than this response.
+		return nil, transientErr("license activation failed: %w", err)
 	}
 	if err := c.bindFingerprint(signed); err != nil {
 		c.logger.Warn().Err(err).Msg("License activation: fingerprint binding mismatch")
-		return nil, fmt.Errorf("license activation failed: %w", err)
+		return nil, transientErr("license activation failed: %w", err)
 	}
 	c.logger.Debug().Msg("signature verified")
 
@@ -221,6 +232,9 @@ func (c *Client) Activate(ctx context.Context) (*License, error) {
 	c.mu.Lock()
 	c.license = license
 	c.mu.Unlock()
+
+	// Persist the verified pair for boot resilience (see cache.go).
+	c.saveCache(activateResp.LicenseFile, activateResp.LicenseSignature)
 
 	c.logger.Info().
 		Str("tier", string(license.Tier)).
@@ -254,7 +268,7 @@ func (c *Client) Verify(ctx context.Context) (*License, error) {
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("License verification request failed")
-		return nil, fmt.Errorf("license verification request failed: %w", err)
+		return nil, transientErr("license verification request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -263,7 +277,7 @@ func (c *Client) Verify(ctx context.Context) (*License, error) {
 	}
 	var verifyResp VerifyResponse
 	if err := readBoundedJSON(resp, &verifyResp); err != nil {
-		return nil, fmt.Errorf("failed to decode verify response: %w", err)
+		return nil, transientErr("failed to decode verify response: %w", err)
 	}
 
 	if !verifyResp.Valid {
@@ -272,18 +286,28 @@ func (c *Client) Verify(ctx context.Context) (*License, error) {
 			errMsg = "license validation failed"
 		}
 		c.logger.Warn().Str("error", errMsg).Msg("License validation failed")
-		return nil, fmt.Errorf("license validation failed: %s", errMsg)
+		// Two envelope rejections are NOT terminal (activation is the intended
+		// recovery); matched EXACTLY against the server's strings here — where
+		// the raw envelope is in hand — rather than substring-scanned on a
+		// wrapped message that also embeds HTTP body previews. The server side
+		// carries a frozen-contract comment on these strings.
+		if errMsg == "machine not activated for this license" || errMsg == "activation has been revoked" {
+			return nil, fmt.Errorf("license validation failed: %w: %s", errActivationMissing, errMsg)
+		}
+		// Everything else = definitive (unknown strings included: the server
+		// spoke the protocol and said no).
+		return nil, definitiveErr("license validation failed: %s", errMsg)
 	}
 
 	// Same detached-signature verification path as Activate.
 	signed, err := VerifyLicenseFile(verifyResp.LicenseFile, verifyResp.LicenseSignature)
 	if err != nil {
 		c.logger.Warn().Err(err).Msg("License verification: signature verification failed")
-		return nil, fmt.Errorf("license validation failed: %w", err)
+		return nil, transientErr("license validation failed: %w", err)
 	}
 	if err := c.bindFingerprint(signed); err != nil {
 		c.logger.Warn().Err(err).Msg("License verification: fingerprint binding mismatch")
-		return nil, fmt.Errorf("license validation failed: %w", err)
+		return nil, transientErr("license validation failed: %w", err)
 	}
 	c.logger.Debug().Msg("signature verified")
 
@@ -293,6 +317,9 @@ func (c *Client) Verify(ctx context.Context) (*License, error) {
 	c.mu.Lock()
 	c.license = license
 	c.mu.Unlock()
+
+	// Persist the verified pair for boot resilience (see cache.go).
+	c.saveCache(verifyResp.LicenseFile, verifyResp.LicenseSignature)
 
 	c.logger.Info().
 		Str("tier", string(license.Tier)).
@@ -313,13 +340,22 @@ func (c *Client) ActivateOrVerify(ctx context.Context) (*License, error) {
 		return license, nil
 	}
 
-	// If verification failed with "machine not activated", try to activate
-	if strings.Contains(err.Error(), "machine not activated") {
-		c.logger.Info().Msg("Machine not activated, attempting activation")
+	// errActivationMissing covers the two NOT-terminal verify rejections —
+	// activation is the server's intended recovery path for both:
+	//   - "machine not activated": first boot on this fingerprint.
+	//   - "activation has been revoked": the server's stale-activation reaper
+	//     revokes activations without a heartbeat for 72h, and Arc has never
+	//     sent heartbeats — so this is a ROUTINE condition for any
+	//     stable-fingerprint machine, not an operator decision. Re-activating
+	//     re-creates the activation record (the server supports it); a
+	//     deliberately revoked LICENSE still rejects the re-activation
+	//     definitively ("license is not active").
+	if errors.Is(err, errActivationMissing) {
+		c.logger.Info().Msg("No live activation for this machine, attempting activation")
 		return c.Activate(ctx)
 	}
 
-	// Other error, return it
+	// Other error, return it (carrying its failure class).
 	return nil, err
 }
 
@@ -333,7 +369,11 @@ func (c *Client) StartPeriodicValidation(interval time.Duration) {
 			select {
 			case <-ticker.C:
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				_, err := c.Verify(ctx)
+				// ActivateOrVerify, not bare Verify: an activation reaped
+				// during a long outage (>72h without a liveness signal)
+				// self-heals on the next tick instead of warning every 4h
+				// until restart — and each success refreshes the cache.
+				_, err := c.ActivateOrVerify(ctx)
 				if err != nil {
 					c.logger.Warn().Err(err).Msg("Periodic license validation failed")
 				}
@@ -506,6 +546,11 @@ func (c *Client) bindFingerprint(signed *SignedLicense) error {
 // 'H' looking for beginning of value" — much easier to triage.
 //
 // Doesn't close resp.Body — caller's defer handles that.
+// checkHTTPStatus returns nil for 2xx and a CLASSIFIED error otherwise: 5xx
+// and 429 are transient; a 4xx is definitive only when its body is the
+// protocol's own JSON error shape — a bare/HTML 4xx is an ingress artifact
+// (the field incident: deploy-window 404s crash-looped a cluster). The message
+// embeds a bounded, rune-safe preview of the body for diagnosis.
 func checkHTTPStatus(resp *http.Response) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
@@ -522,10 +567,16 @@ func checkHTTPStatus(resp *http.Response) error {
 	if runes := []rune(previewStr); len(runes) > 256 {
 		previewStr = string(runes[:256]) + "...[truncated]"
 	}
-	if previewStr == "" {
-		return fmt.Errorf("HTTP %d from license server", resp.StatusCode)
+	definitive := resp.StatusCode >= 400 && resp.StatusCode < 500 &&
+		resp.StatusCode != 429 && isProtocolJSONBody(previewStr)
+	mk := transientErr
+	if definitive {
+		mk = definitiveErr
 	}
-	return fmt.Errorf("HTTP %d from license server: %s", resp.StatusCode, previewStr)
+	if previewStr == "" {
+		return mk("HTTP %d from license server", resp.StatusCode)
+	}
+	return mk("HTTP %d from license server: %s", resp.StatusCode, previewStr)
 }
 
 // readBoundedJSON decodes a JSON response body into `v`, refusing to

--- a/internal/license/outcome.go
+++ b/internal/license/outcome.go
@@ -1,0 +1,101 @@
+package license
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Failure taxonomy for license-server interactions (#license-boot-resilience).
+//
+// The boot path routes on ONE question: did the server SPEAK THE PROTOCOL and
+// say "no" (definitive — fall back to OSS, never use the cache), or could we
+// simply not get a protocol answer (transient — retry, then fall back to the
+// locally cached, signature-verified license)?
+//
+// The classification table (from the reviewed plan; server behavior enumerated
+// from enterprise_activation_server handlers):
+//
+//	transport error (DNS/refused/timeout/TLS)        → transient
+//	HTTP 5xx                                          → transient
+//	HTTP 429 (server's own rate limiter)              → transient
+//	HTTP 4xx WITHOUT a protocol JSON body (ingress /
+//	  deploy-window 404s — the field incident)        → transient
+//	HTTP 4xx WITH protocol JSON ("license not found",
+//	  "license is not active", max machines, ...)     → definitive
+//	200 envelope valid:false / success:false          → definitive
+//	  (server spoke protocol and said no; unknown
+//	   error strings default definitive on purpose)
+//	200 malformed / non-protocol body (proxy default) → transient
+//	signature or fingerprint-binding failure          → transient
+//	  (protocol violation or MITM; the cache is
+//	   independently verified, so falling back to it
+//	   cannot be worse than trusting this response)
+//
+// "machine not activated" and "activation has been revoked" are NOT terminal:
+// ActivateOrVerify attempts Activate and the classification of ITS outcome
+// governs. (The revoked case matters because the server's stale-activation
+// reaper revokes any activation without a heartbeat for 72h — a routine
+// condition for stable machines, not an operator decision.)
+
+// FailureClass says how a license-server failure should be treated.
+type FailureClass int
+
+const (
+	// ClassTransient: no protocol answer was obtained. Retry; if retries
+	// exhaust, the verified cache may serve.
+	ClassTransient FailureClass = iota
+	// ClassDefinitive: the server spoke the protocol and rejected. OSS
+	// fallback; the cache MUST NOT override an explicit rejection.
+	ClassDefinitive
+)
+
+// errActivationMissing marks the two verify rejections for which activation is
+// the intended recovery ("machine not activated for this license",
+// "activation has been revoked"); ActivateOrVerify routes on it with
+// errors.Is. Matched exactly at the envelope, never by substring on wrapped
+// messages.
+var errActivationMissing = errors.New("no live activation for this machine")
+
+// classifiedError carries the class through error wrapping.
+type classifiedError struct {
+	class FailureClass
+	err   error
+}
+
+func (e *classifiedError) Error() string { return e.err.Error() }
+func (e *classifiedError) Unwrap() error { return e.err }
+
+func transientErr(format string, args ...any) error {
+	return &classifiedError{class: ClassTransient, err: fmt.Errorf(format, args...)}
+}
+
+func definitiveErr(format string, args ...any) error {
+	return &classifiedError{class: ClassDefinitive, err: fmt.Errorf(format, args...)}
+}
+
+// FailureClassOf extracts the class from an error chain. Unclassified errors
+// (client-side marshal bugs etc.) default to transient: they carry no server
+// verdict, and the cache path independently re-verifies everything it loads.
+func FailureClassOf(err error) FailureClass {
+	var ce *classifiedError
+	if errors.As(err, &ce) {
+		return ce.class
+	}
+	return ClassTransient
+}
+
+// isProtocolJSONBody reports whether an HTTP error body is the license
+// protocol's own JSON error shape (`{"error": "..."}`), as opposed to an
+// ingress/proxy artifact (HTML error page, empty body, plain text). Only a
+// protocol-shaped body makes a 4xx definitive: the field incident was a
+// deploy-window 404 served by the ingress, not by the handler.
+func isProtocolJSONBody(preview string) bool {
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(preview), &body); err != nil {
+		return false
+	}
+	return body.Error != ""
+}

--- a/internal/license/resilience_test.go
+++ b/internal/license/resilience_test.go
@@ -1,0 +1,283 @@
+package license
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// newTestClient builds a client against a fake server with the test keypair
+// pinned and time compressed.
+func newTestClient(t *testing.T, serverURL, cacheDir string) *Client {
+	t.Helper()
+	withTestPublicKey(t, &rsaKey1.PublicKey)
+	origB, origA, origU := bootRetryPhaseBudget, bootRetryAttempts, bootRetryBackoffUnit
+	bootRetryPhaseBudget, bootRetryAttempts, bootRetryBackoffUnit = 3*time.Second, 3, 5*time.Millisecond
+	t.Cleanup(func() {
+		bootRetryPhaseBudget, bootRetryAttempts, bootRetryBackoffUnit = origB, origA, origU
+	})
+	c, err := NewClient(&ClientConfig{LicenseKey: "ARC-ENT-TEST-KEY", CacheDir: cacheDir, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.serverURL = serverURL
+	c.httpClient.Timeout = 2 * time.Second
+	return c
+}
+
+// signedPairFor mints the detached pair the server would emit for this
+// client's key+fingerprint, valid for `d`.
+func signedPairKF(t *testing.T, key, fingerprint string, d time.Duration) (string, string) {
+	t.Helper()
+	return signDetached(t, rsaKey1, &SignedLicense{
+		Version:            1,
+		LicenseKey:         key,
+		CustomerID:         "cust_test",
+		CustomerName:       "Test Co",
+		Tier:               TierEnterprise,
+		MaxCores:           16,
+		MaxMachines:        20,
+		Features:           []string{"tiering"},
+		MachineFingerprint: fingerprint,
+		IssuedAt:           time.Now().UTC().Add(-time.Hour),
+		ExpiresAt:          time.Now().UTC().Add(d),
+	})
+}
+
+func signedPairFor(t *testing.T, c *Client, d time.Duration) (string, string) {
+	t.Helper()
+	return signedPairKF(t, c.licenseKey, c.fingerprint, d)
+}
+
+// TestFailureClassification pins the definitive-vs-transient table against
+// real HTTP responses — the availability/security pivot of the boot path.
+func TestFailureClassification(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    FailureClass
+	}{
+		{"500", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(500) }, ClassTransient},
+		{"429 rate limited", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(429) }, ClassTransient},
+		{"404 ingress HTML (the field incident)", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(404)
+			fmt.Fprint(w, "<html><body>404 page not found</body></html>")
+		}, ClassTransient},
+		{"404 empty body", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(404) }, ClassTransient},
+		{"404 protocol JSON (activate: license not found)", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(404)
+			fmt.Fprint(w, `{"error":"license not found"}`)
+		}, ClassDefinitive},
+		{"403 protocol JSON (not active)", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(403)
+			fmt.Fprint(w, `{"error":"license is not active"}`)
+		}, ClassDefinitive},
+		{"200 valid:false suspended", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"valid":false,"error":"license is suspended"}`)
+		}, ClassDefinitive},
+		{"200 valid:false unknown string defaults definitive", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"valid":false,"error":"some future rejection"}`)
+		}, ClassDefinitive},
+		{"200 malformed body (proxy default backend)", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "<html>default backend</html>")
+		}, ClassTransient},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(tc.handler)
+			defer ts.Close()
+			c := newTestClient(t, ts.URL, "")
+			_, err := c.Verify(context.Background())
+			if err == nil {
+				t.Fatal("want error")
+			}
+			if got := FailureClassOf(err); got != tc.want {
+				t.Fatalf("class = %v, want %v (err: %v)", got, tc.want, err)
+			}
+		})
+	}
+
+	t.Run("transport error", func(t *testing.T) {
+		c := newTestClient(t, "http://127.0.0.1:1", "")
+		_, err := c.Verify(context.Background())
+		if err == nil || FailureClassOf(err) != ClassTransient {
+			t.Fatalf("connection refused must be transient, got %v", err)
+		}
+	})
+}
+
+// TestRevokedActivationReactivates pins the fix for the stale-activation
+// reaper: the server revokes any activation without a heartbeat for 72h (and
+// Arc never sends heartbeats), so "activation has been revoked" is ROUTINE on
+// stable machines — the client must re-activate, exactly as it does for
+// "machine not activated". Without this, every stable-fingerprint deployment
+// crash-loops on its first restart >72h after activation.
+func TestRevokedActivationReactivates(t *testing.T) {
+	var activated bool
+	var c *Client
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/verify"):
+			fmt.Fprint(w, `{"valid":false,"error":"activation has been revoked"}`)
+		case strings.HasSuffix(r.URL.Path, "/activate"):
+			activated = true
+			lf, sig := signedPairFor(t, c, time.Hour)
+			fmt.Fprintf(w, `{"success":true,"license_file":%q,"license_signature":%q}`, lf, sig)
+		}
+	}))
+	defer ts.Close()
+	c = newTestClient(t, ts.URL, "")
+
+	lic, err := c.ActivateOrVerify(context.Background())
+	if err != nil {
+		t.Fatalf("revoked activation must recover via re-activation: %v", err)
+	}
+	if !activated || lic.Tier != TierEnterprise {
+		t.Fatalf("activate not attempted or wrong license: activated=%v", activated)
+	}
+}
+
+// TestCacheGrid pins every rule of LoadCachedLicense — the rules that make a
+// copied cache file useless (license-multiplication defense).
+func TestCacheGrid(t *testing.T) {
+	mk := func(t *testing.T) *Client {
+		return newTestClient(t, "http://127.0.0.1:1", t.TempDir())
+	}
+
+	t.Run("save then load succeeds", func(t *testing.T) {
+		c := mk(t)
+		lf, sig := signedPairFor(t, c, time.Hour)
+		c.saveCache(lf, sig)
+		lic, err := c.LoadCachedLicense()
+		if err != nil || lic.Tier != TierEnterprise {
+			t.Fatalf("load: %v", err)
+		}
+	})
+
+	t.Run("tampered pair rejected", func(t *testing.T) {
+		c := mk(t)
+		lf, sig := signedPairFor(t, c, time.Hour)
+		c.saveCache(lf, sig[:len(sig)-4]+"AAAA")
+		if _, err := c.LoadCachedLicense(); err == nil {
+			t.Fatal("tampered signature must be rejected")
+		}
+	})
+
+	t.Run("expired rejected", func(t *testing.T) {
+		c := mk(t)
+		lf, sig := signedPairFor(t, c, -time.Minute)
+		c.saveCache(lf, sig)
+		if _, err := c.LoadCachedLicense(); err == nil {
+			t.Fatal("expired cache must be rejected — no grace beyond expires_at")
+		}
+	})
+
+	t.Run("different key rejected and deleted", func(t *testing.T) {
+		c := mk(t)
+		lf, sig := signedPairKF(t, "ARC-ENT-OTHER-KEY", c.fingerprint, time.Hour)
+		c.saveCache(lf, sig)
+		if _, err := c.LoadCachedLicense(); err == nil {
+			t.Fatal("stale cache from a replaced key must not resurrect entitlements")
+		}
+		if _, err := c.LoadCachedLicense(); err == nil || !strings.Contains(err.Error(), "unavailable") {
+			t.Fatalf("mismatched cache must be deleted, second load: %v", err)
+		}
+	})
+
+	t.Run("copied cache (foreign fingerprint) rejected", func(t *testing.T) {
+		c := mk(t)
+		lf, sig := signedPairKF(t, c.licenseKey, "sha256:someoneelsesmachine", time.Hour)
+		c.saveCache(lf, sig)
+		if _, err := c.LoadCachedLicense(); err == nil {
+			t.Fatal("a cache copied from another machine must be rejected")
+		}
+	})
+
+	t.Run("UNBOUND pair rejected as cache", func(t *testing.T) {
+		// bindFingerprint accepts empty-as-unbound for online responses; the
+		// cache must NOT — an unbound blob in the cache slot would be a
+		// universal license (this is also what keeps deliverable B's site
+		// files out of the cache path).
+		c := mk(t)
+		lf, sig := signedPairKF(t, c.licenseKey, "", time.Hour)
+		c.saveCache(lf, sig)
+		if _, err := c.LoadCachedLicense(); err == nil {
+			t.Fatal("unbound pair must be rejected as cache")
+		}
+	})
+}
+
+// TestResilientBootFlows pins the boot routing: transient → retry → cache;
+// definitive → OSS with the cache NEVER consulted.
+func TestResilientBootFlows(t *testing.T) {
+	t.Run("transient failures fall back to cache, fully licensed", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(503)
+		}))
+		defer ts.Close()
+		c := newTestClient(t, ts.URL, t.TempDir())
+		lf, sig := signedPairFor(t, c, time.Hour)
+		c.saveCache(lf, sig)
+
+		lic, src, err := c.ActivateOrVerifyResilient(context.Background())
+		if err != nil {
+			t.Fatalf("resilient: %v", err)
+		}
+		if src != SourceCache || lic.Tier != TierEnterprise {
+			t.Fatalf("src=%v tier=%v", src, lic.Tier)
+		}
+	})
+
+	t.Run("definitive rejection never consults cache", func(t *testing.T) {
+		var verifyCalls int
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			verifyCalls++
+			fmt.Fprint(w, `{"valid":false,"error":"license is suspended"}`)
+		}))
+		defer ts.Close()
+		c := newTestClient(t, ts.URL, t.TempDir())
+		lf, sig := signedPairFor(t, c, time.Hour)
+		c.saveCache(lf, sig) // a valid cache exists — and must be ignored
+
+		_, _, err := c.ActivateOrVerifyResilient(context.Background())
+		if err == nil {
+			t.Fatal("definitive rejection must fail to OSS despite a valid cache")
+		}
+		if FailureClassOf(err) != ClassDefinitive {
+			t.Fatalf("class: %v", err)
+		}
+		if verifyCalls != 1 {
+			t.Fatalf("definitive rejection must not be retried, calls=%d", verifyCalls)
+		}
+	})
+
+	t.Run("transient without cache fails as today", func(t *testing.T) {
+		c := newTestClient(t, "http://127.0.0.1:1", t.TempDir())
+		if _, _, err := c.ActivateOrVerifyResilient(context.Background()); err == nil {
+			t.Fatal("no server + no cache must fail (OSS fallback)")
+		}
+	})
+
+	t.Run("server success writes cache usable on next boot", func(t *testing.T) {
+		var c *Client
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			lf, sig := signedPairFor(t, c, time.Hour)
+			fmt.Fprintf(w, `{"valid":true,"success":true,"license_file":%q,"license_signature":%q}`, lf, sig)
+		}))
+		c = newTestClient(t, ts.URL, t.TempDir())
+		if _, src, err := c.ActivateOrVerifyResilient(context.Background()); err != nil || src != SourceServer {
+			t.Fatalf("online boot: %v src=%v", err, src)
+		}
+		ts.Close() // server gone
+		lic, err := c.LoadCachedLicense()
+		if err != nil || lic == nil {
+			t.Fatalf("cache written by success must load: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Field report**: a transient license-server failure (deploy-window ingress 404) crash-looped a customer cluster — 27 writer restarts — because boot made one blocking license check with no retry/cache, and OSS fallback is fatal for enterprise-required configs. License-server availability was a hard runtime dependency of every pod restart.
- Boot now: **bounded retry** (3 attempts, jitter, one 45s phase deadline) → **failure taxonomy** (definitive = server spoke the protocol and said no → OSS immediately, cache never consulted; transient = unreachable/5xx/429/ingress-4xx/malformed → retry then cache) → **signature-verified cached license**, honored until its own `expires_at`, never past it. Cache loads enforce: pinned-key RSA signature, configured-key match (mismatch = reject + delete), **non-empty local-machine fingerprint** (copied caches rejected), expiry.
- **Latent crash-loop fixed**: the server's 72h stale-activation reaper + Arc never sending heartbeats = every stable-fingerprint machine silently revoked 72h after activation, crash-looping on its next restart (masked on EKS by fingerprint churn). Client re-activates on `activation has been revoked` (exact envelope match, sentinel-routed); periodic ticker self-heals. Companion server PR: `/verify` counts as liveness.
- **Helm startupProbe** on all 3 Arc statefulsets (values knob, default 5min) — liveness could kill slow boots (license retries + WAL replay) at ~60s.
- Not in this PR (explicit): offline/air-gapped license files (deliverable B, next); any grace beyond `expires_at`; revocation enforcement while unreachable (bounded by expiry, stated in notes); help for churning-fingerprint fleets (their fix is B).

## Test plan

- [x] Plan adversarially reviewed BEFORE implementation (3 shipping-grade findings folded in: cache-copy attack, 72h-reaper, missing startupProbe); implementation deep-reviewed with security lens — all findings fixed (first-boot MkdirAll, sentinel routing, unbound-pair guard, probe knob, ticker self-heal)
- [x] Classification table pinned against real httptest responses incl. the incident shape (ingress 404 HTML); revoked→re-activate, cache grid (tamper/expired/wrong-key+delete/foreign-fp/unbound), definitive-never-consults-cache (call-counted) — all revert-verified
- [x] 33/33 packages, `-race` clean, gofmt/vet clean, helm lint + template renders 3 probes
- [x] **Live gates against the PRODUCTION license server** (dev key): real activation → cache written 0600; same machine identity + black-holed server → 3 classified retries → boots FULLY LICENSED from cache with loud Warn; no cache → OSS unchanged. Re-run on the final build.
- [x] Non-default exercised: `ARC_AUTH_DB_PATH` at a non-default path drives the cache location in all gates

Companion: `enterprise_activation_server` branch `fix/verify-updates-last-seen` (deploy is a separate operator decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)