### PR TITLE
fix(cluster): authenticate the Raft consensus transport with the cluster shared secret

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -466,6 +466,39 @@ Closed a query-authorization gap on the `GET /api/v1/query/:measurement` endpoin
 
 Full technical detail will accompany the corresponding security advisory once it is published. Responsibly reported by **zx (Jace)** ([@manus-use](https://github.com/manus-use)).
 
+### Cluster hardening: authenticated Raft consensus transport (Enterprise)
+
+The Raft consensus transport now authenticates every peer connection with the
+cluster `shared_secret` via a mutual HMAC handshake performed at connection
+establishment. Previously the Raft transport was the one cluster channel that
+did not consult the shared secret — every other channel (join, heartbeat, leave,
+replication, sync, file-fetch, cache-invalidate) already did. The handshake works
+over both plaintext and TLS transports, matching Arc's existing "authenticated
+even without TLS" posture. A node now refuses to start its Raft port without a
+configured `cluster.shared_secret` (this was already mandatory to start
+clustering, so no operator action is needed for that guard).
+
+As additional defense-in-depth, a node running `cluster.tls_enabled=true` without
+`cluster.tls_ca_file` now logs a warning that peer certificates are not being
+verified (no mutual TLS) and that inter-node identity rests on the shared-secret
+HMAC. Set `cluster.tls_ca_file` to enable mTLS. This is a warning only — no
+existing deployment stops working.
+
+> **Upgrade note (clustered Enterprise deployments):** because the Raft transport
+> now requires the authenticated handshake, a node on this version will not form
+> consensus with a node on an older version — the interconnect is a hard cutover.
+> Upgrade the cluster as a coordinated restart: **stop all cluster nodes, upgrade
+> the binary on every node, then restart all nodes.** A rolling restart will cause
+> repeated leader elections until the last node is upgraded. Single-node and
+> non-clustered deployments are unaffected.
+>
+> The HMAC handshake authenticates connection *establishment*; for protection
+> against an on-path attacker on a plaintext interconnect, enable
+> `cluster.tls_enabled`.
+
+Full technical detail will accompany the corresponding security advisory once it
+is published. Responsibly reported by **zx (Jace)** ([@manus-use](https://github.com/manus-use)).
+
 ### Dependency: gRPC-Go upgraded past GHSA-hrxh-6v49-42gf
 
 `google.golang.org/grpc` is upgraded from v1.80.0 to v1.83.1, past the v1.82.1

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -208,6 +208,19 @@ func NewCoordinator(cfg *CoordinatorConfig) (*Coordinator, error) {
 		logger.Warn().Msg("Cluster shared_secret configured without TLS — HMAC tokens are visible on the network. Enable cluster.tls_enabled for full security.")
 	}
 
+	// Warn when cluster TLS is enabled but no CA is configured
+	// (GHSA-wwfh-qrfq-6f8g defense-in-depth). Without a CA, client-cert
+	// verification is off (RequireAndVerifyClientCert is only set when
+	// tls_ca_file is non-empty), so TLS provides encryption but not peer
+	// identity — inter-node connections are not mutually authenticated at the
+	// TLS layer. Peer identity in that mode rests on the shared-secret HMAC
+	// (the Raft handshake and the coordinator channels). This is a warning, not
+	// a hard error: TLS-for-encryption + HMAC-for-identity is a supported
+	// posture, but operators should know mTLS is not in effect.
+	if cfg.Config.TLSEnabled && cfg.Config.TLSCAFile == "" {
+		logger.Warn().Msg("Cluster TLS enabled without tls_ca_file — peer certificates are NOT verified (no mTLS); inter-node identity rests on the shared-secret HMAC. Set cluster.tls_ca_file to enable mutual TLS authentication.")
+	}
+
 	// Warn when the public Fiber listener serves HTTPS but cluster TLS
 	// is off: the cache-invalidate fan-out and the request router will
 	// dial https:// against peers using SYSTEM ROOT CAs (no cluster CA
@@ -278,6 +291,8 @@ func NewCoordinator(cfg *CoordinatorConfig) (*Coordinator, error) {
 			SnapshotThreshold: uint64(cfg.Config.RaftSnapshotThreshold),
 			Logger:            cfg.Logger,
 			TLSConfig:         tlsCfg,
+			SharedSecret:      cfg.Config.SharedSecret,
+			ClusterName:       cfg.Config.ClusterName,
 		}
 
 		var err error

--- a/internal/cluster/multi_writer_integration_test.go
+++ b/internal/cluster/multi_writer_integration_test.go
@@ -95,6 +95,7 @@ func startRaftNode(t *testing.T, nodeID, bindAddr string, bootstrap bool) *raft.
 	fsm := raft.NewClusterFSM(zerolog.Nop())
 	cfg := &raft.NodeConfig{
 		NodeID:        nodeID,
+		SharedSecret:  "test-cluster-secret-32-bytes-long!",
 		DataDir:       filepath.Join(t.TempDir(), nodeID),
 		BindAddr:      bindAddr,
 		AdvertiseAddr: bindAddr,

--- a/internal/cluster/raft/node.go
+++ b/internal/cluster/raft/node.go
@@ -46,6 +46,18 @@ type NodeConfig struct {
 
 	// TLSConfig for encrypted Raft transport (nil = plain TCP)
 	TLSConfig *tls.Config
+
+	// SharedSecret authenticates the Raft transport connection via a mutual
+	// HMAC handshake (GHSA-wwfh-qrfq-6f8g). Required whenever a Raft node is
+	// built: the transport is fail-closed if this is empty. In production the
+	// coordinator only reaches NewNode after main.go has already refused to
+	// start clustering without cluster.shared_secret, so this is always set;
+	// the empty-secret guard in Start() is belt-and-suspenders (and forces
+	// tests to exercise the authenticated path).
+	SharedSecret string
+	// ClusterName is bound into the handshake HMAC for domain separation, so a
+	// MAC minted for one cluster cannot authenticate to another.
+	ClusterName string
 }
 
 // DefaultNodeConfig returns a NodeConfig with sensible defaults.
@@ -168,21 +180,37 @@ func (n *Node) Start() error {
 		return fmt.Errorf("failed to resolve advertise address: %w", err)
 	}
 
-	var transport *raft.NetworkTransport
+	// SECURITY (GHSA-wwfh-qrfq-6f8g): the Raft transport MUST authenticate its
+	// peers with the cluster shared secret. Fail closed rather than stand up an
+	// unauthenticated consensus port on which any reachable peer could inject a
+	// forged AppendEntries minting an admin token. This mirrors the coordinator
+	// channels, which already fail closed on an empty secret (main.go). The
+	// guard is keyed on the transport being built here — not a "clustering
+	// enabled" flag NodeConfig cannot see — so every code path that constructs
+	// a Raft node is covered.
+	if n.cfg.SharedSecret == "" {
+		return fmt.Errorf("raft transport requires a cluster shared secret (cluster.shared_secret) for peer authentication; refusing to start an unauthenticated Raft port")
+	}
+
+	// Both branches wrap the base stream layer in AuthenticatedStreamLayer so
+	// the mutual HMAC handshake runs at connection establishment, over
+	// plaintext and TLS alike.
+	var baseStream raft.StreamLayer
 	if n.cfg.TLSConfig != nil {
 		stream, tlsErr := security.NewTLSStreamLayer(n.cfg.BindAddr, addr, n.cfg.TLSConfig)
 		if tlsErr != nil {
 			return fmt.Errorf("failed to create TLS stream layer: %w", tlsErr)
 		}
-		transport = raft.NewNetworkTransport(stream, 3, 10*time.Second, os.Stderr)
+		baseStream = stream
 	} else {
-		var tcpErr error
-		transport, tcpErr = raft.NewTCPTransport(n.cfg.BindAddr, addr, 3, 10*time.Second, os.Stderr)
+		stream, tcpErr := security.NewPlainTCPStreamLayer(n.cfg.BindAddr, addr)
 		if tcpErr != nil {
-			return fmt.Errorf("failed to create transport: %w", tcpErr)
+			return fmt.Errorf("failed to create TCP stream layer: %w", tcpErr)
 		}
+		baseStream = stream
 	}
-	n.transport = transport
+	authStream := security.NewAuthenticatedStreamLayer(baseStream, n.cfg.SharedSecret, n.cfg.ClusterName)
+	n.transport = raft.NewNetworkTransport(authStream, 3, 10*time.Second, os.Stderr)
 
 	// Create log store
 	logStorePath := filepath.Join(n.cfg.DataDir, "raft-log.db")
@@ -217,7 +245,7 @@ func (n *Node) Start() error {
 	// the entry doesn't land in f.files and the counter still
 	// increments — see GHSA-f85q-mvg8-qf37 design notes on
 	// rejectManifestPath).
-	ra, err := raft.NewRaft(raftConfig, n.fsm, logStore, stableStore, snapStore, transport)
+	ra, err := raft.NewRaft(raftConfig, n.fsm, logStore, stableStore, snapStore, n.transport)
 	if err != nil {
 		return fmt.Errorf("failed to create raft instance: %w", err)
 	}

--- a/internal/cluster/raft/node_test.go
+++ b/internal/cluster/raft/node_test.go
@@ -21,6 +21,7 @@ func TestNodeStartStop(t *testing.T) {
 
 	cfg := &NodeConfig{
 		NodeID:           "test-node-1",
+		SharedSecret:     "test-cluster-secret-32-bytes-long!",
 		DataDir:          tmpDir,
 		BindAddr:         "127.0.0.1:0", // Use port 0 for random available port
 		Bootstrap:        true,
@@ -85,6 +86,7 @@ func TestNodeAddNodeViaRaft(t *testing.T) {
 
 	cfg := &NodeConfig{
 		NodeID:           "test-node-1",
+		SharedSecret:     "test-cluster-secret-32-bytes-long!",
 		DataDir:          tmpDir,
 		BindAddr:         "127.0.0.1:0",
 		Bootstrap:        true,
@@ -152,6 +154,7 @@ func TestNodeUpdateNodeStateViaRaft(t *testing.T) {
 
 	cfg := &NodeConfig{
 		NodeID:           "test-node-1",
+		SharedSecret:     "test-cluster-secret-32-bytes-long!",
 		DataDir:          tmpDir,
 		BindAddr:         "127.0.0.1:0",
 		Bootstrap:        true,
@@ -208,6 +211,7 @@ func TestNodeRemoveNodeViaRaft(t *testing.T) {
 
 	cfg := &NodeConfig{
 		NodeID:           "test-node-1",
+		SharedSecret:     "test-cluster-secret-32-bytes-long!",
 		DataDir:          tmpDir,
 		BindAddr:         "127.0.0.1:0",
 		Bootstrap:        true,
@@ -263,6 +267,7 @@ func TestNodeStats(t *testing.T) {
 
 	cfg := &NodeConfig{
 		NodeID:           "test-node-1",
+		SharedSecret:     "test-cluster-secret-32-bytes-long!",
 		DataDir:          tmpDir,
 		BindAddr:         "127.0.0.1:0",
 		Bootstrap:        true,
@@ -313,6 +318,7 @@ func TestNodeDataDirCreated(t *testing.T) {
 	fsm := NewClusterFSM(zerolog.Nop())
 	cfg := &NodeConfig{
 		NodeID:           "test-node-1",
+		SharedSecret:     "test-cluster-secret-32-bytes-long!",
 		DataDir:          dataDir,
 		BindAddr:         "127.0.0.1:0",
 		Bootstrap:        true,

--- a/internal/cluster/security/auth.go
+++ b/internal/cluster/security/auth.go
@@ -30,6 +30,13 @@ const (
 	MsgTypeJoin      MsgType = "join"
 	MsgTypeLeave     MsgType = "leave"
 	MsgTypeHeartbeat MsgType = "heartbeat"
+	// Raft transport connection-handshake labels (GHSA-wwfh-qrfq-6f8g). The
+	// two directions carry distinct labels so a response captured in one
+	// direction cannot be replayed as the other: the server proves the secret
+	// with MsgTypeRaftAuthResp over the client's nonce, the client with
+	// MsgTypeRaftAuth over the server's nonce.
+	MsgTypeRaftAuth     MsgType = "raft-auth"
+	MsgTypeRaftAuthResp MsgType = "raft-auth-resp"
 )
 
 // ComputeHMAC computes HMAC-SHA256 over the parameters of a coordinator

--- a/internal/cluster/security/poc_reject_test.go
+++ b/internal/cluster/security/poc_reject_test.go
@@ -1,0 +1,69 @@
+package security
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-msgpack/v2/codec"
+	"github.com/hashicorp/raft"
+)
+
+// TestRaftForgePOCRejected reproduces exactly what cmd/raftforge-poc does — a
+// raw TCP dial that writes an rpcType byte + a msgpack AppendEntriesRequest,
+// without performing any handshake — and asserts the AuthenticatedStreamLayer
+// rejects it at Accept, so no forged entry ever reaches raft.
+func TestRaftForgePOCRejected(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Wrap a real listener in the auth layer (via a tiny adapter).
+	base := &listenerStreamLayer{ln: ln}
+	layer := NewAuthenticatedStreamLayer(base, testSecret, testCluster)
+
+	acceptErr := make(chan error, 1)
+	go func() {
+		c, err := layer.Accept()
+		if c != nil {
+			c.Close()
+		}
+		acceptErr <- err
+	}()
+
+	// The PoC: raw dial, write rpcType + AppendEntries. No handshake.
+	conn, err := net.DialTimeout("tcp", ln.Addr().String(), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(2 * time.Second))
+	// rpcAppendEntries = 0
+	conn.Write([]byte{0})
+	enc := codec.NewEncoder(conn, &codec.MsgpackHandle{})
+	enc.Encode(&struct {
+		Term   uint64
+		Leader []byte
+	}{Term: 99, Leader: []byte("evil")})
+
+	select {
+	case err := <-acceptErr:
+		if err == nil {
+			t.Fatal("VULNERABLE: auth layer accepted the raw PoC connection")
+		}
+		t.Logf("PoC rejected as expected: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Accept did not return; handshake may be hanging")
+	}
+}
+
+type listenerStreamLayer struct{ ln net.Listener }
+
+func (l *listenerStreamLayer) Accept() (net.Conn, error) { return l.ln.Accept() }
+func (l *listenerStreamLayer) Close() error              { return l.ln.Close() }
+func (l *listenerStreamLayer) Addr() net.Addr            { return l.ln.Addr() }
+func (l *listenerStreamLayer) Dial(a raft.ServerAddress, t time.Duration) (net.Conn, error) {
+	return net.DialTimeout("tcp", string(a), t)
+}

--- a/internal/cluster/security/raft_auth.go
+++ b/internal/cluster/security/raft_auth.go
@@ -1,0 +1,203 @@
+package security
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/hashicorp/raft"
+)
+
+// GHSA-wwfh-qrfq-6f8g: Arc's Raft consensus transport performed no
+// application-layer authentication. Every OTHER cluster channel (join,
+// heartbeat, leave, replication, sync, file-fetch, cache-invalidate) is
+// HMAC-authenticated with cluster.shared_secret; the Raft path was the sole
+// exception. Any peer that could reach the Raft bind port could speak the
+// hashicorp/raft wire protocol and inject a forged higher-term AppendEntries
+// carrying CommandCreateToken with admin permissions — full cluster compromise.
+//
+// This file adds a mutual challenge-response HMAC handshake that runs at
+// CONNECTION ESTABLISHMENT, wrapping any raft.StreamLayer. Both peers prove
+// knowledge of the shared secret before the connection is handed to
+// hashicorp/raft. It works with or without TLS, mirroring the "HMAC even
+// without TLS" posture of the coordinator channels.
+//
+// SCOPE / LIMITATION: this authenticates connection ESTABLISHMENT, not
+// per-packet integrity. On a plaintext transport a full on-path MitM could
+// still inject into an established stream after a successful handshake. The
+// handshake fully blocks the actual vulnerability — a peer that can reach the
+// port minting a token — which is the documented threat. Enable
+// cluster.tls_enabled for on-path-attacker protection.
+
+const (
+	// raftAuthNonceLen is the challenge nonce size in bytes. 32 bytes of CSPRNG
+	// output makes a fresh challenge per connection collision-infeasible, so a
+	// captured response is useless against the next connection's challenge — no
+	// nonce cache is needed (unlike the stateless HTTP message HMACs).
+	raftAuthNonceLen = 32
+	// raftAuthMACLen is the HMAC-SHA256 output size in bytes.
+	raftAuthMACLen = 32
+	// raftAuthDeadline bounds the whole handshake. It MUST sit below the Raft
+	// HeartbeatTimeout (default 500ms) and well below ElectionTimeout (default
+	// 1s): the hashicorp/raft listen loop calls Accept() serially (one
+	// goroutine), so a handshake that blocks inside Accept() blocks acceptance
+	// of every other peer. A tight deadline caps how long one slow/malicious
+	// peer can stall the loop before it is dropped. 400ms leaves headroom under
+	// the 500ms heartbeat.
+	raftAuthDeadline = 400 * time.Millisecond
+)
+
+// AuthenticatedStreamLayer wraps a raft.StreamLayer and performs a mutual
+// HMAC handshake on every accepted and dialed connection before handing the
+// raw net.Conn to hashicorp/raft.
+//
+// The handshake reads FIXED-SIZE fields with io.ReadFull directly on the raw
+// conn — never a bufio.Reader or a msgpack decoder. hashicorp/raft wraps the
+// returned conn in its OWN bufio reader afterward (net_transport.go handleConn
+// / getConn), so any bytes a buffered reader pulled past the handshake would be
+// silently dropped and desynchronise the very first RPC. Fixed-length
+// unbuffered reads consume exactly the handshake and not one byte more.
+type AuthenticatedStreamLayer struct {
+	inner        raft.StreamLayer
+	sharedSecret string
+	clusterName  string
+}
+
+// NewAuthenticatedStreamLayer wraps inner with the shared-secret handshake.
+// sharedSecret must be non-empty (callers fail closed before reaching here).
+func NewAuthenticatedStreamLayer(inner raft.StreamLayer, sharedSecret, clusterName string) *AuthenticatedStreamLayer {
+	return &AuthenticatedStreamLayer{
+		inner:        inner,
+		sharedSecret: sharedSecret,
+		clusterName:  clusterName,
+	}
+}
+
+var _ raft.StreamLayer = (*AuthenticatedStreamLayer)(nil)
+
+// Accept accepts an inner connection and runs the server side of the handshake.
+// On any handshake failure the connection is closed and the error is returned;
+// hashicorp/raft's listen loop logs and continues, so a rejected attacker
+// connection simply dies.
+func (a *AuthenticatedStreamLayer) Accept() (net.Conn, error) {
+	conn, err := a.inner.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if err := a.serverHandshake(conn); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("raft auth handshake (accept): %w", err)
+	}
+	return conn, nil
+}
+
+// Dial dials an inner connection and runs the client side of the handshake.
+func (a *AuthenticatedStreamLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	conn, err := a.inner.Dial(address, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.clientHandshake(conn); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("raft auth handshake (dial): %w", err)
+	}
+	return conn, nil
+}
+
+// Close closes the inner listener.
+func (a *AuthenticatedStreamLayer) Close() error { return a.inner.Close() }
+
+// Addr returns the inner listener address.
+func (a *AuthenticatedStreamLayer) Addr() net.Addr { return a.inner.Addr() }
+
+// raftAuthMAC computes the handshake HMAC over (label, nonce, clusterName).
+// The label provides direction domain-separation; clusterName binds the MAC to
+// this cluster. Fields are NUL-delimited so no field can be smuggled across a
+// boundary to collide with a different arrangement (the discipline ComputeHMAC
+// uses). The raw 32-byte MAC is written on the wire (no hex envelope — this is
+// a binary handshake, not an HTTP header).
+func (a *AuthenticatedStreamLayer) raftAuthMAC(label MsgType, nonce []byte) []byte {
+	msg := fmt.Sprintf("%s\x00%s\x00", label, a.clusterName)
+	return computeRawHMAC(a.sharedSecret, msg+string(nonce))
+}
+
+// serverHandshake: server sends its challenge, the client answers with a MAC
+// over it and sends its own challenge, the server verifies then answers the
+// client's challenge. Both peers thus prove secret knowledge.
+//
+//	S -> C : nonceS
+//	C -> S : macClient = HMAC(raft-auth,    clusterName, nonceS) || nonceC
+//	S -> C : macServer = HMAC(raft-auth-resp, clusterName, nonceC)
+func (a *AuthenticatedStreamLayer) serverHandshake(conn net.Conn) error {
+	if err := conn.SetDeadline(time.Now().Add(raftAuthDeadline)); err != nil {
+		return err
+	}
+
+	nonceS := make([]byte, raftAuthNonceLen)
+	if _, err := rand.Read(nonceS); err != nil {
+		return err
+	}
+	if _, err := conn.Write(nonceS); err != nil {
+		return fmt.Errorf("write server nonce: %w", err)
+	}
+
+	macClient := make([]byte, raftAuthMACLen)
+	if _, err := io.ReadFull(conn, macClient); err != nil {
+		return fmt.Errorf("read client mac: %w", err)
+	}
+	nonceC := make([]byte, raftAuthNonceLen)
+	if _, err := io.ReadFull(conn, nonceC); err != nil {
+		return fmt.Errorf("read client nonce: %w", err)
+	}
+
+	expected := a.raftAuthMAC(MsgTypeRaftAuth, nonceS)
+	if !hmac.Equal(expected, macClient) {
+		return fmt.Errorf("client failed authentication")
+	}
+
+	macServer := a.raftAuthMAC(MsgTypeRaftAuthResp, nonceC)
+	if _, err := conn.Write(macServer); err != nil {
+		return fmt.Errorf("write server mac: %w", err)
+	}
+
+	// Clear the handshake deadline; raft manages its own per-RPC timeouts.
+	return conn.SetDeadline(time.Time{})
+}
+
+// clientHandshake is the dial-side mirror of serverHandshake.
+func (a *AuthenticatedStreamLayer) clientHandshake(conn net.Conn) error {
+	if err := conn.SetDeadline(time.Now().Add(raftAuthDeadline)); err != nil {
+		return err
+	}
+
+	nonceS := make([]byte, raftAuthNonceLen)
+	if _, err := io.ReadFull(conn, nonceS); err != nil {
+		return fmt.Errorf("read server nonce: %w", err)
+	}
+
+	macClient := a.raftAuthMAC(MsgTypeRaftAuth, nonceS)
+	if _, err := conn.Write(macClient); err != nil {
+		return fmt.Errorf("write client mac: %w", err)
+	}
+	nonceC := make([]byte, raftAuthNonceLen)
+	if _, err := rand.Read(nonceC); err != nil {
+		return err
+	}
+	if _, err := conn.Write(nonceC); err != nil {
+		return fmt.Errorf("write client nonce: %w", err)
+	}
+
+	macServer := make([]byte, raftAuthMACLen)
+	if _, err := io.ReadFull(conn, macServer); err != nil {
+		return fmt.Errorf("read server mac: %w", err)
+	}
+	expected := a.raftAuthMAC(MsgTypeRaftAuthResp, nonceC)
+	if !hmac.Equal(expected, macServer) {
+		return fmt.Errorf("server failed authentication")
+	}
+
+	return conn.SetDeadline(time.Time{})
+}

--- a/internal/cluster/security/raft_auth_test.go
+++ b/internal/cluster/security/raft_auth_test.go
@@ -1,0 +1,198 @@
+package security
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+)
+
+const testSecret = "test-cluster-secret-32-bytes-long!"
+const testCluster = "test-cluster"
+
+// pipeStreamLayer is an in-memory raft.StreamLayer backed by net.Pipe, so the
+// handshake can be exercised without binding a real port. Accept returns the
+// server end of the most recent Dial.
+type pipeStreamLayer struct {
+	accept chan net.Conn
+}
+
+func newPipeStreamLayer() *pipeStreamLayer { return &pipeStreamLayer{accept: make(chan net.Conn, 1)} }
+
+func (p *pipeStreamLayer) Accept() (net.Conn, error) { return <-p.accept, nil }
+func (p *pipeStreamLayer) Close() error              { return nil }
+func (p *pipeStreamLayer) Addr() net.Addr            { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1} }
+func (p *pipeStreamLayer) Dial(_ raft.ServerAddress, _ time.Duration) (net.Conn, error) {
+	client, server := net.Pipe()
+	p.accept <- server
+	return client, nil
+}
+
+// handshakePair runs a server Accept and client Dial concurrently over the same
+// pipe and returns the resulting conns (or the errors).
+func handshakePair(t *testing.T, serverLayer, clientLayer *AuthenticatedStreamLayer) (net.Conn, error, net.Conn, error) {
+	t.Helper()
+	type res struct {
+		conn net.Conn
+		err  error
+	}
+	srvCh := make(chan res, 1)
+	go func() {
+		c, err := serverLayer.Accept()
+		srvCh <- res{c, err}
+	}()
+	cliConn, cliErr := clientLayer.Dial("ignored", time.Second)
+	sr := <-srvCh
+	return sr.conn, sr.err, cliConn, cliErr
+}
+
+func TestRaftAuth_MutualSuccess(t *testing.T) {
+	base := newPipeStreamLayer()
+	layer := NewAuthenticatedStreamLayer(base, testSecret, testCluster)
+
+	srvConn, srvErr, cliConn, cliErr := handshakePair(t, layer, layer)
+	if srvErr != nil || cliErr != nil {
+		t.Fatalf("handshake failed: server=%v client=%v", srvErr, cliErr)
+	}
+	defer srvConn.Close()
+	defer cliConn.Close()
+
+	// CRITICAL (B1): the very first bytes written after the handshake must
+	// reach the peer intact — the handshake must not over-read into the raft
+	// stream. Write a sentinel from client to server and read it back.
+	want := []byte{0x00, 0xDE, 0xAD, 0xBE, 0xEF}
+	go func() { cliConn.Write(want) }()
+	got := make([]byte, len(want))
+	srvConn.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := io.ReadFull(srvConn, got); err != nil {
+		t.Fatalf("post-handshake read: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("post-handshake stream desync: got %x want %x", got, want)
+	}
+}
+
+func TestRaftAuth_WrongSecretClientRejected(t *testing.T) {
+	base := newPipeStreamLayer()
+	server := NewAuthenticatedStreamLayer(base, testSecret, testCluster)
+	client := NewAuthenticatedStreamLayer(base, "WRONG-SECRET", testCluster)
+
+	srvConn, srvErr, _, _ := handshakePair(t, server, client)
+	if srvErr == nil {
+		srvConn.Close()
+		t.Fatal("server accepted a client with the wrong secret")
+	}
+}
+
+func TestRaftAuth_WrongSecretServerRejected(t *testing.T) {
+	base := newPipeStreamLayer()
+	server := NewAuthenticatedStreamLayer(base, "WRONG-SECRET", testCluster)
+	client := NewAuthenticatedStreamLayer(base, testSecret, testCluster)
+
+	_, _, cliConn, cliErr := handshakePair(t, server, client)
+	if cliErr == nil {
+		cliConn.Close()
+		t.Fatal("client accepted a server with the wrong secret")
+	}
+}
+
+func TestRaftAuth_WrongClusterNameRejected(t *testing.T) {
+	base := newPipeStreamLayer()
+	server := NewAuthenticatedStreamLayer(base, testSecret, "cluster-a")
+	client := NewAuthenticatedStreamLayer(base, testSecret, "cluster-b")
+
+	srvConn, srvErr, _, _ := handshakePair(t, server, client)
+	if srvErr == nil {
+		srvConn.Close()
+		t.Fatal("server accepted a peer bound to a different cluster name")
+	}
+}
+
+func TestRaftAuth_TruncatedHandshakeRejected(t *testing.T) {
+	// A peer that connects and immediately closes must not authenticate.
+	base := newPipeStreamLayer()
+	server := NewAuthenticatedStreamLayer(base, testSecret, testCluster)
+
+	srvCh := make(chan error, 1)
+	go func() {
+		c, err := server.Accept()
+		if c != nil {
+			c.Close()
+		}
+		srvCh <- err
+	}()
+	client, srv := net.Pipe()
+	base.accept <- srv
+	client.Close() // hang up before sending anything
+
+	if err := <-srvCh; err == nil {
+		t.Fatal("server authenticated a peer that sent no handshake")
+	}
+}
+
+func TestRaftAuth_ReplayedResponseRejected(t *testing.T) {
+	// Capture a legitimate client's response to one server challenge, then
+	// present it to a FRESH server challenge. Because the challenge nonce is
+	// generated per-connection by the verifier, the captured MAC must not
+	// authenticate against the new challenge.
+	layer := NewAuthenticatedStreamLayer(newPipeStreamLayer(), testSecret, testCluster)
+
+	// First connection: capture what a real client sends.
+	c1client, c1server := net.Pipe()
+	captured := make([]byte, raftAuthMACLen+raftAuthNonceLen)
+	go func() {
+		// Act as the server: send a known nonce, read the client's reply.
+		c1server.SetDeadline(time.Now().Add(time.Second))
+		nonceS := make([]byte, raftAuthNonceLen)
+		c1server.Write(nonceS) // all-zero challenge (deterministic)
+		io.ReadFull(c1server, captured)
+		c1server.Close()
+	}()
+	// Real client answers the all-zero challenge.
+	_ = layer.clientHandshake(c1client)
+	c1client.Close()
+
+	// Second connection: real server with a FRESH random challenge; replay the
+	// captured client bytes.
+	c2client, c2server := net.Pipe()
+	srvErrCh := make(chan error, 1)
+	go func() {
+		c, err := layer.Accept2(c2server)
+		if c != nil {
+			c.Close()
+		}
+		srvErrCh <- err
+	}()
+	// Replay captured bytes as the "client".
+	go func() {
+		// Discard the server's real (random) challenge, then replay.
+		io.CopyN(io.Discard, c2client, raftAuthNonceLen)
+		c2client.Write(captured)
+	}()
+	if err := <-srvErrCh; err == nil {
+		t.Fatal("replayed response authenticated against a fresh challenge")
+	}
+	c2client.Close()
+}
+
+// Accept2 runs the server handshake against a caller-supplied conn — a test
+// seam so the replay test can drive a raw pipe without the pipeStreamLayer
+// Accept channel.
+func (a *AuthenticatedStreamLayer) Accept2(conn net.Conn) (net.Conn, error) {
+	if err := a.serverHandshake(conn); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+func TestRaftAuth_DeadlineBelowHeartbeat(t *testing.T) {
+	// Guard the constant so a future edit can't push the handshake deadline
+	// above the Raft heartbeat and reintroduce the serial-accept election-storm
+	// risk.
+	if raftAuthDeadline >= 500*time.Millisecond {
+		t.Fatalf("raftAuthDeadline %v must be below the 500ms default HeartbeatTimeout", raftAuthDeadline)
+	}
+}

--- a/internal/cluster/security/raft_plain.go
+++ b/internal/cluster/security/raft_plain.go
@@ -1,0 +1,73 @@
+package security
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/hashicorp/raft"
+)
+
+// PlainTCPStreamLayer is a plaintext raft.StreamLayer over TCP.
+//
+// hashicorp/raft ships raft.NewTCPTransport, but its internal TCPStreamLayer
+// has unexported fields and no exported constructor, so it cannot be wrapped by
+// AuthenticatedStreamLayer. This reimplements the minimal layer — including the
+// advertise-address validity checks raft's own newTCPTransport performs
+// (tcp_transport.go): reject a nil/unspecified advertise address, since peers
+// could not dial back a node advertising 0.0.0.0. Omitting those checks would
+// let a node bootstrap alone but silently fail when a second node tries to
+// connect.
+type PlainTCPStreamLayer struct {
+	advertise net.Addr
+	listener  *net.TCPListener
+}
+
+var (
+	errNotTCP          = errors.New("local address is not a TCP address")
+	errNotAdvertisable = errors.New("local bind address is not advertisable")
+)
+
+// NewPlainTCPStreamLayer binds bindAddr and returns a plaintext stream layer.
+func NewPlainTCPStreamLayer(bindAddr string, advertise net.Addr) (*PlainTCPStreamLayer, error) {
+	list, err := net.Listen("tcp", bindAddr)
+	if err != nil {
+		return nil, err
+	}
+	s := &PlainTCPStreamLayer{
+		advertise: advertise,
+		listener:  list.(*net.TCPListener),
+	}
+	// Mirror raft's newTCPTransport advertise-address validation.
+	addr, ok := s.Addr().(*net.TCPAddr)
+	if !ok {
+		list.Close()
+		return nil, errNotTCP
+	}
+	if addr.IP == nil || addr.IP.IsUnspecified() {
+		list.Close()
+		return nil, errNotAdvertisable
+	}
+	return s, nil
+}
+
+// Dial connects to a Raft peer over plain TCP.
+func (t *PlainTCPStreamLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("tcp", string(address), timeout)
+}
+
+// Accept waits for an incoming plaintext connection.
+func (t *PlainTCPStreamLayer) Accept() (net.Conn, error) { return t.listener.Accept() }
+
+// Close closes the listener.
+func (t *PlainTCPStreamLayer) Close() error { return t.listener.Close() }
+
+// Addr returns the advertised address if set, else the listener address.
+func (t *PlainTCPStreamLayer) Addr() net.Addr {
+	if t.advertise != nil {
+		return t.advertise
+	}
+	return t.listener.Addr()
+}
+
+var _ raft.StreamLayer = (*PlainTCPStreamLayer)(nil)


### PR DESCRIPTION
## Summary

The Raft consensus transport was the one cluster channel that did not consult `cluster.shared_secret`. Every other channel (join, heartbeat, leave, replication, sync, file-fetch, cache-invalidate) already authenticates with an HMAC over the shared secret. This closes that gap.

- Adds a **mutual challenge-response HMAC handshake** at Raft connection establishment, wrapping both the plaintext and TLS stream layers, gated on the shared secret and fail-closed when a Raft node is constructed.
- Works over plaintext and TLS alike, matching the coordinator channels' "authenticated even without TLS" posture.
- Defense-in-depth: warns (does not error) when `cluster.tls_enabled=true` without `cluster.tls_ca_file` — TLS then provides encryption but not peer identity (no mTLS); identity rests on the HMAC handshake.

A listener sweep confirmed the Raft transport was the **only** unauthenticated listener Arc opens.

## ⚠️ Breaking for clustered deployments

A node on this version will **not** form consensus with an older node — the Raft interconnect is a hard cutover. Upgrade as a coordinated restart:

1. Stop all cluster nodes
2. Upgrade the binary on every node
3. Restart all nodes

A rolling restart causes repeated leader elections until the last node is upgraded. **Single-node and non-clustered deployments are unaffected.**

## Test plan

- [x] Handshake unit tests: mutual success + **post-handshake stream integrity** (no over-read into the first RPC), wrong-secret both directions, wrong cluster name, truncated handshake, **replay-against-fresh-challenge**, deadline-below-heartbeat guard
- [x] The reporter's raw-dial PoC is rejected at `Accept` (dedicated test)
- [x] Fail-closed guard proven to bite when the secret is absent
- [x] `go build -tags=duckdb_arrow ./cmd/... ./internal/...`
- [x] `go test ./internal/cluster/...` and `go test -race ./internal/cluster/...` — pass
- [x] `gofmt -l` clean on changed files; `go vet ./internal/cluster/...` clean
- [x] **Live licensed 3-writer + 1-reader Enterprise cluster:** legitimate consensus forms over the authenticated transport (election won, all nodes joined, ForwardApply replicating); the forged-`AppendEntries` PoC fired from inside the cluster network is rejected at the handshake (`client failed authentication`), **zero** tokens created, cluster stays healthy

Full technical detail will accompany the corresponding security advisory. Responsibly reported by **zx (Jace)** (@manus-use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)