### PR TITLE
fix(throttle): a first fire in the clock tick of construction no longer disarms the window

### DIFF
--- a/internal/throttle/throttle.go
+++ b/internal/throttle/throttle.go
@@ -65,6 +65,14 @@ func New(interval time.Duration) *Debouncer {
 // false — exactly one caller wins per interval.
 func (d *Debouncer) TryAcquire() bool {
 	now := time.Since(d.processStart).Nanoseconds()
+	// The monotonic clock's resolution is coarser than a function call: a
+	// TryAcquire in the same tick as construction sees now==0, and storing 0
+	// would record the firing AS the "never fired" sentinel — re-arming the
+	// throttle immediately. Nudge to 1ns; the window is off by a nanosecond,
+	// the sentinel stays unambiguous.
+	if now == 0 {
+		now = 1
+	}
 	last := d.lastNanos.Load()
 	// last==0 means "never fired" — the first call always proceeds. See the
 	// package comment for why this sentinel is required with monotonic time.


### PR DESCRIPTION
## Summary
- `TryAcquire` stores nanoseconds-since-process-start, with `0` meaning "never fired". On Apple Silicon the monotonic clock's ~41ns tick means a `TryAcquire` in the same tick as `New` reads `now == 0` (~40% of immediate calls, measured 402/1000) and records the firing **as the sentinel** — the next caller then bypasses the throttle window entirely.
- Fix: nudge a zero reading to 1ns before storing. The window is off by a nanosecond; the sentinel stays unambiguous.
- No production impact today (the memory-release debouncers first fire long after startup), but the invariant was broken and `TestDebouncer_NonPositiveIntervalClamped` fails near-deterministically on unmodified `main` on M-series hardware. No release-notes entry — no user-visible behavior change.

## Test plan
- [x] `TestDebouncer_NonPositiveIntervalClamped` fails on `main`, passes with the fix (the existing test IS the regression test)
- [x] `go test ./internal/throttle/ -count=20 -race` green
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)