### PR TITLE
feat(edgesync): operator requeue/dismiss for failed ledger rows (#612)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -281,6 +281,10 @@ Three admin endpoints drive it:
 | `POST /api/v1/spoke-sync/run` | Run one sync pass and return what it did. |
 | `GET /api/v1/spoke-sync/status` | Pending/synced/failed counts and sync lag. |
 | `GET /api/v1/spoke-sync/ledger` | Per-file state, attempts, and last error. |
+| `POST /api/v1/spoke-sync/ledger/requeue` | Return failed (or dismissed) entries to pending with a fresh retry budget. |
+| `POST /api/v1/spoke-sync/ledger/dismiss` | Mark failed entries operator-dismissed: out of the view, reversible while the file survives. |
+
+A file that exhausts its retries — or hits a content conflict — used to sit in `failed` forever with no exit: stale failures buried live problems in the ledger view, and (with delivery-deferred compaction) held their partition's compaction hostage. Both remediation endpoints take `{"path": "..."}` for one entry or `{"all": true}` for the lot; a dismissal is deliberately *skipped-not-deleted*, because a deleted row whose file still exists would be re-tracked by the next discovery pass and resurrect as pending — the exact noise the operator asked to silence. Requeue a conflict only after resolving the divergence on the hub, or it will simply conflict again. A dismissal is reversible via requeue **while the file survives**: dismissing also makes the file eligible for local compaction (delivery was renounced, so the partition must not stay wedged on it), and once compaction or retention consumes it there is nothing left to requeue — on a spoke with delivery-deferred compaction that can be the next compaction cycle.
 
 A pass recovers transfers interrupted by a crash, discovers new files, reconciles the backlog, and streams what the hub lacks — **newest first**, so a contact window that closes mid-backlog has already delivered the freshest telemetry. It **pages until the backlog drains**, so one pass on a spoke returning from a long outage moves everything, not just the first batch. Conflicts are reported in full rather than counted and are not retried: the same path holding different content means a spoke-ID collision or corruption, and re-sending would either be refused or destroy evidence.
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2626,13 +2626,13 @@ func main() {
 						}
 					}
 					if sweepOutputs {
-						swept, err := spokeLedger.SweepCompactedOutputRows(pruneCtx,
+						swept, err := spokeLedger.SweepSkippedRows(pruneCtx,
 							cfg.EdgeSync.Spoke.HubID, storageBackend.Exists)
 						if err != nil {
-							pruneLogger.Warn().Err(err).Msg("Edge sync compacted-output row sweep failed")
+							pruneLogger.Warn().Err(err).Msg("Edge sync skipped-row sweep failed")
 						} else if swept > 0 {
 							pruneLogger.Info().Int64("rows", swept).
-								Msg("Swept compacted-output ledger rows whose file is gone")
+								Msg("Swept file-backed skipped ledger rows whose file is gone")
 						}
 					}
 				}

