### PR TITLE
docs: release-notes entry + README contributor credit for #622 (#299)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Thanks to everyone who has contributed code to Arc:
 - [@schotime](https://github.com/schotime) (Adam Schroder) — Data-time partitioning, compaction API triggers, UTC fixes, bare-JOIN SQL rewriting fix
 - [@khalid244](https://github.com/khalid244) — S3 partition pruning improvements, multi-line SQL query support
 - [@SAY-5](https://github.com/SAY-5) (Sai Asish Y) — MQTT nil-guard hardening (handlers + manager) with regression coverage
+- [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn) — backup/restore concurrency fix: atomic admission guard so competing operations get 409 instead of silently queuing
 
 And a thank-you to community members whose bug reports drove fixes:
 

--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -462,6 +462,23 @@ Reachable only when RBAC is enabled (the multi-tenant authorization boundary); n
 
 ## Bug fixes
 
+### Concurrent backup/restore requests are now rejected with 409 instead of silently queuing ([#299](https://github.com/Basekick-Labs/arc/issues/299))
+
+The backup API checked "is an operation running?" before launching the work in
+a background goroutine — but the running flag was only set *inside* that
+goroutine. Two concurrent `POST /api/v1/backup` requests could both observe an
+idle manager, both receive `202 Accepted`, and the second backup would silently
+queue behind the first instead of being refused. The same window existed on
+`POST /api/v1/backup/restore`.
+
+Backup and restore now share a single atomic admission slot, acquired before
+the goroutine is launched: exactly one request gets `202 Accepted`, every
+concurrent competitor gets `409 Conflict`, and the slot is released on every
+completion and failure path. Request validation still runs before admission, so
+a malformed request never occupies the slot. Contributed by
+[@mvanhorn](https://github.com/mvanhorn) in
+[#622](https://github.com/Basekick-Labs/arc/pull/622).
+
 ### Quoted identifiers in SQL now resolve to storage paths
 
 `SELECT * FROM "my-db".cpu` used to return zero rows, silently. The query


### PR DESCRIPTION
## Summary
- Adds the 26.09.1 release-notes entry for the backup/restore admission race fixed in #622 (external contributions don't carry release-notes updates, so this closes the gap)
- Adds @mvanhorn (Matt Van Horn) to the README contributors list

## Test plan
- [x] Docs-only; rendered markdown checked