### PR TITLE
feat(license): offline air-gapped license files + license state in /health

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -456,7 +456,16 @@ Two more fixes in the same change:
 - **A latent crash-loop nobody had reported yet**: the license server reaps activations that haven't been heard from in 72 hours, but the "heard from" signal was only ever sent by a heartbeat call Arc never made — so any machine with a stable fingerprint was silently revoked 72 hours after activating, and its next restart crash-looped. Arc now re-activates on that condition (a deliberately revoked *license* still refuses definitively), and the license server counts successful verifications as liveness.
 - The Helm chart's Arc pods gain a **startupProbe** (5 minutes of grace): the liveness probe used to be able to kill a legitimately slow boot — license retries plus multi-writer WAL recovery — at about 60 seconds, before the HTTP listener even bound.
 
-Air-gapped, fully offline license files (no server dependency at all) are the follow-up currently in flight.
+**Offline (air-gapped) license files.** For environments that cannot reach `enterprise.basekick.net` at all, an administrator can now download an offline license file from the activation server (an explicit *site license*: unbound, activates any machine until its expiry, acknowledged at mint time and audit-logged) and point Arc at it:
+
+```toml
+[license]
+file_path = "/etc/arc/license.json"   # or ARC_LICENSE_FILE_PATH
+```
+
+`/health` now also carries a `license` field — tier, status, source (`server` / `cache` / `file`), and expiry, with status derived at read time so an expiring license goes visibly non-`active` within a probe interval. A pod whose configured license failed reports `tier: oss, status: unlicensed` instead of being indistinguishable from a healthy one — the silently-degraded state behind the crash-loop incident above. No key material, customer identity, or feature list is exposed. Deployments with no license configured omit the field.
+
+The file is the same signed payload the online activation emits, verified from disk against the pinned public key — **no network calls, ever**: no activation, no periodic validation, no cache. `file_path` wins over `license.key`, and it fails closed: a rejected file means OSS mode, never a silent fallback to online licensing. A file bound to a specific machine (an online activation response) still enforces its binding, and expiry is checked at every boot — a file that expires while a process is running is rejected at the next restart. Verified end-to-end: a production-signed site file boots a fully licensed Arc in a container with **no network attached**.
 
 ### Azure managed-identity credentials on the query path now refresh — and no longer die an hour in ([#605](https://github.com/Basekick-Labs/arc/issues/605))
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -73,6 +73,41 @@ const uploadSubdirName = "arc-uploads"
 // at the same instant its MAC would be rejected as stale.
 const cacheInvalidateHMACTolerance = security.HMACTimestampTolerance
 
