### PR TITLE
chore(edgesync): cleanup sweep — relay exclusion, hub-ID disclosure, dead schema (#616)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -252,6 +252,8 @@ Reconcile is answered from a hub-side index of received files rather than by rea
 
 Resume is supported on local storage. On S3 and Azure a dropped transfer restarts from zero, because block objects cannot be appended to; this is a throughput cost on intermittent links, not a correctness problem.
 
+**A hub that is also a spoke no longer relays other spokes' data upstream.** On a dual-role node, discovery used to walk the whole storage backend — including the namespaces this node holds *as a hub* — and forward other edges' received files, double-namespaced, to its own upstream hub: an undocumented, unbounded relay. Received spoke namespaces (the registered spoke IDs) are now excluded from the node's own sync discovery; explicit relay topologies may become a real feature later. One operational note: deleting a spoke's registration deliberately keeps its files, but a dual-role node stops excluding an unregistered namespace — keep registrations for as long as the data sits in storage, and don't name a local database the same as a registered spoke ID. Two smaller cleanups ride along: the hub-ID mismatch answer on `/sync/file` and `/sync/reconcile` now comes *after* HMAC verification (an unauthenticated caller could previously confirm the hub's ID by iterating candidates), and the never-written `sync_history` table is dropped from spoke ledgers.
+
 Abandoned partial uploads are swept from the staging area hourly once they are older than `edge_sync.staging_sweep_max_age_hours` (default 72 — deliberately longer than a plausible contact gap, because a staged partial is also the spoke's resume checkpoint; 0 disables the sweep).
 
 ### The spoke side

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2087,6 +2087,9 @@ func main() {
 	// Either role independently: a hub can take network pushes, drives off an
 	// air gap, or both. They share the registry, index, and receiver, which is
 	// why they live in one block.
+	// Hoisted: on a dual-role (hub+spoke) node the spoke block below needs
+	// the registry to exclude received namespaces from its own discovery.
+	var spokeRegistry *edgesync.Registry
 	if cfg.EdgeSync.Enabled || cfg.EdgeSync.Import.Enabled {
 		var registerFile func(context.Context, *edgesync.ReceivedFile) error
 		if clusterCoordinator != nil {
@@ -2156,7 +2159,7 @@ func main() {
 			log.Fatal().Err(err).Msg("Failed to create the edge sync secret encryptor; refusing to start")
 		}
 
-		spokeRegistry, err := edgesync.NewRegistry(syncDB, syncEncryptor, logger.Get("edgesync"))
+		spokeRegistry, err = edgesync.NewRegistry(syncDB, syncEncryptor, logger.Get("edgesync"))
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to create the edge sync spoke registry; refusing to start")
 		}
@@ -2506,6 +2509,9 @@ func main() {
 				log.Fatal().Err(err).Msg("Failed to create the edge sync agent; refusing to start")
 			}
 			syncAgent.SetCompactionDeferEpoch(compactionDeferEpoch)
+			if spokeRegistry != nil {
+				syncAgent.SetNamespaceExcluder(receivedNamespaces(spokeRegistry))
+			}
 		}
 
 		// Air-gap export, independent of the network agent above.
@@ -2545,6 +2551,9 @@ func main() {
 				log.Fatal().Err(err).Msg("Failed to create the bundle discoverer; refusing to start")
 			}
 			bundleDiscoverer.SetCompactionDeferEpoch(compactionDeferEpoch)
+			if spokeRegistry != nil {
+				bundleDiscoverer.SetNamespaceExcluder(receivedNamespaces(spokeRegistry))
+			}
 
 			bundleExporter, err = edgesync.NewExporter(edgesync.ExporterConfig{
 				Ledger:     spokeLedger,
@@ -3653,6 +3662,28 @@ func sharedSQLiteHandle(authManager *auth.AuthManager, dbPath string) (db *sql.D
 	db.SetMaxIdleConns(1)
 	db.SetConnMaxLifetime(time.Hour)
 	return db, true, nil
+}
+
+// receivedNamespaces returns a Discoverer namespace excluder backed by the
+// hub's spoke registry: on a dual-role (hub+spoke) node, top-level segments
+// matching registered spoke IDs are OTHER edges' data held here as a hub,
+// and this node's own sync must not forward them upstream (an undocumented,
+// unbounded relay otherwise — 2026-08-19 audit M2). A namespace left behind
+// by a DELETED registration is not excluded; deleting a registration keeps
+// the files deliberately, so document that dual-role operators should keep
+// registrations for as long as the data sits in storage.
+func receivedNamespaces(registry *edgesync.Registry) func(ctx context.Context) (map[string]struct{}, error) {
+	return func(ctx context.Context) (map[string]struct{}, error) {
+		spokes, err := registry.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make(map[string]struct{}, len(spokes))
+		for _, sp := range spokes {
+			out[sp.SpokeID] = struct{}{}
+		}
+		return out, nil
+	}
 }
 
 // createWALRecoveryCallback creates a reusable WAL recovery callback function.

--- a/internal/api/edgesync.go
+++ b/internal/api/edgesync.go
@@ -212,14 +212,6 @@ func (h *EdgeSyncHandler) receiveFile(c *fiber.Ctx) error {
 		})
 	}
 
-	// The hub ID must match this hub. A MAC minted for a different hub that
-	// shares the spoke's secret is not valid here.
-	if hubID != h.hubID {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "hub ID mismatch",
-		})
-	}
-
 	size, err := strconv.ParseInt(c.Get(headerSize), 10, 64)
 	if err != nil || size < 0 {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -272,6 +264,20 @@ func (h *EdgeSyncHandler) receiveFile(c *fiber.Ctx) error {
 		security.HMACTimestampTolerance,
 	); err != nil {
 		return h.authFailure(c, spokeID, err)
+	}
+
+	// The hub ID must match this hub — a MAC minted for a different hub that
+	// shares the spoke's secret is not valid here. Checked AFTER the MAC:
+	// answered early it let an unauthenticated caller confirm this hub's ID
+	// by iterating candidates (400 mismatch vs 401 anything-else). Now the
+	// difference is visible only to a caller holding a valid spoke secret
+	// (the misconfigured spoke this 400 exists to help) or replaying a
+	// captured in-window request signed for another hub — which reveals
+	// secret reuse across hubs, never this hub's ID (the ID is MAC-bound).
+	if hubID != h.hubID {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "hub ID mismatch",
+		})
 	}
 
 	// The body is fully buffered, not streamed: the Fiber app is constructed
