### PR TITLE
fix(edgesync): close the four audit blockers before 26.09.1

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -244,13 +244,15 @@ max_reconcile_entries = 10000      # ~2MB per discovery batch
 
 With it enabled, `POST /api/v1/sync/file` accepts an authenticated file push from a registered spoke, and `POST /api/v1/sync/reconcile` answers — in **one round-trip** — which of a spoke's pending files the hub already holds. That second endpoint is what makes a long disconnection survivable: a spoke returning with 5,000 pending files asks once rather than 5,000 times, and any file whose acknowledgment was lost is discovered in bulk rather than re-uploaded. Every upload is streamed to a staging area, hashed on the way in, and **verified before it is promoted** to its final location — a checksum mismatch is discarded and never appears where a reader would find it. Redelivering a file the hub already holds is a no-op; the same path arriving with *different* content is refused with `409` rather than overwritten, because one of the two copies is wrong and silently replacing either destroys the evidence.
 
-Two independent authentication layers apply: Arc's API token middleware, and a per-spoke HMAC binding the spoke, the hub, the path, and the content digest.
+Two independent authentication layers apply: Arc's API token middleware (write level — the endpoints are ingest-shaped, and a spoke should not hold admin credentials), and a per-spoke HMAC binding the spoke, the hub, the path, and the content digest. The spoke presents both: the HMAC is derived from its secret, and the API token comes from a second environment-only credential, `ARC_EDGE_SYNC_HUB_TOKEN` — any hub token with write permission. A spoke without it gets a `401` whose error text names the variable, and warns at startup. Only a hub running with auth disabled needs none.
 
 **Spokes are registered through the API.** `POST /api/v1/sync-spokes` generates a cryptographically random secret and returns it **once** — it is never readable again, so an operator who loses it rotates rather than retrieves. Secrets are encrypted at rest with `ARC_ENCRYPTION_KEY`, the same key MQTT uses for broker passwords; a hub enabled without that key **refuses to start** rather than storing write credentials in a database that also holds audit logs. Spokes can be listed, rotated, disabled (reversible, keeping history and counters), and deleted — deleting a registration deliberately leaves the files that spoke already sent.
 
 Reconcile is answered from a hub-side index of received files rather than by reading Parquet, so it stays cheap regardless of backlog size and works identically on a standalone hub and a clustered one. A batch larger than `max_reconcile_entries` is refused with `413` and the limit, so a spoke pages rather than sending an unbounded body — the request body is buffered before authentication, so an uncapped batch would be a memory claim by an unauthenticated caller.
 
 Resume is supported on local storage. On S3 and Azure a dropped transfer restarts from zero, because block objects cannot be appended to; this is a throughput cost on intermittent links, not a correctness problem.