+// applyLicenseCoreLimits enforces lic.MaxCores on every execution surface —
+// Go runtime (GOMAXPROCS), DuckDB native threads (cfg.Database.ThreadCount is
+// the REAL DuckDB enforcement; GOMAXPROCS does not bound CGo threads), and
+// ingestion flush workers. Shared by the online, cached and offline-file
+// license paths so no path can partially enforce (a 4-core site license on a
+// 64-core air-gapped box must not run DuckDB with 64 threads).
+func applyLicenseCoreLimits(lic *license.License, cfg *config.Config) {
+	if lic.MaxCores <= 0 {
+		return
+	}
+	machineCores := runtime.NumCPU()
+	if machineCores <= lic.MaxCores {
+		return
+	}
+	previousGOMAXPROCS := runtime.GOMAXPROCS(lic.MaxCores)
+	log.Info().
+		Int("machine_cores", machineCores).
+		Int("licensed_cores", lic.MaxCores).
+		Int("gomaxprocs_before", previousGOMAXPROCS).
+		Int("gomaxprocs_after", lic.MaxCores).
+		Msg("License core limit applied via GOMAXPROCS")
+
+	cfg.Database.ThreadCount = lic.MaxCores
+	log.Info().
+		Int("duckdb_threads", lic.MaxCores).
+		Msg("License core limit applied to DuckDB threads")
+
+	if cfg.Ingest.FlushWorkers > lic.MaxCores {
+		cfg.Ingest.FlushWorkers = lic.MaxCores
+		log.Info().
+			Int("flush_workers", lic.MaxCores).
+			Msg("License core limit applied to ingestion flush workers")
+	}
+}
+
 func main() {
 	// Check for subcommands before loading full config
 	if len(os.Args) > 1 && os.Args[1] == "compact" {
@@ -122,7 +157,28 @@ func main() {
 	// Validate Enterprise License early (before component initialization)
 	// This allows us to apply core limits to DuckDB and ingestion workers
 	var licenseClient *license.Client
-	if cfg.License.Key != "" {
+	if cfg.License.FilePath != "" {
+		// Offline (air-gapped) license file: verified entirely from disk
+		// against the pinned public key — no license-server dependency, no
+		// activation, no periodic validation, no cache. WINS over license.key.
+		// Fail-closed: any error falls through to OSS mode.
+		log.Info().Str("file_path", cfg.License.FilePath).Msg("Loading offline enterprise license file")
+		lc, err := license.NewOfflineClient(cfg.License.FilePath, logger.Get("license"))
+		if err != nil {
+			log.Warn().Err(err).Str("file_path", cfg.License.FilePath).
+				Msg("Offline license file rejected - enterprise features disabled")
+		} else {
+			licenseClient = lc
+			lic := lc.GetLicense()
+			log.Info().
+				Str("tier", string(lic.Tier)).
+				Int("max_cores", lic.MaxCores).
+				Time("expires_at", lic.ExpiresAt).
+				Strs("features", lic.Features).
+				Msg("Enterprise license loaded from offline file")
+			applyLicenseCoreLimits(lic, cfg)
+		}
+	} else if cfg.License.Key != "" {
 		log.Info().
 			Str("license_key", cfg.License.Key[:min(12, len(cfg.License.Key))]+"...").
 			Str("server_url", license.LicenseServerURL).
@@ -169,36 +225,9 @@ func main() {
 						Msg("Enterprise license verified successfully")
 				}
 
-				// Apply core limits from license to config
-				// This ensures DuckDB and ingestion workers respect the license
-				if lic.MaxCores > 0 {
-					machineCores := runtime.NumCPU()
-
-					if machineCores > lic.MaxCores {
-						// Limit Go runtime to licensed cores - this is the real enforcement
-						previousGOMAXPROCS := runtime.GOMAXPROCS(lic.MaxCores)
-						log.Info().
-							Int("machine_cores", machineCores).
-							Int("licensed_cores", lic.MaxCores).
-							Int("gomaxprocs_before", previousGOMAXPROCS).
-							Int("gomaxprocs_after", lic.MaxCores).
-							Msg("License core limit applied via GOMAXPROCS")
-
-						// Also set DuckDB thread count to match
-						cfg.Database.ThreadCount = lic.MaxCores
-						log.Info().
-							Int("duckdb_threads", lic.MaxCores).
-							Msg("License core limit applied to DuckDB threads")
-
-						// Limit ingestion flush workers to licensed cores
-						if cfg.Ingest.FlushWorkers > lic.MaxCores {
-							cfg.Ingest.FlushWorkers = lic.MaxCores
-							log.Info().
-								Int("flush_workers", lic.MaxCores).
-								Msg("License core limit applied to ingestion flush workers")
-						}
-					}
-				}
+				// Apply core limits from license to config (shared with the
+				// offline-file path).
+				applyLicenseCoreLimits(lic, cfg)
 			}
 		}
 	} else {
@@ -1706,6 +1735,19 @@ func main() {
 	}
 
 	server := api.NewServer(serverConfig, logger.Get("server"))
+
+	// /health "license" field: reports the live client when licensed; when a
+	// license was CONFIGURED but failed (rejected file, definitive server
+	// rejection, unreachable+no-cache), reports tier "oss"/"unlicensed" —
+	// the silently-degraded state behind the 27-restart field incident.
+	// Absent entirely when no license is configured.
+	if licenseClient != nil {
+		server.SetLicenseStatus(licenseClient.HealthStatus)
+	} else if cfg.License.FilePath != "" || cfg.License.Key != "" {
+		server.SetLicenseStatus(func() license.LicenseHealth {
+			return license.LicenseHealth{Tier: "oss", Status: "unlicensed", Source: "none"}
+		})
+	}
 
 	// #603: surface per-tier storage credential state in /health (and /ready
 	// when the knob is set). In-memory reads from the credential refresher —

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/basekick-labs/arc/internal/auth"
 	"github.com/basekick-labs/arc/internal/database"
 	"github.com/basekick-labs/arc/internal/fips"
+	"github.com/basekick-labs/arc/internal/license"
 	"github.com/basekick-labs/arc/internal/logger"
 	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/gofiber/fiber/v2"
@@ -62,6 +63,16 @@ type Server struct {
 	// deployments may be healthy or permanently credential-less by design and
 	// must not flap the LB.
 	storageCredsFailReady bool
+
+	// licenseStatus supplies the /health "license" field: tier/status/source/
+	// expiry only — no key material, no customer identity, no feature list
+	// (unauthenticated endpoint, same posture as the "storage" field). Wired
+	// by main.go whenever a license is CONFIGURED — including the
+	// configured-but-failed case, which reports tier "oss"/status
+	// "unlicensed" so monitoring catches a pod that silently fell back
+	// (the invisible state behind the 27-restart field incident). Absent for
+	// deployments with no license configured at all.
+	licenseStatus func() license.LicenseHealth
 }
 
 // ServerConfig holds server configuration
@@ -220,6 +231,11 @@ func (s *Server) RegisterLogsRoute(authManager *auth.AuthManager) {
 	s.app.Get("/api/v1/logs", withAdminAuth(authManager), s.logsHandler)
 }
 
+// SetLicenseStatus wires the /health "license" field source.
+func (s *Server) SetLicenseStatus(fn func() license.LicenseHealth) {
+	s.licenseStatus = fn
+}
+
 // SetStorageStatus wires the per-tier storage credential status source
 // (database.DuckDB.StorageCredentialStatus) into /health and, when
 // server.storage_credentials_fail_ready is set, /ready. failReady gates the
@@ -256,6 +272,9 @@ func (s *Server) healthHandler(c *fiber.Ctx) error {
 		if st := s.storageStatus(); len(st) > 0 {
 			payload["storage"] = st
 		}
+	}
+	if s.licenseStatus != nil {
+		payload["license"] = s.licenseStatus()
 	}
 	return c.JSON(payload)
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/license"
 
 	"github.com/rs/zerolog"
 )
@@ -349,6 +350,56 @@ func TestReadyStorageCredentialsKnob(t *testing.T) {
 		s.SetStorageStatus(statusFn("ok"), true)
 		if code := get(s); code != 503 {
 			t.Fatalf("code = %d, want 503 (startup gating untouched)", code)
+		}
+	})
+}
+
+// TestHealthLicenseField: /health carries the license field when wired
+// (including the configured-but-failed "unlicensed" state — the silently
+// degraded mode behind the 27-restart field incident), and omits it when no
+// license is configured.
+func TestHealthLicenseField(t *testing.T) {
+	get := func(s *Server) map[string]any {
+		t.Helper()
+		s.RegisterRoutes()
+		resp, err := s.app.Test(httptest.NewRequest("GET", "/health", nil), 2000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		return body
+	}
+
+	t.Run("absent when not wired", func(t *testing.T) {
+		s := NewServer(DefaultServerConfig(), zerolog.Nop())
+		if _, ok := get(s)["license"]; ok {
+			t.Fatal("license field must be absent when no license is configured")
+		}
+	})
+
+	t.Run("licensed", func(t *testing.T) {
+		s := NewServer(DefaultServerConfig(), zerolog.Nop())
+		exp := time.Now().UTC().Add(24 * time.Hour)
+		s.SetLicenseStatus(func() license.LicenseHealth {
+			return license.LicenseHealth{Tier: "enterprise", Status: "active", Source: "file", ExpiresAt: &exp, SiteLicense: true}
+		})
+		lic := get(s)["license"].(map[string]any)
+		if lic["tier"] != "enterprise" || lic["status"] != "active" || lic["source"] != "file" || lic["site_license"] != true {
+			t.Fatalf("license = %v", lic)
+		}
+	})
+
+	t.Run("configured but unlicensed is visible", func(t *testing.T) {
+		s := NewServer(DefaultServerConfig(), zerolog.Nop())
+		s.SetLicenseStatus(func() license.LicenseHealth {
+			return license.LicenseHealth{Tier: "oss", Status: "unlicensed", Source: "none"}
+		})
+		lic := get(s)["license"].(map[string]any)
+		if lic["status"] != "unlicensed" {
+			t.Fatalf("license = %v", lic)
 		}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -430,6 +430,12 @@ type QueryConfig struct {
 type LicenseConfig struct {
 	Enabled bool   // Enable license validation (default: false)
 	Key     string // License key (ARC-ENT-XXXX-XXXX-XXXX-XXXX)
+	// FilePath points at an offline license file downloaded from the
+	// activation server admin ({license_file, license_signature}). When set it
+	// WINS over Key: the license is verified entirely from disk against the
+	// pinned public key — no network calls, no activation, no periodic
+	// re-validation. The air-gapped path.
+	FilePath string
 }
 
 // SchedulerConfig holds configuration for automatic schedulers (Enterprise features)
@@ -901,8 +907,9 @@ func Load() (*Config, error) {
 			S3CacheTTLSeconds:    v.GetInt("query.s3_cache_ttl_seconds"),
 		},
 		License: LicenseConfig{
-			Enabled: v.GetBool("license.enabled"),
-			Key:     v.GetString("license.key"),
+			Enabled:  v.GetBool("license.enabled"),
+			Key:      v.GetString("license.key"),
+			FilePath: strings.TrimSpace(v.GetString("license.file_path")),
 		},
 		Scheduler: SchedulerConfig{
 			RetentionSchedule: v.GetString("scheduler.retention_schedule"),
@@ -1548,6 +1555,7 @@ func setDefaults(v *viper.Viper) {
 	// Note: Server URL and validation interval are hardcoded in internal/license/client.go
 	v.SetDefault("license.enabled", false) // Disabled by default
 	v.SetDefault("license.key", "")        // Must be provided
+	v.SetDefault("license.file_path", "")  // Offline license file (air-gapped); wins over license.key
 
 	// Scheduler defaults (Enterprise features)
 	// Note: CQ and retention schedulers are auto-enabled when their features are enabled AND license allows

--- a/internal/license/cache.go
+++ b/internal/license/cache.go
@@ -167,6 +167,7 @@ func (c *Client) LoadCachedLicense() (*License, error) {
 	lic := signed.ToRuntimeLicense(now)
 	c.mu.Lock()
 	c.license = lic
+	c.source = SourceCache
 	c.mu.Unlock()
 	return lic, nil
 }
@@ -224,4 +225,54 @@ func (c *Client) ActivateOrVerifyResilient(ctx context.Context) (*License, Licen
 		return nil, SourceServer, fmt.Errorf("license server unreachable and no usable cache: %w", lastErr)
 	}
 	return lic, SourceCache, nil
+}
+
+// SourceFile marks an offline license file (NewOfflineClient).
+const SourceFile LicenseSource = "file"
+
+// LicenseHealth is the /health "license" payload: enough for monitoring to
+// catch "running but unlicensed/expiring", nothing more. Deliberately
+// excludes the license key, customer identity, and the feature list — /health
+// is unauthenticated (see the decision comments in internal/api/server.go).
+type LicenseHealth struct {
+	Tier          string     `json:"tier"`
+	Status        string     `json:"status"`
+	Source        string     `json:"source"`
+	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
+	DaysRemaining int        `json:"days_remaining,omitempty"`
+	SiteLicense   bool       `json:"site_license,omitempty"`
+}
+
+// HealthStatus reports the current license for /health. Status is derived at
+// READ time against the clock (the #603 lesson): enforcement stays boot-time,
+// but health tells the truth — a license that expires mid-process shows
+// "expired" here within a probe interval, even though features remain enabled
+// until the next restart rejects it.
+func (c *Client) HealthStatus() LicenseHealth {
+	c.mu.RLock()
+	lic := c.license
+	src := c.source
+	c.mu.RUnlock()
+	if lic == nil {
+		return LicenseHealth{Tier: "oss", Status: "unlicensed", Source: string(src)}
+	}
+	status := lic.Status
+	now := time.Now().UTC()
+	days := 0
+	if !lic.ExpiresAt.IsZero() {
+		if !now.Before(lic.ExpiresAt) {
+			status = "expired"
+		} else {
+			days = int(time.Until(lic.ExpiresAt).Hours() / 24)
+		}
+	}
+	exp := lic.ExpiresAt.UTC()
+	return LicenseHealth{
+		Tier:          string(lic.Tier),
+		Status:        status,
+		Source:        string(src),
+		ExpiresAt:     &exp,
+		DaysRemaining: days,
+		SiteLicense:   c.offline && c.fingerprint == "",
+	}
 }

--- a/internal/license/client.go
+++ b/internal/license/client.go
@@ -48,11 +48,18 @@ type Client struct {
 	licenseKey  string
 	fingerprint string
 	cacheDir    string
-	httpClient  *http.Client
-	license     *License
-	mu          sync.RWMutex
-	stopCh      chan struct{}
-	logger      zerolog.Logger
+	// offline marks a file-mode client (NewOfflineClient): network-free, no
+	// periodic validation, no cache.
+	offline bool
+	// source says where the CURRENT license came from ("server", "cache",
+	// "file") for /health; guarded by mu. A cache-boot flips to "server" on
+	// the first successful background verify.
+	source     LicenseSource
+	httpClient *http.Client
+	license    *License
+	mu         sync.RWMutex
+	stopCh     chan struct{}
+	logger     zerolog.Logger
 }
 
 // VerifyRequest represents a license verification request
@@ -152,6 +159,9 @@ type ActivateResponse struct {
 
 // Activate registers this machine with the license server
 func (c *Client) Activate(ctx context.Context) (*License, error) {
+	if c.offline {
+		return nil, fmt.Errorf("license client is in offline file mode; network operations are disabled")
+	}
 	url := fmt.Sprintf("%s/api/v1/activate", c.serverURL)
 
 	hostname, _ := os.Hostname()
@@ -231,6 +241,7 @@ func (c *Client) Activate(ctx context.Context) (*License, error) {
 	// Store the license
 	c.mu.Lock()
 	c.license = license
+	c.source = SourceServer
 	c.mu.Unlock()
 
 	// Persist the verified pair for boot resilience (see cache.go).
@@ -249,6 +260,9 @@ func (c *Client) Activate(ctx context.Context) (*License, error) {
 
 // Verify validates the license with the enterprise server
 func (c *Client) Verify(ctx context.Context) (*License, error) {
+	if c.offline {
+		return nil, fmt.Errorf("license client is in offline file mode; network operations are disabled")
+	}
 	url := fmt.Sprintf("%s/api/v1/verify", c.serverURL)
 
 	c.logger.Debug().
@@ -316,6 +330,7 @@ func (c *Client) Verify(ctx context.Context) (*License, error) {
 	// Store the license
 	c.mu.Lock()
 	c.license = license
+	c.source = SourceServer
 	c.mu.Unlock()
 
 	// Persist the verified pair for boot resilience (see cache.go).
@@ -361,6 +376,10 @@ func (c *Client) ActivateOrVerify(ctx context.Context) (*License, error) {
 
 // StartPeriodicValidation starts background license validation
 func (c *Client) StartPeriodicValidation(interval time.Duration) {
+	if c.offline {
+		c.logger.Debug().Msg("offline license mode: periodic validation disabled")
+		return
+	}
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()

--- a/internal/license/offline.go
+++ b/internal/license/offline.go
@@ -1,0 +1,100 @@
+package license
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Offline (air-gapped) license file support — deliverable B of the reviewed
+// plan behind #608's boot resilience. The file is the SAME detached pair the
+// online endpoints emit ({license_file, license_signature}; extra fields such
+// as the human-readable "summary" are ignored), downloaded from the activation
+// server admin and pointed at via license.file_path / ARC_LICENSE_FILE_PATH.
+//
+// Source-context rules (deliberately different from the boot cache):
+//   - The offline file MAY be unbound (empty fingerprint): it is a site
+//     license by design — one file activates any machine until expiry,
+//     acknowledged at mint time and audit-logged server-side.
+//   - A BOUND pair in the file slot still binds: a non-empty signed
+//     fingerprint must match this machine (someone pointing file_path at a
+//     copied online response gets the online rules, not a bypass).
+//   - The boot CACHE, by contrast, requires a non-empty matching fingerprint
+//     (cache.go) — so an offline file dropped into the cache slot is rejected
+//     there, and the two paths cannot be confused into weakening each other.
+//
+// Offline mode is network-free, full stop: no activation, no verification
+// calls, no periodic re-validation, no cache. Expiry is enforced AT LOAD —
+// a file that expires mid-process keeps its features until the next restart
+// rejects it (consistent with the boot-only enforcement philosophy of the
+// resilience work; do not claim runtime expiry enforcement in docs).
+// Fail-closed: any error → OSS.
+
+// offlineFile is the accepted file shape; unknown fields (summary) ignored.
+type offlineFile struct {
+	LicenseFile      string `json:"license_file"`
+	LicenseSignature string `json:"license_signature"`
+}
+
+// NewOfflineClient builds a license client whose license comes entirely from
+// the file at path. The returned client never contacts the license server:
+// StartPeriodicValidation on it is a no-op, and there is no cache.
+func NewOfflineClient(path string, logger zerolog.Logger) (*Client, error) {
+	c := &Client{
+		licenseKey: "", // no key in file mode; the signed payload is authoritative
+		offline:    true,
+		stopCh:     make(chan struct{}),
+		logger:     logger.With().Str("component", "license-offline").Logger(),
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("offline license file unreadable: %w", err)
+	}
+	var f offlineFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("offline license file malformed: %w", err)
+	}
+	if f.LicenseFile == "" || f.LicenseSignature == "" {
+		return nil, fmt.Errorf("offline license file missing license_file/license_signature")
+	}
+	signed, err := VerifyLicenseFile(f.LicenseFile, f.LicenseSignature)
+	if err != nil {
+		return nil, fmt.Errorf("offline license verification failed: %w", err)
+	}
+	// Bound files still bind; empty = unbound site license (allowed HERE, and
+	// only here — see the source-context rules above). The fingerprint is
+	// generated LAZILY, only for bound files: an unbound site license must not
+	// fail on a box where fingerprinting fails — exotic air-gapped hardware is
+	// exactly this feature's audience (#B review MED-4).
+	if signed.MachineFingerprint != "" {
+		fingerprint, err := GenerateMachineFingerprint()
+		if err != nil {
+			return nil, fmt.Errorf("offline license is machine-bound but fingerprinting failed: %w", err)
+		}
+		c.fingerprint = fingerprint
+		if err := c.bindFingerprint(signed); err != nil {
+			return nil, fmt.Errorf("offline license verification failed: %w", err)
+		}
+	}
+	now := time.Now().UTC()
+	if !now.Before(signed.ExpiresAt) {
+		return nil, fmt.Errorf("offline license expired at %s", signed.ExpiresAt.UTC().Format(time.RFC3339))
+	}
+
+	lic := signed.ToRuntimeLicense(now)
+	c.mu.Lock()
+	c.license = lic
+	c.source = SourceFile
+	c.mu.Unlock()
+
+	c.logger.Info().
+		Str("tier", string(lic.Tier)).
+		Time("expires_at", lic.ExpiresAt).
+		Bool("site_license", signed.MachineFingerprint == "").
+		Msg("offline license loaded and verified")
+	return c, nil
+}

--- a/internal/license/offline_test.go
+++ b/internal/license/offline_test.go
@@ -1,0 +1,158 @@
+package license
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func writeOfflineFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "license.json")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestOfflineClientGrid pins the file loader's source-context rules: unbound
+// site files load; bound files still bind; everything else fails closed.
+func TestOfflineClientGrid(t *testing.T) {
+	withTestPublicKey(t, &rsaKey1.PublicKey)
+	localFP, err := GenerateMachineFingerprint()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mint := func(fp string, d time.Duration) (string, string) {
+		return signedPairKF(t, "ARC-ENT-SITE-KEY", fp, d)
+	}
+
+	t.Run("unbound site file loads with full entitlements", func(t *testing.T) {
+		lf, sig := mint("", time.Hour)
+		path := writeOfflineFile(t, `{"license_file":"`+lf+`","license_signature":"`+sig+`","summary":{"note":"ignored"}}`)
+		c, err := NewOfflineClient(path, zerolog.Nop())
+		if err != nil {
+			t.Fatalf("unbound site file must load: %v", err)
+		}
+		lic := c.GetLicense()
+		if lic.Tier != TierEnterprise || !lic.IsValid() {
+			t.Fatalf("license: %+v", lic)
+		}
+	})
+
+	t.Run("bound-to-this-machine file loads", func(t *testing.T) {
+		lf, sig := mint(localFP, time.Hour)
+		path := writeOfflineFile(t, `{"license_file":"`+lf+`","license_signature":"`+sig+`"}`)
+		if _, err := NewOfflineClient(path, zerolog.Nop()); err != nil {
+			t.Fatalf("bound-to-local file must load: %v", err)
+		}
+	})
+
+	t.Run("bound-to-other-machine file rejected", func(t *testing.T) {
+		lf, sig := mint("sha256:someoneelse", time.Hour)
+		path := writeOfflineFile(t, `{"license_file":"`+lf+`","license_signature":"`+sig+`"}`)
+		if _, err := NewOfflineClient(path, zerolog.Nop()); err == nil {
+			t.Fatal("a pair bound to another machine must not load from file_path")
+		}
+	})
+
+	t.Run("tampered signature rejected", func(t *testing.T) {
+		lf, sig := mint("", time.Hour)
+		path := writeOfflineFile(t, `{"license_file":"`+lf+`","license_signature":"`+sig[:len(sig)-4]+`AAAA"}`)
+		if _, err := NewOfflineClient(path, zerolog.Nop()); err == nil {
+			t.Fatal("tampered file must be rejected")
+		}
+	})
+
+	t.Run("expired rejected", func(t *testing.T) {
+		lf, sig := mint("", -time.Minute)
+		path := writeOfflineFile(t, `{"license_file":"`+lf+`","license_signature":"`+sig+`"}`)
+		if _, err := NewOfflineClient(path, zerolog.Nop()); err == nil {
+			t.Fatal("expired file must be rejected")
+		}
+	})
+
+	t.Run("missing file / malformed / empty fields rejected", func(t *testing.T) {
+		if _, err := NewOfflineClient(filepath.Join(t.TempDir(), "nope.json"), zerolog.Nop()); err == nil {
+			t.Fatal("missing file")
+		}
+		if _, err := NewOfflineClient(writeOfflineFile(t, "not json"), zerolog.Nop()); err == nil {
+			t.Fatal("malformed")
+		}
+		if _, err := NewOfflineClient(writeOfflineFile(t, `{"license_file":""}`), zerolog.Nop()); err == nil {
+			t.Fatal("empty fields")
+		}
+	})
+
+	t.Run("periodic validation is a no-op in offline mode", func(t *testing.T) {
+		lf, sig := mint("", time.Hour)
+		path := writeOfflineFile(t, `{"license_file":"`+lf+`","license_signature":"`+sig+`"}`)
+		c, err := NewOfflineClient(path, zerolog.Nop())
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Must not panic/spawn network activity; Stop must be clean.
+		c.StartPeriodicValidation(time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
+		c.Stop()
+	})
+
+	t.Run("offline file rejected by the boot CACHE gates", func(t *testing.T) {
+		// The two source contexts must not weaken each other: an unbound site
+		// file dropped into license_cache.json fails the cache's non-empty
+		// fingerprint gate.
+		lf, sig := mint("", time.Hour)
+		dir := t.TempDir()
+		c := newTestClient(t, "http://127.0.0.1:1", dir)
+		c.licenseKey = "ARC-ENT-SITE-KEY" // even with matching key...
+		if err := os.WriteFile(filepath.Join(dir, cacheFileName),
+			[]byte(`{"license_file":"`+lf+`","license_signature":"`+sig+`"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.LoadCachedLicense(); err == nil {
+			t.Fatal("unbound site file must be rejected as a cache")
+		}
+	})
+}
+
+// TestLicenseHealthStatus pins the /health license payload: source labels,
+// read-time expired derivation (#603 lesson — health tells the truth even
+// though enforcement is boot-time), and the site-license flag.
+func TestLicenseHealthStatus(t *testing.T) {
+	withTestPublicKey(t, &rsaKey1.PublicKey)
+
+	t.Run("offline site file reports file source + site flag", func(t *testing.T) {
+		lf, sig := signedPairKF(t, "ARC-ENT-SITE-KEY", "", time.Hour)
+		path := writeOfflineFile(t, `{"license_file":"`+lf+`","license_signature":"`+sig+`"}`)
+		c, err := NewOfflineClient(path, zerolog.Nop())
+		if err != nil {
+			t.Fatal(err)
+		}
+		h := c.HealthStatus()
+		if h.Source != "file" || !h.SiteLicense || h.Tier != string(TierEnterprise) || h.Status != "active" {
+			t.Fatalf("health = %+v", h)
+		}
+	})
+
+	t.Run("expired derives at read time", func(t *testing.T) {
+		c := &Client{license: &License{Tier: TierEnterprise, Status: "active",
+			ExpiresAt: time.Now().UTC().Add(50 * time.Millisecond)}, source: SourceCache}
+		if h := c.HealthStatus(); h.Status != "active" || h.Source != "cache" {
+			t.Fatalf("pre-expiry: %+v", h)
+		}
+		time.Sleep(60 * time.Millisecond)
+		if h := c.HealthStatus(); h.Status != "expired" {
+			t.Fatalf("post-expiry (same frozen license!): %+v", h)
+		}
+	})
+
+	t.Run("nil license reports unlicensed", func(t *testing.T) {
+		c := &Client{}
+		if h := c.HealthStatus(); h.Tier != "oss" || h.Status != "unlicensed" {
+			t.Fatalf("health = %+v", h)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Deliverable B** of the boot-resilience plan (companion to #608): `license.file_path` / `ARC_LICENSE_FILE_PATH` loads an admin-minted offline license file, verified from disk against the pinned public key — **zero network dependency** (no activation, periodic validation, or cache). Wins over `license.key`; fails closed to OSS (never a silent fallback to online licensing).
- Source-context rules keep the paths from weakening each other: offline files may be **unbound site licenses** (mint-time ack, audit-logged server-side); bound pairs still bind; the boot cache still rejects unbound blobs. Lazy fingerprinting for unbound files (review finding — air-gapped boxes where fingerprinting fails are this feature's audience).
- `applyLicenseCoreLimits` shared helper (review High): file mode now gets the online path's **full** core enforcement — GOMAXPROCS + DuckDB native threads + flush workers.
- **`/health` gains a `license` field**: tier / status / source (`server`/`cache`/`file`) / expiry, status derived at read time; a configured-but-failed license reports `oss/unlicensed` — the invisible state behind the 27-restart field incident. No key/customer/feature-list exposure.

## Test plan

- [x] Deep review (security lens) — all findings fixed; bind + expiry checks revert-verified; 33/33 packages, `-race` clean
- [x] Offline grid (unbound/bound-this/bound-other/tamper/expired/missing/malformed), cross-context cache rejection both directions, health-status derivation (read-time expiry), API-level `/health` field tests incl. the `unlicensed` state
- [x] **Live, twice**: production-signed site file boots fully licensed with `--network none`
- [x] **Operator-verified end-to-end**: minted via the admin UI button, loaded on a disconnected laptop — licensed boot, core caps applied (8/14), and a hand-tampered payload rejected to OSS
- [x] Non-default exercised: `ARC_LICENSE_FILE_PATH` is the live-gate path; `ARC_AUTH_DB_PATH` non-default in prior gates

Companions (merged): activation-server #4 (mint endpoint + UI button), #5 (quoting fix), docs #35.