@@ -351,10 +357,6 @@ func (h *EdgeSyncHandler) reconcile(c *fiber.Ctx) error {
 			"error": "missing required sync headers",
 		})
 	}
-	if hubID != h.hubID {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "hub ID mismatch"})
-	}
-
 	ts, err := strconv.ParseInt(c.Get(headerTS), 10, 64)
 	if err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -381,6 +383,12 @@ func (h *EdgeSyncHandler) reconcile(c *fiber.Ctx) error {
 		security.HMACTimestampTolerance,
 	); err != nil {
 		return h.authFailure(c, spokeID, err)
+	}
+
+	// Post-MAC for the same reason as receiveFile: the early 400 disclosed
+	// the hub ID to unauthenticated callers.
+	if hubID != h.hubID {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "hub ID mismatch"})
 	}
 
 	var req reconcileRequest

--- a/internal/edgesync/agent.go
+++ b/internal/edgesync/agent.go
@@ -2,8 +2,6 @@ package edgesync
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -52,6 +50,16 @@ type Agent struct {
 	// compactionDeferEpoch is forwarded to the per-pass Discoverer so it can
 	// tell crash-orphaned compacted outputs from legacy ones (issue #610).
 	compactionDeferEpoch time.Time
+
+	// namespaceExcluder is forwarded to the per-pass Discoverer on dual-role
+	// nodes (see Discoverer.SetNamespaceExcluder).
+	namespaceExcluder func(ctx context.Context) (map[string]struct{}, error)
+}
+
+// SetNamespaceExcluder forwards the dual-role received-namespace exclusion
+// to this agent's discovery passes. nil deactivates it.
+func (a *Agent) SetNamespaceExcluder(fn func(ctx context.Context) (map[string]struct{}, error)) {
+	a.namespaceExcluder = fn
 }
 
 // SetCompactionDeferEpoch forwards the issue-#610 enablement epoch to this