+
+Abandoned partial uploads are swept from the staging area hourly once they are older than `edge_sync.staging_sweep_max_age_hours` (default 72 — deliberately longer than a plausible contact gap, because a staged partial is also the spoke's resume checkpoint; 0 disables the sweep).
 
 ### The spoke side
 
@@ -264,10 +266,13 @@ spoke_id = "rocket-01"                # this spoke's ID, as registered on the hu
 hub_id = "ground-station"             # the REMOTE hub's edge_sync.hub_id
 max_attempts = 5                      # attempts before a file is marked failed
 max_concurrent = 2                    # simultaneous transfers
-batch_size = 0                        # files per reconcile round-trip; 0 = hub default
+batch_size = 1000                     # files per reconcile round-trip; 0 = whole backlog at once
+ledger_retention_days = 90            # prune synced/skipped ledger rows; 0 = never
 ```
 
-The secret is **environment-only**: `ARC_EDGE_SYNC_SPOKE_SECRET`, the value the hub returned once at registration. A secret in the config file is **refused at startup** rather than ignored — one that is ignored still leaks, and leaving it in place makes the committed copy look load-bearing. `hub_id` is validated at load for the same reason it is easy to get wrong: it is bound into every request MAC, so a mismatch fails *every* request with a `400` that looks like a hub problem.
+A reconcile page the hub refuses as too large (over its `max_reconcile_entries`, or its byte limit) is **split and retried within the same pass** — the 413 carries the hub's cap, and the agent adapts to it. No `batch_size` value can leave a backlog undrainable.
+
+The secret is **environment-only**: `ARC_EDGE_SYNC_SPOKE_SECRET`, the value the hub returned once at registration; the hub API token is `ARC_EDGE_SYNC_HUB_TOKEN`, handled the same way. A secret in the config file is **refused at startup** rather than ignored — one that is ignored still leaks, and leaving it in place makes the committed copy look load-bearing. `hub_id` is validated at load for the same reason it is easy to get wrong: it is bound into every request MAC, so a mismatch fails *every* request with a `400` that looks like a hub problem.
 
 Three admin endpoints drive it:
 
@@ -280,6 +285,10 @@ Three admin endpoints drive it:
 A pass recovers transfers interrupted by a crash, discovers new files, reconciles the backlog, and streams what the hub lacks — **newest first**, so a contact window that closes mid-backlog has already delivered the freshest telemetry. It **pages until the backlog drains**, so one pass on a spoke returning from a long outage moves everything, not just the first batch. Conflicts are reported in full rather than counted and are not retried: the same path holding different content means a spoke-ID collision or corruption, and re-sending would either be refused or destroy evidence.
 
 Files are hashed once at discovery, and the ledger survives restarts, so a spoke re-run after a crash neither re-hashes nor re-sends what already landed. Nothing is deleted from the spoke — sync is a copy, and local retention stays in the operator's hands.
+
+**A tracked file that vanishes before delivery is marked `skipped`, not retried.** Compaction (on by default) rewrites raw Parquet and deletes the sources; retention deletes whole partitions. A file caught by either after discovery but before delivery has nothing left to send — the ledger records it as `skipped` (reported in `/status` and each pass/export result) instead of burning the retry budget or, on the air-gap path, failing the export outright. The check is deliberately one-directional: only a storage backend positively reporting the file gone skips it; a transient storage error never does. Terminal rows (`synced`, `skipped`) are pruned automatically after `ledger_retention_days`.
+
+**Compaction on a syncing spoke duplicates rows on the hub.** Raw files synced before compaction stay on the hub; the compacted file carrying the same rows then syncs as a new path, and hub queries over that partition double-count. Until hub-side supersede logic ships, either disable compaction on databases a spoke syncs, or account for duplicates in hub queries.
 
 ### Air-gap bundles
 
@@ -440,6 +449,26 @@ The fix rejects, in `ValidateSQLRequest` (before any transform or RBAC check run
 Reachable only when RBAC is enabled (the multi-tenant authorization boundary); no CVE is being filed, as it is a residual of GHSA-93cm scoped to within the allow-list, tracked under the advisory above. Reported by [@arpitjain099](https://github.com/arpitjain099).
 
 ## Bug fixes
+
+### Quoted identifiers in SQL now resolve to storage paths
+
+`SELECT * FROM "my-db".cpu` used to return zero rows, silently. The query
+layer masked double-quoted tokens as if they were string literals, so the
+quotes were spliced back **inside** the generated `read_parquet` glob —
+`…/"my-db"/cpu/**` — a literal directory that never exists. Since a hyphenated
+name *must* be quoted (unquoted it is a SQL parser error), any database or
+measurement with a hyphen was unqueryable by any syntax. Edge sync made this
+mainline: the hub stores each spoke's data under the spoke ID, and every
+spoke-ID example in the docs is hyphenated.
+
+Double-quoted tokens are now masked as a distinct identifier class, resolved
+to their unquoted names (and validated — a quoted identifier carrying path
+characters is refused rather than globbed) before storage paths are built.
+The RBAC permission extractor resolves the same way, so quoted references are
+permission-checked under their real names, and the cross-database rejection
+for `x-arc-database` requests now sees quoted `db.table` syntax too. Quoted
+CTE names, quoted column names, and string literals that merely *contain*
+table-like text all behave as before.
 
 ### License-server outages no longer crash-loop Enterprise clusters ([field report])
 
@@ -846,7 +875,7 @@ The forwarding-header and loop-guard changes are cluster-only; the partition-pru
 2. **No API or on-disk format changes.** Reads, queries, and storage layout are untouched. Queries with a start date earlier than `1970-01-01` are pruned from the epoch forward; since Arc stores no pre-epoch data, results are unchanged.
 3. **Clustered operators:** if any external tooling deliberately sets `X-Arc-Forwarded-By`, `X-Real-IP`, or `X-Forwarded-*` headers on requests to Arc and expects them to survive an inter-node forward, note that these are now stripped on the forwarding hop and re-established by Arc. Client IP has never been derived from these headers, so log/audit attribution is unchanged.
 4. **Active licenses keep working.** No re-activation required.
-5. **Edge sync is off by default and nothing changes unless you enable it.** With `edge_sync.enabled=false` (the default) the hub mounts no routes and `/api/v1/sync/file` returns 404. With `edge_sync.spoke.enabled=false` (the default) no spoke routes are mounted, no `sync_ledger` or `sync_history` tables are created, and nothing is read from local storage. Both sides are independent: a hub need not be a spoke, and a spoke need not be a hub.
+5. **Edge sync is off by default and nothing changes unless you enable it.** With `edge_sync.enabled=false` (the default) the hub mounts no routes and `/api/v1/sync/file` returns 404. With `edge_sync.spoke.enabled=false` (the default) no spoke routes are mounted, no `sync_ledger` or `sync_history` tables are created, and nothing is read from local storage. Both sides are independent: a hub need not be a spoke, and a spoke need not be a hub. (One related change applies everywhere: the quoted-identifier query fix under Bug fixes — quoted names now resolve instead of returning zero rows.)
 
 ## Dependencies
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2180,6 +2180,42 @@ func main() {
 				log.Fatal().Err(err).Msg("Failed to create edge sync handler; refusing to start")
 			}
 			syncHandler.RegisterRoutes(server.GetApp())
+
+			// Hourly staging sweep. A spoke that declares a large upload, sends
+			// a few bytes, and never returns leaves a partial in .sync-staging;
+			// without this nothing ever reclaims that space and the staging
+			// area grows without bound (the receiver's own doc-comment calls
+			// out the DoS). Network hub only: staged partials exist only where
+			// uploads arrive, and the import path never stages.
+			sweepAge := time.Duration(cfg.EdgeSync.StagingSweepMaxAgeHours) * time.Hour
+			if sweepAge > 0 {
+				sweepCtx, sweepCancel := context.WithCancel(context.Background())
+				shutdownCoordinator.RegisterHook("edgesync-staging-sweep", func(ctx context.Context) error {
+					sweepCancel()
+					return nil
+				}, shutdown.PriorityBuffer)
+				go func() {
+					sweepLogger := logger.Get("edgesync")
+					ticker := time.NewTicker(time.Hour)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-sweepCtx.Done():
+							return
+						case <-ticker.C:
+							swept, err := receiver.SweepStaging(sweepCtx, sweepAge, time.Now())
+							if err != nil {
+								sweepLogger.Warn().Err(err).Msg("Edge sync staging sweep failed")
+								continue
+							}
+							if swept > 0 {
+								sweepLogger.Info().Int("swept", swept).
+									Msg("Reclaimed abandoned staged uploads")
+							}
+						}
+					}
+				}()
+			}
 		}
 
 		// Air-gap import, independent of the network receive endpoints.
@@ -2339,9 +2375,10 @@ func main() {
 	if cfg.EdgeSync.Spoke.Enabled || cfg.EdgeSync.Spoke.Bundle.Enabled {
 		spokeLogger := logger.Get("edgesync-spoke")
 
-		// The ledger shares the auth database, like the hub index. Reuse the
-		// handle opened for the hub block when both roles are enabled on one
-		// instance, rather than opening a second one on the same file.
+		// The ledger shares the auth database file, like the hub index. With
+		// auth enabled both roles borrow the auth manager's handle; with auth
+		// disabled each role opens its own handle on the same file — safe
+		// under WAL + busy_timeout, just not shared.
 		spokeDB, spokeOwnsDB, err := sharedSQLiteHandle(authManager, cfg.Auth.DBPath)
 		if err != nil {
 			log.Fatal().Err(err).Str("path", cfg.Auth.DBPath).Msg("Failed to open the edge sync spoke database; refusing to start")
@@ -2361,10 +2398,16 @@ func main() {
 		// which has no hub URL to build a transport from.
 		var syncAgent *edgesync.Agent
 		if cfg.EdgeSync.Spoke.Enabled {
+			if cfg.EdgeSync.Spoke.HubToken == "" {
+				log.Warn().Msg("ARC_EDGE_SYNC_HUB_TOKEN is not set; a hub running with auth enabled " +
+					"(the default) will reject every sync request with 401. Set it to an Arc API " +
+					"token with write permission on the hub, or disable auth on the hub.")
+			}
 			spokeTransport, err := edgesync.NewHTTPTransport(edgesync.HTTPTransportConfig{
-				BaseURL: cfg.EdgeSync.Spoke.HubURL,
-				SpokeID: cfg.EdgeSync.Spoke.SpokeID,
-				Secret:  cfg.EdgeSync.Spoke.Secret,
+				BaseURL:  cfg.EdgeSync.Spoke.HubURL,
+				SpokeID:  cfg.EdgeSync.Spoke.SpokeID,
+				Secret:   cfg.EdgeSync.Spoke.Secret,
+				APIToken: cfg.EdgeSync.Spoke.HubToken,
 			})
 			if err != nil {
 				log.Fatal().Err(err).Msg("Failed to create the edge sync transport; refusing to start")
@@ -2461,6 +2504,58 @@ func main() {
 			evt.Msg("Edge sync spoke enabled; trigger a pass with POST /api/v1/spoke-sync/run")
 		default:
 			evt.Msg("Edge sync air-gap export enabled; write a bundle with POST /api/v1/spoke-sync/export")
+		}
+
+		// Periodic ledger prune of terminal rows (synced, skipped). Every
+		// sync action is operator-triggered, but hygiene must not be: an
+		// air-gapped spoke may go months between operator visits, and the
+		// terminal rows those visits produce would otherwise accumulate
+		// forever on the box least able to receive one. Twice daily, plus
+		// once shortly after startup so a long-stopped spoke catches up.
+		if retentionDays := cfg.EdgeSync.Spoke.LedgerRetentionDays; retentionDays > 0 {
+			pruneCtx, pruneCancel := context.WithCancel(context.Background())
+			shutdownCoordinator.RegisterHook("edgesync-ledger-prune", func(ctx context.Context) error {
+				pruneCancel()
+				return nil
+			}, shutdown.PriorityBuffer)
+			go func() {
+				pruneLogger := logger.Get("edgesync")
+				runPrune := func() {
+					synced, err := spokeLedger.PruneSynced(pruneCtx, retentionDays)
+					if err != nil {
+						pruneLogger.Warn().Err(err).Msg("Edge sync ledger prune (synced) failed")
+					}
+					skipped, err := spokeLedger.PruneSkipped(pruneCtx, retentionDays)
+					if err != nil {
+						pruneLogger.Warn().Err(err).Msg("Edge sync ledger prune (skipped) failed")
+					}
+					if synced+skipped > 0 {
+						pruneLogger.Info().
+							Int64("synced_rows", synced).
+							Int64("skipped_rows", skipped).
+							Msg("Pruned terminal edge sync ledger rows")
+					}
+				}
+				// Deferred first run: not at startup itself, where a large
+				// backlogged DELETE would compete with WAL recovery and
+				// ingest warm-up for the shared SQLite handle.
+				select {
+				case <-pruneCtx.Done():
+					return
+				case <-time.After(5 * time.Minute):
+					runPrune()
+				}
+				ticker := time.NewTicker(12 * time.Hour)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-pruneCtx.Done():
+						return
+					case <-ticker.C:
+						runPrune()
+					}
+				}
+			}()
 		}
 	}
 

--- a/internal/api/edgesync.go
+++ b/internal/api/edgesync.go
@@ -156,7 +156,12 @@ func (h *EdgeSyncHandler) RegisterRoutes(app fiber.Router) {
 	})
 
 	if h.authManager != nil {
-		group.Use(auth.RequireAdmin(h.authManager))
+		// Write-level, not admin: these endpoints are ingest-shaped (a spoke
+		// pushes data files), and the ingest endpoints gate on RequireWrite.
+		// Requiring admin here would force every spoke to hold a credential
+		// that can also rotate tokens and delete data on the hub. The spoke
+		// presents the token from ARC_EDGE_SYNC_HUB_TOKEN.
+		group.Use(auth.RequireWrite(h.authManager))
 	}
 
 	group.Post("/file", h.receiveFile)

--- a/internal/api/edgesync_spoke.go
+++ b/internal/api/edgesync_spoke.go
@@ -118,6 +118,7 @@ func (h *EdgeSyncSpokeHandler) run(c *fiber.Ctx) error {
 		Int("already_present", res.AlreadyPresent).
 		Int("partial", res.Partial).
 		Int("failed", res.Failed).
+		Int("skipped", res.Skipped).
 		Int("conflicts", len(res.Conflicts)).
 		Dur("duration", res.Duration).
 		Msg("Manual sync pass complete")
@@ -130,6 +131,7 @@ func (h *EdgeSyncSpokeHandler) run(c *fiber.Ctx) error {
 		"bytes_sent":      res.BytesSent,
 		"partial":         res.Partial,
 		"failed":          res.Failed,
+		"skipped":         res.Skipped,
 		"duration_ms":     res.Duration.Milliseconds(),
 	}
 
@@ -187,9 +189,12 @@ func (h *EdgeSyncSpokeHandler) status(c *fiber.Ctx) error {
 		"in_flight": st.InFlight,
 		// Files on physical media awaiting an ack. Reported separately so an
 		// operator can tell "queued here" from "in transit on a drive".
-		"exported":      st.Exported,
-		"synced":        st.Synced,
-		"failed":        st.Failed,
+		"exported": st.Exported,
+		"synced":   st.Synced,
+		"failed":   st.Failed,
+		// Source files that vanished (compaction/retention) before delivery.
+		// Terminal bookkeeping, excluded from pending_bytes.
+		"skipped":       st.Skipped,
 		"pending_bytes": st.PendingBytes,
 	}
 	if st.LastSyncedAt != nil {
@@ -344,11 +349,14 @@ func (h *EdgeSyncSpokeHandler) export(c *fiber.Ctx) error {
 		Msg("Bundle exported")
 
 	return c.JSON(fiber.Map{
-		"exported":    true,
-		"bundle_id":   res.BundleID,
-		"dir":         res.Dir,
-		"files":       res.FileCount,
-		"bytes":       res.Bytes,
+		"exported":  true,
+		"bundle_id": res.BundleID,
+		"dir":       res.Dir,
+		"files":     res.FileCount,
+		"bytes":     res.Bytes,
+		// Eligible entries whose source file vanished before export
+		// (compaction or retention); recorded as skipped in the ledger.
+		"skipped":     res.Skipped,
 		"duration_ms": res.Duration.Milliseconds(),
 		// The bundle is on media but no hub has confirmed it. Saying so here
 		// stops an operator reading "exported" as "delivered".

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1091,10 +1091,26 @@ func (h *QueryHandler) StartBackgroundWorkers(ctx context.Context) {
 }
 
 // extractTableReferences extracts all database.measurement references from SQL
-// Returns a slice of TableReference structs for permission checking
-func extractTableReferences(sql string) []TableReference {
+// Returns a slice of TableReference structs for permission checking.
+//
+// identNames maps __IDENT_n__ placeholders (masked double-quoted identifiers)
+// back to their unquoted names; pass the result of sqlutil.IdentifierNames on
+// the same masks the sql was masked with, or nil when the sql contains no
+// quoted identifiers. Resolution here MUST mirror the query transform's
+// (resolveIdent in convertSQLToStoragePaths): if extraction saw placeholder
+// text while execution resolved real names, a quoted reference would be
+// permission-checked as `__IDENT_0__` — a grant that can never exist — while
+// the query still executed against the real measurement.
+func extractTableReferences(sql string, identNames map[string]string) []TableReference {
 	var refs []TableReference
 	seen := make(map[string]bool)
+
+	resolve := func(name string) string {
+		if orig, ok := identNames[name]; ok {
+			return orig
+		}
+		return name
+	}
 
 	// CTE names (WITH t AS (...)) are virtual, not real measurements. The query
 	// transform (convertSQLToStoragePaths) skips them, so the permission check
@@ -1107,12 +1123,13 @@ func extractTableReferences(sql string) []TableReference {
 	dbTableMatches := patternDBTable.FindAllStringSubmatch(sql, -1)
 	for _, match := range dbTableMatches {
 		if len(match) >= 3 {
-			key := match[1] + "." + match[2]
+			db, table := resolve(match[1]), resolve(match[2])
+			key := db + "." + table
 			if !seen[key] {
 				seen[key] = true
 				refs = append(refs, TableReference{
-					Database:    match[1],
-					Measurement: match[2],
+					Database:    db,
+					Measurement: table,
 				})
 			}
 		}
@@ -1124,12 +1141,13 @@ func extractTableReferences(sql string) []TableReference {
 		// Group 1 is the join prefix (LEFT JOIN, ASOF JOIN, ...); the
 		// database/measurement identifiers are groups 2 and 3.
 		if len(match) >= 4 {
-			key := match[2] + "." + match[3]
+			db, table := resolve(match[2]), resolve(match[3])
+			key := db + "." + table
 			if !seen[key] {
 				seen[key] = true
 				refs = append(refs, TableReference{
-					Database:    match[2],
-					Measurement: match[3],
+					Database:    db,
+					Measurement: table,
 				})
 			}
 		}
@@ -1140,7 +1158,7 @@ func extractTableReferences(sql string) []TableReference {
 	simpleMatches := patternSimpleTable.FindAllStringSubmatchIndex(sql, -1)
 	for _, matchIdx := range simpleMatches {
 		if len(matchIdx) >= 4 {
-			tableName := sql[matchIdx[2]:matchIdx[3]]
+			tableName := resolve(sql[matchIdx[2]:matchIdx[3]])
 			table := strings.ToLower(tableName)
 
 			// Skip system tables and already-converted paths
@@ -1149,7 +1167,9 @@ func extractTableReferences(sql string) []TableReference {
 			}
 
 			// Skip CTE names — they are virtual, not real measurements.
-			if cteNames[table] {
+			// Checked on the RESOLVED name too: a quoted reference to an
+			// unquoted CTE names the same virtual table.
+			if cteNames[table] || cteNames[strings.ToLower(sql[matchIdx[2]:matchIdx[3]])] {
 				continue
 			}
 
@@ -1187,7 +1207,7 @@ func extractTableReferences(sql string) []TableReference {
 		// Group 1 is the join prefix (indices 2:4); the table identifier is
 		// group 2, at indices 4:6.
 		if len(matchIdx) >= 6 {
-			tableName := sql[matchIdx[4]:matchIdx[5]]
+			tableName := resolve(sql[matchIdx[4]:matchIdx[5]])
 			table := strings.ToLower(tableName)
 
 			if shouldSkipTableConversion(table) {
@@ -1195,7 +1215,8 @@ func extractTableReferences(sql string) []TableReference {
 			}
 
 			// Skip CTE names — they are virtual, not real measurements.
-			if cteNames[table] {
+			// Checked on the RESOLVED name too, as above.
+			if cteNames[table] || cteNames[strings.ToLower(sql[matchIdx[4]:matchIdx[5]])] {
 				continue
 			}
 
@@ -1254,12 +1275,14 @@ func (h *QueryHandler) checkQueryPermissions(c *fiber.Ctx, sql, permission strin
 	//     `SELECT * FROM /* x */ secret.cpu` would otherwise yield zero refs
 	//     here yet still execute against secret.cpu after the transform).
 	features := scanSQLFeatures(sql)
-	normalisedSQL, _ := sqlutil.MaskStringLiterals(sql, features.hasQuotes)
+	normalisedSQL, permMasks := sqlutil.MaskStringLiterals(sql, features.hasQuotes)
 	normalisedSQL, _ = sqlutil.MaskFromKeywordsInFunctionBodies(normalisedSQL)
 	normalisedSQL = stripSQLComments(normalisedSQL, features.hasDashComment || features.hasBlockComment)
 
-	// Extract table references from the normalised SQL
-	tableRefs := extractTableReferences(normalisedSQL)
+	// Extract table references from the normalised SQL. The identifier-mask
+	// table rides along so quoted references are checked under their real
+	// names — the same resolution the query transform applies.
+	tableRefs := extractTableReferences(normalisedSQL, sqlutil.IdentifierNames(permMasks))
 	if len(tableRefs) == 0 {
 		// No tables referenced (e.g., SELECT 1+1)
 		return nil
@@ -2112,7 +2135,7 @@ func ValidateSQLRequest(sql string) error {
 	// (never reconstructed into executable SQL), so the swap is safe here.
 	maskInput := backticksToDoubleQuotes(sql)
 	features := scanSQLFeatures(maskInput)
-	normalised, _ := sqlutil.MaskStringLiterals(maskInput, features.hasQuotes)
+	normalised, vMasks := sqlutil.MaskStringLiterals(maskInput, features.hasQuotes)
 	normalised = stripSQLComments(normalised, features.hasDashComment || features.hasBlockComment)
 
 	// SECURITY: reject multi-statement queries. A second statement smuggled
@@ -2216,15 +2239,30 @@ func ValidateSQLRequest(sql string) error {
 		return &SQLValidationError{Message: "String literal not allowed in table position (replacement scans are disabled); reference a table by name"}
 	}
 
+	// SECURITY: reject a double-quoted token in table position whose unquoted
+	// name is not a valid identifier — `FROM "db2/**/*.parquet"` is the
+	// double-quoted spelling of the replacement scan above, invisible to the
+	// I/O denylist (no function name) and, in a comma cross-join, to RBAC
+	// extraction as well. No legitimate Arc database or measurement can carry
+	// the rejected characters, so a valid quoted name (`FROM "my-db"`) and an
+	// invalid one anywhere OUTSIDE table position (`SELECT "my col"`) both
+	// pass. Runs on the shared normalisation, where quoted identifiers are
+	// distinct __IDENT__ placeholders. (2026-08 edge-sync audit follow-up to
+	// GHSA-w8x2.)
+	if name := invalidQuotedIdentifierInTablePosition(normalised, sqlutil.IdentifierNames(vMasks)); name != "" {
+		return &SQLValidationError{Message: "Quoted identifier in table position is not a valid database or measurement name (replacement scans are disabled): " + name}
+	}
+
 	return nil
 }
 
-// tablePosPlaceholder matches a MaskStringLiterals placeholder (`__STR_<n>__`).
+// tablePosPlaceholder matches a MaskStringLiterals placeholder — either the
+// string class (`__STR_<n>__`) or the identifier class (`__IDENT_<n>__`).
 // Used to isolate placeholders with surrounding spaces before tokenising, so a
 // placeholder that abuts a keyword with no whitespace (`FROM'…'` masks to the
 // glued `FROM__STR_0__`) is not swallowed into one identifier token — a real
 // replacement-scan bypass otherwise (GHSA-w8x2 review, blocker 2).
-var tablePosPlaceholder = regexp.MustCompile(`__STR_\d+__`)
+var tablePosPlaceholder = regexp.MustCompile(`__(?:STR|IDENT)_\d+__`)
 
 // tablePosTokenPattern tokenises the (space-isolated) masked/normalised SQL into
 // the atoms the table-position scanner cares about: a masked string placeholder
@@ -2232,7 +2270,7 @@ var tablePosPlaceholder = regexp.MustCompile(`__STR_\d+__`)
 // (keywords, table names, aliases). Everything else (whitespace, operators) is
 // skipped. The placeholder alternative is matched BEFORE the generic identifier
 // run so it wins even though `_`/digits are also identifier bytes.
-var tablePosTokenPattern = regexp.MustCompile(`__STR_\d+__|[A-Za-z_][A-Za-z0-9_]*|[(),]`)
+var tablePosTokenPattern = regexp.MustCompile(`__(?:STR|IDENT)_\d+__|[A-Za-z_][A-Za-z0-9_]*|[(),]`)
 
 // stringLiteralInTablePosition reports whether `normalised` — SQL whose SINGLE-
 // quoted string literals have already been masked to `__STR_<n>__` placeholders,
@@ -2255,6 +2293,60 @@ var tablePosTokenPattern = regexp.MustCompile(`__STR_\d+__|[A-Za-z_][A-Za-z0-9_]
 // outer FROM clause — otherwise the trailing comma cross-join is wrongly
 // disarmed and the replacement scan slips through (GHSA-w8x2 review, blocker 1).
 func stringLiteralInTablePosition(normalised string) bool {
+	return maskedTokenInTablePosition(normalised, func(tok string) bool {
+		return strings.HasPrefix(tok, "__STR_")
+	}) != ""
+}
+
+// invalidQuotedIdentifierInTablePosition reports the first double-quoted
+// identifier standing in table position whose UNQUOTED name fails
+// validateIdentifier — returning the offending name, or "".
+//
+// Rationale: DuckDB resolves a quoted token in table position that looks like
+// a path (`FROM "db2/**/*.parquet"`) as a REPLACEMENT SCAN, reading the file
+// directly with no function name — the double-quoted sibling of the
+// single-quoted GHSA-w8x2 case above, and invisible to both the I/O-function
+// denylist (no name to match) and RBAC extraction in positions the table
+// patterns do not reach (a comma cross-join). The characters
+// validateIdentifier rejects (`/`, `*`, `.`) are exactly the ones that make a
+// token replacement-scan-capable, and no legitimate Arc database or
+// measurement can carry them, so rejecting here loses nothing. A VALID quoted
+// identifier (`FROM "my-db"`) passes untouched, as does an invalid one in any
+// non-table position (`SELECT "my col" …`).
+//
+// normalised must be the shared ValidateSQLRequest normalisation (identifier
+// placeholders intact); identNames maps those placeholders to unquoted names.
+func invalidQuotedIdentifierInTablePosition(normalised string, identNames map[string]string) string {
+	if identNames == nil {
+		return ""
+	}
+	var offending string
+	maskedTokenInTablePosition(normalised, func(tok string) bool {
+		if !strings.HasPrefix(tok, "__IDENT_") {
+			return false
+		}
+		name, known := identNames[tok]
+		if !known {
+			// A placeholder-shaped token this mask table did not produce.
+			// Fail closed: it is in table position and unaccounted for.
+			offending = tok
+			return true
+		}
+		if validateIdentifier(name) != nil {
+			offending = name
+			return true
+		}
+		return false
+	})
+	return offending
+}
+
+// maskedTokenInTablePosition is the shared table-position scanner: it walks
+// the masked/normalised SQL and returns the first placeholder token for which
+// flag returns true while the token stands in table position (directly after
+// FROM or JOIN, or after a comma continuing an armed FROM clause's table
+// list). Returns "" when no flagged placeholder is in table position.
+func maskedTokenInTablePosition(normalised string, flag func(tok string) bool) string {
 	// fromArmed[d] is true when, at paren depth d, we are inside a FROM clause
 	// whose table list is still open — so a comma at depth d continues that
 	// list (a cross-join table position). Indexed by depth; grows as needed.
@@ -2298,14 +2390,16 @@ func stringLiteralInTablePosition(normalised string) bool {
 		}
 
 		// tok is a placeholder or an identifier/keyword run.
-		if strings.HasPrefix(tok, "__STR_") {
-			// A masked single-quoted string standing in table position.
-			if afterFromJoin {
-				return true
+		if strings.HasPrefix(tok, "__STR_") || strings.HasPrefix(tok, "__IDENT_") {
+			// A masked token standing in table position: the caller's flag
+			// decides whether this class of placeholder is a violation.
+			if afterFromJoin && flag(tok) {
+				return tok
 			}
-			// A string that is NOT in table position (a value, a function arg)
-			// closes the "immediately after FROM/JOIN" window but leaves the
-			// FROM clause's armed state (for a following cross-join comma) alone.
+			// A placeholder that is NOT flagged (or not in table position — a
+			// value, a function arg, a legitimate quoted table) closes the
+			// "immediately after FROM/JOIN" window but leaves the FROM
+			// clause's armed state (for a following cross-join comma) alone.
 			afterFromJoin = false
 			continue
 		}
@@ -2327,7 +2421,7 @@ func stringLiteralInTablePosition(normalised string) bool {
 			}
 		}
 	}
-	return false
+	return ""
 }
 
 // fromClauseTerminator reports whether a lower-cased keyword ends the table
@@ -2536,13 +2630,29 @@ func (h *QueryHandler) convertSQLToStoragePaths(ctx context.Context, sql string)
 	// Extract CTE names to avoid converting them to storage paths
 	cteNames := extractCTENames(sql)
 
+	// Quoted identifiers (`"rocket-01"`) were masked to __IDENT_n__
+	// placeholders above, and a placeholder is word-shaped, so the table
+	// patterns match it like any bare name. Resolve back to the unquoted
+	// identifier before building a storage path — and validate it, because a
+	// quoted token can carry characters (`..`, `/`, `*`) that a bare match
+	// never could. A name that fails validation resolves to an inert sentinel
+	// path segment instead: leaving the raw quoted token in the output SQL is
+	// NOT safe, because DuckDB executes a path-shaped quoted token in table
+	// position as a replacement scan (deep-review finding on the quoted-
+	// identifier fix; ValidateSQLRequest rejects these queries up front, and
+	// this keeps the transform safe for any caller that skips validation).
+	identNames := sqlutil.IdentifierNames(masks)
+	resolveIdent := makeIdentResolver(identNames)
+
 	// Handle FROM database.table references
 	sql = patternDBTable.ReplaceAllStringFunc(sql, func(match string) string {
 		parts := patternDBTable.FindStringSubmatch(match)
 		if len(parts) < 3 {
 			return match
 		}
-		path := h.getStoragePath(parts[1], parts[2])
+		db, _ := resolveIdent(parts[1])
+		table, _ := resolveIdent(parts[2])
+		path := h.getStoragePath(db, table)
 		return h.buildReadParquetExpr(ctx, path, originalSQL, "FROM")
 	})
 
@@ -2552,7 +2662,9 @@ func (h *QueryHandler) convertSQLToStoragePaths(ctx context.Context, sql string)
 		if len(parts) < 4 {
 			return match
 		}
-		path := h.getStoragePath(parts[2], parts[3])
+		db, _ := resolveIdent(parts[2])
+		table, _ := resolveIdent(parts[3])
+		path := h.getStoragePath(db, table)
 		return h.buildReadParquetExpr(ctx, path, originalSQL, joinKeyword(parts[1]))
 	})
 
