### PR TITLE
fix(deploy): reference public ghcr.io/basekick-labs/arc image in compose + k8s

### DIFF
--- a/deploy/docker-compose/enterprise-local/docker-compose.yml
+++ b/deploy/docker-compose/enterprise-local/docker-compose.yml
@@ -7,7 +7,7 @@
 # =============================================================================
 
 x-arc-common: &arc-common
-  image: basekick/arc:latest
+  image: ghcr.io/basekick-labs/arc:latest
   networks:
     - arc-cluster
 

--- a/deploy/docker-compose/enterprise-shared/README.md
+++ b/deploy/docker-compose/enterprise-shared/README.md
@@ -189,7 +189,7 @@ curl -X POST "http://localhost:8000/api/v1/query" \
 | `non-leader-crash` | Same as base, but `docker kill` a non-leader writer mid-ingest. Asserts: every HTTP-success record is queryable (durability invariant). In-flight buffer on the killed writer may be lost. |
 | `leader-crash` | Same as base, but kill the current Raft leader mid-ingest. Asserts: Raft elects a new leader within seconds; writes continue via LB to surviving writers; durability invariant holds. |
 
-The smoke uses `docker-compose.override.smoke.yml` to build Arc **from source** rather than pulling `basekick/arc:latest`, so you can run it against branch under review.
+The smoke uses `docker-compose.override.smoke.yml` to build Arc **from source** rather than pulling `ghcr.io/basekick-labs/arc:latest`, so you can run it against branch under review.
 
 ```bash
 export ARC_LICENSE_KEY="ARC-ENT-..."           # dev key (NOT the customer .env key)

--- a/deploy/docker-compose/enterprise-shared/docker-compose.override.smoke.yml
+++ b/deploy/docker-compose/enterprise-shared/docker-compose.override.smoke.yml
@@ -2,7 +2,7 @@
 #
 # - Builds the Arc image FROM SOURCE in this checkout (Dockerfile at the
 #   repo root). The smoke needs to test the actual branch under review,
-#   not whatever is at basekick/arc:latest. Per
+#   not whatever is at ghcr.io/basekick-labs/arc:latest. Per
 #   memory/feedback_compose_build_from_source.md — pre-tagging a local
 #   image is brittle across docker contexts; `build:` is the path that
 #   reliably picks up the working tree.

--- a/deploy/docker-compose/enterprise-shared/docker-compose.yml
+++ b/deploy/docker-compose/enterprise-shared/docker-compose.yml
@@ -8,7 +8,7 @@
 # =============================================================================
 
 x-arc-common: &arc-common
-  image: basekick/arc:latest
+  image: ghcr.io/basekick-labs/arc:latest
   networks:
     - arc-cluster
   depends_on:

--- a/deploy/docker-compose/oss-local/docker-compose.yml
+++ b/deploy/docker-compose/oss-local/docker-compose.yml
@@ -10,7 +10,7 @@
 
 services:
   arc:
-    image: basekick/arc:latest
+    image: ghcr.io/basekick-labs/arc:latest
     container_name: arc
     hostname: arc
     ports:

--- a/deploy/docker-compose/oss-s3/docker-compose.yml
+++ b/deploy/docker-compose/oss-s3/docker-compose.yml
@@ -12,7 +12,7 @@
 
 services:
   arc:
-    image: basekick/arc:latest
+    image: ghcr.io/basekick-labs/arc:latest
     container_name: arc
     hostname: arc
     ports:

--- a/deploy/docker-compose/oss-traefik/docker-compose.yml
+++ b/deploy/docker-compose/oss-traefik/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - arc
 
   arc:
-    image: basekick/arc:latest
+    image: ghcr.io/basekick-labs/arc:latest
     container_name: arc
     hostname: arc
     environment:

--- a/deploy/kubernetes-local/statefulset.yaml
+++ b/deploy/kubernetes-local/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: arc
-          image: basekick/arc:latest
+          image: ghcr.io/basekick-labs/arc:latest
           ports:
             - containerPort: 8000
               name: http
@@ -134,7 +134,7 @@ spec:
     spec:
       containers:
         - name: arc
-          image: basekick/arc:latest
+          image: ghcr.io/basekick-labs/arc:latest
           ports:
             - containerPort: 8000
               name: http

--- a/deploy/kubernetes/statefulset.yaml
+++ b/deploy/kubernetes/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: arc
-          image: basekick/arc:latest
+          image: ghcr.io/basekick-labs/arc:latest
           ports:
             - containerPort: 8000
               name: http
@@ -119,7 +119,7 @@ spec:
     spec:
       containers:
         - name: arc
-          image: basekick/arc:latest
+          image: ghcr.io/basekick-labs/arc:latest
           ports:
             - containerPort: 8000
               name: http


### PR DESCRIPTION
## Summary

All deployment manifests referenced `basekick/arc:latest`, which resolves to `docker.io/basekick/arc` — a path that **does not exist**. The Docker Hub repo is `basekicklabs/arc`, and the primary published image is on GHCR. So `docker pull` / `docker compose pull` against these files fails with access-denied; it only appeared to work when a local image was manually tagged with that exact name.

This points every reference at the canonical **public** image `ghcr.io/basekick-labs/arc:latest` (published first on every release, no auth required to pull), so a fresh `docker compose up` / `kubectl apply` pulls the real latest published binary with no manual tagging.

## Changes

- 6 docker-compose stacks: `oss-local`, `oss-s3`, `oss-traefik`, `enterprise-local`, `enterprise-shared`
- `kubernetes/` and `kubernetes-local/` statefulsets (2 image lines each)
- 2 prose references (enterprise-shared smoke override comment + README)

## Test plan

- [x] `docker compose config` validates and resolves to `ghcr.io/basekick-labs/arc:latest`
- [x] Confirmed the GHCR image is public and pullable (`docker pull ghcr.io/basekick-labs/arc:latest`)
- [x] `grep -rn basekick/arc deploy/` returns nothing — no docker.io shorthand remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)