@@ -391,6 +399,7 @@ func (a *Agent) Discover(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	d.SetCompactionDeferEpoch(a.compactionDeferEpoch)
+	d.SetNamespaceExcluder(a.namespaceExcluder)
 	return d.Discover(ctx)
 }
 
@@ -608,15 +617,6 @@ func (a *Agent) openAt(ctx context.Context, path string, offset int64) (io.ReadC
 	}()
 
 	return pr, nil
-}
-
-// hashFile computes a file's SHA-256 without holding it in memory.
-func (a *Agent) hashFile(ctx context.Context, path string) (string, error) {
-	h := sha256.New()
-	if err := a.backend.ReadTo(ctx, path, hasherWriter{h}); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // UnfinishedEntries returns files that have not reached the hub — those still

--- a/internal/edgesync/blocker_fixes_test.go
+++ b/internal/edgesync/blocker_fixes_test.go
@@ -10,6 +10,7 @@ package edgesync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -429,5 +430,52 @@ func TestLedger_RequeueAndDismissFailedRows(t *testing.T) {
 	}
 	if n, err := ledger.DismissFailed(ctx, DefaultHubID, ""); err != nil || n != 0 {
 		t.Errorf("dismiss all with none failed = %d, %v; want 0, nil", n, err)
+	}
+}
+
+// Dual-role nodes (#616 audit M2): a hub that is also a spoke must not
+// re-discover OTHER spokes' received data and forward it upstream. Received
+// namespaces are excluded from discovery; an excluder error aborts the pass
+// (proceeding without the set would silently start relaying).
+func TestDiscovery_ExcludesReceivedSpokeNamespaces(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	rig.writeFile(t, "metrics/cpu/2026/08/07/14/own.parquet", []byte("own telemetry"))
+	rig.writeFile(t, "rocket-02/metrics/cpu/2026/08/07/14/theirs.parquet", []byte("received from another spoke"))
+	// Two-segment shape: a root-level file another spoke synced, stored as
+	// {spokeID}/x.parquet — the deep-review edge that escaped splitFirstTwo.
+	rig.writeFile(t, "rocket-02/shallow.parquet", []byte("shallow received file"))
+
+	d, err := NewDiscoverer(rig.ledger, rig.backend, DefaultHubID, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("discoverer: %v", err)
+	}
+	d.SetNamespaceExcluder(func(context.Context) (map[string]struct{}, error) {
+		return map[string]struct{}{"rocket-02": {}}, nil
+	})
+
+	n, err := d.Discover(ctx)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("discovered = %d, want 1 (own file only)", n)
+	}
+	for _, p := range []string{
+		"rocket-02/metrics/cpu/2026/08/07/14/theirs.parquet",
+		"rocket-02/shallow.parquet",
+	} {
+		if _, err := rig.ledger.Get(ctx, DefaultHubID, p); err == nil {
+			t.Errorf("%s entered the ledger; it would relay upstream", p)
+		}
+	}
+
+	// Excluder failure aborts rather than relaying.
+	d.SetNamespaceExcluder(func(context.Context) (map[string]struct{}, error) {
+		return nil, errors.New("registry unavailable")
+	})
+	if _, err := d.Discover(ctx); err == nil {
+		t.Error("discovery proceeded without the exclusion set; must abort on excluder error")
 	}
 }

