### PR TITLE
fix(backup): DELETE joins the operation admission slot; progress reads no longer race the writer

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -488,6 +488,20 @@ a malformed request never occupies the slot. Contributed by
 [@mvanhorn](https://github.com/mvanhorn) in
 [#622](https://github.com/Basekick-Labs/arc/pull/622).
 
+`DELETE /api/v1/backup/:id` joins the same admission slot
+([#626](https://github.com/Basekick-Labs/arc/issues/626)): deleting a backup
+while a backup or restore is running — including the backup the restore is
+reading — now returns `409 Conflict` instead of tearing files out from under
+the operation. The manager additionally refuses deletes at its own boundary
+while an operation holds it, as a belt for any future non-HTTP caller.
+
+The same review also closed a long-standing data race on the progress object:
+the manager published its live progress struct and kept writing to it (status,
+error, counters) while `/status` polls and the admission check read it
+unsynchronized. Progress is now published as immutable snapshots, republished
+after each file, so pollers see live counters without ever sharing memory with
+the writer.
+
 ### Quoted identifiers in SQL now resolve to storage paths
 
 `SELECT * FROM "my-db".cpu` used to return zero rows, silently. The query

--- a/internal/api/backup_routes.go
+++ b/internal/api/backup_routes.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"sync/atomic"
 	"time"
@@ -164,10 +165,29 @@ func (h *BackupHandler) DeleteBackup(c *fiber.Ctx) error {
 		})
 	}
 
+	// Deletion shares the backup/restore admission slot (#626): deleting the
+	// backup a restore is reading tears files out from under it, and deleting
+	// one mid-write leaves a half-written directory. Unlike backup/restore the
+	// delete is synchronous, so the handler holds the slot for its duration.
+	acquired, err := h.acquireOperation(c, "delete")
+	if !acquired {
+		return err
+	}
+	defer h.activeOperation.Store(nil)
+
 	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
 	defer cancel()
 
 	if err := h.manager.DeleteBackup(ctx, id); err != nil {
+		// Belt for operations started outside this handler: the manager
+		// refuses to delete while its own mutex is held.
+		if errors.Is(err, backup.ErrOperationInProgress) {
+			operation := "unknown"
+			if p := h.manager.GetProgress(); p != nil && p.Status == "running" {
+				operation = p.Operation
+			}
+			return h.operationConflict(c, operation)
+		}
 		h.logger.Error().Err(err).Str("backup_id", id).Msg("Failed to delete backup")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to delete backup",
@@ -255,11 +275,13 @@ func (h *BackupHandler) acquireOperation(c *fiber.Ctx, operation string) (bool, 
 		return false, h.operationConflict(c, p.Operation)
 	}
 	if !h.activeOperation.CompareAndSwap(nil, &operation) {
-		activeOperation := ""
+		// The holder may release between the failed CAS and this Load; report
+		// "unknown" rather than an empty operation in that sliver (#622 review).
+		held := "unknown"
 		if active := h.activeOperation.Load(); active != nil {
-			activeOperation = *active
+			held = *active
 		}
-		return false, h.operationConflict(c, activeOperation)
+		return false, h.operationConflict(c, held)
 	}
 	return true, nil
 }

--- a/internal/api/backup_routes_test.go
+++ b/internal/api/backup_routes_test.go
@@ -234,3 +234,57 @@ func TestBackupHandlerReleasesAdmissionAfterFailure(t *testing.T) {
 	}
 	waitForOperationRelease(t, rig.handler)
 }
+
+func (r *backupRouteRig) delete(t *testing.T, path string) int {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	resp, err := r.app.Test(req, 5_000)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// #626: DELETE shares the backup/restore admission slot. Deleting while a
+// backup runs is refused with 409; once the operation finishes, a real backup
+// deletes cleanly and the slot is free for the next operation.
+func TestDeleteBackupSharesAdmissionSlot(t *testing.T) {
+	rig := newBackupRouteRig(t, nil)
+
+	if status := rig.mustPost(t, "/api/v1/backup/", `{}`); status != fiber.StatusAccepted {
+		t.Fatalf("initial backup status=%d, want %d", status, fiber.StatusAccepted)
+	}
+	select {
+	case <-rig.storage.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("accepted backup did not reach storage discovery")
+	}
+
+	if status := rig.delete(t, "/api/v1/backup/backup-20260820-120000-deadbeef"); status != fiber.StatusConflict {
+		t.Fatalf("delete during running backup status=%d, want %d", status, fiber.StatusConflict)
+	}
+
+	close(rig.storage.release)
+	waitForOperationRelease(t, rig.handler)
+
+	// The backup that just completed is a real, deletable backup.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	backups, err := rig.handler.manager.ListBackups(ctx)
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("ListBackups = %v backups, err %v; want exactly 1", len(backups), err)
+	}
+	if status := rig.delete(t, "/api/v1/backup/"+backups[0].BackupID); status != fiber.StatusOK {
+		t.Fatalf("delete after completion status=%d, want %d", status, fiber.StatusOK)
+	}
+
+	// The delete released the slot: the next operation is admitted.
+	waitForOperationRelease(t, rig.handler)
+	if status := rig.mustPost(t, "/api/v1/backup/", `{}`); status != fiber.StatusAccepted {
+		t.Fatalf("backup after delete status=%d, want %d", status, fiber.StatusAccepted)
+	}
+	waitForListCalls(t, rig.storage, 2)
+	waitForOperationRelease(t, rig.handler)
+}

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -170,6 +170,7 @@ func (m *Manager) CreateBackup(ctx context.Context, opts BackupOptions) (*Backup
 	// never exceeds TotalFiles. The manifest inventory (TotalFiles) counts only data files.
 	progress.TotalFiles = manifest.TotalFiles + int64(len(icebergMetaFiles))
 	progress.TotalBytes = manifest.TotalSizeBytes
+	m.setProgress(progress)
 
 	// ── 2. Copy parquet files ───────────────────────────────────────────
 	if err := m.copyDataFiles(ctx, backupID, parquetFiles, progress); err != nil {
@@ -301,6 +302,9 @@ func (m *Manager) copyDataFiles(ctx context.Context, backupID string, files []st
 
 		atomic.AddInt64(&progress.ProcessedFiles, 1)
 		atomic.AddInt64(&progress.ProcessedBytes, written)
+		// Republish so /status polling sees live counters — published Progress
+		// values are immutable snapshots, not the struct being mutated here.
+		m.setProgress(progress)
 
 		if atomic.LoadInt64(&progress.ProcessedFiles)%100 == 0 {
 			m.logger.Info().
@@ -313,6 +317,7 @@ func (m *Manager) copyDataFiles(ctx context.Context, backupID string, files []st
 	// Accumulate rather than overwrite: CreateBackup calls this once per file
 	// group, and a later group must not erase an earlier group's skips.
 	atomic.AddInt64(&progress.SkippedFiles, skipped)
+	m.setProgress(progress)
 
 	if skipped == 0 {
 		return nil

--- a/internal/backup/delete_guard_test.go
+++ b/internal/backup/delete_guard_test.go
@@ -1,0 +1,95 @@
+package backup
+
+// Regression tests for #626: DeleteBackup must refuse to run while a backup or
+// restore operation holds the manager, rather than racing its storage reads.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// blockingLister wraps a backend and parks ListObjects until released, so a
+// test can hold CreateBackup (and therefore m.mu) at a known point.
+type blockingLister struct {
+	storage.Backend
+
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
+}
+
+func (b *blockingLister) ListObjects(ctx context.Context, prefix string) ([]storage.ObjectInfo, error) {
+	b.startOnce.Do(func() { close(b.started) })
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return b.Backend.(storage.ObjectLister).ListObjects(ctx, prefix)
+}
+
+func TestDeleteBackup_RefusesWhileOperationHoldsManager(t *testing.T) {
+	data, err := storage.NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("data backend: %v", err)
+	}
+	t.Cleanup(func() { data.Close() })
+
+	blocked := &blockingLister{
+		Backend: data,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m, err := NewManager(&ManagerConfig{
+		DataStorage: blocked,
+		BackupPath:  t.TempDir(),
+		Logger:      zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		m.CreateBackup(ctx, BackupOptions{}) //nolint:errcheck // completion is all this test needs
+	}()
+
+	select {
+	case <-blocked.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backup never reached storage discovery")
+	}
+
+	// The operation holds m.mu: the delete must refuse immediately, not queue.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := m.DeleteBackup(ctx, "backup-20260820-120000-deadbeef"); !errors.Is(err, ErrOperationInProgress) {
+		t.Fatalf("delete during running backup: err = %v, want ErrOperationInProgress", err)
+	}
+
+	close(blocked.release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("backup did not finish after release")
+	}
+
+	// The lock is released: the delete now proceeds far enough to discover the
+	// ID does not exist — a different error, proving the guard did not stick.
+	// Fresh context: the first one has been aging across the waits above.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+	err = m.DeleteBackup(ctx2, "backup-20260820-120000-deadbeef")
+	if err == nil || errors.Is(err, ErrOperationInProgress) {
+		t.Fatalf("delete after completion: err = %v, want a not-found error", err)
+	}
+}

--- a/internal/backup/manager.go
+++ b/internal/backup/manager.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -103,13 +104,23 @@ func generateBackupID() string {
 }
 
 // GetProgress returns the current active operation progress, or nil if idle.
+// The returned value is an immutable snapshot — the operation goroutine never
+// writes to a published Progress (see setProgress) — so callers may read and
+// marshal it freely, but must not mutate it. It can lag the live operation by
+// up to one file's worth of work.
 func (m *Manager) GetProgress() *Progress {
 	return m.active.Load()
 }
 
-// setProgress stores the current operation progress.
+// setProgress publishes an immutable snapshot of p. The operation goroutine
+// keeps mutating its own private Progress and republishes after each update;
+// readers (GetProgress, the /status handler, the API admission check) only
+// ever see copies, so their unsynchronized field reads cannot race with the
+// writer. Publishing the live pointer instead is a data race: every field
+// write after the initial publish would race the readers.
 func (m *Manager) setProgress(p *Progress) {
-	m.active.Store(p)
+	snapshot := *p
+	m.active.Store(&snapshot)
 }
 
 // ListBackups returns summaries of all available backups in the default backup storage.
@@ -156,8 +167,25 @@ func (m *Manager) GetBackup(ctx context.Context, backupID string) (*Manifest, er
 	return UnmarshalManifest(data)
 }
 
+// ErrOperationInProgress is returned by DeleteBackup when a backup or restore
+// operation holds the manager. The API layer maps it to 409 Conflict.
+var ErrOperationInProgress = errors.New("a backup or restore operation is in progress")
+
 // DeleteBackup removes all files for a backup from the default backup storage.
+//
+// It refuses to run concurrently with a backup or restore (#626): deleting the
+// backup a restore is reading tears files out from under it mid-operation, and
+// deleting the backup being written leaves a half-written/half-deleted
+// directory. TryLock rather than Lock — an operation can hold m.mu for hours,
+// and queuing a synchronous HTTP-driven delete behind it would pin the request
+// goroutine long past its context deadline. Callers get ErrOperationInProgress
+// and retry when the operation finishes.
 func (m *Manager) DeleteBackup(ctx context.Context, backupID string) error {
+	if !m.mu.TryLock() {
+		return ErrOperationInProgress
+	}
+	defer m.mu.Unlock()
+
 	// List all files under this backup ID
 	prefix := backupID + "/"
 	files, err := m.backupStorage.List(ctx, prefix)

--- a/internal/backup/progress_race_test.go
+++ b/internal/backup/progress_race_test.go
@@ -1,0 +1,81 @@
+package backup
+
+// Regression test for the Progress publication race (found in the #626
+// review): the manager published its live *Progress and kept writing to it —
+// Status, Error, totals, and counters — while GetProgress readers (the
+// /status handler, the API admission check) read the same object with no
+// synchronization. Run under -race, a poller during a live backup trips the
+// detector on the pre-fix code. The fix publishes immutable snapshots.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+func TestGetProgress_DoesNotRaceALiveBackup(t *testing.T) {
+	dataDir := t.TempDir()
+	data, err := storage.NewLocalBackend(dataDir, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("data backend: %v", err)
+	}
+	t.Cleanup(func() { data.Close() })
+
+	// Enough files that the copy loop and the poller genuinely overlap.
+	ctx := context.Background()
+	for i := 0; i < 400; i++ {
+		path := fmt.Sprintf("db/m/2026/08/20/10/f%03d.parquet", i)
+		if err := data.Write(ctx, path, []byte("parquet-bytes")); err != nil {
+			t.Fatalf("seed file: %v", err)
+		}
+	}
+
+	m, err := NewManager(&ManagerConfig{
+		DataStorage: data,
+		BackupPath:  t.TempDir(),
+		Logger:      zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		opCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if _, err := m.CreateBackup(opCtx, BackupOptions{}); err != nil {
+			t.Errorf("backup failed: %v", err)
+		}
+	}()
+
+	// Poll exactly the way production readers do: field reads plus a full JSON
+	// marshal (GetStatus), for the whole life of the operation.
+	for {
+		select {
+		case <-done:
+			p := m.GetProgress()
+			if p == nil || p.Status != "completed" {
+				t.Fatalf("final progress = %+v, want completed", p)
+			}
+			if p.ProcessedFiles != 400 {
+				t.Fatalf("processed = %d, want 400", p.ProcessedFiles)
+			}
+			return
+		default:
+		}
+		if p := m.GetProgress(); p != nil {
+			_ = p.Status
+			_ = p.ProcessedFiles
+			_ = p.ProcessedBytes
+			if _, err := json.Marshal(p); err != nil {
+				t.Fatalf("marshal progress: %v", err)
+			}
+		}
+	}
+}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -104,6 +104,7 @@ func (m *Manager) restoreDataFiles(ctx context.Context, backupID string, manifes
 
 	progress.TotalFiles = int64(len(files))
 	progress.TotalBytes = manifest.TotalSizeBytes
+	m.setProgress(progress)
 
 	for _, srcPath := range files {
 		select {
@@ -127,6 +128,9 @@ func (m *Manager) restoreDataFiles(ctx context.Context, backupID string, manifes
 
 		atomic.AddInt64(&progress.ProcessedFiles, 1)
 		atomic.AddInt64(&progress.ProcessedBytes, bytesWritten)
+		// Republish so /status polling sees live counters — published Progress
+		// values are immutable snapshots, not the struct being mutated here.
+		m.setProgress(progress)
 
 		if atomic.LoadInt64(&progress.ProcessedFiles)%100 == 0 {
 			m.logger.Info().


### PR DESCRIPTION
## Summary
- **DELETE shares the #622 admission slot** (closes #626): a delete during a running backup/restore gets `409 Conflict` instead of racing the operation's storage reads; ID validation stays ahead of admission; the slot releases on every path (deferred).
- **Manager belt**: `Manager.DeleteBackup` refuses via `mu.TryLock()` → `ErrOperationInProgress` (mapped to the same 409 body) — TryLock so a delete never queues behind an hours-long operation. Ordering proof: operations release `m.mu` strictly before the slot, so the belt can never falsely fire for handler-admitted deletes.
- **Progress publication race fixed** (pre-existing, found in this review): the live `*Progress` was published and then mutated while `/status` and the admission check read it unsynchronized. `setProgress` now publishes immutable snapshots, republished per file, so polling stays live with zero shared mutable memory. Both operations are single-goroutine, so the snapshot copy is race-free by construction.
- #622 review nit: a failed-CAS 409 with a just-released slot now reports `"operation": "unknown"` instead of `""`.
- Release notes updated; docs (`backup-restore.md`) PR in docs.basekick.net follows.

## Test plan
- [x] `TestDeleteBackupSharesAdmissionSlot` — 409 during running backup, real delete succeeds after, slot released (fails pre-fix: delete ran concurrently, 500)
- [x] `TestDeleteBackup_RefusesWhileOperationHoldsManager` — belt refuses while `m.mu` held, releases after (fails pre-fix)
- [x] `TestGetProgress_DoesNotRaceALiveBackup` — hostile poller over a 400-file backup (pre-fix: 7 race-detector warnings; post-fix green ×3)
- [x] Full `internal/api` + `internal/backup` suites green under `-race`; gofmt/vet clean
- [x] Deep adversarial review: merge verdict, no blockers/highs; configuration matrix confirmed on all rows
- [x] Live binary: write → backup → delete (200) → re-backup (202) cycle, no panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)