@@ -2568,8 +2680,17 @@ func (h *QueryHandler) convertSQLToStoragePaths(ctx context.Context, sql string)
 			return parts[0]
 		}
 
+		// A quoted name resolves before the skip/CTE checks below run against
+		// it — a placeholder token would never match either. The CTE check
+		// runs on BOTH forms: `WITH x AS (…) SELECT * FROM "x"` names the
+		// same virtual table in DuckDB whether or not the reference is quoted.
+		resolved, _ := resolveIdent(parts[1])
+		if cteNames[strings.ToLower(resolved)] {
+			return parts[0]
+		}
+
 		// Skip already converted read_parquet, system tables, etc.
-		if shouldSkipTableConversion(table) {
+		if shouldSkipTableConversion(strings.ToLower(resolved)) {
 			return parts[0]
 		}
 
@@ -2578,7 +2699,7 @@ func (h *QueryHandler) convertSQLToStoragePaths(ctx context.Context, sql string)
 			return parts[0]
 		}
 
-		path := h.getStoragePath("default", parts[1])
+		path := h.getStoragePath("default", resolved)
 		return h.buildReadParquetExpr(ctx, path, originalSQL, "FROM")
 	})
 
@@ -2594,8 +2715,14 @@ func (h *QueryHandler) convertSQLToStoragePaths(ctx context.Context, sql string)
 			return parts[0]
 		}
 
+		// Same resolve-then-check ordering as the FROM handler above.
+		resolved, _ := resolveIdent(parts[2])
+		if cteNames[strings.ToLower(resolved)] {
+			return parts[0]
+		}
+
 		// Skip already converted read_parquet, system tables, etc.
-		if shouldSkipTableConversion(table) {
+		if shouldSkipTableConversion(strings.ToLower(resolved)) {
 			return parts[0]
 		}
 
@@ -2604,17 +2731,49 @@ func (h *QueryHandler) convertSQLToStoragePaths(ctx context.Context, sql string)
 			return parts[0]
 		}
 
-		path := h.getStoragePath("default", parts[2])
+		path := h.getStoragePath("default", resolved)
 		return h.buildReadParquetExpr(ctx, path, originalSQL, joinKeyword(parts[1]))
 	})
 
 	// Restore masked FROM keywords and string literals. Both use content-
 	// addressed placeholders, so the intermediate length-changing regex
-	// rewrites above are safe.
+	// rewrites above are safe. Identifier placeholders consumed by the table
+	// rewrites above are gone from the SQL (their names went into storage
+	// paths); the unmask restores only the ones that remain — quoted column
+	// names, aliases, and any reference left unrewritten.
 	sql = sqlutil.UnmaskFromKeywordsInFunctionBodies(sql, fromMasks)
 	sql = sqlutil.UnmaskStringLiterals(sql, masks)
 
 	return sql
+}
+
+// arcInvalidIdentifierSentinel is the path segment an invalid quoted
+// identifier resolves to. No real database or measurement can collide with it
+// (validateIdentifier forbids a leading dot), so the resulting read_parquet
+// glob matches nothing and the query returns empty instead of the raw quoted
+// token surviving into executable SQL — where a path-shaped token in table
+// position would run as a DuckDB replacement scan. ValidateSQLRequest rejects
+// such queries with an explicit error before the transform normally runs;
+// this sentinel is the transform's own backstop.
+const arcInvalidIdentifierSentinel = ".arc-invalid-quoted-identifier"
+
+// makeIdentResolver returns the resolver the table rewriters use to map a
+// captured token to a clean storage-path segment. Bare tokens pass through;
+// identifier placeholders resolve to their unquoted names when valid, and to
+// arcInvalidIdentifierSentinel when not. The second return is false only for
+// the sentinel case, letting callers log or count if they care — every caller
+// still receives a safe segment to build a path from.
+func makeIdentResolver(identNames map[string]string) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		orig, isPlaceholder := identNames[name]
+		if !isPlaceholder {
+			return name, true
+		}
+		if err := validateIdentifier(orig); err != nil {
+			return arcInvalidIdentifierSentinel, false
+		}
+		return orig, true
+	}
 }
 
 // getStoragePath returns the storage path for a database.table