--- a/internal/edgesync/discover.go
+++ b/internal/edgesync/discover.go
@@ -26,6 +26,17 @@ type Discoverer struct {
 	hubID   string
 	logger  zerolog.Logger
 
+	// namespaceExcluder, when set, returns the top-level path segments this
+	// node holds ON BEHALF OF OTHERS — the spoke namespaces a dual-role
+	// (hub+spoke) node received from other edges. Discovery skips them:
+	// without this, a hub that is also a spoke re-discovers other spokes'
+	// received files and forwards them, double-namespaced, to ITS upstream
+	// hub — an undocumented, unbounded relay (2026-08-19 audit M2). Relaying
+	// may become a real feature; today it is opt-nothing and surprising, so
+	// it is off. An excluder ERROR aborts discovery (fail-safe: a transient
+	// registry error must not silently start relaying).
+	namespaceExcluder func(ctx context.Context) (map[string]struct{}, error)
+
 	// compactionDeferEpoch, when non-zero, activates issue-#610 handling of
 	// tier-suffixed compacted files that are NOT in the ledger: one whose
 	// embedded timestamp is AFTER the epoch is a crash orphan — produced
@@ -42,6 +53,12 @@ type Discoverer struct {
 // discrimination (issue #610). Zero deactivates it.
 func (d *Discoverer) SetCompactionDeferEpoch(epoch time.Time) {
 	d.compactionDeferEpoch = epoch
+}
+
+// SetNamespaceExcluder installs the received-namespace exclusion for
+// dual-role nodes. nil deactivates it.
+func (d *Discoverer) SetNamespaceExcluder(fn func(ctx context.Context) (map[string]struct{}, error)) {
+	d.namespaceExcluder = fn
 }
 
 // NewDiscoverer validates configuration and returns a ready discoverer.
@@ -79,6 +96,16 @@ func (d *Discoverer) Discover(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("edgesync: list local files: %w", err)
 	}
 
+	var excluded map[string]struct{}
+	if d.namespaceExcluder != nil {
+		excluded, err = d.namespaceExcluder(ctx)
+		if err != nil {
+			// Fail-safe: proceeding without the exclusion set would relay
+			// other spokes' received data upstream on a registry blip.
+			return 0, fmt.Errorf("edgesync: list received namespaces for discovery exclusion: %w", err)
+		}
+	}
+
 	entries := make([]*LedgerEntry, 0, len(objects))
 	for _, obj := range objects {
 		if err := ctx.Err(); err != nil {
@@ -86,6 +113,20 @@ func (d *Discoverer) Discover(ctx context.Context) (int, error) {
 		}
 		if !isSyncableFile(obj.Path) {
 			continue
+		}
+		if len(excluded) > 0 {
+			// First segment alone, NOT splitFirstTwo: that helper requires
+			// three segments, but a spoke can legally sync a root-level file
+			// the hub stores as {spokeID}/x.parquet — two segments, which
+			// would escape the exclusion and relay upstream (deep-review
+			// High on this change).
+			if i := strings.IndexByte(obj.Path, '/'); i > 0 {
+				if _, isReceived := excluded[obj.Path[:i]]; isReceived {
+					// Another spoke's data, held here as a hub. Not this
+					// node's telemetry; never forwarded upstream.
+					continue
+				}
+			}
 		}
 
 		// Skip anything already tracked BEFORE hashing it. Discovery runs

--- a/internal/edgesync/ledger.go
+++ b/internal/edgesync/ledger.go
@@ -217,27 +217,11 @@ func (l *Ledger) initSchema() error {
 	CREATE INDEX IF NOT EXISTS idx_sync_ledger_synced
 		ON sync_ledger(state, synced_at, hub_id);
 
-	-- One row per contact session (connectivity acquired -> lost), which is
-	-- the unit an operator reasons about. A session may span many agent ticks.
-	--
-	-- TODO(#569): created here but not yet written. The session lifecycle
-	-- belongs to the sync agent (PR 8). Defined now so the schema lands in one
-	-- migration rather than altering a live edge database later — on a
-	-- disconnected box that is a site visit, not a config push. If PR 8 ships
-	-- without using it, delete the table rather than leaving it dead.
-	CREATE TABLE IF NOT EXISTS sync_history (
-		id           INTEGER PRIMARY KEY AUTOINCREMENT,
-		hub_id       TEXT NOT NULL,
-		started_at   TIMESTAMP NOT NULL,
-		completed_at TIMESTAMP,
-		files_synced INTEGER NOT NULL DEFAULT 0,
-		bytes_synced INTEGER NOT NULL DEFAULT 0,
-		transport    TEXT NOT NULL,
-		status       TEXT NOT NULL DEFAULT 'in_progress'
-	);
-
-	CREATE INDEX IF NOT EXISTS idx_sync_history_started
-		ON sync_history(hub_id, started_at);
+	-- sync_history was defined pre-emptively for a session-lifecycle feature
+	-- (TODO(#569) PR 8) that shipped without using it. Its own comment said
+	-- to delete it in that case rather than leave dead schema; the DROP
+	-- below retires it on existing spokes too. Nothing ever wrote a row.
+	DROP TABLE IF EXISTS sync_history;
 
 	-- Spoke-local key/value facts that must survive restarts. First user:
 	-- the compaction-defer enablement epoch (issue #610), which lets
@@ -1329,20 +1313,6 @@ func scanEntry(s rowScanner) (*LedgerEntry, error) {
 		e.ExportedAt = &t
 	}
 	return &e, nil
-}
-
-// checkAffected turns a zero-row UPDATE into ErrNotFound. Without this a state
-// transition against a path that isn't tracked would silently succeed, and the
-// agent would believe it had advanced an entry that does not exist.
-func checkAffected(res sql.Result, path string) error {
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("edgesync: rows affected for %q: %w", path, err)
-	}
-	if n == 0 {
-		return fmt.Errorf("edgesync: %q: %w", path, ErrNotFound)
-	}
-	return nil
 }
 
 // checkTransition reports the outcome of a guarded state transition. A guarded


### PR DESCRIPTION
## Summary

Closes #616 — the four residual cleanup items from the 2026-08-19 edge sync audit:

- **Dual-role relay closed** (audit M2): a hub that is also a spoke no longer re-discovers other edges' received files and forwards them upstream double-namespaced. Discovery excludes registered spoke namespaces; an excluder error **aborts** the pass (a registry blip must not silently start relaying). The deep review caught the fix's own edge — shallow received paths (`{spoke}/x.parquet`) escaped the three-segment splitter — closed with a first-segment match, both shapes test-pinned.
- **Pre-auth hub-ID disclosure closed**: the "hub ID mismatch" 400 on `/sync/file` and `/sync/reconcile` now fires *after* HMAC verification. The MAC binds the *claimed* hub ID, so a correctly-signed-but-misconfigured spoke still reaches the helpful 400; unauthenticated callers get a uniform 401 and can no longer confirm the hub's ID by iteration.
- **Dead `sync_history` table dropped** with an in-schema migration for existing spokes (its own TODO said to delete it if it shipped unused; it did).
- **Dead helpers removed**: `Agent.hashFile`, `Ledger.checkAffected`.

## Test plan

- [x] Exclusion test covers deep AND shallow received paths + excluder-error abort; full edgesync/api suites green incl. `-race`; `gofmt`/`go vet` clean
- [x] Deep reviewer traced the full matrix (plain spoke unchanged, hub-only unchanged, MAC-binds-claimed-hub-ID for the 400 path, replay/nonce interplay, registry lifetime at shutdown) — its one High (shallow-path escape) fixed and re-verified
- [x] Live: `DROP TABLE` migration on an existing spoke DB (table gone, ledger intact); **dual-role rig** — child spoke registered on the node, received files planted deep and shallow, one sync pass sent exactly the node's own telemetry and zero child paths reached the upstream hub
- [x] Release notes + new "Dual-role nodes" docs section with both operator rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)