--- a/internal/api/edgesync_spoke.go
+++ b/internal/api/edgesync_spoke.go
@@ -78,6 +78,8 @@ func (h *EdgeSyncSpokeHandler) RegisterRoutes(app fiber.Router) {
 	group.Post("/run", h.run)
 	group.Get("/status", h.status)
 	group.Get("/ledger", h.ledger)
+	group.Post("/ledger/requeue", h.requeueFailed)
+	group.Post("/ledger/dismiss", h.dismissFailed)
 	group.Post("/export", h.export)
 	group.Post("/export/:bundle_id/revert", h.revertExport)
 	group.Post("/ack", h.applyAck)
@@ -192,8 +194,9 @@ func (h *EdgeSyncSpokeHandler) status(c *fiber.Ctx) error {
 		"exported": st.Exported,
 		"synced":   st.Synced,
 		"failed":   st.Failed,
-		// Source files that vanished (compaction/retention) before delivery.
-		// Terminal bookkeeping, excluded from pending_bytes.
+		// Deliberately-not-delivered entries: vanished source files,
+		// compacted outputs, and operator-dismissed failures. Terminal
+		// bookkeeping, excluded from pending_bytes.
 		"skipped":       st.Skipped,
 		"pending_bytes": st.PendingBytes,
 	}
@@ -205,6 +208,104 @@ func (h *EdgeSyncSpokeHandler) status(c *fiber.Ctx) error {
 		out["seconds_since_last_sync"] = int64(time.Since(*st.LastSyncedAt).Seconds())
 	}
 	return c.JSON(out)
+}
+
+// ledgerSelector is the body both remediation endpoints accept: exactly one
+// of a single path or the whole failed set.
+type ledgerSelector struct {
+	Path string `json:"path"`
+	All  bool   `json:"all"`
+}
+
+func parseLedgerSelector(c *fiber.Ctx) (*ledgerSelector, error) {
+	var sel ledgerSelector
+	if err := c.BodyParser(&sel); err != nil {
+		return nil, errors.New("invalid JSON body")
+	}
+	if (sel.Path == "") == !sel.All {
+		return nil, errors.New(`provide exactly one of "path" or "all": true`)
+	}
+	return &sel, nil
+}
+
+// remediate runs one ledger remediation op through whichever transport
+// exists, mirroring the /ledger read path.
+func (h *EdgeSyncSpokeHandler) remediate(c *fiber.Ctx, verb string,
+	viaAgent func(context.Context, string) (int64, error),
+	viaExporter func(context.Context, string) (int64, error)) error {
+
+	sel, err := parseLedgerSelector(c)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	var n int64
+	switch {
+	case viaAgent != nil:
+		n, err = viaAgent(ctx, sel.Path)
+	case viaExporter != nil:
+		n, err = viaExporter(ctx, sel.Path)
+	default:
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "no edge sync transport is enabled",
+		})
+	}
+	if err != nil {
+		h.logger.Error().Err(err).Str("op", verb).Msg("Ledger remediation failed")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "ledger remediation failed",
+		})
+	}
+
+	// A named path that matched nothing is a miss the operator should hear
+	// about — they typed it expecting a row. all:true with zero eligible rows
+	// is a clean no-op. The message is per-verb: dismiss only matches failed
+	// rows, and its most common miss is re-dismissing an already-dismissed
+	// path — the generic wording would deny an entry that is sitting right
+	// there.
+	if n == 0 && sel.Path != "" {
+		msg := "no failed or operator-dismissed entry at that path"
+		if verb == "dismissed" {
+			msg = "no failed entry at that path (an already-dismissed entry stays dismissed)"
+		}
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": msg})
+	}
+
+	h.logger.Info().Str("op", verb).Str("path", sel.Path).Bool("all", sel.All).
+		Int64("rows", n).Msg("Ledger remediation applied")
+	return c.JSON(fiber.Map{verb: n})
+}
+
+// requeueFailed handles POST /api/v1/spoke-sync/ledger/requeue: failed (and
+// operator-dismissed) rows return to pending with a fresh retry budget. The
+// usual reason is a fixed transient cause — hub reachable again, token
+// rotated, a conflict resolved on the hub side.
+func (h *EdgeSyncSpokeHandler) requeueFailed(c *fiber.Ctx) error {
+	var viaAgent, viaExporter func(context.Context, string) (int64, error)
+	if h.agent != nil {
+		viaAgent = h.agent.RequeueFailed
+	}
+	if h.exporter != nil {
+		viaExporter = h.exporter.RequeueFailed
+	}
+	return h.remediate(c, "requeued", viaAgent, viaExporter)
+}
+
+// dismissFailed handles POST /api/v1/spoke-sync/ledger/dismiss: failed rows
+// become operator-dismissed (skipped) — out of the troubleshooting view,
+// pruned after retention, reversible via /ledger/requeue.
+func (h *EdgeSyncSpokeHandler) dismissFailed(c *fiber.Ctx) error {
+	var viaAgent, viaExporter func(context.Context, string) (int64, error)
+	if h.agent != nil {
+		viaAgent = h.agent.DismissFailed
+	}
+	if h.exporter != nil {
+		viaExporter = h.exporter.DismissFailed
+	}
+	return h.remediate(c, "dismissed", viaAgent, viaExporter)
 }
 
 // ledger handles GET /api/v1/spoke-sync/ledger.

