### PR TITLE
fix(arcx): close the three router review follow-ups

### DIFF
--- a/internal/arcxengine/arcxengine_stub.go
+++ b/internal/arcxengine/arcxengine_stub.go
@@ -6,7 +6,10 @@
 
 package arcxengine
 
-import "github.com/apache/arrow-go/v18/arrow"
+import (
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
 
 // Available reports whether the arcx engine is linked in. False in this build.
 func Available() bool { return false }
@@ -26,6 +29,13 @@ func (e ErrUnsupported) Error() string { return "arcx: unsupported: " + e.msg }
 
 // Query always declines in the stub build — the caller falls back to DuckDB.
 func Query(sql string, ctx Context) (arrow.Record, error) {
+	return nil, ErrUnsupported{msg: "arcx engine not built into this binary"}
+}
+
+// QueryStream always declines in the stub build. Was missing entirely — the untagged
+// build never calls it, so its absence compiled fine and would only have broken the
+// first time someone referenced it from shared (non-tagged) code.
+func QueryStream(sql string, ctx Context) (array.RecordReader, error) {
 	return nil, ErrUnsupported{msg: "arcx engine not built into this binary"}
 }
 

--- a/internal/arcxengine/arcxengine_test.go
+++ b/internal/arcxengine/arcxengine_test.go
@@ -13,7 +13,20 @@ import (
 
 // A real Arc parquet fixture with a known row count (243 rows), matching the
 // arcx-side FFI test and the differential harness.
-const fixture243 = "/Users/nacho/dev/basekick-labs/arc/data/arc/agent_memory/agent_events/2026/02/03/agent_events_20260209_184547_daily.parquet"
+// Fixture path: ARCX_TEST_FIXTURE, else the repo-relative default below. It was a
+// hardcoded absolute developer path, which meant these tests SILENTLY SKIPPED on every
+// other machine (and in CI) — so the FFI bridge appeared covered while it was not.
+var fixture243 = func() string {
+	if p := os.Getenv("ARCX_TEST_FIXTURE"); p != "" {
+		return p
+	}
+	// MUST be absolute: the engine sandbox rejects any `..` component outright (it
+	// refuses the traversal *intent*, before resolving), so a repo-relative path would
+	// be declined rather than read.
+	abs, _ := filepath.Abs(filepath.Join("..", "..", "data", "arc", "agent_memory",
+		"agent_events", "2026", "02", "03", "agent_events_20260209_184547_daily.parquet"))
+	return abs
+}()
 
 // fixtureCtx is a Context whose sandbox actually contains the fixture.
 //

--- a/internal/arcxengine/compare_test.go
+++ b/internal/arcxengine/compare_test.go
@@ -37,7 +37,15 @@ import (
 	duckdb "github.com/duckdb/duckdb-go/v2"
 )
 
-const arcDataRoot = "/Users/nacho/dev/basekick-labs/arc/data/arc"
+// ARCX_TEST_DATA_ROOT, else repo-relative. See the note in arcxengine_test.go —
+// a hardcoded absolute path made this skip everywhere but one machine.
+var arcDataRoot = func() string {
+	if p := os.Getenv("ARCX_TEST_DATA_ROOT"); p != "" {
+		return p
+	}
+	abs, _ := filepath.Abs(filepath.Join("..", "..", "data", "arc"))
+	return abs
+}()
 
 // --- embedded DuckDB (Arc's real in-process engine) ------------------------
 

--- a/internal/arcxrouter/build_scan_sql_test.go
+++ b/internal/arcxrouter/build_scan_sql_test.go
@@ -96,8 +96,8 @@ func TestBuildScanSQL_DeclinesUnsafe(t *testing.T) {
 		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "LIKE", num: "1"}}},                // bad op
 		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "=", num: "1x"}}},                  // bad int literal
 		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "=", num: "1.2x", isFloat: true}}}, // bad float literal
