### PR TITLE
fix(security): harden SQL validation on measurement query, CQ, and delete endpoints

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -460,6 +460,12 @@ The fix rejects, in `ValidateSQLRequest` (before any transform or RBAC check run
 
 Reachable only when RBAC is enabled (the multi-tenant authorization boundary); no CVE is being filed, as it is a residual of GHSA-93cm scoped to within the allow-list, tracked under the advisory above. Reported by [@arpitjain099](https://github.com/arpitjain099).
 
+### Query-authorization hardening on the measurement query endpoint
+
+Closed a query-authorization gap on the `GET /api/v1/query/:measurement` endpoint and tightened the shared SQL validator that guards every user-SQL path. The measurement endpoint now routes its request through the same validation as the raw-query API, and the continuous-query and delete endpoints received the same input-validation pass so the whole surface is consistent. On RBAC-enabled multi-tenant instances this removes an authorization gap; standalone single-tenant deployments were not exposed to a cross-tenant boundary. No configuration changes are required.
+
+Full technical detail will accompany the corresponding security advisory once it is published. Responsibly reported by **zx (Jace)** ([@manus-use](https://github.com/manus-use)).
+
 ### Dependency: gRPC-Go upgraded past GHSA-hrxh-6v49-42gf
 
 `google.golang.org/grpc` is upgraded from v1.80.0 to v1.83.1, past the v1.82.1

--- a/internal/api/continuous_query.go
+++ b/internal/api/continuous_query.go
@@ -330,6 +330,11 @@ func (h *ContinuousQueryHandler) handleCreate(c *fiber.Ctx) error {
 		})
 	}
 
+	// Run the shared SQL validator over the definition before storing it.
+	if err := validateCQQuery(req.Query); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
 	// Validate tag columns before storing — they end up in Parquet arc:tags
 	// metadata and compaction's PARTITION BY, so unsafe names must be rejected
 	// at the boundary (#521).
@@ -438,6 +443,14 @@ func (h *ContinuousQueryHandler) handleUpdate(c *fiber.Ctx) error {
 	if err := validateTagColumns(req.TagColumns); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
 	}
+
+	// UPDATE overwrites the stored definition, so the new body needs the same
+	// validation handleCreate applies — otherwise a create-time check is
+	// trivially bypassed by creating a benign CQ and immediately updating it.
+	if err := validateCQQuery(req.Query); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
 	tagColumnsJSON, err := encodeTagColumns(req.TagColumns)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to encode tag_columns"})
@@ -1256,4 +1269,33 @@ func (h *ContinuousQueryHandler) updateLastProcessedTime(queryID int64, processe
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to update last processed time")
 	}
+}
+
+// validateCQQuery runs the shared SQL validator over a continuous-query
+// definition before it is stored.
+//
+// SECURITY: the CQ body is user-supplied SQL that executeAggregation later runs
+// verbatim on the shared DuckDB handle. Before this check it reached DuckDB with
+// no validation at all — no I/O-function denylist, no replacement-scan check, no
+// multi-statement rejection — so a stored CQ could read any file inside the
+// sandbox's allowlisted storage root (every tenant's Parquet) or mutate session
+// state via ATTACH/INSTALL/LOAD. The endpoint is admin-gated, but an admin token
+// is not meant to be a DuckDB shell, and the definition persists and re-executes
+// on a schedule long after the request that created it.
+// (GHSA-wmjj-g8xc-6hwr adversarial review, H3.)
+//
+// The {start_time}/{end_time} placeholders are substituted with quoted RFC3339
+// timestamps at execution (see executeAggregation), so they are replaced with
+// representative literals here — validating the raw form would leave a bare
+// `{start_time}` token in the statement and produce spurious parse-shaped input.
+func validateCQQuery(query string) error {
+	if strings.TrimSpace(query) == "" {
+		return nil // emptiness is reported by the caller's own required-field check
+	}
+	probe := strings.ReplaceAll(query, "{start_time}", "'2026-01-01T00:00:00Z'")
+	probe = strings.ReplaceAll(probe, "{end_time}", "'2026-01-01T01:00:00Z'")
+	if err := ValidateSQLRequest(probe); err != nil {
+		return fmt.Errorf("invalid query: %w", err)
+	}
+	return nil
 }

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -142,6 +142,30 @@ var dangerousPunctuationPatterns = []string{
 // Uses \b word boundaries to avoid false positives on column names like "offset", "payload", "dataset"
 var dangerousKeywordPattern = regexp.MustCompile(`(?i)\b(DROP|DELETE|INSERT|UPDATE|EXEC|EXECUTE|UNION|SELECT|CREATE|ALTER|COPY|ATTACH|DETACH|LOAD|INSTALL|PRAGMA|CALL|SET)\b`)
 
+// dangerousIOFunctionPattern rejects DuckDB's filesystem-I/O table-function
+// family in a DELETE WHERE clause.
+//
+// The keyword list above blocks SELECT, which kills the scalar-subquery vector
+// that made GHSA-wmjj-g8xc-6hwr exploitable on the query endpoint — but these
+// readers do not need a subquery to run. The WHERE clause is interpolated into
+// `SELECT ... FROM read_parquet(...) WHERE <where>`, so a scalar expression like
+// `1=1 OR list_contains(glob('/data/**'), 'x')` reaches DuckDB with no SELECT of
+// its own and turns the row count into a cross-tenant existence oracle. DELETE is
+// admin-gated, but an admin token is not meant to be a filesystem read primitive.
+//
+// Matches the function NAME anywhere in the clause, not anchored to a FROM/JOIN
+// position — these can sit in any scalar expression. Kept as a separate pattern
+// from the keyword list so the error message can name the offending function.
+var dangerousIOFunctionPattern = regexp.MustCompile(`(?i)\b(` + strings.Join([]string{
+	"read_parquet", "parquet_scan", "read_csv", "read_csv_auto",
+	"read_json", "read_json_auto", "read_ndjson", "read_ndjson_auto",
+	"read_text", "read_blob", "read_xlsx", "glob",
+	"parquet_metadata", "parquet_schema", "parquet_file_metadata",
+	"parquet_kv_metadata", "parquet_bloom_probe",
+	"delta_scan", "iceberg_scan", "iceberg_metadata", "iceberg_snapshots",
+	"arc_partition_agg",
+}, "|") + `)\s*\(`)
+
 // Dangerous prefix patterns (match at word start)
 var dangerousPrefixPatterns = []string{
 	"xp_",
@@ -468,6 +492,14 @@ func (h *DeleteHandler) validateWhereClause(where string) (bool, error) {
 	// on column names like "offset" (contains SET), "payload" (contains LOAD), "dataset" (contains SET)
 	if match := dangerousKeywordPattern.FindString(where); match != "" {
 		return false, fmt.Errorf("WHERE clause contains forbidden keyword: %s", strings.ToUpper(match))
+	}
+
+	// Reject filesystem-I/O table functions (see dangerousIOFunctionPattern).
+	// Matched against the identifier-quote-stripped form so the quoted spelling
+	// `"glob"(...)`, which DuckDB executes identically, cannot slip past.
+	ioCheck := strings.NewReplacer(`"`, "", "`", "").Replace(where)
+	if m := dangerousIOFunctionPattern.FindStringSubmatch(ioCheck); m != nil {
+		return false, fmt.Errorf("WHERE clause contains forbidden file I/O function: %s()", m[1])
 	}
 
 	// Check for dangerous prefixes

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -550,7 +550,11 @@ func scanSQLFeatures(sql string) sqlFeatures {
 	var f sqlFeatures
 	for i := 0; i < len(sql); i++ {
 		ch := sql[i]
-		if ch == '\'' || ch == '"' {
+		// `$` is treated as a quote opener: a dollar-quoted string ($tag$…$tag$)
+		// contains no ' or ", so gating masking on those alone left the construct
+		// unmasked and a replacement scan visible to DuckDB but not to the
+		// table-position scanner (GHSA-wmjj-g8xc-6hwr).
+		if ch == '\'' || ch == '"' || ch == '$' {
 			f.hasQuotes = true
 		} else if ch == '-' && i+1 < len(sql) && sql[i+1] == '-' {
 			f.hasDashComment = true
@@ -4281,6 +4285,37 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	sql += " ORDER BY " + orderBy
 	sql += fmt.Sprintf(" LIMIT %d", limit)
 	sql += fmt.Sprintf(" OFFSET %d", offset)
+
+	// SECURITY (GHSA-wmjj-g8xc-6hwr): run the SHARED validator over the fully
+	// assembled statement.
+	//
+	// validateWhereClauseQuery above is a substring blocklist that blocks
+	// neither SELECT nor any DuckDB I/O table function, so a `where` fragment
+	// could smuggle a cross-tenant read through a scalar subquery
+	// (`time > (SELECT max(v) FROM parquet_scan('/other-tenant/d.parquet'))`).
+	// RBAC only inspects the path params, and the DuckDB sandbox allowlists the
+	// whole storage root, so nothing downstream caught it. This endpoint was the
+	// only user-SQL path that never reached ValidateSQLRequest — which is where
+	// the I/O denylist, replacement-scan, and quoted-identifier checks live.
+	//
+	// Validating the ASSEMBLED statement (rather than bolting the denylist onto
+	// the fragment) is deliberate: the fragment blocklist cannot see the
+	// replacement-scan class, which has no function name to key on, and keeping
+	// one validator means future hardening lands here automatically instead of
+	// having to be mirrored into a second code path.
+	//
+	// Ordering matters: this MUST run before getTransformedSQL, which emits
+	// Arc's own read_parquet() and would self-trip the denylist. It is also why
+	// the bug was so clean to exploit — an injected read_parquet hits the
+	// fast-path at getTransformedSQL and is returned verbatim, untransformed.
+	if err := ValidateSQLRequest(sql); err != nil {
+		m.IncQueryErrors()
+		return c.Status(fiber.StatusBadRequest).JSON(QueryResponse{
+			Success:   false,
+			Error:     "Invalid query: " + err.Error(),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		})
+	}
 
 	// Convert SQL to storage paths (with caching)
 	// Note: This endpoint builds its own db.measurement SQL, so no header optimization

--- a/internal/api/query_measurement_security_test.go
+++ b/internal/api/query_measurement_security_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// assembleMeasurementSQL mirrors exactly what queryMeasurement builds so these
+// tests exercise the same string the handler validates.
+func assembleMeasurementSQL(database, measurement, where string) string {
+	sql := "SELECT * FROM " + database + "." + measurement
+	if where != "" {
+		sql += " WHERE " + where
+	}
+	return sql + " ORDER BY time DESC LIMIT 100 OFFSET 0"
+}
+
+// TestQueryMeasurementWhereRejectsCrossTenantReads covers GHSA-wmjj-g8xc-6hwr.
+//
+// GET /api/v1/query/:measurement guarded its user-controlled `where` param only
+// with validateWhereClauseQuery — a substring blocklist that blocks neither
+// SELECT nor any DuckDB I/O table function. The fragment is concatenated into
+// `SELECT * FROM db.meas WHERE <where> ...` and executed on a DuckDB handle whose
+// sandbox allowlists the entire storage root, while RBAC inspects only the path
+// params. A token scoped to one measurement could therefore read any tenant's
+// files through a scalar subquery.
+//
+// Each payload below passes validateWhereClauseQuery (asserted explicitly) and
+// must now be rejected by the shared validator.
+func TestQueryMeasurementWhereRejectsCrossTenantReads(t *testing.T) {
+	payloads := []struct {
+		name  string
+		where string
+	}{
+		// Class 1: I/O table functions (the reported vector).
+		{"parquet_scan subquery", `time > (SELECT max(value) FROM parquet_scan('/data/arc/secretdb/cpu/d.parquet'))`},
+		{"glob enumeration", `time > (SELECT count(*) FROM glob('/data/arc/secretdb/cpu/d.parquet'))`},
+		{"read_parquet subquery", `time > (SELECT max(value) FROM read_parquet('/data/arc/secretdb/cpu/d.parquet'))`},
+		{"parquet_metadata oracle", `1=1 AND (SELECT count(*) FROM parquet_metadata('/data/arc/secretdb/cpu/d.parquet')) > 0`},
+		{"read_csv non-parquet", `time > (SELECT max(c) FROM read_csv('/data/arc/arc.db'))`},
+		{"read_text non-parquet", `time > (SELECT len(content) FROM read_text('/data/arc/arc.db'))`},
+		{"iceberg_scan", `time > (SELECT max(v) FROM iceberg_scan('/data/arc/secretdb/tbl'))`},
+
+		// Class 2: quoted-identifier spelling (GHSA-93cm round 2).
+		{"quoted identifier fn", `time > (SELECT max(v) FROM "parquet_scan"('/data/arc/secretdb/cpu/d.parquet'))`},
+
+		// Class 3: bare-string replacement scan, no function name (GHSA-w8x2).
+		{"replacement scan subquery", `time > (SELECT max(v) FROM '/data/arc/secretdb/cpu/d.parquet')`},
+
+		// Class 3b: non-standard string syntaxes for the same replacement scan.
+		// These carry no ' or " at all in the $$ form, so they also evade the
+		// fragment blocklist's quote-parity check.
+		{"E-string replacement scan", `time > (SELECT max(v) FROM e'/data/arc/secretdb/cpu/d.parquet')`},
+		{"E-string uppercase", `time > (SELECT max(v) FROM E'/data/arc/secretdb/cpu/d.parquet')`},
+		{"dollar-quoted replacement scan", `time > (SELECT max(v) FROM $$/data/arc/secretdb/cpu/d.parquet$$)`},
+		{"tagged dollar-quote", `time > (SELECT max(v) FROM $t$/data/arc/secretdb/cpu/d.parquet$t$)`},
+
+		// Class 4: comma cross-join inside a subquery.
+		{"comma cross-join", `time > (SELECT max(b.v) FROM cpu, '/data/arc/secretdb/x.parquet' b)`},
+	}
+
+	for _, p := range payloads {
+		t.Run(p.name, func(t *testing.T) {
+			// Precondition: the legacy fragment blocklist does NOT catch this.
+			// If this ever starts failing, the payload stopped exercising the gap.
+			if err := validateWhereClauseQuery(p.where); err != nil {
+				t.Fatalf("payload no longer exercises the gap — fragment blocklist rejected it: %v", err)
+			}
+
+			sql := assembleMeasurementSQL("default", "cpu", p.where)
+			if err := ValidateSQLRequest(sql); err == nil {
+				t.Errorf("VULNERABLE: cross-tenant payload accepted\n  where: %s\n  sql:   %s", p.where, sql)
+			}
+		})
+	}
+}
+
+// TestQueryMeasurementWhereAllowsLegitimateFilters guards against false
+// positives. This endpoint is public and working; rejecting valid filters would
+// break production users. Every fragment here must keep passing.
+func TestQueryMeasurementWhereAllowsLegitimateFilters(t *testing.T) {
+	valid := []struct {
+		name  string
+		where string
+	}{
+		{"empty where", ``},
+		{"timestamp comparison", `time > '2026-01-01'`},
+		{"conjunction", `host = 'server1' AND value > 10`},
+		{"date_trunc call", `date_trunc('hour', time) > '2026-01-01'`},
+		{"between", `time BETWEEN '2026-01-01' AND '2026-01-02'`},
+		{"in list", `status IN ('active', 'idle')`},
+		{"like wildcard", `host LIKE 'web-%'`},
+		{"is not null", `value IS NOT NULL`},
+		{"escaped quote", `msg = 'it''s fine'`},
+		{"nested parens", `(value > 10 AND value < 100) OR host = 'a'`},
+		{"scientific notation", `value > 1e5`},
+		{"dollar in literal", `msg = 'cost$5'`},
+		{"column named e", `e > 5`},
+		{"quoted keyword column", `"load" > 1`},
+		{"substring keyword columns", `created_at_ms > 0 AND payload_size < 10`},
+	}
+
+	for _, v := range valid {
+		t.Run(v.name, func(t *testing.T) {
+			sql := assembleMeasurementSQL("mydb", "cpu", v.where)
+			if err := ValidateSQLRequest(sql); err != nil {
+				t.Errorf("FALSE POSITIVE: legitimate filter rejected\n  where: %s\n  err:   %v", v.where, err)
+			}
+		})
+	}
+}
+
+// TestValidateSQLRequestBlocksNonStandardStringLiterals covers the review
+// Blocker: MaskStringLiterals recognised only '…' and "…", so DuckDB's E'…' and
+// $tag$…$tag$ spellings of the same replacement scan bypassed the table-position
+// check. This hole was live on POST /api/v1/query, /estimate, and /arrow — every
+// endpoint that calls ValidateSQLRequest — not just the measurement endpoint.
+//
+// Verified against DuckDB v1.4.3: all three spellings execute a replacement scan
+// and return the target file's contents.
+func TestValidateSQLRequestBlocksNonStandardStringLiterals(t *testing.T) {
+	blocked := []string{
+		`SELECT * FROM '/data/arc/secretdb/cpu/d.parquet'`,
+		`SELECT * FROM e'/data/arc/secretdb/cpu/d.parquet'`,
+		`SELECT * FROM E'/data/arc/secretdb/cpu/d.parquet'`,
+		`SELECT * FROM $$/data/arc/secretdb/cpu/d.parquet$$`,
+		`SELECT * FROM $t$/data/arc/secretdb/cpu/d.parquet$t$`,
+		`SELECT * FROM cpu, $$/data/arc/secretdb/d.parquet$$ b`,
+		`SELECT * FROM cpu WHERE x > (SELECT max(v) FROM e'/data/arc/o/d.parquet')`,
+	}
+	for _, sql := range blocked {
+		if err := ValidateSQLRequest(sql); err == nil {
+			t.Errorf("VULNERABLE: replacement scan accepted: %s", sql)
+		}
+	}
+
+	allowed := []string{
+		`SELECT * FROM cpu WHERE host = 'server1'`,
+		`SELECT * FROM cpu WHERE price > 100`,
+		`SELECT * FROM cpu WHERE name = 'a$b'`,
+		`SELECT * FROM cpu WHERE msg LIKE '%$%'`,
+		`SELECT e FROM cpu`,
+		`SELECT * FROM cpu WHERE value > 1e5`,
+		`SELECT * FROM cpu WHERE code = 'e'`,
+		`SELECT * FROM cpu WHERE a = 'it''s'`,
+	}
+	for _, sql := range allowed {
+		if err := ValidateSQLRequest(sql); err != nil {
+			t.Errorf("FALSE POSITIVE: %s -> %v", sql, err)
+		}
+	}
+}
+
+// TestDeleteWhereRejectsIOFunctions covers review finding H4. The DELETE
+// blocklist blocks SELECT (killing the subquery vector) but omitted the I/O
+// function family, so a scalar expression needing no subquery turned the
+// affected-row count into a cross-tenant existence oracle.
+func TestDeleteWhereRejectsIOFunctions(t *testing.T) {
+	h := &DeleteHandler{}
+	payloads := []string{
+		`1=1 OR list_contains(glob('/data/arc/**'), 'x')`,
+		`time > 0 AND len(read_text('/data/arc/arc.db')) > 0`,
+		`time > 0 AND "glob"('/data/arc/**') IS NOT NULL`,
+		`time > 0 AND parquet_metadata('/data/arc/o/d.parquet') IS NOT NULL`,
+	}
+	for _, where := range payloads {
+		if _, err := h.validateWhereClause(where); err == nil {
+			t.Errorf("VULNERABLE: DELETE accepted I/O function: %s", where)
+		}
+	}
+
+	// Legitimate DELETE filters must still work.
+	valid := []string{
+		`time < '2026-01-01'`,
+		`host = 'server1' AND value > 10`,
+		`payload_size > 100`,
+		`offset_ms < 5`,
+	}
+	for _, where := range valid {
+		if _, err := h.validateWhereClause(where); err != nil {
+			t.Errorf("FALSE POSITIVE: DELETE rejected valid filter %q: %v", where, err)
+		}
+	}
+}
+
+// TestValidateCQQueryRejectsUnsafeSQL covers review finding H3. Continuous
+// queries stored a fully user-supplied SQL body with no validation at all and
+// re-executed it on a schedule.
+func TestValidateCQQueryRejectsUnsafeSQL(t *testing.T) {
+	unsafe := []string{
+		`SELECT * FROM parquet_scan('/data/arc/secretdb/cpu/d.parquet') WHERE time BETWEEN {start_time} AND {end_time}`,
+		`SELECT * FROM '/data/arc/secretdb/cpu/d.parquet' WHERE time BETWEEN {start_time} AND {end_time}`,
+		`SELECT * FROM e'/data/arc/secretdb/d.parquet' WHERE time BETWEEN {start_time} AND {end_time}`,
+		`ATTACH '/tmp/evil.db' AS evil; SELECT 1 WHERE {start_time} < {end_time}`,
+		`SELECT * FROM cpu WHERE time BETWEEN {start_time} AND {end_time}; DROP TABLE cpu`,
+	}
+	for _, q := range unsafe {
+		if err := validateCQQuery(q); err == nil {
+			t.Errorf("VULNERABLE: CQ accepted unsafe query: %s", q)
+		}
+	}
+
+	safe := []string{
+		`SELECT mean(value) AS value, host FROM cpu WHERE time BETWEEN {start_time} AND {end_time} GROUP BY host`,
+		`SELECT count(*) AS c FROM cpu WHERE time >= {start_time} AND time < {end_time}`,
+		`SELECT date_trunc('hour', time) AS time, sum(bytes) AS bytes FROM net WHERE time BETWEEN {start_time} AND {end_time} GROUP BY 1`,
+	}
+	for _, q := range safe {
+		if err := validateCQQuery(q); err != nil {
+			t.Errorf("FALSE POSITIVE: CQ rejected valid query %q: %v", q, err)
+		}
+	}
+
+	// Empty is handled by the caller's required-field check, not here.
+	if err := validateCQQuery("   "); err != nil {
+		t.Errorf("blank query should defer to required-field check, got: %v", err)
+	}
+	_ = strings.TrimSpace
+}

--- a/internal/sql/mask.go
+++ b/internal/sql/mask.go
@@ -54,6 +54,60 @@ func MaskStringLiterals(sql string, hasQuotes bool) (string, []StringMask) {
 	for i < len(sql) {
 		ch := sql[i]
 
+		// SECURITY: dollar-quoted strings ($tag$…$tag$). DuckDB accepts these
+		// wherever a single-quoted literal is legal — including table position,
+		// where the string triggers a replacement scan that reads the file
+		// directly. Because the form carries NO quote character at all, an
+		// unmasked $$…$$ payload also slips past every quote-parity check.
+		// Left unmasked, `FROM $$/other-tenant/d.parquet$$` reached DuckDB and
+		// returned cross-tenant rows (GHSA-wmjj-g8xc-6hwr review; verified on
+		// DuckDB 1.4.3). Masked here so the table-position and denylist scanners
+		// see an inert placeholder, exactly as they do for '…'.
+		if ch == '$' {
+			if tag, ok := dollarQuoteTag(sql, i); ok {
+				closing := "$" + tag + "$"
+				end := strings.Index(sql[i+len(closing):], closing)
+				if end >= 0 {
+					stop := i + len(closing) + end + len(closing)
+					original := sql[i:stop]
+					placeholder := fmt.Sprintf("__STR_%d__", maskIndex)
+					maskIndex++
+					masks = append(masks, StringMask{Placeholder: placeholder, Original: original})
+					result.WriteString(placeholder)
+					i = stop
+					continue
+				}
+				// Unterminated dollar quote: mask the remainder so no scanner
+				// treats the trailing content as executable SQL.
+				original := sql[i:]
+				placeholder := fmt.Sprintf("__STR_%d__", maskIndex)
+				maskIndex++
+				masks = append(masks, StringMask{Placeholder: placeholder, Original: original})
+				result.WriteString(placeholder)
+				i = len(sql)
+				continue
+			}
+		}
+
+		// SECURITY: escape-string literals (E'…' / e'…'). DuckDB treats the
+		// E prefix as part of the literal, so `FROM e'/other/d.parquet'` is the
+		// same replacement scan as the bare-quoted form. Masking the quoted body
+		// alone would leave a stray `e` bareword sitting in table position, which
+		// reads as a plain identifier and hides the replacement scan from
+		// stringLiteralInTablePosition. Consume the prefix WITH the literal so the
+		// whole construct collapses to one placeholder (GHSA-wmjj-g8xc-6hwr).
+		if (ch == 'e' || ch == 'E') && i+1 < len(sql) && sql[i+1] == '\'' && !isIdentifierByte(prevByte(sql, i)) {
+			start := i
+			i++ // move onto the opening quote
+			i = scanQuoted(sql, i, '\'')
+			original := sql[start:i]
+			placeholder := fmt.Sprintf("__STR_%d__", maskIndex)
+			maskIndex++
+			masks = append(masks, StringMask{Placeholder: placeholder, Original: original})
+			result.WriteString(placeholder)
+			continue
+		}
+
 		// Check for string literal start (single or double quote)
 		if ch == '\'' || ch == '"' {
 			quote := ch
@@ -154,8 +208,13 @@ func IdentifierNames(masks []StringMask) map[string]string {
 
 // HasQuotes returns true if the SQL string contains any quote characters.
 // This is a fast check to avoid unnecessary processing in MaskStringLiterals.
+// `$` counts as a quote character here: a dollar-quoted string ($tag$…$tag$)
+// carries no ' or " at all, so gating masking on those alone let the whole
+// construct through unmasked (GHSA-wmjj-g8xc-6hwr). The masker still verifies
+// the `$` actually opens a valid dollar quote, so a stray `$` only costs one
+// scan pass, never a false mask.
 func HasQuotes(sql string) bool {
-	return strings.ContainsAny(sql, "'\"")
+	return strings.ContainsAny(sql, "'\"$")
 }
 
 // fromKeywordFunctions lists SQL builtins whose argument list contains a bare
@@ -535,4 +594,75 @@ func equalFoldASCII(a, b string) bool {
 // buildReadParquetExpr for the call sites.
 func EscapeStringLiteral(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
+}
+
+// dollarQuoteTag reports whether a dollar-quote opener starts at sql[i] and, if
+// so, returns its tag (empty for the anonymous `$$` form).
+//
+// DuckDB/Postgres dollar quoting is `$tag$body$tag$`, where tag is empty or a
+// valid identifier that must not start with a digit. Bounding the tag this way
+// keeps `a$1` (a legal identifier) and `$1` (a positional parameter) from being
+// misread as string openers — misreading either would swallow the rest of the
+// query into a placeholder and hide real SQL from every scanner.
+func dollarQuoteTag(sql string, i int) (string, bool) {
+	if i >= len(sql) || sql[i] != '$' {
+		return "", false
+	}
+	// A `$` immediately following an identifier character is part of that
+	// identifier (or a positional parameter), not a quote opener.
+	if isIdentifierByte(prevByte(sql, i)) {
+		return "", false
+	}
+	j := i + 1
+	for j < len(sql) && sql[j] != '$' {
+		c := sql[j]
+		isAlpha := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+		isDigit := c >= '0' && c <= '9'
+		if !isAlpha && !(isDigit && j > i+1) {
+			return "", false
+		}
+		j++
+	}
+	if j >= len(sql) {
+		return "", false
+	}
+	return sql[i+1 : j], true
+}
+
+// scanQuoted returns the index just past the literal whose opening quote sits at
+// sql[i], handling doubled (”) and backslash escapes. If the literal is
+// unterminated it returns len(sql).
+func scanQuoted(sql string, i int, quote byte) int {
+	i++ // move past the opening quote
+	for i < len(sql) {
+		if sql[i] == quote {
+			if i+1 < len(sql) && sql[i+1] == quote {
+				i += 2
+				continue
+			}
+			if i > 0 && sql[i-1] == '\\' {
+				i++
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return len(sql)
+}
+
+// isIdentifierByte reports whether c can appear inside an unquoted SQL identifier.
+func isIdentifierByte(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}
+
+// prevByte returns the byte before index i, or 0 at the start of the string.
+func prevByte(s string, i int) byte {
+	if i == 0 {
+		return 0
+	}
+	return s[i-1]
 }


### PR DESCRIPTION
## Summary

- Routes `GET /api/v1/query/:measurement` through the shared `ValidateSQLRequest` — it was the only user-SQL path that never reached the shared validator, relying solely on a substring blocklist for its `where` param.
- Applies the same validation pass to the continuous-query (create **and** update) and delete endpoints, so every user-SQL path shares one validation layer instead of each maintaining its own partial blocklist.
- Hardens the shared string-literal masker so validation sees through all of DuckDB's string syntaxes, not just the two most common.

Hardens query authorization on RBAC-enabled multi-tenant instances. Standalone single-tenant deployments are not exposed to a cross-tenant boundary. No configuration changes required.

Full technical detail accompanies the forthcoming security advisory. Responsibly reported by **zx (Jace)** (@manus-use).

## Test plan

- [x] New regression tests for each newly-guarded path, each verified to **fail pre-fix** (revert-run-restore)
- [x] `go build -tags=duckdb_arrow ./cmd/arc ./internal/...`
- [x] `go test ./internal/api/... ./internal/sql/...` — pass
- [x] `go test -race ./internal/api/... ./internal/sql/...` — pass
- [x] `gofmt -l` clean on changed files; `go vet` clean
- [x] Verified end-to-end on the running binary: exploit payloads rejected `400`; legitimate `where` filters return `200` with correct rows; empty-`where`, `date_trunc`, `IN`/`LIKE`/`BETWEEN` all unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)