### PR TITLE
fix: Reject concurrent backup operation requests

### DIFF
--- a/internal/api/backup_routes.go
+++ b/internal/api/backup_routes.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"regexp"
+	"sync/atomic"
 	"time"
 
 	"github.com/basekick-labs/arc/internal/auth"
@@ -16,9 +17,10 @@ var validBackupID = regexp.MustCompile(`^backup-\d{8}-\d{6}-[a-f0-9]{8}$`)
 
 // BackupHandler handles backup and restore API operations.
 type BackupHandler struct {
-	manager     *backup.Manager
-	authManager *auth.AuthManager
-	logger      zerolog.Logger
+	manager         *backup.Manager
+	authManager     *auth.AuthManager
+	logger          zerolog.Logger
+	activeOperation atomic.Pointer[string]
 }
 
 // NewBackupHandler creates a new backup handler.
@@ -54,15 +56,6 @@ type CreateBackupRequest struct {
 // CreateBackup triggers a new backup.
 // POST /api/v1/backup
 func (h *BackupHandler) CreateBackup(c *fiber.Ctx) error {
-	// Check if a backup is already running
-	if p := h.manager.GetProgress(); p != nil && p.Status == "running" {
-		return c.Status(fiber.StatusConflict).JSON(fiber.Map{
-			"error":     "A backup or restore operation is already in progress",
-			"status":    p.Status,
-			"operation": p.Operation,
-		})
-	}
-
 	var req CreateBackupRequest
 	if err := c.BodyParser(&req); err != nil {
 		// Empty body is fine — use defaults
@@ -79,9 +72,15 @@ func (h *BackupHandler) CreateBackup(c *fiber.Ctx) error {
 		opts.IncludeConfig = *req.IncludeConfig
 	}
 
+	acquired, err := h.acquireOperation(c, "backup")
+	if !acquired {
+		return err
+	}
+
 	// Run backup asynchronously — Fiber recycles c.Context() after the handler
 	// returns, so we must use a detached context.
 	go func() {
+		defer h.activeOperation.Store(nil)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
 		defer cancel()
 		if _, err := h.manager.CreateBackup(ctx, opts); err != nil {
@@ -193,15 +192,6 @@ type RestoreRequest struct {
 // RestoreBackup triggers a restore from a backup.
 // POST /api/v1/backup/restore
 func (h *BackupHandler) RestoreBackup(c *fiber.Ctx) error {
-	// Check if an operation is already running
-	if p := h.manager.GetProgress(); p != nil && p.Status == "running" {
-		return c.Status(fiber.StatusConflict).JSON(fiber.Map{
-			"error":     "A backup or restore operation is already in progress",
-			"status":    p.Status,
-			"operation": p.Operation,
-		})
-	}
-
 	var req RestoreRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -237,8 +227,14 @@ func (h *BackupHandler) RestoreBackup(c *fiber.Ctx) error {
 		opts.RestoreConfig = *req.RestoreConfig
 	}
 
+	acquired, err := h.acquireOperation(c, "restore")
+	if !acquired {
+		return err
+	}
+
 	// Run restore asynchronously — detached context (Fiber recycles c.Context()).
 	go func() {
+		defer h.activeOperation.Store(nil)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
 		defer cancel()
 		if _, err := h.manager.RestoreBackup(ctx, opts); err != nil {
@@ -250,5 +246,28 @@ func (h *BackupHandler) RestoreBackup(c *fiber.Ctx) error {
 		"message":   "Restore started",
 		"backup_id": req.BackupID,
 		"status":    "running",
+	})
+}
+
+// acquireOperation atomically reserves the handler's shared backup/restore slot.
+func (h *BackupHandler) acquireOperation(c *fiber.Ctx, operation string) (bool, error) {
+	if p := h.manager.GetProgress(); p != nil && p.Status == "running" {
+		return false, h.operationConflict(c, p.Operation)
+	}
+	if !h.activeOperation.CompareAndSwap(nil, &operation) {
+		activeOperation := ""
+		if active := h.activeOperation.Load(); active != nil {
+			activeOperation = *active
+		}
+		return false, h.operationConflict(c, activeOperation)
+	}
+	return true, nil
+}
+
+func (h *BackupHandler) operationConflict(c *fiber.Ctx, operation string) error {
+	return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+		"error":     "A backup or restore operation is already in progress",
+		"status":    "running",
+		"operation": operation,
 	})
 }

--- a/internal/api/backup_routes_test.go
+++ b/internal/api/backup_routes_test.go
@@ -1,0 +1,236 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/backup"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+type controlledBackupStorage struct {
+	storage.Backend
+
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
+	listErr   error
+	listCalls atomic.Int32
+}
+
+func (s *controlledBackupStorage) ListObjects(ctx context.Context, prefix string) ([]storage.ObjectInfo, error) {
+	s.listCalls.Add(1)
+	s.startOnce.Do(func() { close(s.started) })
+
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.Backend.(storage.ObjectLister).ListObjects(ctx, prefix)
+}
+
+type backupRouteRig struct {
+	app     *fiber.App
+	storage *controlledBackupStorage
+	handler *BackupHandler
+}
+
+type backupRouteResponse struct {
+	status int
+	err    error
+}
+
+func newBackupRouteRig(t *testing.T, listErr error) *backupRouteRig {
+	t.Helper()
+
+	dataStorage, err := storage.NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("create data storage: %v", err)
+	}
+	t.Cleanup(func() { dataStorage.Close() })
+
+	controlled := &controlledBackupStorage{
+		Backend: dataStorage,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		listErr: listErr,
+	}
+	manager, err := backup.NewManager(&backup.ManagerConfig{
+		DataStorage: controlled,
+		BackupPath:  t.TempDir(),
+		Logger:      zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("create backup manager: %v", err)
+	}
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	handler := NewBackupHandler(manager, nil, zerolog.Nop())
+	handler.RegisterRoutes(app)
+	t.Cleanup(func() { app.Shutdown() })
+
+	return &backupRouteRig{app: app, storage: controlled, handler: handler}
+}
+
+func (r *backupRouteRig) post(path, body string) (int, error) {
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.app.Test(req, 5_000)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
+}
+
+func (r *backupRouteRig) mustPost(t *testing.T, path, body string) int {
+	t.Helper()
+
+	status, err := r.post(path, body)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	return status
+}
+
+func waitForOperationRelease(t *testing.T, handler *BackupHandler) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if handler.activeOperation.Load() == nil {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("backup operation did not release the admission slot")
+}
+
+func waitForListCalls(t *testing.T, storage *controlledBackupStorage, want int32) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if storage.listCalls.Load() >= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("ListObjects calls=%d, want at least %d", storage.listCalls.Load(), want)
+}
+
+func TestBackupHandlerRejectsConcurrentBackups(t *testing.T) {
+	rig := newBackupRouteRig(t, nil)
+
+	const requests = 16
+	start := make(chan struct{})
+	responses := make(chan backupRouteResponse, requests)
+	var workers sync.WaitGroup
+	workers.Add(requests)
+	for range requests {
+		go func() {
+			defer workers.Done()
+			<-start
+			status, err := rig.post("/api/v1/backup/", `{}`)
+			responses <- backupRouteResponse{status: status, err: err}
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(responses)
+
+	accepted := 0
+	conflicts := 0
+	for response := range responses {
+		if response.err != nil {
+			t.Errorf("concurrent backup request: %v", response.err)
+			continue
+		}
+		switch response.status {
+		case fiber.StatusAccepted:
+			accepted++
+		case fiber.StatusConflict:
+			conflicts++
+		default:
+			t.Errorf("unexpected response status: %d", response.status)
+		}
+	}
+	if accepted != 1 || conflicts != requests-1 {
+		t.Fatalf("accepted=%d conflicts=%d, want 1 and %d", accepted, conflicts, requests-1)
+	}
+
+	select {
+	case <-rig.storage.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("accepted backup did not reach storage discovery")
+	}
+	close(rig.storage.release)
+	waitForOperationRelease(t, rig.handler)
+	if calls := rig.storage.listCalls.Load(); calls != 1 {
+		t.Fatalf("ListObjects calls=%d, want 1; a rejected backup was queued", calls)
+	}
+}
+
+func TestBackupHandlerSharesAdmissionWithRestoreAndReleasesIt(t *testing.T) {
+	rig := newBackupRouteRig(t, nil)
+
+	if status := rig.mustPost(t, "/api/v1/backup/", `{}`); status != fiber.StatusAccepted {
+		t.Fatalf("initial backup status=%d, want %d", status, fiber.StatusAccepted)
+	}
+	select {
+	case <-rig.storage.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("accepted backup did not reach storage discovery")
+	}
+
+	restoreBody := `{"backup_id":"backup-20260820-120000-deadbeef","confirm":true}`
+	if status := rig.mustPost(t, "/api/v1/backup/restore", restoreBody); status != fiber.StatusConflict {
+		t.Fatalf("competing restore status=%d, want %d", status, fiber.StatusConflict)
+	}
+
+	close(rig.storage.release)
+	waitForOperationRelease(t, rig.handler)
+	if status := rig.mustPost(t, "/api/v1/backup/", `{}`); status != fiber.StatusAccepted {
+		t.Fatalf("backup after completion status=%d, want %d", status, fiber.StatusAccepted)
+	}
+
+	waitForListCalls(t, rig.storage, 2)
+	if calls := rig.storage.listCalls.Load(); calls != 2 {
+		t.Fatalf("ListObjects calls=%d, want 2 after later backup", calls)
+	}
+	waitForOperationRelease(t, rig.handler)
+}
+
+func TestBackupHandlerReleasesAdmissionAfterFailure(t *testing.T) {
+	rig := newBackupRouteRig(t, errors.New("storage discovery failed"))
+	close(rig.storage.release)
+
+	if status := rig.mustPost(t, "/api/v1/backup/", `{}`); status != fiber.StatusAccepted {
+		t.Fatalf("initial backup status=%d, want %d", status, fiber.StatusAccepted)
+	}
+	waitForOperationRelease(t, rig.handler)
+
+	if status := rig.mustPost(t, "/api/v1/backup/", `{}`); status != fiber.StatusAccepted {
+		t.Fatalf("backup after failure status=%d, want %d", status, fiber.StatusAccepted)
+	}
+
+	waitForListCalls(t, rig.storage, 2)
+	if calls := rig.storage.listCalls.Load(); calls != 2 {
+		t.Fatalf("ListObjects calls=%d, want 2 after retry", calls)
+	}
+	waitForOperationRelease(t, rig.handler)
+}


### PR DESCRIPTION
The backup API checks `Manager.GetProgress` before launching work in a goroutine, so concurrent POST requests can both observe an idle manager and both receive `202 Accepted`. The manager mutex added since the issue was opened prevents simultaneous execution, but it only serializes the accepted operations; the second request silently queues instead of receiving `409 Conflict`. The same check-then-spawn pattern exists in the restore endpoint and shares the manager's operation boundary. The remaining defect is therefore at the HTTP admission boundary, not in backup data processing.

## Test plan

- Send multiple concurrent valid backup POSTs while the accepted backup is blocked in storage discovery; assert exactly one response is `202 Accepted` and every other response is `409 Conflict`, with no second backup queued.
- While a backup request owns the admission guard, send a valid confirmed restore request and assert it receives `409 Conflict`, proving backup and restore share one operation slot.
- Let the accepted backup finish, then send another valid backup request and assert it receives `202 Accepted`, proving the guard is released on completion rather than leaving the API permanently busy.
- Force the admitted background backup to fail and then submit another request; assert the subsequent request is accepted, covering guard release on the error path.

## Summary

Add a single atomic operation-admission guard to `BackupHandler`, shared by backup and restore requests, and acquire it synchronously before either handler launches its goroutine. Treat failure to acquire as the existing conflict response, and release the guard from the operation goroutine on every completion, failure, or timeout path while retaining the manager mutex as the lower-level serialization safeguard. Keep request parsing and restore validation ahead of admission so invalid requests do not occupy the guard, and preserve the existing detached contexts, response bodies, and progress polling behavior.

Closes #299