-		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "=", num: "0.0", isFloat: true}}}, // ±0.0 float (declines defense-in-depth)
-		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "<", num: "0.0", isFloat: true}}}, // ±0.0 inequality still declines (2b-4)
+		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "=", num: "0.0", isFloat: true}}},  // ±0.0 float (declines defense-in-depth)
+		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "<", num: "0.0", isFloat: true}}},  // ±0.0 inequality still declines (2b-4)
 	}
 	for i, d := range bad {
 		if _, ok := buildScanSQL(d, "['/a.parquet']"); ok {

--- a/internal/arcxrouter/e2e_smoke_test.go
+++ b/internal/arcxrouter/e2e_smoke_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/basekick-labs/arc/internal/arcxengine"
@@ -23,7 +24,16 @@ import (
 // (Y/M/D, no hour dir) — perfect for exercising the day accept AND the hour
 // decline. Root the backend at data/arc so the List prefix is
 // agent_memory/agent_events/.
-const dataRoot = "/Users/nacho/dev/basekick-labs/arc/data"
+// ARCX_TEST_DATA_ROOT, else repo-relative. See the note in
+// arcxengine/arcxengine_test.go — a hardcoded absolute path made this skip everywhere
+// but one machine, so the e2e coverage was effectively developer-local.
+var dataRoot = func() string {
+	if p := os.Getenv("ARCX_TEST_DATA_ROOT"); p != "" {
+		return filepath.Dir(p)
+	}
+	abs, _ := filepath.Abs(filepath.Join("..", "..", "data"))
+	return abs
+}()
 
 func smokeDepsRootedAtArc(t *testing.T) (Deps, bool) {
 	t.Helper()

--- a/internal/arcxrouter/resolve.go
+++ b/internal/arcxrouter/resolve.go
@@ -10,11 +10,19 @@ import (
 	arcsql "github.com/basekick-labs/arc/internal/sql"
 )
 
-// validIdent mirrors Arc's validateIdentifier charset (query.go:746): alphanumeric,
-// underscore, hyphen. Database and measurement names must match, or we decline —
-// a name outside this set would be a path-injection risk and isn't a real Arc
-// measurement anyway.
-var validIdent = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+// validIdent is DELIBERATELY stricter than Arc's validateIdentifier (query.go), which
+// also permits a hyphen. It must match what Arc's RBAC patterns can actually parse:
+// patternDBTable / patternSimpleTable / patternJoinDBTable (query.go) are all
+// `[a-zA-Z0-9_]` with NO hyphen, so RBAC reads `FROM my-db.cpu` as database `default`,
+// measurement `my`. If a hyphenated name reached the router, the router and RBAC would
+// disagree about which database is being read — a permission check against one name and
+// a read against another.
+//
+// That is unreachable today (the tokenizer rejects `-` inside an identifier), so this is
+// defense in depth: the router must never be the component that widens what RBAC believes
+// it authorized. Decline instead — the shape falls back to DuckDB, which does its own
+// checks.
+var validIdent = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // resolveMeasurementToken splits a FROM token (as written) into (database,
 // measurement) and folds headerDB for the bare form, mirroring
@@ -60,7 +68,7 @@ func isBareIdent(col string) bool {
 // and `starts_with(host, 'web')` / `ends_with`/`contains` (2f-2). The function name and
 // column arg are bare identifiers; the remaining args are EITHER (optionally `-`-signed)
 // integers (substr) OR a single properly-escaped single-quoted string literal (the 2f-2
-// needle, `'([^']|'')*'` — every embedded `'` is DOUBLED, so no unescaped quote can break
+// needle, `'([^']|”)*'` — every embedded `'` is DOUBLED, so no unescaped quote can break
 // out). Injection-safe. `isProjFuncItem` is the SQL-boundary defensive re-check that the
 // item came from matchProjFunc.
 var projFuncItem = regexp.MustCompile(

--- a/internal/arcxrouter/resolve_test.go
+++ b/internal/arcxrouter/resolve_test.go
@@ -17,7 +17,12 @@ func TestResolveMeasurementToken(t *testing.T) {
 		{"bare no header defaults", "cpu", "", "default", "cpu", true},
 		{"dotted uses own db", "mydb.cpu", "prod", "mydb", "cpu", true},
 		{"dotted ignores header", "mydb.cpu", "prod", "mydb", "cpu", true},
-		{"hyphen ok", "my-db.my-meas", "", "my-db", "my-meas", true},
+		// Hyphens DECLINE: Arc's RBAC patterns are `[a-zA-Z0-9_]` with no hyphen, so RBAC
+		// would read `my-db.cpu` as database `default`, measurement `my`. Accepting a
+		// hyphen here would let the router read one database while RBAC authorized
+		// another. Decline instead — the shape falls back to DuckDB. (Unreachable today:
+		// the tokenizer already rejects `-` in an identifier; this is defense in depth.)
+		{"hyphen declines (RBAC cannot parse it)", "my-db.my-meas", "", "", "", false},
 		{"underscore ok", "my_db.my_meas", "", "my_db", "my_meas", true},
 		{"three parts declines", "a.b.c", "", "", "", false},
 		{"invalid char declines", "cpu$", "prod", "", "", false},

--- a/internal/arcxrouter/router_stub.go
+++ b/internal/arcxrouter/router_stub.go
@@ -7,7 +7,13 @@
 
 package arcxrouter
 
-import "github.com/gofiber/fiber/v2"
+import (
+	"context"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/gofiber/fiber/v2"
+)
 
 // Handler is the subset of the query handler the router needs. In the stub build
 // it is unconstrained (any type) since Decide/Run ignore it — declared as `any`
@@ -23,4 +29,15 @@ type Decision struct {
 func Decide(sql, headerDB string, h Handler) Decision { return Decision{} }
 
 // Run never handles in the stub build; the caller falls through to DuckDB.
-func Run(c *fiber.Ctx, d Decision, h Handler, mode Mode) (handled bool) { return false }
+//
+// The signature MUST track the tagged build's exactly. It had drifted (missing
+// `start`) and compiled only because nothing in the untagged build calls it — so the
+// break would have surfaced whenever someone first wired the stub, far from the cause.
+func Run(c *fiber.Ctx, d Decision, h Handler, mode Mode, start time.Time) (handled bool) {
+	return false
+}
+
+// RunArrow never serves in the stub build. Was missing entirely; same drift risk as Run.
+func RunArrow(ctx context.Context, d Decision, h Handler, mode Mode) (reader array.RecordReader, served bool) {
+	return nil, false
+}


### PR DESCRIPTION
Follow-ups from the pre-merge review of #644. None was reachable in production; all three are
the kind of latent defect that surfaces far from its cause.

## 1. `validIdent` accepted hyphens; Arc's RBAC cannot parse them

The router allowed `[a-zA-Z0-9_-]` for database/measurement names, but `patternDBTable`,
`patternSimpleTable` and `patternJoinDBTable` are all `[a-zA-Z0-9_]` — **no hyphen**. RBAC
therefore reads `FROM my-db.cpu` as database `default`, measurement `my`.

Had a hyphenated name reached the router, **RBAC would have authorized one database while the
router read another**. Unreachable today because the tokenizer rejects `-` inside an identifier,
so this is defense in depth — the router must never be the component that widens what RBAC
believes it authorized. Now declines, and the test asserts the decline rather than the previous
permissive behavior.

## 2. Stub signature drift

`router_stub.Run` was missing the `start` parameter the tagged build gained, and `RunArrow` /
`arcxengine.QueryStream` were absent from their stubs entirely. These compiled only because
nothing in the untagged build calls them — the break would have appeared the first time someone
referenced a stub from shared code, with a confusing error far from the actual cause. Stubs now
track the tagged signatures exactly.

## 3. Test fixtures were hardcoded absolute developer paths

They `t.Skip` cleanly on a missing file, which meant the FFI bridge and e2e tests **silently
skipped on every machine but one** — the coverage looked green while providing nothing.

Now `ARCX_TEST_FIXTURE` / `ARCX_TEST_DATA_ROOT` with a repo-relative default, matching the
pattern `bridge_stress_test.go` already used. Paths resolve to **absolute**, because the engine
sandbox rejects any `..` component outright (it refuses the traversal *intent* before resolving),
so a repo-relative path would be declined rather than read.

Verified: `TestBridgeCountStar` and `TestBridgeRepeatedCallsNoCrash` now **run and pass** instead
of skipping.

## Verification

- `internal/arcxrouter` and `internal/arcxengine` pass under `-race`
- Untagged build still produces a binary with **zero arcx symbols**
- `gofmt` and `go vet` clean

The `build_scan_sql_test.go` hunk is gofmt comment alignment only (pre-existing drift), not a
behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)