--- a/internal/api/edgesync_spoke_test.go
+++ b/internal/api/edgesync_spoke_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/basekick-labs/arc/internal/edgesync"
@@ -338,5 +339,73 @@ func TestEdgeSyncSpoke_LedgerShowsExhaustedFiles(t *testing.T) {
 	}
 	if row["last_error"] == nil {
 		t.Error("the exhausted file does not say why it failed")
+	}
+}
+
+func (r *spokeRig) doJSON(t *testing.T, method, path, body string) (*http.Response, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.app.Test(req, 30_000)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var out map[string]any
+	if len(raw) > 0 {
+		json.Unmarshal(raw, &out)
+	}
+	return resp, out
+}
+
+// Operator remediation endpoints (#612): selector validation, honest misses,
+// and the requeue/dismiss round trip through the HTTP layer.
+func TestEdgeSyncSpoke_LedgerRemediation(t *testing.T) {
+	ctx := context.Background()
+	rig := newSpokeRig(t)
+
+	// A file that fails delivery terminally: transport closed, one attempt.
+	if err := rig.backend.Write(ctx, "metrics/cpu/2026/08/07/14/f.parquet", []byte("x")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Keep failing it until the agent gives up (the exhausted-files idiom).
+	for i := 0; i < edgesync.DefaultMaxAttempts+2; i++ {
+		rig.transport.ScriptPut("ground-station", "metrics/cpu/2026/08/07/14/f.parquet",
+			&edgesync.PutResult{Outcome: edgesync.OutcomeChecksumMismatch})
+		rig.do(t, "POST", "/api/v1/spoke-sync/run")
+	}
+	resp, out := rig.do(t, "GET", "/api/v1/spoke-sync/status")
+	if resp.StatusCode != 200 || out["failed"].(float64) < 1 {
+		t.Fatalf("setup did not produce a failed row: %v %v", resp.StatusCode, out)
+	}
+
+	// Selector validation.
+	if resp, _ := rig.doJSON(t, "POST", "/api/v1/spoke-sync/ledger/requeue", `{}`); resp.StatusCode != 400 {
+		t.Errorf("empty selector = %d, want 400", resp.StatusCode)
+	}
+	if resp, _ := rig.doJSON(t, "POST", "/api/v1/spoke-sync/ledger/requeue", `{"path":"x","all":true}`); resp.StatusCode != 400 {
+		t.Errorf("both selectors = %d, want 400", resp.StatusCode)
+	}
+	if resp, _ := rig.doJSON(t, "POST", "/api/v1/spoke-sync/ledger/dismiss", `{"path":"metrics/cpu/nope.parquet"}`); resp.StatusCode != 404 {
+		t.Errorf("dismiss miss = %d, want 404", resp.StatusCode)
+	}
+
+	// Dismiss all, then requeue all (reversibility through HTTP).
+	resp, out = rig.doJSON(t, "POST", "/api/v1/spoke-sync/ledger/dismiss", `{"all":true}`)
+	if resp.StatusCode != 200 || out["dismissed"].(float64) < 1 {
+		t.Fatalf("dismiss all = %d %v", resp.StatusCode, out)
+	}
+	_, st := rig.do(t, "GET", "/api/v1/spoke-sync/status")
+	if st["failed"].(float64) != 0 {
+		t.Errorf("failed = %v after dismissing all", st["failed"])
+	}
+	resp, out = rig.doJSON(t, "POST", "/api/v1/spoke-sync/ledger/requeue", `{"all":true}`)
+	if resp.StatusCode != 200 || out["requeued"].(float64) < 1 {
+		t.Fatalf("requeue all = %d %v", resp.StatusCode, out)
+	}
+	_, st = rig.do(t, "GET", "/api/v1/spoke-sync/status")
+	if st["pending"].(float64) < 1 {
+		t.Errorf("pending = %v after requeue; dismissal must be reversible", st["pending"])
 	}
 }

--- a/internal/edgesync/agent.go
+++ b/internal/edgesync/agent.go
@@ -633,6 +633,16 @@ func (a *Agent) UnfinishedEntries(ctx context.Context, limit int) ([]*LedgerEntr
 	return a.ledger.Unfinished(ctx, a.hubID, limit)
 }
 
+// RequeueFailed returns failed (and operator-dismissed) rows to pending.
+func (a *Agent) RequeueFailed(ctx context.Context, path string) (int64, error) {
+	return a.ledger.RequeueFailed(ctx, a.hubID, path)
+}
+
+// DismissFailed moves failed rows to operator-dismissed skipped.
+func (a *Agent) DismissFailed(ctx context.Context, path string) (int64, error) {
+	return a.ledger.DismissFailed(ctx, a.hubID, path)
+}
+
 // Status reports what the spoke still has to send.
 func (a *Agent) Status(ctx context.Context) (*Stats, error) {
 	return a.ledger.Stats(ctx, a.hubID)

--- a/internal/edgesync/blocker_fixes_test.go
+++ b/internal/edgesync/blocker_fixes_test.go
@@ -329,3 +329,105 @@ func TestHTTPTransport_SendsTheHubAPIToken(t *testing.T) {
 		t.Errorf("tokenless Authorization = %q, want empty", gotAuth[1])
 	}
 }
+
+// Operator remediation (#612): failed rows can be requeued (fresh retry
+// budget) or dismissed (terminal, prunable, reversible); the other two
+// skipped classes — vanished files and compacted outputs — must never
+// re-enter the queue through either op.
+func TestLedger_RequeueAndDismissFailedRows(t *testing.T) {
+	ctx := context.Background()
+	ledger := setupTestLedger(t)
+
+	add := func(path string) {
+		t.Helper()
+		if err := ledger.Track(ctx, &LedgerEntry{
+			HubID: DefaultHubID, Path: path, SHA256: "aa", SizeBytes: 2,
+			Database: "metrics", Measurement: "cpu",
+			PartitionTime: time.Date(2026, 8, 7, 14, 0, 0, 0, time.UTC),
+			DiscoveredAt:  time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("add %s: %v", path, err)
+		}
+	}
+	fail := func(path string) {
+		t.Helper()
+		if err := ledger.MarkInFlight(ctx, DefaultHubID, path); err != nil {
+			t.Fatalf("inflight %s: %v", path, err)
+		}
+		if err := ledger.MarkFailed(ctx, DefaultHubID, path, "boom", 1); err != nil {
+			t.Fatalf("fail %s: %v", path, err)
+		}
+	}
+	state := func(path string) SyncState {
+		t.Helper()
+		e, err := ledger.Get(ctx, DefaultHubID, path)
+		if err != nil {
+			t.Fatalf("get %s: %v", path, err)
+		}
+		return e.State
+	}
+
+	f1 := "metrics/cpu/2026/08/07/14/f1.parquet"
+	f2 := "metrics/cpu/2026/08/07/14/f2.parquet"
+	add(f1)
+	add(f2)
+	fail(f1)
+	fail(f2)
+
+	// Vanished-skip and compacted-output rows: untouchable by both ops.
+	vanished := "metrics/cpu/2026/08/07/14/vanished.parquet"
+	add(vanished)
+	if err := ledger.MarkSkipped(ctx, DefaultHubID, vanished, "source file removed before delivery (compaction or retention)"); err != nil {
+		t.Fatalf("skip vanished: %v", err)
+	}
+	output := "metrics/cpu/2026/08/07/14/cpu_20260807_140000_1754575200000000000_b1_compacted.parquet"
+	if err := ledger.TrackCompactedOutput(ctx, DefaultHubID, output); err != nil {
+		t.Fatalf("track output: %v", err)
+	}
+
+	// Requeue one by path: pending again, attempts reset.
+	n, err := ledger.RequeueFailed(ctx, DefaultHubID, f1)
+	if err != nil || n != 1 {
+		t.Fatalf("requeue f1 = %d, %v", n, err)
+	}
+	e, _ := ledger.Get(ctx, DefaultHubID, f1)
+	if e.State != StatePending || e.Attempts != 0 {
+		t.Errorf("f1 = %s attempts=%d, want pending/0", e.State, e.Attempts)
+	}
+
+	// Dismiss the other: skipped with the operator note, prune-eligible.
+	n, err = ledger.DismissFailed(ctx, DefaultHubID, f2)
+	if err != nil || n != 1 {
+		t.Fatalf("dismiss f2 = %d, %v", n, err)
+	}
+	e, _ = ledger.Get(ctx, DefaultHubID, f2)
+	if e.State != StateSkipped || e.LastError != NoteOperatorDismissed {
+		t.Errorf("f2 = %s/%q, want skipped/operator-dismissed", e.State, e.LastError)
+	}
+
+	// Dismissal is reversible; the OTHER skip classes are not.
+	n, err = ledger.RequeueFailed(ctx, DefaultHubID, "")
+	if err != nil {
+		t.Fatalf("requeue all: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("requeue all touched %d rows, want 1 (only the dismissed row)", n)
+	}
+	if got := state(f2); got != StatePending {
+		t.Errorf("dismissed row after requeue = %s, want pending", got)
+	}
+	if got := state(vanished); got != StateSkipped {
+		t.Errorf("vanished row = %s; must stay skipped", got)
+	}
+	if got := state(output); got != StateSkipped {
+		t.Errorf("compacted-output row = %s; must stay skipped", got)
+	}
+
+	// Misses and empty-alls report honestly.
+	if n, err := ledger.RequeueFailed(ctx, DefaultHubID, "metrics/cpu/nope.parquet"); err != nil || n != 0 {
+		t.Errorf("requeue miss = %d, %v; want 0, nil", n, err)
+	}
+	if n, err := ledger.DismissFailed(ctx, DefaultHubID, ""); err != nil || n != 0 {
+		t.Errorf("dismiss all with none failed = %d, %v; want 0, nil", n, err)
+	}
+}

--- a/internal/edgesync/compaction_gate.go
+++ b/internal/edgesync/compaction_gate.go
@@ -47,6 +47,13 @@ func NewCompactionEligibility(ledger *Ledger, hubID string, epoch time.Time, log
 				out[p] = true
 			case tracked && ds.State == StateSkipped && ds.Note == NoteCompactedOutput:
 				out[p] = true
+			case tracked && ds.State == StateSkipped && ds.Note == NoteOperatorDismissed:
+				// The operator explicitly renounced delivery of this file
+				// (POST /spoke-sync/ledger/dismiss), so consuming it locally
+				// destroys nothing the hub is still owed — and leaving it
+				// ineligible would wedge its partition's compaction forever
+				// on a file the operator already wrote off.
+				out[p] = true
 			case !tracked:
 				if ts, isCompacted := compactedFileTimestamp(p); isCompacted && ts.After(epoch) {
 					// Post-epoch orphan: the observer insert was lost to a

--- a/internal/edgesync/compaction_gate_test.go
+++ b/internal/edgesync/compaction_gate_test.go
@@ -255,17 +255,17 @@ func TestCompactedOutputRows_PruneExemptUntilFileGone(t *testing.T) {
 	}
 
 	// Sweep with the file "existing" keeps the row; gone deletes it.
-	kept, err := l.SweepCompactedOutputRows(ctx, DefaultHubID,
+	kept, err := l.SweepSkippedRows(ctx, DefaultHubID,
 		func(context.Context, string) (bool, error) { return true, nil })
 	if err != nil || kept != 0 {
 		t.Fatalf("sweep(existing) = %d, %v; want 0, nil", kept, err)
 	}
 	// An exists ERROR must keep the row (fail-safe).
-	if n, err := l.SweepCompactedOutputRows(ctx, DefaultHubID,
+	if n, err := l.SweepSkippedRows(ctx, DefaultHubID,
 		func(context.Context, string) (bool, error) { return false, errors.New("storage down") }); err != nil || n != 0 {
 		t.Fatalf("sweep(error) = %d, %v; want 0, nil", n, err)
 	}
-	swept, err := l.SweepCompactedOutputRows(ctx, DefaultHubID,
+	swept, err := l.SweepSkippedRows(ctx, DefaultHubID,
 		func(context.Context, string) (bool, error) { return false, nil })
 	if err != nil || swept != 1 {
 		t.Fatalf("sweep(gone) = %d, %v; want 1, nil", swept, err)
@@ -422,5 +422,74 @@ func TestClearMeta_UngatedPeriodOutputsClassifyAsLegacy(t *testing.T) {
 	NewCompactedOutputObserver(l, DefaultHubID, epoch, zerolog.Nop())(ungatedOutput)
 	if _, err := l.Get(ctx, DefaultHubID, ungatedOutput); err == nil {
 		t.Error("ungated-period output tracked as delivered; must stay legacy so it syncs once")
+	}
+}
+
+// An operator-dismissed file is compaction-eligible: delivery was explicitly
+// renounced, so local compaction destroys nothing the hub is owed — and
+// ineligibility would wedge the partition forever on a written-off file.
+func TestCompactionEligibility_DismissedFilesAreEligible(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	p := "metrics/cpu/2026/08/07/14/junk.parquet"
+	gateAdd(t, l, p, func(c context.Context) error {
+		if err := l.MarkInFlight(c, DefaultHubID, p); err != nil {
+			return err
+		}
+		if err := l.MarkFailed(c, DefaultHubID, p, "boom", 1); err != nil {
+			return err
+		}
+		_, err := l.DismissFailed(c, DefaultHubID, p)
+		return err
+	})
+
+	gate := NewCompactionEligibility(l, DefaultHubID, time.Now().UTC(), zerolog.Nop())
+	got, err := gate(ctx, []string{p})
+	if err != nil {
+		t.Fatalf("gate: %v", err)
+	}
+	if !got[p] {
+		t.Error("operator-dismissed file must be compaction-eligible")
+	}
+}
+
+// Deep-review H1 (#612): an operator-dismissed row must survive the blind
+// retention prune while its file exists — pruning it would let discovery
+// re-track the file and resurrect the dismissed failure — and is reclaimed
+// by the existence-gated sweep once the file is gone.
+func TestDismissedRows_PruneExemptUntilFileGone(t *testing.T) {
+	ctx := context.Background()
+	l := setupTestLedger(t)
+
+	p := "metrics/cpu/2026/08/07/14/junk.parquet"
+	gateAdd(t, l, p, func(c context.Context) error {
+		if err := l.MarkInFlight(c, DefaultHubID, p); err != nil {
+			return err
+		}
+		if err := l.MarkFailed(c, DefaultHubID, p, "boom", 1); err != nil {
+			return err
+		}
+		_, err := l.DismissFailed(c, DefaultHubID, p)
+		return err
+	})
+
+	if _, err := l.db.ExecContext(ctx,
+		`UPDATE sync_ledger SET last_attempt = ? WHERE state = 'skipped'`,
+		time.Now().UTC().AddDate(0, 0, -100)); err != nil {
+		t.Fatalf("age: %v", err)
+	}
+	pruned, err := l.PruneSkipped(ctx, 90)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if pruned != 0 {
+		t.Errorf("prune deleted %d dismissed rows; they must be exempt while the file may exist", pruned)
+	}
+
+	swept, err := l.SweepSkippedRows(ctx, DefaultHubID,
+		func(context.Context, string) (bool, error) { return false, nil })
+	if err != nil || swept != 1 {
+		t.Fatalf("sweep(gone) = %d, %v; want 1", swept, err)
 	}
 }

--- a/internal/edgesync/exporter.go
+++ b/internal/edgesync/exporter.go
@@ -273,6 +273,16 @@ func (e *Exporter) UnfinishedEntries(ctx context.Context, limit int) ([]*LedgerE
 	return e.ledger.Unfinished(ctx, e.hubID, limit)
 }
 
+// RequeueFailed returns failed (and operator-dismissed) rows to pending.
+func (e *Exporter) RequeueFailed(ctx context.Context, path string) (int64, error) {
+	return e.ledger.RequeueFailed(ctx, e.hubID, path)
+}
+
+// DismissFailed moves failed rows to operator-dismissed skipped.
+func (e *Exporter) DismissFailed(ctx context.Context, path string) (int64, error) {
+	return e.ledger.DismissFailed(ctx, e.hubID, path)
+}
+
 // ApplyAck reads an acknowledgment from a returned bundle directory and
 // advances the ledger.
 //

--- a/internal/edgesync/ledger.go
+++ b/internal/edgesync/ledger.go
@@ -64,13 +64,14 @@ const (
 	// StateFailed — exhausted retries. Terminal until an operator intervenes.
 	StateFailed SyncState = "failed"
 
-	// StateSkipped — the source file vanished from local storage (compaction
-	// or retention deleted it) before it could be delivered. Terminal: the
-	// content no longer exists to send. Without this state a vanished pending
-	// file wedged air-gap export forever (the export failed wholesale and
-	// re-selected the same entry every time) and burned the network path's
-	// full retry budget per pass. Counted in Stats and reported in /status;
-	// reclaimed by PruneSkipped.
+	// StateSkipped — deliberately not (or no longer) deliverable. Three
+	// classes, told apart by last_error: the source file VANISHED before
+	// delivery (compaction/retention got it first); a COMPACTED OUTPUT whose
+	// contents were already delivered (NoteCompactedOutput — must never
+	// sync); or an OPERATOR-DISMISSED failure (NoteOperatorDismissed —
+	// reversible via requeue while its file survives). Counted in Stats and
+	// /status. Vanished rows prune normally; the two file-backed classes are
+	// prune-exempt and reclaimed by SweepSkippedRows once their file is gone.
 	StateSkipped SyncState = "skipped"
 )
 
@@ -79,7 +80,7 @@ const (
 // state synced, so the output must never sync — it would duplicate rows on
 // the hub. Rows carrying this note are EXEMPT from PruneSkipped while their
 // file exists (a pruned row would let discovery rediscover and sync the
-// output) and are instead reclaimed by SweepCompactedOutputRows once the
+// output) and are instead reclaimed by SweepSkippedRows once the
 // file is gone. They are also ELIGIBLE compaction inputs (daily consumes
 // hourly outputs).
 const NoteCompactedOutput = "compaction output; contents already delivered"
@@ -761,6 +762,80 @@ func (l *Ledger) EnsureMetaOnce(ctx context.Context, key, value string) (string,
 	return out, nil
 }
 
+// NoteOperatorDismissed marks a skipped row an operator deliberately
+// dismissed via POST /api/v1/spoke-sync/ledger/dismiss. Distinct from the
+// vanished-file and compacted-output notes: dismissed rows are the only
+// skipped class Requeue may resurrect, and they prune normally.
+const NoteOperatorDismissed = "dismissed by an operator"
+
+// RequeueFailed returns failed rows — and operator-dismissed rows, so a
+// dismissal is reversible — to pending for a fresh delivery attempt.
+// path == "" requeues every eligible row for the hub. Attempts reset to 0:
+// the operator is explicitly granting a new retry budget. bytes_sent is
+// kept so a partial transfer resumes; a checkpoint the hub no longer holds
+// already restarts from zero via the stale-checkpoint path.
+//
+// The state predicate lives in SQL so only legal sources transition:
+// vanished-file and compacted-output skips have nothing to deliver (or
+// would duplicate) and must never re-enter the queue.
+func (l *Ledger) RequeueFailed(ctx context.Context, hubID, path string) (int64, error) {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	query := `
+		UPDATE sync_ledger
+		SET state = ?, attempts = 0, last_error = NULL
+		WHERE hub_id = ?
+		  AND (state = ? OR (state = ? AND last_error = ?))`
+	args := []any{string(StatePending), hubID,
+		string(StateFailed), string(StateSkipped), NoteOperatorDismissed}
+	if path != "" {
+		query += ` AND path = ?`
+		args = append(args, path)
+	}
+	res, err := l.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: requeue failed rows: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: count requeued rows: %w", err)
+	}
+	return n, nil
+}
+
+// DismissFailed moves failed rows to skipped with the operator note —
+// terminal, pruned after retention, and reversible via RequeueFailed.
+// path == "" dismisses every failed row for the hub.
+//
+// Skipped, not deleted: a deleted row whose file still exists would be
+// re-tracked by the next discovery pass and resurrect as pending — the
+// exact noise the operator asked to silence.
+func (l *Ledger) DismissFailed(ctx context.Context, hubID, path string) (int64, error) {
+	if hubID == "" {
+		hubID = DefaultHubID
+	}
+	query := `
+		UPDATE sync_ledger
+		SET state = ?, last_error = ?, last_attempt = ?
+		WHERE hub_id = ? AND state = ?`
+	args := []any{string(StateSkipped), NoteOperatorDismissed, time.Now().UTC(),
+		hubID, string(StateFailed)}
+	if path != "" {
+		query += ` AND path = ?`
+		args = append(args, path)
+	}
+	res, err := l.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: dismiss failed rows: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("edgesync: count dismissed rows: %w", err)
+	}
+	return n, nil
+}
+
 // ClearMeta removes a sync_meta key. Used when the compaction defer gate is
 // INACTIVE while compaction may run (issue #610): the epoch's meaning is
 // "the gate has been continuously active since this instant", so any ungated
@@ -856,22 +931,24 @@ func (l *Ledger) DeliveryStates(ctx context.Context, hubID string, paths []strin
 	return out, nil
 }
 
-// SweepCompactedOutputRows deletes compacted-output rows whose file no
-// longer exists (consumed by a later compaction tier, or removed by
-// retention). These rows are exempt from PruneSkipped — pruning one whose
-// file still exists would let discovery re-sync the output — so this sweep
-// is their only reclamation path and must run regardless of the retention
-// setting. exists is consulted per row; an exists ERROR keeps the row
-// (fail-safe: never delete bookkeeping on an uncertain answer).
-func (l *Ledger) SweepCompactedOutputRows(ctx context.Context, hubID string, exists func(context.Context, string) (bool, error)) (int64, error) {
+// SweepSkippedRows deletes the FILE-BACKED skipped rows — compacted outputs
+// and operator-dismissed entries — whose file no longer exists (consumed by
+// compaction, or removed by retention). These two classes are exempt from
+// PruneSkipped: pruning one whose file still exists would let discovery
+// re-track the file (re-syncing a compacted output, or resurrecting a
+// dismissed failure as pending). This sweep is their only reclamation path
+// and runs regardless of the retention setting. exists is consulted per
+// row; an exists ERROR keeps the row (fail-safe: never delete bookkeeping
+// on an uncertain answer).
+func (l *Ledger) SweepSkippedRows(ctx context.Context, hubID string, exists func(context.Context, string) (bool, error)) (int64, error) {
 	if hubID == "" {
 		hubID = DefaultHubID
 	}
 	rows, err := l.db.QueryContext(ctx, `
 		SELECT id, path FROM sync_ledger
-		WHERE hub_id = ? AND state = ? AND last_error = ?
+		WHERE hub_id = ? AND state = ? AND last_error IN (?, ?)
 		ORDER BY id ASC`,
-		hubID, string(StateSkipped), NoteCompactedOutput)
+		hubID, string(StateSkipped), NoteCompactedOutput, NoteOperatorDismissed)
 	if err != nil {
 		return 0, fmt.Errorf("edgesync: list compacted-output rows: %w", err)
 	}
@@ -904,9 +981,9 @@ func (l *Ledger) SweepCompactedOutputRows(ctx context.Context, hubID string, exi
 			continue
 		}
 		if _, err := l.db.ExecContext(ctx,
-			`DELETE FROM sync_ledger WHERE id = ? AND state = ? AND last_error = ?`,
-			r.id, string(StateSkipped), NoteCompactedOutput); err != nil {
-			return deleted, fmt.Errorf("edgesync: sweep compacted-output row %q: %w", r.path, err)
+			`DELETE FROM sync_ledger WHERE id = ? AND state = ? AND last_error IN (?, ?)`,
+			r.id, string(StateSkipped), NoteCompactedOutput, NoteOperatorDismissed); err != nil {
+			return deleted, fmt.Errorf("edgesync: sweep skipped row %q: %w", r.path, err)
 		}
 		deleted++
 	}
@@ -1156,16 +1233,20 @@ func (l *Ledger) PruneSkipped(ctx context.Context, retentionDays int) (int64, er
 
 	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
 
-	// Compacted-output rows are excluded (NULL-safe: last_error is nullable):
-	// pruning one whose file still exists lets discovery rediscover and SYNC
-	// the output — duplicates returning after retention days. They are
-	// reclaimed by SweepCompactedOutputRows once the file is gone instead.
+	// Rows whose local FILE may still exist are excluded (NULL-safe:
+	// last_error is nullable): pruning a compacted-output row lets discovery
+	// rediscover and SYNC the output (duplicates return), and pruning an
+	// operator-dismissed row lets discovery re-track the file as pending
+	// (the dismissed failure resurrects — the exact noise the operator
+	// silenced). Both classes are reclaimed by SweepSkippedRows once their
+	// file is actually gone. Vanished-file rows have no file by definition
+	// and prune normally.
 	var maxID int64
 	err := l.db.QueryRowContext(ctx, `
 		SELECT COALESCE(MAX(id), 0) FROM sync_ledger
 		WHERE state = ? AND last_attempt IS NOT NULL AND last_attempt < ?
-		  AND (last_error IS NULL OR last_error <> ?)`,
-		string(StateSkipped), cutoff, NoteCompactedOutput).Scan(&maxID)
+		  AND (last_error IS NULL OR last_error NOT IN (?, ?))`,
+		string(StateSkipped), cutoff, NoteCompactedOutput, NoteOperatorDismissed).Scan(&maxID)
 	if err != nil {
 		return 0, fmt.Errorf("edgesync: find skipped prune cutoff: %w", err)
 	}
@@ -1185,9 +1266,9 @@ func (l *Ledger) PruneSkipped(ctx context.Context, retentionDays int) (int64, er
 			DELETE FROM sync_ledger WHERE id IN (
 				SELECT id FROM sync_ledger
 				WHERE id <= ? AND state = ? AND last_attempt IS NOT NULL AND last_attempt < ?
-				  AND (last_error IS NULL OR last_error <> ?)
+				  AND (last_error IS NULL OR last_error NOT IN (?, ?))
 				ORDER BY id ASC LIMIT ?
-			)`, maxID, string(StateSkipped), cutoff, NoteCompactedOutput, batchSize)
+			)`, maxID, string(StateSkipped), cutoff, NoteCompactedOutput, NoteOperatorDismissed, batchSize)
 		if err != nil {
 			return total, fmt.Errorf("edgesync: prune skipped entries: %w", err)
 		}


### PR DESCRIPTION
## Summary

Closes #612. Failed edge-sync ledger rows were terminal with no operator exit — stale failures buried live problems in the ledger view, and (since #618) held their partition's compaction hostage. Two admin endpoints on the existing `/api/v1/spoke-sync` group, served by either transport:

- **`POST /spoke-sync/ledger/requeue`** (`{"path": ...}` or `{"all": true}`) — failed and operator-dismissed rows return to `pending` with a fresh retry budget (attempts reset, stale error cleared, `bytes_sent` kept for resume). A requeued conflict cleanly conflicts again until the hub-side divergence is fixed — documented.
- **`POST /spoke-sync/ledger/dismiss`** — failed rows become operator-dismissed: out of the view, reversible **while the file survives**, and deliberately compaction-**eligible** (delivery was renounced, so the partition must not stay wedged on a written-off file).

Dismissed-not-deleted (a deleted row's surviving file would be re-discovered and resurrect as pending). The deep review caught the slow-fuse variant in the first cut: dismissed rows were prunable after retention regardless of file survival, so the 90-day prune would resurrect the dismissed failure. Dismissed rows now join compacted outputs as prune-exempt file-backed skips, reclaimed by the renamed `SweepSkippedRows` once the file is actually gone.

SQL-side state predicates guarantee the untouchable skip classes (vanished files, compacted outputs) can never re-enter the queue through either endpoint.

## Test plan

- [x] Ledger transition grid: both ops × failed/dismissed/vanished/compacted-output rows, path-vs-all selectors, honest miss/no-op counts
- [x] Handler round trip: selector XOR validation (400), named-path miss (404, per-verb message), dismiss-all → requeue-all reversibility through HTTP
- [x] H1 regression: dismissed row with surviving file survives the retention prune; swept once the file is gone. Dismissed-file compaction eligibility pinned
- [x] Suites green incl. `-race` on edgesync; `gofmt`/`go vet` clean; no new config keys
- [x] Live binary smoke: 401 unauthenticated, 400 bad selector, 200 `{dismissed:0}` clean no-op, 404 miss
- [x] Release notes + docs guide gained a "Fixing stuck entries" section (the #618 deferral log points operators at it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)