@@ -3178,6 +3337,12 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(ctx context.Context,
 	// OPTIMIZATION: Skip patternDBTable and patternJoinDBTable entirely
 	// since we know all tables use the header-specified database
 
+	// Quoted measurement names arrive as __IDENT_n__ placeholders; resolve
+	// and validate exactly as convertSQLToStoragePaths does, so the header-db
+	// path and the dotted path agree on what a quoted name means.
+	identNames := sqlutil.IdentifierNames(masks)
+	resolveIdent := makeIdentResolver(identNames)
+
 	// Handle FROM simple_table references - apply header database
 	sql = replaceTableRefs(sql, patternSimpleTable, func(parts []string, end int) string {
 		if len(parts) < 2 {
@@ -3190,8 +3355,15 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(ctx context.Context,
 			return parts[0]
 		}
 
+		// Resolve-then-check, matching convertSQLToStoragePaths: the CTE and
+		// skip checks must see the clean name, never a placeholder token.
+		resolved, _ := resolveIdent(parts[1])
+		if cteNames[strings.ToLower(resolved)] {
+			return parts[0]
+		}
+
 		// Skip already converted read_parquet, system tables, etc.
-		if shouldSkipTableConversion(table) {
+		if shouldSkipTableConversion(strings.ToLower(resolved)) {
 			return parts[0]
 		}
 
@@ -3201,7 +3373,7 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(ctx context.Context,
 		}
 
 		// Use header database instead of "default"
-		path := h.getStoragePath(database, parts[1])
+		path := h.getStoragePath(database, resolved)
 		return h.buildReadParquetExpr(ctx, path, originalSQL, "FROM")
 	})
 
@@ -3217,8 +3389,14 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(ctx context.Context,
 			return parts[0]
 		}
 
+		// Same resolve-then-check ordering as the FROM handler above.
+		resolved, _ := resolveIdent(parts[2])
+		if cteNames[strings.ToLower(resolved)] {
+			return parts[0]
+		}
+
 		// Skip already converted read_parquet, system tables, etc.
-		if shouldSkipTableConversion(table) {
+		if shouldSkipTableConversion(strings.ToLower(resolved)) {
 			return parts[0]
 		}
 
@@ -3228,7 +3406,7 @@ func (h *QueryHandler) convertSQLToStoragePathsWithHeaderDB(ctx context.Context,
 		}
 
 		// Use header database instead of "default"
-		path := h.getStoragePath(database, parts[2])
+		path := h.getStoragePath(database, resolved)
 		return h.buildReadParquetExpr(ctx, path, originalSQL, joinKeyword(parts[1]))
 	})
 

--- a/internal/api/query_rbac_test.go
+++ b/internal/api/query_rbac_test.go
@@ -762,7 +762,7 @@ GROUP BY a.host, b.region`
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = extractTableReferences(sql)
+		_ = extractTableReferences(sql, nil)
 	}
 }
 

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -116,9 +116,13 @@ func TestMaskStringLiterals(t *testing.T) {
 			expectedMasks:  1,
 		},
 		{
-			name:           "double quoted string",
+			// A double-quoted token is a DuckDB IDENTIFIER, not a string, so
+			// it masks into the distinct __IDENT__ class the table rewriter
+			// resolves through (quoted/hyphenated database names — the fix
+			// that made edge-sync spoke data queryable on a hub).
+			name:           "double quoted identifier",
 			input:          `SELECT * FROM t WHERE x = "hello"`,
-			expectedMasked: "SELECT * FROM t WHERE x = __STR_0__",
+			expectedMasked: "SELECT * FROM t WHERE x = __IDENT_0__",
 			expectedMasks:  1,
 		},
 		{
@@ -1174,7 +1178,15 @@ func TestValidateSQLRequest_BypassesAndFalsePositives(t *testing.T) {
 		{name: "trailing semicolon with spaces allowed", sql: "SELECT * FROM cpu;   ", shouldFail: false},
 		{name: "semicolon inside string literal allowed", sql: "SELECT * FROM logs WHERE msg = 'a;b'", shouldFail: false},
 		{name: "semicolon inside comment allowed", sql: "SELECT * FROM cpu -- a;b\n", shouldFail: false},
-		{name: "semicolon inside backtick identifier allowed", sql: "SELECT * FROM `my;db`", shouldFail: false},
+		// Since the quoted-identifier table-position check (26.09.1), an
+		// identifier that can never name a real Arc table is rejected
+		// explicitly IN TABLE POSITION — with the identifier error, not the
+		// multi-statement one this case originally pinned against. The
+		// original property (a `;` inside a quoted identifier is not a
+		// statement separator) is preserved by the column-position case
+		// below, which must stay allowed.
+		{name: "semicolon inside backtick identifier in table position rejected as invalid name", sql: "SELECT * FROM `my;db`", shouldFail: true},
+		{name: "semicolon inside backtick identifier in column position allowed", sql: "SELECT `my;col` FROM cpu", shouldFail: false},
 		{name: "SHOW smuggled behind semicolon in backtick db", sql: "SHOW TABLES FROM `db`; SELECT 1", shouldFail: true},
 	}
 
@@ -2092,7 +2104,7 @@ func TestJoinModifierRBACExtraction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.sql, func(t *testing.T) {
-			got := extractTableReferences(tt.sql)
+			got := extractTableReferences(tt.sql, nil)
 
 			for _, want := range tt.want {
 				found := false

--- a/internal/api/quoted_identifier_test.go
+++ b/internal/api/quoted_identifier_test.go
@@ -1,0 +1,228 @@
+package api
+
+// Regression tests for quoted-identifier resolution in the query transform.
+//
+// Double-quoted tokens are DuckDB IDENTIFIERS, but MaskStringLiterals used to
+// mask them like string literals: `"rocket-01".telemetry` became
+// `__STR_0__.telemetry`, the placeholder matched the table pattern, and the
+// unmask spliced the QUOTES back inside the read_parquet glob —
+// `<root>/"rocket-01"/telemetry/**` — a literal directory that never exists.
+// Net effect: any quoted database or measurement returned zero rows, and a
+// hyphenated name (every edge-sync spoke ID in the docs) had NO working
+// syntax, because the unquoted form is a SQL parser error. Live-reproduced on
+// a hub in the 2026-08-19 edge-sync audit.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/pruning"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
+	"github.com/rs/zerolog"
+)
+
+func newQuotedIdentTestHandler() *QueryHandler {
+	return &QueryHandler{
+		storage: &mockLocalBackend{basePath: "./data"},
+		pruner:  pruning.NewPartitionPruner(zerolog.Nop()),
+		logger:  zerolog.Nop(),
+	}
+}
+
+func TestConvertSQL_QuotedIdentifiers(t *testing.T) {
+	h := newQuotedIdentTestHandler()
+
+	tests := []struct {
+		name             string
+		inputSQL         string
+		shouldContain    []string
+		shouldNotContain []string
+	}{
+		{
+			// The audit's exact failing shape: hyphenated spoke database.
+			name:          "quoted hyphenated database, bare measurement",
+			inputSQL:      `SELECT count(*) FROM "rocket-01".telemetry`,
+			shouldContain: []string{"read_parquet('./data/rocket-01/telemetry/**/*.parquet'"},
+			shouldNotContain: []string{
+				`"rocket-01"`, // the quotes must never reach the path
+				"__IDENT_",    // nor a leaked placeholder
+			},
+		},
+		{
+			name:          "quoted database and quoted measurement",
+			inputSQL:      `SELECT * FROM "rocket-01"."engine-temp"`,
+			shouldContain: []string{"read_parquet('./data/rocket-01/engine-temp/**/*.parquet'"},
+			shouldNotContain: []string{
+				`"rocket-01"`, `"engine-temp"`, "__IDENT_",
+			},
+		},
+		{
+			name:          "bare database, quoted measurement",
+			inputSQL:      `SELECT * FROM telemetry."engine-temp"`,
+			shouldContain: []string{"read_parquet('./data/telemetry/engine-temp/**/*.parquet'"},
+		},
+		{
+			name:          "quoted measurement alone resolves under default",
+			inputSQL:      `SELECT * FROM "engine-temp"`,
+			shouldContain: []string{"read_parquet('./data/default/engine-temp/**/*.parquet'"},
+		},
+		{
+			name:          "quoted db.meas in a JOIN",
+			inputSQL:      `SELECT * FROM telemetry.cpu JOIN "rocket-01"."engine-temp" ON true`,
+			shouldContain: []string{"read_parquet('./data/rocket-01/engine-temp/**/*.parquet'"},
+		},
+		{
+			// Masking still protects string literals: a table-shaped string
+			// value must never be rewritten.
+			name:          "string literal containing a table reference is preserved",
+			inputSQL:      `SELECT * FROM "rocket-01".telemetry WHERE msg = 'FROM mydb.cpu'`,
+			shouldContain: []string{"'FROM mydb.cpu'", "read_parquet('./data/rocket-01/telemetry/**/*.parquet'"},
+			shouldNotContain: []string{
+				"read_parquet('./data/mydb/cpu/",
+			},
+		},
+		{
+			// An invalid quoted identifier must NEVER survive into the output
+			// SQL: DuckDB executes a path-shaped quoted token in table
+			// position as a replacement scan (deep-review Blocker on this
+			// fix). The transform resolves it to an inert sentinel segment
+			// instead — the raw token must be gone.
+			name:          "traversal inside a quoted identifier resolves to the inert sentinel",
+			inputSQL:      `SELECT * FROM "../../etc".telemetry`,
+			shouldContain: []string{arcInvalidIdentifierSentinel},
+			shouldNotContain: []string{
+				`"../../etc"`,
+				"__IDENT_",
+			},
+		},
+		{
+			// The reviewer's live-verified replacement-scan shape: a glob in
+			// a quoted identifier. Both segments of the output path must be
+			// sentinel-or-clean; the quoted glob must not survive.
+			name:          "glob-shaped quoted identifier resolves to the inert sentinel",
+			inputSQL:      `SELECT * FROM "db2/**/*.parquet"`,
+			shouldContain: []string{arcInvalidIdentifierSentinel},
+			shouldNotContain: []string{
+				`"db2/**/*.parquet"`,
+				"__IDENT_",
+			},
+		},
+		{
+			// A quoted CTE reference is the same virtual table as its
+			// declaration; it must not be rewritten to a storage path.
+			name:             "quoted CTE name is not rewritten",
+			inputSQL:         `WITH "windowed-avg" AS (SELECT 1 AS x) SELECT * FROM "windowed-avg"`,
+			shouldNotContain: []string{"read_parquet('./data/default/windowed-avg"},
+		},
+		{
+			// Quoted column identifiers elsewhere in the query must be
+			// restored untouched.
+			name:          "quoted column identifier survives the round trip",
+			inputSQL:      `SELECT "my col" FROM telemetry.cpu`,
+			shouldContain: []string{`"my col"`, "read_parquet('./data/telemetry/cpu/**/*.parquet'"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.convertSQLToStoragePaths(context.Background(), tt.inputSQL)
+			for _, substr := range tt.shouldContain {
+				if !strings.Contains(result, substr) {
+					t.Errorf("missing %q\ninput:  %s\nresult: %s", substr, tt.inputSQL, result)
+				}
+			}
+			for _, substr := range tt.shouldNotContain {
+				if strings.Contains(result, substr) {
+					t.Errorf("must not contain %q\ninput:  %s\nresult: %s", substr, tt.inputSQL, result)
+				}
+			}
+		})
+	}
+}
+
+// The header-database path (x-arc-database) must resolve quoted measurements
+// the same way the dotted path does.
+func TestConvertSQLWithDatabase_QuotedMeasurement(t *testing.T) {
+	h := newQuotedIdentTestHandler()
+
+	result := h.convertSQLToStoragePathsWithHeaderDB(context.Background(),
+		`SELECT * FROM "engine-temp"`, "rocket-01")
+	want := "read_parquet('./data/rocket-01/engine-temp/**/*.parquet'"
+	if !strings.Contains(result, want) {
+		t.Errorf("missing %q\nresult: %s", want, result)
+	}
+	if strings.Contains(result, "__IDENT_") {
+		t.Errorf("leaked placeholder in: %s", result)
+	}
+}
+
+// RBAC extraction must see the same names execution resolves — a quoted
+// reference checked as placeholder text would be a grant that can never
+// exist, and one not extracted at all would skip the permission check.
+func TestExtractTableReferences_QuotedIdentifiers(t *testing.T) {
+	sql := `SELECT * FROM "rocket-01"."engine-temp" JOIN "fleet-db".status ON true`
+	masked, masks := sqlutil.MaskStringLiterals(sql, true)
+
+	refs := extractTableReferences(masked, sqlutil.IdentifierNames(masks))
+	got := make(map[string]bool, len(refs))
+	for _, r := range refs {
+		got[r.Database+"."+r.Measurement] = true
+	}
+	for _, want := range []string{"rocket-01.engine-temp", "fleet-db.status"} {
+		if !got[want] {
+			t.Errorf("missing extracted ref %q; got %v", want, got)
+		}
+	}
+}
+
+// With an x-arc-database header set, a quoted db.meas reference is cross-
+// database syntax and must now be DETECTED (it was invisible when quoted
+// tokens masked to string placeholders the scanner skipped... they matched
+// as word-runs either way; this pins the intended behavior).
+func TestHasCrossDatabaseSyntax_QuotedReference(t *testing.T) {
+	if !hasCrossDatabaseSyntax(`SELECT * FROM "other-db".cpu`) {
+		t.Error(`quoted "other-db".cpu not detected as cross-database syntax`)
+	}
+	if hasCrossDatabaseSyntax(`SELECT * FROM "engine-temp"`) {
+		t.Error(`a lone quoted measurement wrongly detected as cross-database`)
+	}
+}
+
+// ValidateSQLRequest must reject a path-shaped quoted identifier in table
+// position — the double-quoted spelling of the GHSA-w8x2 replacement scan,
+// including the comma cross-join position no table pattern reaches. Valid
+// quoted tables and invalid quoted tokens OUTSIDE table position stay legal.
+func TestValidateSQL_QuotedIdentifierReplacementScans(t *testing.T) {
+	reject := []struct{ name, sql string }{
+		{"direct FROM", `SELECT * FROM "db2/**/*.parquet"`},
+		{"absolute path", `SELECT * FROM "/data/arc/db2/secrets/f.parquet"`},
+		{"comma cross-join", `SELECT b.v FROM cpu, "db2/**/*.parquet" b`},
+		{"JOIN position", `SELECT * FROM cpu JOIN "db2/x.parquet" b ON true`},
+		{"subquery FROM", `SELECT * FROM (SELECT * FROM "db2/x.parquet")`},
+		{"traversal", `SELECT * FROM "../../etc".telemetry`},
+		{"backtick spelling", "SELECT * FROM `db2/**/*.parquet`"},
+	}
+	for _, tt := range reject {
+		t.Run("reject "+tt.name, func(t *testing.T) {
+			if err := ValidateSQLRequest(tt.sql); err == nil {
+				t.Errorf("accepted: %s", tt.sql)
+			}
+		})
+	}
+
+	allow := []struct{ name, sql string }{
+		{"valid quoted table", `SELECT * FROM "my-db".cpu`},
+		{"valid quoted measurement", `SELECT * FROM "engine-temp"`},
+		{"invalid quoted token as column", `SELECT "my col" FROM cpu`},
+		{"path-shaped single-quoted VALUE", `SELECT * FROM cpu WHERE f = 'db2/**/*.parquet'`},
+		{"quoted alias after table", `SELECT * FROM cpu "a b"`},
+	}
+	for _, tt := range allow {
+		t.Run("allow "+tt.name, func(t *testing.T) {
+			if err := ValidateSQLRequest(tt.sql); err != nil {
+				t.Errorf("rejected legal SQL %q: %v", tt.sql, err)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -258,6 +258,13 @@ type EdgeSyncConfig struct {
 	// O(files) — while bounding the exposure. Default 10,000 entries (~2MB).
 	MaxReconcileEntries int
 
+	// StagingSweepMaxAgeHours is how old an abandoned staged partial upload
+	// must be before the hourly sweep reclaims it. A staged prefix is also a
+	// spoke's RESUME CHECKPOINT, so this must be comfortably longer than a
+	// plausible contact gap — sweeping too aggressively forces full re-sends
+	// on exactly the intermittent links resume exists for. Default 72h.
+	StagingSweepMaxAgeHours int
+
 	// Import is the hub's air-gap side: taking a bundle off removable media.
 	Import EdgeSyncImportConfig
 }
@@ -320,6 +327,14 @@ type EdgeSyncSpokeConfig struct {
 	// the committed copy looking load-bearing while still being leaked.
 	Secret string
 
+	// HubToken is an Arc API token for the hub, read ONLY from
+	// ARC_EDGE_SYNC_HUB_TOKEN. The hub's /api/v1/sync endpoints sit behind
+	// Arc's token middleware (write level) in addition to the per-spoke HMAC;
+	// this is the credential that satisfies the token layer. Optional: a hub
+	// running with auth disabled needs none, so an empty value is a startup
+	// warning rather than an error. Env-only for the same reason Secret is.
+	HubToken string
+
 	// MaxAttempts before a file is given up on. Zero uses the package default.
 	MaxAttempts int
 
@@ -327,9 +342,18 @@ type EdgeSyncSpokeConfig struct {
 	// are small.
 	MaxConcurrent int
 
-	// BatchSize caps how many files one reconcile asks about. Zero lets the
-	// hub's own limit decide, and a larger backlog pages.
+	// BatchSize caps how many files one reconcile asks about; a larger
+	// backlog pages. Zero offers the whole backlog in one reconcile. Either
+	// way, a page the hub refuses as too large is split and retried, so no
+	// value can leave a backlog undrainable.
 	BatchSize int
+
+	// LedgerRetentionDays is how long terminal ledger rows (synced, skipped)
+	// are kept before the periodic prune deletes them. The rows are
+	// bookkeeping about files that finished their journey; without pruning
+	// the ledger grows without bound on the box least able to receive a site
+	// visit. 0 disables pruning. Default 90.
+	LedgerRetentionDays int
 
 	// Bundle configures air-gap export.
 	Bundle EdgeSyncBundleConfig
@@ -806,24 +830,27 @@ func Load() (*Config, error) {
 			ForceBootstrap: v.GetBool("auth.force_bootstrap"),
 		},
 		EdgeSync: EdgeSyncConfig{
-			Enabled:             v.GetBool("edge_sync.enabled"),
-			HubID:               v.GetString("edge_sync.hub_id"),
-			MaxFileBytes:        int64(v.GetInt64("edge_sync.max_file_bytes")),
-			MaxReconcileEntries: v.GetInt("edge_sync.max_reconcile_entries"),
+			Enabled:                 v.GetBool("edge_sync.enabled"),
+			HubID:                   v.GetString("edge_sync.hub_id"),
+			MaxFileBytes:            int64(v.GetInt64("edge_sync.max_file_bytes")),
+			MaxReconcileEntries:     v.GetInt("edge_sync.max_reconcile_entries"),
+			StagingSweepMaxAgeHours: v.GetInt("edge_sync.staging_sweep_max_age_hours"),
 			Import: EdgeSyncImportConfig{
 				Enabled:     v.GetBool("edge_sync.import.enabled"),
 				AllowedDirs: v.GetStringSlice("edge_sync.import.allowed_dirs"),
 				MaxFiles:    v.GetInt64("edge_sync.import.max_files"),
 			},
 			Spoke: EdgeSyncSpokeConfig{
-				Enabled:       v.GetBool("edge_sync.spoke.enabled"),
-				HubURL:        v.GetString("edge_sync.spoke.hub_url"),
-				SpokeID:       v.GetString("edge_sync.spoke.spoke_id"),
-				HubID:         v.GetString("edge_sync.spoke.hub_id"),
-				Secret:        os.Getenv("ARC_EDGE_SYNC_SPOKE_SECRET"),
-				MaxAttempts:   v.GetInt("edge_sync.spoke.max_attempts"),
-				MaxConcurrent: v.GetInt("edge_sync.spoke.max_concurrent"),
-				BatchSize:     v.GetInt("edge_sync.spoke.batch_size"),
+				Enabled:             v.GetBool("edge_sync.spoke.enabled"),
+				HubURL:              v.GetString("edge_sync.spoke.hub_url"),
+				SpokeID:             v.GetString("edge_sync.spoke.spoke_id"),
+				HubID:               v.GetString("edge_sync.spoke.hub_id"),
+				Secret:              os.Getenv("ARC_EDGE_SYNC_SPOKE_SECRET"),
+				HubToken:            os.Getenv("ARC_EDGE_SYNC_HUB_TOKEN"),
+				MaxAttempts:         v.GetInt("edge_sync.spoke.max_attempts"),
+				MaxConcurrent:       v.GetInt("edge_sync.spoke.max_concurrent"),
+				BatchSize:           v.GetInt("edge_sync.spoke.batch_size"),
+				LedgerRetentionDays: v.GetInt("edge_sync.spoke.ledger_retention_days"),
 				Bundle: EdgeSyncBundleConfig{
 					Enabled:     v.GetBool("edge_sync.spoke.bundle.enabled"),
 					AllowedDirs: v.GetStringSlice("edge_sync.spoke.bundle.allowed_dirs"),
@@ -1203,6 +1230,11 @@ func Load() (*Config, error) {
 			"supply it via the ARC_EDGE_SYNC_SPOKE_SECRET environment variable so a write credential " +
 			"is not stored in a file that gets copied, backed up, and committed")
 	}
+	if v.InConfig("edge_sync.spoke.hub_token") {
+		return nil, fmt.Errorf("edge_sync.spoke.hub_token must not be set in the configuration file; " +
+			"supply it via the ARC_EDGE_SYNC_HUB_TOKEN environment variable so a write credential " +
+			"is not stored in a file that gets copied, backed up, and committed")
+	}
 
 	if cfg.EdgeSync.Spoke.Enabled {
 		if cfg.EdgeSync.Spoke.HubURL == "" {
@@ -1237,7 +1269,7 @@ func Load() (*Config, error) {
 		// for; the agent clamps defensively, but an operator who typed it
 		// should be told at startup rather than have it quietly ignored.
 		if cfg.EdgeSync.Spoke.BatchSize < 0 {
-			return nil, fmt.Errorf("edge_sync.spoke.batch_size must be >= 0 (got %d); 0 means \"use the hub's cap\"",
+			return nil, fmt.Errorf("edge_sync.spoke.batch_size must be >= 0 (got %d); 0 means \"offer the whole backlog in one reconcile\"",
 				cfg.EdgeSync.Spoke.BatchSize)
 		}
 		if cfg.EdgeSync.Spoke.MaxAttempts < 0 {
@@ -1455,6 +1487,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("edge_sync.hub_id", "")
 	v.SetDefault("edge_sync.max_file_bytes", 512*1024*1024) // 512MiB per upload
 	v.SetDefault("edge_sync.max_reconcile_entries", 10000)  // ~2MB per discovery batch
+	// 72h, not shorter: a staged partial is also a spoke's resume checkpoint,
+	// and sweeping inside a plausible contact gap forces full re-sends on
+	// exactly the intermittent links resume exists for.
+	v.SetDefault("edge_sync.staging_sweep_max_age_hours", 72)
 
 	// Spoke side. Declared here rather than relying only on the agent's
 	// zero-value fallbacks so the defaults are visible to an operator reading
@@ -1465,7 +1501,13 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("edge_sync.spoke.hub_id", "")
 	v.SetDefault("edge_sync.spoke.max_attempts", 5)   // before a file is marked failed
 	v.SetDefault("edge_sync.spoke.max_concurrent", 2) // edge boxes are small
-	v.SetDefault("edge_sync.spoke.batch_size", 0)     // 0 defers to the hub's cap
+	// 1000, not 0: a page must fit under the hub's max_reconcile_entries
+	// (default 10000) AND its derived byte limit, and it bounds how much of
+	// the backlog the spoke loads into memory per page. 0 ("send the whole
+	// backlog in one reconcile") is an explicit opt-in; the agent splits and
+	// retries on a 413 either way, so no value can strand a backlog.
+	v.SetDefault("edge_sync.spoke.batch_size", 1000)
+	v.SetDefault("edge_sync.spoke.ledger_retention_days", 90) // terminal (synced/skipped) rows; 0 = never prune
 
 	// Air-gap bundle export. allowed_dirs has no default on purpose: an empty
 	// list refuses every export, so an operator must state where bundles may

--- a/internal/config/edgesync_spoke_test.go
+++ b/internal/config/edgesync_spoke_test.go
@@ -67,6 +67,29 @@ func TestSpokeConfig_SecretInFileIsRefused(t *testing.T) {
 	}
 }
 
+// The hub API token follows the secret's rules exactly: environment only,
+// refused in the file, and reachable from the config when supplied via env.
+func TestSpokeConfig_HubTokenEnvOnlyAndRefusedInFile(t *testing.T) {
+	t.Setenv("ARC_EDGE_SYNC_SPOKE_SECRET", strings.Repeat("a", 64))
+	t.Setenv("ARC_EDGE_SYNC_HUB_TOKEN", "hub-write-token")
+
+	cfg, err := loadWith(t, validSpokeConfig)
+	if err != nil {
+		t.Fatalf("a spoke supplying its hub token via the environment failed to load: %v", err)
+	}
+	if cfg.EdgeSync.Spoke.HubToken != "hub-write-token" {
+		t.Errorf("hub token from the environment did not reach the config: %q", cfg.EdgeSync.Spoke.HubToken)
+	}
+
+	_, err = loadWith(t, validSpokeConfig+`hub_token = "hunter2"`+"\n")
+	if err == nil {
+		t.Fatal("a config file carrying hub_token loaded without complaint")
+	}
+	if !strings.Contains(err.Error(), "ARC_EDGE_SYNC_HUB_TOKEN") {
+		t.Errorf("the error does not say where the token belongs: %v", err)
+	}
+}
+
 // A mismatched or missing hub_id fails every request with a 400. Catching it
 // at load turns a silent total failure into a startup message.
 func TestSpokeConfig_RequiresIdentitiesAndURL(t *testing.T) {
@@ -120,10 +143,12 @@ func TestSpokeConfig_DefaultsAreDeclared(t *testing.T) {
 	if got := cfg.EdgeSync.Spoke.MaxConcurrent; got != 2 {
 		t.Errorf("max_concurrent = %d, want 2", got)
 	}
-	// 0 means "defer to the hub's cap", which is a real value here, not an
-	// unset field.
-	if got := cfg.EdgeSync.Spoke.BatchSize; got != 0 {
-		t.Errorf("batch_size = %d, want 0", got)
+	// 1000 pages under the hub's default max_reconcile_entries (10000) and
+	// bounds per-page spoke memory. 0 ("whole backlog in one reconcile") is
+	// an explicit opt-in, not the default — a default-config spoke with a
+	// large backlog must not depend on 413 splitting to make progress.
+	if got := cfg.EdgeSync.Spoke.BatchSize; got != 1000 {
+		t.Errorf("batch_size = %d, want 1000", got)
 	}
 }
 

--- a/internal/edgesync/agent.go
+++ b/internal/edgesync/agent.go
@@ -71,8 +71,9 @@ type AgentConfig struct {
 	// are small, and §8.2 caps this low deliberately.
 	MaxConcurrent int
 
-	// BatchSize caps how many files one reconcile asks about. Zero means the
-	// hub's own default. A spoke with a larger backlog pages.
+	// BatchSize caps how many files one reconcile asks about; a larger
+	// backlog pages. Zero offers the whole backlog in one reconcile — a page
+	// the hub refuses as too large is split and retried either way.
 	BatchSize int
 
 	Logger zerolog.Logger
@@ -107,6 +108,10 @@ type RunResult struct {
 
 	// Failed is how many transfers errored.
 	Failed int
+
+	// Skipped is how many entries were dropped because their source file
+	// vanished (compaction or retention) before delivery.
+	Skipped int
 
 	// Conflicts are same-path-different-content disagreements. These need an
 	// operator, not a retry, so they are surfaced rather than counted away.
@@ -245,11 +250,60 @@ func (a *Agent) Run(ctx context.Context) (*RunResult, error) {
 }
 
 // runBatch reconciles one page of pending files and sends what the hub lacks.
+//
+// A page the hub refuses as too large (413) is split and retried rather than
+// failing the pass: the spoke has no reliable way to learn the hub's caps up
+// front (batch_size is operator-set, and the byte limit depends on path
+// lengths), so the refusal itself is the negotiation. Every split strictly
+// shrinks the page, and a single-entry page that still gets refused is a real
+// error — so this terminates.
 func (a *Agent) runBatch(ctx context.Context, pending []*LedgerEntry, res *RunResult) error {
+	queue := [][]*LedgerEntry{pending}
+	for len(queue) > 0 {
+		page := queue[0]
+		queue = queue[1:]
+
+		err := a.reconcileAndSend(ctx, page, res)
+		if err == nil {
+			continue
+		}
+		var tooLarge *ReconcileTooLargeError
+		if !errors.As(err, &tooLarge) || len(page) <= 1 {
+			return err
+		}
+		size := tooLarge.MaxEntries
+		if size <= 0 || size >= len(page) {
+			// Byte-limit refusal (no advertised cap), or an entry cap the
+			// page already satisfies: halving is the only signal available.
+			size = len(page) / 2
+		}
+		a.logger.Warn().
+			Int("page_entries", len(page)).
+			Int("retrying_at", size).
+			Msg("Hub refused reconcile page as too large; splitting and retrying")
+		for start := 0; start < len(page); start += size {
+			end := start + size
+			if end > len(page) {
+				end = len(page)
+			}
+			queue = append(queue, page[start:end])
+		}
+	}
+	return nil
+}
+
+// reconcileAndSend performs one reconcile round-trip and the transfers it
+// prescribes.
+func (a *Agent) reconcileAndSend(ctx context.Context, pending []*LedgerEntry, res *RunResult) error {
 	// One round-trip for the whole backlog. This is the property that makes a
 	// long disconnection survivable: 5,000 pending files cost one request.
 	reconciled, err := a.transport.Reconcile(ctx, a.hubID, pending)
 	if err != nil {
+		var tooLarge *ReconcileTooLargeError
+		if errors.As(err, &tooLarge) {
+			// Preserved un-wrapped for runBatch's split-and-retry.
+			return err
+		}
 		return fmt.Errorf("edgesync: reconcile: %w", err)
 	}
 	if err := reconciled.Validate(); err != nil {
@@ -334,6 +388,7 @@ func (a *Agent) sendAll(ctx context.Context, missing []*LedgerEntry, res *RunRes
 	type outcome struct {
 		sent      bool
 		partial   bool
+		skipped   bool
 		failed    bool
 		bytesSent int64
 	}
@@ -361,8 +416,8 @@ func (a *Agent) sendAll(ctx context.Context, missing []*LedgerEntry, res *RunRes
 
 		go func(entry *LedgerEntry) {
 			defer func() { <-sem }()
-			sent, partial, n, err := a.sendOne(ctx, entry)
-			results <- outcome{sent: sent, partial: partial, failed: err != nil, bytesSent: n}
+			sent, partial, skipped, n, err := a.sendOne(ctx, entry)
+			results <- outcome{sent: sent, partial: partial, skipped: skipped, failed: err != nil, bytesSent: n}
 		}(e)
 	}
 
@@ -373,6 +428,8 @@ func (a *Agent) sendAll(ctx context.Context, missing []*LedgerEntry, res *RunRes
 			res.Sent++
 		case o.partial:
 			res.Partial++
+		case o.skipped:
+			res.Skipped++
 		case o.failed:
 			res.Failed++
 		}
@@ -381,24 +438,34 @@ func (a *Agent) sendAll(ctx context.Context, missing []*LedgerEntry, res *RunRes
 }
 
 // sendOne transfers a single file, resuming from its checkpoint if it has one.
-func (a *Agent) sendOne(ctx context.Context, e *LedgerEntry) (sent, partial bool, bytesSent int64, err error) {
+func (a *Agent) sendOne(ctx context.Context, e *LedgerEntry) (sent, partial, skipped bool, bytesSent int64, err error) {
 	if err := a.ledger.MarkInFlight(ctx, a.hubID, e.Path); err != nil {
 		// Usually a concurrent pass already claimed it. Not an error worth
 		// failing the run over.
 		a.logger.Debug().Err(err).Str("path", e.Path).Msg("Could not claim a file for transfer")
-		return false, false, 0, err
+		return false, false, false, 0, err
 	}
 
 	offset := e.BytesSent
 	body, err := a.openAt(ctx, e.Path, offset)
 	if err != nil {
+		if a.skipIfVanished(ctx, e) {
+			return false, false, true, 0, nil
+		}
 		a.fail(ctx, e, fmt.Sprintf("open: %v", err))
-		return false, false, 0, err
+		return false, false, false, 0, err
 	}
 	defer body.Close()
 
 	res, err := a.transport.PutFile(ctx, a.hubID, e, body, offset)
 	if err != nil {
+		// openAt streams through an io.Pipe, so a source file deleted by
+		// compaction or retention surfaces HERE, as a transfer error, not at
+		// open. Without this check the row burns its whole retry budget on a
+		// file that no longer exists and then sits terminally failed.
+		if a.skipIfVanished(ctx, e) {
+			return false, false, true, 0, nil
+		}
 		// A resume the hub cannot honour: it no longer holds the prefix our
 		// checkpoint refers to. That happens when a hub restarts, sweeps its
 		// staging area, or runs on a backend that cannot append at all. The
@@ -415,25 +482,25 @@ func (a *Agent) sendOne(ctx context.Context, e *LedgerEntry) (sent, partial bool
 			}
 		}
 		a.fail(ctx, e, err.Error())
-		return false, false, 0, err
+		return false, false, false, 0, err
 	}
 	// A hub is remote code as far as the spoke is concerned; an inconsistent
 	// answer must not become ledger state.
 	if err := res.Validate(e); err != nil {
 		a.fail(ctx, e, fmt.Sprintf("invalid hub response: %v", err))
-		return false, false, 0, err
+		return false, false, false, 0, err
 	}
 
 	switch {
 	case res.Outcome.Done():
 		if err := a.ledger.MarkSynced(ctx, a.hubID, e.Path); err != nil {
-			return false, false, 0, err
+			return false, false, false, 0, err
 		}
 		// A file the hub already had cost no bytes; only count a real transfer.
 		if res.Outcome == OutcomeCommitted {
-			return true, false, res.BytesAccepted - offset, nil
+			return true, false, false, res.BytesAccepted - offset, nil
 		}
-		return true, false, 0, nil
+		return true, false, false, 0, nil
 
 	case res.Outcome == OutcomePartial:
 		// Record the hub's offset, not our own guess: the two can disagree,
@@ -442,7 +509,7 @@ func (a *Agent) sendOne(ctx context.Context, e *LedgerEntry) (sent, partial bool
 			a.logger.Warn().Err(err).Str("path", e.Path).Msg("Could not record a resume checkpoint")
 		}
 		a.fail(ctx, e, "transfer ended early; will resume")
-		return false, true, res.BytesAccepted - offset, nil
+		return false, true, false, res.BytesAccepted - offset, nil
 
 	case res.Outcome == OutcomeConflict:
 		// Terminal by design. Retrying cannot resolve a content disagreement,
@@ -455,13 +522,13 @@ func (a *Agent) sendOne(ctx context.Context, e *LedgerEntry) (sent, partial bool
 		if err := a.ledger.MarkFailed(ctx, a.hubID, e.Path, "conflict: hub holds different content", 1); err != nil {
 			a.logger.Warn().Err(err).Str("path", e.Path).Msg("Could not mark a conflicted file failed")
 		}
-		return false, false, 0, nil
+		return false, false, false, 0, nil
 
 	default:
 		// Checksum mismatch or backpressure: retryable, so let the attempt
 		// counter decide when to give up.
 		a.fail(ctx, e, string(res.Outcome))
-		return false, false, 0, nil
+		return false, false, false, 0, nil
 	}
 }
 
@@ -486,6 +553,30 @@ func (a *Agent) fail(ctx context.Context, e *LedgerEntry, msg string) {
 	if err := a.ledger.MarkFailed(ctx, a.hubID, e.Path, msg, a.maxAttempts); err != nil {
 		a.logger.Warn().Err(err).Str("path", e.Path).Msg("Could not record a transfer failure")
 	}
+}
+
+// skipIfVanished checks whether a transfer failed because the source file no
+// longer exists (compaction or retention deleted it after discovery), and if
+// so marks the entry skipped. Returns true when the entry was skipped.
+//
+// The direction of the check is deliberate: Exists must POSITIVELY report the
+// file gone. On an Exists error nothing is skipped — a transient storage
+// error must never terminally skip a file that still exists, so uncertainty
+// falls through to the normal retry path.
+func (a *Agent) skipIfVanished(ctx context.Context, e *LedgerEntry) bool {
+	present, err := a.backend.Exists(ctx, e.Path)
+	if err != nil || present {
+		return false
+	}
+	if err := a.ledger.MarkSkipped(ctx, a.hubID, e.Path,
+		"source file removed before delivery (compaction or retention)"); err != nil {
+		a.logger.Warn().Err(err).Str("path", e.Path).Msg("Could not mark a vanished file skipped")
+		return false
+	}
+	a.logger.Info().
+		Str("path", e.Path).
+		Msg("Source file vanished before delivery; marked skipped (compaction or retention removed it)")
+	return true
 }
 
 // openAt returns a reader positioned at offset.

--- a/internal/edgesync/blocker_fixes_test.go
+++ b/internal/edgesync/blocker_fixes_test.go
@@ -1,0 +1,331 @@
+package edgesync
+
+// Regression tests for the pre-26.09.1 edge sync audit blockers:
+//
+//   - a spoke whose reconcile batch exceeds the hub's cap must split and
+//     retry rather than failing every pass identically (B3);
+//   - a pending file deleted by compaction/retention must be marked skipped,
+//     not wedge air-gap export forever or burn the network retry budget (B4);
+//   - the ledger must be able to reclaim skipped rows (PruneSkipped).
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// A spoke at batch_size=0 (offer the whole backlog at once) against a hub
+// whose reconcile cap is smaller must still drain: the 413 carries the hub's
+// cap, and the agent splits the page. Before the fix this failed every pass
+// with the same 413 and moved zero files — the audit's live-reproduced B3.
+func TestAgent_RunSplitsAReconcilePageTheHubRefuses(t *testing.T) {
+	ctx := context.Background()
+	const hubCap, total = 3, 10
+	rig := newAgentRigWithBatch(t, 0)
+	rig.transport.MaxReconcileEntries = hubCap
+
+	for i := 0; i < total; i++ {
+		rig.writeFile(t, fmt.Sprintf("metrics/cpu/2026/08/07/14/f_%02d.parquet", i),
+			[]byte(fmt.Sprintf("payload %02d", i)))
+	}
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run failed instead of splitting the refused page: %v", err)
+	}
+	if res.Sent != total {
+		t.Errorf("sent = %d of %d after 413 splitting", res.Sent, total)
+	}
+
+	pending, err := rig.ledger.Pending(ctx, DefaultHubID, 0)
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("%d files left pending; the refused page was not fully retried", len(pending))
+	}
+}
+
+// An explicit batch_size larger than the hub's cap is the same shape from the
+// hub's side; the split must land under the cap rather than erroring.
+func TestAgent_RunSplitsWhenExplicitBatchExceedsTheHubCap(t *testing.T) {
+	ctx := context.Background()
+	const hubCap, batch, total = 2, 5, 6
+	rig := newAgentRigWithBatch(t, batch)
+	rig.transport.MaxReconcileEntries = hubCap
+
+	for i := 0; i < total; i++ {
+		rig.writeFile(t, fmt.Sprintf("metrics/cpu/2026/08/07/14/g_%02d.parquet", i),
+			[]byte(fmt.Sprintf("payload %02d", i)))
+	}
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Sent != total {
+		t.Errorf("sent = %d of %d", res.Sent, total)
+	}
+}
+
+// A pending file deleted from local storage after discovery (compaction is on
+// by default and rewrites-then-deletes raw parquet) must be marked skipped by
+// the network pass — not retried into terminal `failed` noise. Before the fix
+// each such file burned the full attempt budget and sat failed forever (H3).
+func TestAgent_RunSkipsAFileDeletedAfterDiscovery(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	rig.writeFile(t, "metrics/cpu/2026/08/07/14/keep.parquet", []byte("kept"))
+	rig.writeFile(t, "metrics/cpu/2026/08/07/14/gone.parquet", []byte("doomed"))
+
+	// Discover both, then delete one underneath the ledger — what compaction
+	// does between discovery and the next pass.
+	if _, err := rig.agent.Discover(ctx); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if err := rig.backend.Delete(ctx, "metrics/cpu/2026/08/07/14/gone.parquet"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	res, err := rig.agent.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Sent != 1 {
+		t.Errorf("sent = %d, want 1 (the surviving file)", res.Sent)
+	}
+	if res.Skipped != 1 {
+		t.Errorf("skipped = %d, want 1 (the vanished file)", res.Skipped)
+	}
+	if res.Failed != 0 {
+		t.Errorf("failed = %d; a vanished file must skip, not burn attempts", res.Failed)
+	}
+
+	stats, err := rig.ledger.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Skipped != 1 {
+		t.Errorf("ledger skipped = %d, want 1", stats.Skipped)
+	}
+	if stats.Pending != 0 {
+		t.Errorf("ledger pending = %d, want 0", stats.Pending)
+	}
+}
+
+// Air-gap export with a vanished pending file must produce a bundle with the
+// surviving files and mark the vanished one skipped. Before the fix the whole
+// export failed, the entry stayed pending, and every future export re-selected
+// it — a permanent wedge on the box least able to receive a site visit (B2 of
+// the audit; the flagship air-gap deployment is exactly the one with no
+// network fallback).
+func TestExporter_ExportSkipsAVanishedFileInsteadOfWedging(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	rig.writeFile(t, "metrics/cpu/2026/08/07/14/keep.parquet", []byte("kept"))
+	rig.writeFile(t, "metrics/cpu/2026/08/07/15/gone.parquet", []byte("doomed"))
+
+	dest, err := os.MkdirTemp("", "bundle-dest-*")
+	if err != nil {
+		t.Fatalf("dest dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dest) })
+
+	policy, err := NewDestinationPolicy([]string{dest}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	writer, err := NewBundleWriter(BundleWriterConfig{
+		Backend: rig.backend,
+		SpokeID: "rocket-01",
+		HubID:   DefaultHubID,
+		Secret:  "0123456789abcdef0123456789abcdef",
+		Logger:  zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	discoverer, err := NewDiscoverer(rig.ledger, rig.backend, DefaultHubID, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("discoverer: %v", err)
+	}
+	exporter, err := NewExporter(ExporterConfig{
+		Ledger:     rig.ledger,
+		Writer:     writer,
+		Policy:     policy,
+		Discoverer: discoverer,
+		HubID:      DefaultHubID,
+		Logger:     zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("exporter: %v", err)
+	}
+
+	// Discover both, then delete one underneath the ledger.
+	if _, err := discoverer.Discover(ctx); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if err := rig.backend.Delete(ctx, "metrics/cpu/2026/08/07/15/gone.parquet"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	res, err := exporter.Export(ctx, dest, 0)
+	if err != nil {
+		t.Fatalf("Export failed instead of skipping the vanished file: %v", err)
+	}
+	if res.FileCount != 1 {
+		t.Errorf("bundle files = %d, want 1", res.FileCount)
+	}
+	if res.Skipped != 1 {
+		t.Errorf("export skipped = %d, want 1", res.Skipped)
+	}
+
+	stats, err := rig.ledger.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Skipped != 1 {
+		t.Errorf("ledger skipped = %d, want 1", stats.Skipped)
+	}
+	if stats.Exported != 1 {
+		t.Errorf("ledger exported = %d, want 1", stats.Exported)
+	}
+
+	// The wedge regression proper: the NEXT export must not re-select the
+	// vanished file — with nothing new it reports nothing to export.
+	if _, err := exporter.Export(ctx, dest, 0); err != ErrNothingToExport {
+		t.Errorf("second export = %v, want ErrNothingToExport (the vanished file must stay skipped)", err)
+	}
+}
+
+// MarkSkipped is legal from pending and in_flight only; terminal states must
+// refuse it, and PruneSkipped must reclaim old skipped rows by last_attempt.
+func TestLedger_MarkSkippedAndPruneSkipped(t *testing.T) {
+	ctx := context.Background()
+	ledger := setupTestLedger(t)
+
+	add := func(path string) {
+		t.Helper()
+		if err := ledger.Track(ctx, &LedgerEntry{
+			HubID: DefaultHubID, Path: path, SHA256: "aa", SizeBytes: 2,
+			Database: "metrics", Measurement: "cpu",
+			PartitionTime: time.Date(2026, 8, 7, 14, 0, 0, 0, time.UTC),
+			DiscoveredAt:  time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("add %s: %v", path, err)
+		}
+	}
+
+	add("metrics/cpu/2026/08/07/14/a.parquet")
+	if err := ledger.MarkSkipped(ctx, DefaultHubID, "metrics/cpu/2026/08/07/14/a.parquet", "gone"); err != nil {
+		t.Fatalf("MarkSkipped from pending: %v", err)
+	}
+
+	add("metrics/cpu/2026/08/07/14/b.parquet")
+	if err := ledger.MarkInFlight(ctx, DefaultHubID, "metrics/cpu/2026/08/07/14/b.parquet"); err != nil {
+		t.Fatalf("MarkInFlight: %v", err)
+	}
+	if err := ledger.MarkSkipped(ctx, DefaultHubID, "metrics/cpu/2026/08/07/14/b.parquet", "gone"); err != nil {
+		t.Fatalf("MarkSkipped from in_flight: %v", err)
+	}
+
+	// From synced: must refuse — skipping delivered data would misreport it.
+	add("metrics/cpu/2026/08/07/14/c.parquet")
+	if err := ledger.MarkInFlight(ctx, DefaultHubID, "metrics/cpu/2026/08/07/14/c.parquet"); err != nil {
+		t.Fatalf("MarkInFlight c: %v", err)
+	}
+	if err := ledger.MarkSynced(ctx, DefaultHubID, "metrics/cpu/2026/08/07/14/c.parquet"); err != nil {
+		t.Fatalf("MarkSynced c: %v", err)
+	}
+	if err := ledger.MarkSkipped(ctx, DefaultHubID, "metrics/cpu/2026/08/07/14/c.parquet", "gone"); err == nil {
+		t.Error("MarkSkipped from synced succeeded; must refuse")
+	}
+
+	stats, err := ledger.Stats(ctx, DefaultHubID)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Skipped != 2 {
+		t.Fatalf("skipped = %d, want 2", stats.Skipped)
+	}
+
+	// Fresh skipped rows survive a prune with a 1-day retention...
+	pruned, err := ledger.PruneSkipped(ctx, 1)
+	if err != nil {
+		t.Fatalf("PruneSkipped: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("pruned %d fresh rows; retention must protect them", pruned)
+	}
+
+	// ...and are reclaimed once last_attempt ages past the cutoff.
+	if _, err := ledger.db.ExecContext(ctx,
+		`UPDATE sync_ledger SET last_attempt = ? WHERE state = 'skipped'`,
+		time.Now().UTC().AddDate(0, 0, -10)); err != nil {
+		t.Fatalf("age rows: %v", err)
+	}
+	pruned, err = ledger.PruneSkipped(ctx, 7)
+	if err != nil {
+		t.Fatalf("PruneSkipped aged: %v", err)
+	}
+	if pruned != 2 {
+		t.Errorf("pruned = %d, want 2", pruned)
+	}
+}
+
+// The hub mounts Arc's token middleware (write level) ahead of the sync
+// routes, so the transport must present the API token from
+// ARC_EDGE_SYNC_HUB_TOKEN on every request. Before the fix no token was ever
+// sent and every spoke request against an auth-enabled hub — the default
+// production posture — died with 401 (the audit's live-reproduced top
+// blocker).
+func TestHTTPTransport_SendsTheHubAPIToken(t *testing.T) {
+	var gotAuth []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"missing":[],"present":[],"conflicts":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	transport, err := NewHTTPTransport(HTTPTransportConfig{
+		BaseURL:  srv.URL,
+		SpokeID:  "rocket-01",
+		Secret:   "0123456789abcdef0123456789abcdef",
+		APIToken: "hub-write-token",
+	})
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if _, err := transport.Reconcile(context.Background(), DefaultHubID, nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(gotAuth) != 1 || gotAuth[0] != "Bearer hub-write-token" {
+		t.Errorf("Authorization = %v, want [Bearer hub-write-token]", gotAuth)
+	}
+
+	// Without a token no Authorization header is sent at all — an empty
+	// Bearer would read as a malformed credential rather than "none".
+	bare, err := NewHTTPTransport(HTTPTransportConfig{
+		BaseURL: srv.URL,
+		SpokeID: "rocket-01",
+		Secret:  "0123456789abcdef0123456789abcdef",
+	})
+	if err != nil {
+		t.Fatalf("bare transport: %v", err)
+	}
+	if _, err := bare.Reconcile(context.Background(), DefaultHubID, nil); err != nil {
+		t.Fatalf("bare reconcile: %v", err)
+	}
+	if gotAuth[1] != "" {
+		t.Errorf("tokenless Authorization = %q, want empty", gotAuth[1])
+	}
+}

--- a/internal/edgesync/bundle.go
+++ b/internal/edgesync/bundle.go
@@ -195,6 +195,11 @@ type ExportResult struct {
 	FileCount int
 	Bytes     int64
 	Duration  time.Duration
+
+	// Skipped is how many eligible entries were dropped because their source
+	// file vanished before export (compaction or retention). Set by the
+	// Exporter's pre-check, not the writer.
+	Skipped int
 }
 
 // Export writes entries to a new bundle directory under parent.

--- a/internal/edgesync/exporter.go
+++ b/internal/edgesync/exporter.go
@@ -138,6 +138,44 @@ func (e *Exporter) Export(ctx context.Context, dest string, limit int) (*ExportR
 		return nil, ErrNothingToExport
 	}
 
+	// Drop entries whose source file vanished (compaction or retention beat
+	// the export to it) BEFORE the writer runs. Without this the write fails
+	// wholesale on the missing file, the entry stays pending, and the next
+	// export re-selects it — the bundle path is wedged until someone edits
+	// SQLite by hand, on exactly the air-gapped box no one can reach.
+	//
+	// The check direction is deliberate: Exists must POSITIVELY report the
+	// file gone. On an Exists error the entry is kept — the copy then fails
+	// and aborts the export as before, because a transient storage error must
+	// never terminally skip a file that still exists. A file deleted between
+	// this check and the copy still aborts this export, but the next one
+	// skips it here: the window self-heals instead of wedging.
+	alive := entries[:0]
+	skipped := 0
+	for _, entry := range entries {
+		present, existsErr := e.writer.backend.Exists(ctx, entry.Path)
+		if existsErr != nil || present {
+			alive = append(alive, entry)
+			continue
+		}
+		if markErr := e.ledger.MarkSkipped(ctx, e.hubID, entry.Path,
+			"source file removed before export (compaction or retention)"); markErr != nil {
+			e.logger.Warn().Err(markErr).Str("path", entry.Path).
+				Msg("Could not mark a vanished file skipped; keeping it in the export")
+			alive = append(alive, entry)
+			continue
+		}
+		skipped++
+		e.logger.Info().Str("path", entry.Path).
+			Msg("Source file vanished before export; marked skipped (compaction or retention removed it)")
+	}
+	entries = alive
+	if len(entries) == 0 {
+		// Everything eligible had vanished. The ledger now reflects that, so
+		// this converges to a clean "nothing to export" instead of recurring.
+		return nil, ErrNothingToExport
+	}
+
 	// Byte cap applied by truncating the selection, not by failing: a backlog
 	// larger than one drive is the expected case, and the operator's next
 	// bundle continues from where this one stopped. Entries are newest-first,
@@ -168,6 +206,7 @@ func (e *Exporter) Export(ctx context.Context, dest string, limit int) (*ExportR
 	if err != nil {
 		return nil, err
 	}
+	res.Skipped = skipped
 
 	// A file that cannot be marked is NOT fatal: it is already in a signed,
 	// verified bundle on disk. Leaving it pending means a later bundle carries

--- a/internal/edgesync/ledger.go
+++ b/internal/edgesync/ledger.go
@@ -64,12 +64,13 @@ const (
 	// StateFailed — exhausted retries. Terminal until an operator intervenes.
 	StateFailed SyncState = "failed"
 
-	// StateSkipped — deliberately excluded (e.g. a future filtering policy).
-	//
-	// TODO(#569): reserved, nothing sets it in phase 1. Stats deliberately
-	// does not count it, so a skipped row would be invisible to operators —
-	// whoever introduces the first writer must add it to Stats at the same
-	// time, or drop this constant.
+	// StateSkipped — the source file vanished from local storage (compaction
+	// or retention deleted it) before it could be delivered. Terminal: the
+	// content no longer exists to send. Without this state a vanished pending
+	// file wedged air-gap export forever (the export failed wholesale and
+	// re-selected the same entry every time) and burned the network path's
+	// full retry budget per pass. Counted in Stats and reported in /status;
+	// reclaimed by PruneSkipped.
 	StateSkipped SyncState = "skipped"
 )
 
@@ -719,6 +720,30 @@ func (l *Ledger) MarkFailed(ctx context.Context, hubID, path, errMsg string, max
 	return l.checkTransition(ctx, res, hubID, path, StateInFlight)
 }
 
+// MarkSkipped records that an entry's source file vanished from storage
+// before delivery — compaction or retention got to it first.
+//
+// Legal from pending (the export pre-check finds the file gone) AND from
+// in_flight (the network path only learns mid-transfer: openAt streams
+// through an io.Pipe, so a missing file surfaces as a PutFile error after
+// MarkInFlight has already run). last_attempt is stamped because it is the
+// column PruneSkipped keys on — synced_at stays NULL on this path.
+func (l *Ledger) MarkSkipped(ctx context.Context, hubID, path, note string) error {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	res, err := l.db.ExecContext(ctx, `
+		UPDATE sync_ledger
+		SET state = ?, last_error = ?, last_attempt = ?
+		WHERE hub_id = ? AND path = ? AND state IN (?, ?)`,
+		string(StateSkipped), note, time.Now().UTC(),
+		hubID, path, string(StatePending), string(StateInFlight))
+	if err != nil {
+		return fmt.Errorf("edgesync: mark skipped %q: %w", path, err)
+	}
+	return l.checkTransition(ctx, res, hubID, path, StatePending, StateInFlight)
+}
+
 // RecoverInFlight reverts in_flight entries to pending. Call once at startup.
 //
 // An in_flight row can only have been written by a transfer that is no longer
@@ -759,6 +784,11 @@ type Stats struct {
 	Synced int64
 	Failed int64
 
+	// Skipped — the source file vanished (compaction/retention) before
+	// delivery. Terminal bookkeeping, not backlog: excluded from
+	// PendingBytes because there is nothing left to send.
+	Skipped int64
+
 	// PendingBytes is what has not reached a hub, INCLUDING exported bytes:
 	// a file on a drive in transit has not arrived. Excluding it would make an
 	// air-gap spoke's backlog appear to shrink the moment a bundle is written,
@@ -783,10 +813,11 @@ func (l *Ledger) Stats(ctx context.Context, hubID string) (*Stats, error) {
 			COALESCE(SUM(state = 'exported'), 0),
 			COALESCE(SUM(state = 'synced'), 0),
 			COALESCE(SUM(state = 'failed'), 0),
+			COALESCE(SUM(state = 'skipped'), 0),
 			COALESCE(SUM(CASE WHEN state IN ('pending','in_flight','exported')
 			                  THEN size_bytes - bytes_sent ELSE 0 END), 0)
 		FROM sync_ledger WHERE hub_id = ?`, hubID).
-		Scan(&s.Pending, &s.InFlight, &s.Exported, &s.Synced, &s.Failed, &s.PendingBytes)
+		Scan(&s.Pending, &s.InFlight, &s.Exported, &s.Synced, &s.Failed, &s.Skipped, &s.PendingBytes)
 	if err != nil {
 		return nil, fmt.Errorf("edgesync: ledger stats: %w", err)
 	}
@@ -908,6 +939,63 @@ func (l *Ledger) PruneSynced(ctx context.Context, retentionDays int) (int64, err
 		deleted, err := res.RowsAffected()
 		if err != nil {
 			return total, fmt.Errorf("edgesync: count pruned entries: %w", err)
+		}
+		total += deleted
+
+		if deleted < batchSize {
+			break
+		}
+	}
+	return total, nil
+}
+
+// PruneSkipped deletes skipped rows older than retentionDays.
+//
+// Same shape and discipline as PruneSynced (resolved id bound, 1000-row
+// batches, ctx checked between batches, Go-time-vs-Go-time comparison — see
+// the domain note there). Keys on last_attempt, which MarkSkipped stamps:
+// synced_at is NULL for a file that never arrived anywhere, so PruneSynced's
+// predicate can never reclaim these rows.
+func (l *Ledger) PruneSkipped(ctx context.Context, retentionDays int) (int64, error) {
+	if retentionDays <= 0 {
+		return 0, nil
+	}
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
+
+	var maxID int64
+	err := l.db.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(id), 0) FROM sync_ledger
+		WHERE state = ? AND last_attempt IS NOT NULL AND last_attempt < ?`,
+		string(StateSkipped), cutoff).Scan(&maxID)
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: find skipped prune cutoff: %w", err)
+	}
+	if maxID == 0 {
+		return 0, nil
+	}
+
+	const batchSize = 1000
+	var total int64
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+
+		res, err := l.db.ExecContext(ctx, `
+			DELETE FROM sync_ledger WHERE id IN (
+				SELECT id FROM sync_ledger
+				WHERE id <= ? AND state = ? AND last_attempt IS NOT NULL AND last_attempt < ?
+				ORDER BY id ASC LIMIT ?
+			)`, maxID, string(StateSkipped), cutoff, batchSize)
+		if err != nil {
+			return total, fmt.Errorf("edgesync: prune skipped entries: %w", err)
+		}
+
+		deleted, err := res.RowsAffected()
+		if err != nil {
+			return total, fmt.Errorf("edgesync: count pruned skipped entries: %w", err)
 		}
 		total += deleted
 

--- a/internal/edgesync/transport_http.go
+++ b/internal/edgesync/transport_http.go
@@ -21,10 +21,11 @@ import (
 // outcome taxonomy, resume — lives above this in the interface, so an S3-relay
 // or sneakernet transport reuses it unchanged and only the wire format differs.
 type HTTPTransport struct {
-	baseURL string
-	spokeID string
-	secret  string
-	client  *http.Client
+	baseURL  string
+	spokeID  string
+	secret   string
+	apiToken string
+	client   *http.Client
 }
 
 // HTTPTransportConfig configures an HTTPTransport.
@@ -38,6 +39,12 @@ type HTTPTransportConfig struct {
 	// Secret is the hub-issued shared secret. Never logged, never persisted
 	// by this package — it arrives from the environment and stays in memory.
 	Secret string
+
+	// APIToken is an Arc API token for the hub's token middleware, which
+	// gates /api/v1/sync at write level ahead of the per-spoke HMAC. Optional:
+	// empty means no Authorization header, which only works against a hub
+	// running with auth disabled. Same handling discipline as Secret.
+	APIToken string
 
 	// Timeout bounds a single request. Zero means 30 minutes, matching the
 	// hub's receive timeout: a large Parquet file over a constrained link is
@@ -73,11 +80,28 @@ func NewHTTPTransport(cfg HTTPTransportConfig) (*HTTPTransport, error) {
 	}
 
 	return &HTTPTransport{
-		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
-		spokeID: cfg.SpokeID,
-		secret:  cfg.Secret,
-		client:  client,
+		baseURL:  strings.TrimRight(cfg.BaseURL, "/"),
+		spokeID:  cfg.SpokeID,
+		secret:   cfg.Secret,
+		apiToken: cfg.APIToken,
+		client:   client,
 	}, nil
+}
+
+// ReconcileTooLargeError reports that the hub refused a reconcile batch with
+// 413. MaxEntries is the hub's advertised entry cap, or 0 when the refusal
+// came from a byte limit that advertises none (the route-level body cap).
+// The agent reacts by splitting the page and retrying, so this error never
+// fails a pass on its own.
+type ReconcileTooLargeError struct {
+	MaxEntries int
+}
+
+func (e *ReconcileTooLargeError) Error() string {
+	if e.MaxEntries > 0 {
+		return fmt.Sprintf("edgesync: hub refused reconcile batch as too large (max_entries=%d)", e.MaxEntries)
+	}
+	return "edgesync: hub refused reconcile batch as too large"
 }
 
 // Reconcile asks the hub which of the pending files it already holds.
@@ -122,6 +146,17 @@ func (t *HTTPTransport) Reconcile(ctx context.Context, hubID string, pending []*
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusRequestEntityTooLarge {
+		// Two producers on the hub: the reconciler's entry cap (body carries
+		// max_entries) and the route-level byte limit (no max_entries). Both
+		// are typed so the agent splits the page instead of failing the pass.
+		var refusal struct {
+			MaxEntries int `json:"max_entries"`
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		_ = json.Unmarshal(body, &refusal)
+		return nil, &ReconcileTooLargeError{MaxEntries: refusal.MaxEntries}
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, t.statusError(resp, "reconcile")
 	}
@@ -242,6 +277,12 @@ func (t *HTTPTransport) decodePutResponse(resp *http.Response, entry *LedgerEntr
 
 // setAuthHeaders applies the headers every sync request carries.
 func (t *HTTPTransport) setAuthHeaders(req *http.Request, hubID, nonce string, ts int64, mac string) {
+	// Two layers, matching the hub's mount order: the Arc API token satisfies
+	// the token middleware ahead of the routes, then the HMAC headers bind
+	// this request to a spoke identity and its content.
+	if t.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+t.apiToken)
+	}
 	req.Header.Set(headerSyncSpokeID, t.spokeID)
 	req.Header.Set(headerSyncHubID, hubID)
 	req.Header.Set(headerSyncNonce, nonce)
@@ -260,6 +301,18 @@ func (t *HTTPTransport) statusError(resp *http.Response, op string) error {
 	msg := strings.TrimSpace(string(body))
 	if msg == "" {
 		msg = resp.Status
+	}
+	// The two failures whose remedy is on THIS box, not the hub: the hub's
+	// token middleware rejected the request before the sync handler ran.
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		if t.apiToken == "" {
+			msg += " (hub requires an Arc API token; set ARC_EDGE_SYNC_HUB_TOKEN on this spoke)"
+		} else {
+			msg += " (the ARC_EDGE_SYNC_HUB_TOKEN on this spoke was rejected by the hub, or the request MAC failed; check the token, then the spoke secret and hub_id)"
+		}
+	case http.StatusForbidden:
+		msg += " (the ARC_EDGE_SYNC_HUB_TOKEN on this spoke lacks write permission on the hub)"
 	}
 	return fmt.Errorf("edgesync: %s failed with %d: %s", op, resp.StatusCode, msg)
 }

--- a/internal/edgesync/transport_memory.go
+++ b/internal/edgesync/transport_memory.go
@@ -27,6 +27,11 @@ import (
 type MemoryTransport struct {
 	mu sync.Mutex
 
+	// MaxReconcileEntries, when > 0, refuses larger reconcile batches with
+	// ReconcileTooLargeError — mirroring the real hub's cap so agent paging
+	// and 413 splitting are testable. Set before use; not synchronized.
+	MaxReconcileEntries int
+
 	// files is the hub's contents, keyed by hub ID then path.
 	files map[string]map[string]*memFile
 
@@ -157,6 +162,9 @@ func (m *MemoryTransport) stagingLocked(hubID string) map[string]*memFile {
 func (m *MemoryTransport) Reconcile(ctx context.Context, hubID string, pending []*LedgerEntry) (*ReconcileResult, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+	if m.MaxReconcileEntries > 0 && len(pending) > m.MaxReconcileEntries {
+		return nil, &ReconcileTooLargeError{MaxEntries: m.MaxReconcileEntries}
 	}
 
 	m.mu.Lock()

--- a/internal/sql/mask.go
+++ b/internal/sql/mask.go
@@ -11,6 +11,17 @@ import (
 type StringMask struct {
 	Placeholder string
 	Original    string
+
+	// Identifier marks a double-quoted token. In DuckDB SQL `"…"` is an
+	// IDENTIFIER, never a string — masking it identically to '…' literals is
+	// what made quoted database/measurement names resolve to quote-polluted
+	// storage paths (the quotes were spliced back inside the read_parquet
+	// glob at unmask time). Identifier masks get a distinct placeholder class
+	// so the table-reference rewriter can resolve them to their unquoted
+	// names, while every other masking consumer (comment stripping,
+	// validateSQL, the FROM-in-function-body scanner, the partition pruner)
+	// still sees an inert placeholder.
+	Identifier bool
 }
 
 // MaskStringLiterals replaces string literals with placeholders to prevent regex from matching inside them.
@@ -31,6 +42,14 @@ func MaskStringLiterals(sql string, hasQuotes bool) (string, []StringMask) {
 
 	i := 0
 	maskIndex := 0
+	// Identical quoted identifiers share ONE placeholder. The CTE-name
+	// registry and the table rewriter compare captured names textually, so
+	// `WITH "x-y" AS (…) SELECT * FROM "x-y"` must present the same token at
+	// both sites — per-occurrence placeholders would make the FROM site miss
+	// the CTE and rewrite it to a nonexistent storage path.
+	// Allocated lazily: the common single-quote-only query on this hot path
+	// never carries a double-quoted identifier.
+	var identPlaceholders map[string]string
 
 	for i < len(sql) {
 		ch := sql[i]
@@ -64,12 +83,28 @@ func MaskStringLiterals(sql string, hasQuotes bool) (string, []StringMask) {
 				i++
 			}
 
-			// Extract the full string literal and create a placeholder
+			// Extract the full quoted token and create a placeholder.
 			original := sql[start:i]
-			placeholder := fmt.Sprintf("__STR_%d__", maskIndex)
-			masks = append(masks, StringMask{Placeholder: placeholder, Original: original})
-			result.WriteString(placeholder)
-			maskIndex++
+			if quote == '"' {
+				// Identifier class: deduplicated, distinct prefix (see the
+				// StringMask.Identifier comment).
+				placeholder, seen := identPlaceholders[original]
+				if !seen {
+					if identPlaceholders == nil {
+						identPlaceholders = make(map[string]string)
+					}
+					placeholder = fmt.Sprintf("__IDENT_%d__", maskIndex)
+					identPlaceholders[original] = placeholder
+					masks = append(masks, StringMask{Placeholder: placeholder, Original: original, Identifier: true})
+					maskIndex++
+				}
+				result.WriteString(placeholder)
+			} else {
+				placeholder := fmt.Sprintf("__STR_%d__", maskIndex)
+				masks = append(masks, StringMask{Placeholder: placeholder, Original: original})
+				result.WriteString(placeholder)
+				maskIndex++
+			}
 		} else {
 			result.WriteByte(ch)
 			i++
@@ -83,9 +118,38 @@ func MaskStringLiterals(sql string, hasQuotes bool) (string, []StringMask) {
 func UnmaskStringLiterals(sql string, masks []StringMask) string {
 	result := sql
 	for _, mask := range masks {
+		if mask.Identifier {
+			// Identifier placeholders are deduplicated at mask time, so one
+			// mask entry may stand for several occurrences.
+			result = strings.ReplaceAll(result, mask.Placeholder, mask.Original)
+			continue
+		}
 		result = strings.Replace(result, mask.Placeholder, mask.Original, 1)
 	}
 	return result
+}
+
+// IdentifierNames maps each identifier placeholder to its UNQUOTED name:
+// surrounding double quotes stripped and the `""` escape collapsed. This is
+// what the table-reference rewriter and the RBAC extractor resolve captured
+// placeholders through, so both see the same clean name — the
+// extraction-must-match-execution invariant.
+func IdentifierNames(masks []StringMask) map[string]string {
+	var out map[string]string
+	for _, mask := range masks {
+		if !mask.Identifier {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string)
+		}
+		name := mask.Original
+		if len(name) >= 2 && name[0] == '"' && name[len(name)-1] == '"' {
+			name = name[1 : len(name)-1]
+		}
+		out[mask.Placeholder] = strings.ReplaceAll(name, `""`, `"`)
+	}
+	return out
 }
 
 // HasQuotes returns true if the SQL string contains any quote characters.
@@ -315,7 +379,7 @@ func UnmaskFromKeywordsInFunctionBodies(sql string, masks []FromMask) string {
 // masker runs before stripSQLComments, so `EXTRACT /* c */ (YEAR FROM x)`
 // must still be recognised.
 //
-// Rejects quoted identifiers — `"EXTRACT"(...)` or `` `EXTRACT`(...) `` is
+// Rejects quoted identifiers — `"EXTRACT"(...)` or “ `EXTRACT`(...) “ is
 // a user column, not the builtin. DuckDB does not accept backticks for
 // identifiers in its default parser, but the check costs nothing and
 // matches gemini-code-assist's defensive guidance.
@@ -459,7 +523,7 @@ func equalFoldASCII(a, b string) bool {
 }
 
 // EscapeStringLiteral escapes single quotes for safe use as a DuckDB
-// single-quoted string literal: 'foo' → 'foo', 'it's' → 'it''s'.
+// single-quoted string literal: 'foo' → 'foo', 'it's' → 'it”s'.
 // Use this for every interpolation into a DuckDB SQL fragment that
 // cannot be parameterised — most importantly `read_parquet('PATH')`,
 // where the path comes from user-controlled inputs (database header,

--- a/internal/sql/mask_test.go
+++ b/internal/sql/mask_test.go
@@ -12,8 +12,8 @@ func TestMaskFromKeywordsInFunctionBodies(t *testing.T) {
 		wantMasks int
 		// After mask runs, the table-rewriter regex should NOT see "FROM x"
 		// where x is the inner column, but SHOULD still see the outer FROM.
-		mustContainOuterFROM     []string
-		mustNotContainInnerFROM  []string
+		mustContainOuterFROM    []string
+		mustNotContainInnerFROM []string
 	}{
 		{
 			name:                    "EXTRACT(YEAR FROM time) FROM table",


### PR DESCRIPTION
## Summary

An internal audit of the shipped edge sync subsystem (#576–#584) found four release blockers. All are fixed here and live-verified on a two-node rig; the remaining audit findings are filed as #610–#616.

- **Auth**: the spoke transport never sent an Arc API token while the hub required one — network sync was unusable against any auth-enabled hub (the default). Hub `/api/v1/sync` now gates at **write** level (matching ingest); the spoke carries env-only `ARC_EDGE_SYNC_HUB_TOKEN` with the same config-file-refusal discipline as the secret; tokenless spokes warn at startup and the 401 text names the variable.
- **Quoted identifiers** (general query-layer bug, not edge-sync-specific): double-quoted tokens were masked as string literals, so `"my-db".cpu` resolved to a quote-polluted glob and returned zero rows — hyphenated names (every spoke ID) had no working syntax. They now mask into a distinct `__IDENT__` placeholder class resolved to validated unquoted names in the transform, the header-db path, and RBAC extraction alike. The deep review of this fix caught that restoring an *invalid* quoted identifier verbatim would hand DuckDB a replacement scan: `ValidateSQLRequest` now rejects invalid quoted identifiers in table position (generalizing the GHSA-w8x2 scanner — which also closes the pre-existing double-quoted comma-cross-join bypass), with an inert-sentinel backstop in the transform. One deliberate behavior change: `` FROM `my;db` `` now returns an explicit 400 instead of silent zero rows.
- **Reconcile paging**: `batch_size` now defaults to 1000, and a 413-refused page is split and retried in-pass using the hub's advertised cap (halving on byte-limit refusals). Previously the default sent the whole backlog at once and any backlog above the hub cap failed every pass identically, forever.
- **Vanished files**: `StateSkipped` is wired. A file compaction/retention deletes after discovery is skipped (fail-safe `Exists` check — a transient error can never skip a live file), export continues instead of wedging permanently, skipped counts appear in `/status` and pass/export results, and skipped rows are pruned.
- **Dead code wired**: `SweepStaging` (hub staging DoS guard) runs hourly (`staging_sweep_max_age_hours=72`); `PruneSynced`/`PruneSkipped` run twice daily on spokes (`ledger_retention_days=90`).
- Release notes updated in the same PR, including a new Bug fixes entry for the quoted-identifier fix and loud compaction-duplication warnings (#610 tracks the proper supersede fix).

## Test plan

- [x] ~35 new regression tests: 413 splitting (both batch modes), vanished-file skip on both transports, `MarkSkipped` transitions + `PruneSkipped`, transport token header, quoted-identifier conversion ×13 (incl. RBAC extraction parity, header-db path, CTE, traversal/glob sentinels), replacement-scan rejection ×7 with 5 allow-cases
- [x] Full suites green: `internal/edgesync` (incl. `-race`), `internal/api`, `internal/sql`, `internal/config`; `gofmt`/`go vet` clean on touched packages
- [x] Config matrix traced (14 rows) + single deep reviewer pass; its one Blocker finding (replacement scan via invalid quoted identifier) fixed and re-verified
- [x] Live two-node rig, every previously-broken cell: auth-enabled hub + write-scope token drains 8/8 through a cap-3 hub at `batch_size=0`; `"rocket-01".telemetry` returns real rows on the hub; discovered-then-deleted file lands `skipped`; tokenless 401 names its remedy; export with a vanished pending file yields a valid bundle and completes import → ack; replacement-scan shapes rejected over HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)