### PR TITLE
feat(arcx): decline census — classify why queries aren't arcx-eligible, without logging query text

### DIFF
--- a/internal/api/arcx_hook.go
+++ b/internal/api/arcx_hook.go
@@ -383,3 +383,20 @@ func (m arcxMetrics) ArcxShadowDeclined(shape string) {
 func (m arcxMetrics) ArcxLatency(engine, shape string, micros int64) {
 	m.logger.Debug().Str("engine", engine).Str("shape", shape).Int64("micros", micros).Msg("arcx latency")
 }
+
+// recordArcxShapeCensus classifies one query for the decline census and bumps
+// the closed-set counter. Called from handleQuery BEFORE the parallel/single
+// dispatch — placement is load-bearing (see CensusClassify): the parallel
+// executor takes exactly the simple single-table population arcx targets, so a
+// census taken at the arcx hook would systematically miss it.
+//
+// Emits NO query text anywhere — reason is a compile-time constant, tokens an
+// integer. `off` keeps its zero-cost kill-switch meaning: no census either.
+func (h *QueryHandler) recordArcxShapeCensus(rawSQL, headerDB string) {
+	if arcxMode() == arcxrouter.ModeOff {
+		return
+	}
+	reason, tokens := arcxrouter.CensusClassify(rawSQL, headerDB)
+	metrics.Get().IncArcxShapeCensus(reason)
+	h.logger.Debug().Str("reason", reason).Int("tokens", tokens).Msg("arcx census")
+}

--- a/internal/api/arcx_hook_stub.go
+++ b/internal/api/arcx_hook_stub.go
@@ -30,3 +30,8 @@ func (h *QueryHandler) tryArcxRouter(
 func (h *QueryHandler) tryArcxRouterArrow(c *fiber.Ctx, execCtx context.Context, cancel context.CancelFunc, rawSQL, headerDB, convertedSQL string) (handled bool) {
 	return false
 }
+
+// recordArcxShapeCensus is a no-op in the stub build. Deliberately EMPTY — a
+// stub that counted would newly link the recognizer into stock Arc, undoing
+// the zero-arcx-symbols property the stubs exist to preserve.
+func (h *QueryHandler) recordArcxShapeCensus(rawSQL, headerDB string) {}

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1616,6 +1616,12 @@ localProcessing:
 	// Convert SQL to storage paths and check for parallel execution opportunity
 	convertedSQL, parallelInfo, cached := h.getTransformedSQLForParallel(c.Context(), req.SQL, headerDB)
 
+	// arcx decline census (no-op stub in stock builds; no query text is emitted).
+	// MUST sit before the parallel dispatch below: parallel takes exactly the
+	// simple single-table queries arcx targets, so counting at the arcx hook in
+	// the else-branch would bias the census against the shapes worth building.
+	h.recordArcxShapeCensus(req.SQL, headerDB)
+
 	if h.debugEnabled {
 		h.logger.Debug().
 			Str("original_sql", req.SQL).

--- a/internal/arcxrouter/decline.go
+++ b/internal/arcxrouter/decline.go
@@ -1,0 +1,221 @@
+// Decline census: classify WHY a query is not arcx-eligible, from the full token
+// stream — not from the recognizer's bail point. The recognizer is a sequence
+// matcher that stops at the first off-path token, so 16 of 18 structurally
+// distinct decline shapes (GROUP BY, JOIN, CTE, window, DISTINCT, …) look
+// identical to it; a census built on its rejection sites would report one
+// giant "not recognized" bucket. This classifier scans everything the lexer
+// produced and picks a label from a CLOSED, compile-time set.
+//
+// HARD CONSTRAINT (repo-owner decision): no census path may log, store, or
+// return query text — not literals, not identifiers, not function names, not
+// even redacted. The Arc repo is public; the code must not APPEAR to leak on
+// inspection, so there is deliberately no code path here where user bytes can
+// reach a return value. Every returned string is a constant from
+// declineReasonNames; identifiers are counted, never named (`fn_other`, never
+// `fn_other:<name>`), which also keeps the metric label set bounded.
+
+//go:build cgo && arcx_engine
+
+package arcxrouter
+
+import "strings"
+
+// declineReason indexes declineReasonNames. uint8 by value: measured to add
+// zero allocations to the classify path.
+type declineReason uint8
+
+// Append-only: these indices feed the metrics census array, so reordering
+// silently re-labels historical dashboards.
+const (
+	reasonEligible declineReason = iota
+	reasonNoneIneligible
+	reasonUnlexable
+	reasonTzSetting
+	reasonCollation
+	reasonNullOrder
+	reasonCTE
+	reasonJoin
+	reasonSetOp
+	reasonWindow
+	reasonHaving
+	reasonGroupBy
+	reasonDistinct
+	reasonOffset
+	reasonStarProjection
+	reasonAggFn
+	reasonFnOther
+	reasonUnresolvableMeasurement
+	numDeclineReasons
+)
+
+// The ONLY strings this file can emit. Compile-time constants; the closed set
+// is what keeps user bytes out of logs/metrics and the label cardinality fixed.
+var declineReasonNames = [numDeclineReasons]string{
+	"eligible",
+	"none_ineligible",
+	"unlexable",
+	"tz_setting",
+	"collation",
+	"null_order",
+	"cte",
+	"join",
+	"set_op",
+	"window",
+	"having",
+	"group_by",
+	"distinct",
+	"offset",
+	"star_projection",
+	"agg_fn",
+	"fn_other",
+	"unresolvable_measurement",
+}
+
+func (r declineReason) String() string {
+	if r >= numDeclineReasons {
+		return "none_ineligible" // unreachable; belt-and-braces over a panic
+	}
+	return declineReasonNames[r]
+}
+
+// aggFns: one bucket, deliberately per-set not per-function. "Which aggregate?"
+// is answerable offline once the census says aggregation is the top bucket, and
+// collapsing removes any temptation to derive a label from the function name.
+var aggFns = map[string]bool{
+	"count": true, "sum": true, "avg": true, "min": true, "max": true,
+	"median": true, "stddev": true, "stddev_samp": true, "stddev_pop": true,
+	"variance": true, "var_samp": true, "var_pop": true,
+	"first": true, "last": true, "mode": true, "percentile_cont": true,
+	"percentile_disc": true, "approx_quantile": true,
+}
+
+// knownFns: functions the router/engine already handle in SOME form — their
+// presence is not itself the decline signal, so they don't claim `fn_other`.
+var knownFns = map[string]bool{
+	"length": true, "substr": true, "substring": true,
+	"starts_with": true, "ends_with": true, "contains": true,
+	"date_trunc": true, "time_bucket": true, "read_parquet": true,
+}
+
+// CensusClassify buckets one query for the decline census. Returns a label
+// (always a member of declineReasonNames — never derived from input) and the
+// token count for the DEBUG fingerprint. It never calls the engine.
+//
+// Runs in the tagged build only, on every query that passed validation + RBAC,
+// BEFORE the parallel/single dispatch — placement is load-bearing: the parallel
+// executor takes exactly the simple single-table population arcx targets, so a
+// census taken at the arcx hook (which only the non-parallel branch reaches)
+// would systematically under-count the shapes most worth building next.
+func CensusClassify(sql, headerDB string) (string, int) {
+	// Session-setting guards first, mirroring eligibleShape's order — these are
+	// their own buckets because they are correctness gates, not missing features.
+	low := strings.ToLower(sql)
+	for _, t := range tzInjectionTokens {
+		if strings.Contains(low, t) {
+			return reasonTzSetting.String(), 0
+		}
+	}
+	for _, t := range collationTokens {
+		if strings.Contains(low, t) {
+			return reasonCollation.String(), 0
+		}
+	}
+	for _, t := range nullOrderTokens {
+		if strings.Contains(low, t) {
+			return reasonNullOrder.String(), 0
+		}
+	}
+
+	if m, ok := eligibleShape(sql); ok {
+		if _, _, ok := resolveMeasurementToken(m.measurement, headerDB); ok {
+			return reasonEligible.String(), 0
+		}
+		return reasonUnresolvableMeasurement.String(), 0
+	}
+
+	toks, ok := tokenize(sql)
+	if !ok {
+		// Outside the lexer's narrow vocabulary (arithmetic operators, ||, …).
+		// An honest bucket of its own — not silently folded into a guess.
+		return reasonUnlexable.String(), 0
+	}
+	return classifyDecline(toks).String(), len(toks)
+}
+
+// classifyDecline picks the highest-signal structural feature present.
+// Priority: multi-relation / compositional shapes first (they are whole engine
+// phases), then clause-level features, then projection-level ones.
+func classifyDecline(toks []token) declineReason {
+	var hasJoin, hasSetOp, hasWindow, hasHaving, hasGroupBy bool
+	var hasDistinct, hasOffset, hasStar, hasAggFn, hasFnOther bool
+
+	if len(toks) > 0 && toks[0].kind == tokIdent && toks[0].lower == "with" {
+		return reasonCTE
+	}
+	for i, t := range toks {
+		if t.kind == tokPunct && t.punct == '*' {
+			// `count(*)` is the agg's star, not a star projection.
+			if i == 0 || toks[i-1].kind != tokPunct || toks[i-1].punct != '(' {
+				hasStar = true
+			}
+			continue
+		}
+		if t.kind != tokIdent {
+			continue
+		}
+		switch t.lower {
+		case "join":
+			hasJoin = true
+		case "union", "intersect", "except":
+			hasSetOp = true
+		case "over":
+			hasWindow = true
+		case "having":
+			hasHaving = true
+		case "group":
+			if i+1 < len(toks) && toks[i+1].kind == tokIdent && toks[i+1].lower == "by" {
+				hasGroupBy = true
+			}
+		case "distinct":
+			hasDistinct = true
+		case "offset":
+			hasOffset = true
+		default:
+			// ident immediately followed by `(` is a function call.
+			if i+1 < len(toks) && toks[i+1].kind == tokPunct && toks[i+1].punct == '(' {
+				switch {
+				case aggFns[t.lower]:
+					hasAggFn = true
+				case knownFns[t.lower]:
+					// already-handled function: not the signal
+				default:
+					hasFnOther = true
+				}
+			}
+		}
+	}
+
+	switch {
+	case hasSetOp:
+		return reasonSetOp
+	case hasJoin:
+		return reasonJoin
+	case hasWindow:
+		return reasonWindow
+	case hasHaving:
+		return reasonHaving
+	case hasGroupBy:
+		return reasonGroupBy
+	case hasDistinct:
+		return reasonDistinct
+	case hasAggFn:
+		return reasonAggFn
+	case hasOffset:
+		return reasonOffset
+	case hasStar:
+		return reasonStarProjection
+	case hasFnOther:
+		return reasonFnOther
+	}
+	return reasonNoneIneligible
+}

--- a/internal/arcxrouter/decline_test.go
+++ b/internal/arcxrouter/decline_test.go
@@ -1,0 +1,87 @@
+//go:build cgo && arcx_engine
+
+package arcxrouter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/metrics"
+)
+
+// The classifier's whole value is separating shapes the recognizer collapses.
+// These probes mirror the adversarial review's 18-shape corpus that proved the
+// recognizer alone buckets 16 of them identically.
+func TestCensusClassifySeparatesShapes(t *testing.T) {
+	cases := []struct {
+		sql, want string
+	}{
+		{"SELECT host, avg(usage_idle) FROM cpu GROUP BY host", "group_by"},
+		{"SELECT a.host FROM cpu a JOIN meta b ON a.host = b.host", "join"},
+		{"WITH t AS (SELECT host FROM cpu) SELECT host FROM t", "cte"},
+		{"SELECT host FROM cpu UNION SELECT host FROM mem", "set_op"},
+		{"SELECT host, row_number() OVER (ORDER BY value) FROM cpu", "window"},
+		{"SELECT host FROM cpu GROUP BY host HAVING count(host) > 1", "having"},
+		{"SELECT DISTINCT host FROM cpu", "distinct"},
+		{"SELECT host FROM cpu LIMIT 10 OFFSET 5", "offset"},
+		{"SELECT * FROM cpu", "star_projection"},
+		{"SELECT median(value) FROM cpu", "agg_fn"},
+		{"SELECT upper(host) FROM cpu", "fn_other"},
+		// Guards keep their own buckets (correctness gates, not missing features).
+		{"SELECT host FROM cpu WHERE t AT TIME ZONE 'UTC' > 1", "tz_setting"},
+		{"SELECT host FROM cpu ORDER BY host COLLATE nocase", "collation"},
+		// Outside the lexer's vocabulary (`|` — string concat): an honest
+		// bucket, not a guess. NOTE `+`/`/` DO lex (2e arithmetic), so plain
+		// arithmetic lands in none_ineligible, which is correct.
+		{"SELECT host || 'x' FROM cpu", "unlexable"},
+		{"SELECT value + 1 FROM cpu", "none_ineligible"},
+	}
+	for _, c := range cases {
+		got, _ := CensusClassify(c.sql, "production")
+		if got != c.want {
+			t.Errorf("%q: got %q, want %q", c.sql, got, c.want)
+		}
+	}
+}
+
+// THE LOAD-BEARING TEST (repo-owner hard constraint): no user bytes may reach
+// any census output. Sentinel-laden SQL through every path; the returned label
+// must be a member of the closed set and free of the sentinel — which also
+// covers the DEBUG log and the metric, since both receive only this string.
+func TestCensusNeverEmitsUserBytes(t *testing.T) {
+	allowed := make(map[string]bool, len(declineReasonNames))
+	for _, n := range declineReasonNames {
+		allowed[n] = true
+	}
+	probes := []string{
+		"SELECT zzsentinelzz(zzcolzz) FROM zzmeaszz WHERE h = 'ZZSENTINELZZ'",
+		"SELECT zzcolzz FROM zzmeaszz GROUP BY zzcolzz",
+		"WITH zzcte AS (SELECT 1) SELECT * FROM zzcte",
+		"SELECT * FROM zzmeaszz WHERE zzcolzz AT TIME ZONE 'zz' > 1",
+		"SELECT zzcolzz FROM zz-not-an-ident.zzmeaszz",
+		"SELECT \x00zz FROM zzmeaszz",
+	}
+	for _, sql := range probes {
+		got, _ := CensusClassify(sql, "zzheaderzz")
+		if !allowed[got] {
+			t.Fatalf("out-of-set label %q for %q — input-derived?", got, sql)
+		}
+		if strings.Contains(strings.ToLower(got), "zz") {
+			t.Fatalf("sentinel leaked into label %q for %q", got, sql)
+		}
+	}
+}
+
+// Pins arcxrouter's reason table to internal/metrics' storage slots. The index
+// IS the slot, so divergence silently re-labels dashboard history.
+func TestArcxCensusReasonSetMatchesRouter(t *testing.T) {
+	stored := metrics.ArcxCensusReasons()
+	if len(stored) != int(numDeclineReasons) {
+		t.Fatalf("metrics has %d reasons, router has %d", len(stored), numDeclineReasons)
+	}
+	for i, name := range declineReasonNames {
+		if stored[i] != name {
+			t.Fatalf("slot %d: metrics=%q router=%q", i, stored[i], name)
+		}
+	}
+}

--- a/internal/metrics/arcx_census.go
+++ b/internal/metrics/arcx_census.go
@@ -1,0 +1,80 @@
+// arcx decline-census counters. Untagged: the counters compile into every build
+// (they are plain atomics with no arcx linkage, so stock Arc's binary gains no
+// arcx symbols), but ONLY the arcx_engine-tagged census path increments them —
+// in stock Arc they exist and stay zero, which the JSON snapshot makes obvious.
+//
+// The label set is CLOSED and enforced HERE as well as at the producer: an
+// unknown reason string is never stored or emitted — it increments an
+// `invalid` counter with no name attached. That is defense in depth against a
+// future caller passing an input-derived string (the bug that turns a metric
+// into both a data leak and a cardinality bomb at once), and it fails loudly
+// on a dashboard instead of silently minting a new label.
+
+package metrics
+
+import "sync/atomic"
+
+// arcxCensusReasons mirrors arcxrouter's declineReasonNames. APPEND-ONLY: the
+// index is the storage slot, so reordering silently re-labels history. The two
+// tables are pinned to each other by TestArcxCensusReasonSetMatchesRouter in
+// the arcxrouter package (which can see both).
+var arcxCensusReasons = [...]string{
+	"eligible",
+	"none_ineligible",
+	"unlexable",
+	"tz_setting",
+	"collation",
+	"null_order",
+	"cte",
+	"join",
+	"set_op",
+	"window",
+	"having",
+	"group_by",
+	"distinct",
+	"offset",
+	"star_projection",
+	"agg_fn",
+	"fn_other",
+	"unresolvable_measurement",
+}
+
+var (
+	arcxCensusCounts  [len(arcxCensusReasons)]atomic.Int64
+	arcxCensusInvalid atomic.Int64
+)
+
+// IncArcxShapeCensus records one classified query. `reason` must be a member of
+// arcxCensusReasons; anything else is counted as invalid WITHOUT recording the
+// string (closed-set boundary — see the file comment).
+func (m *Metrics) IncArcxShapeCensus(reason string) {
+	for i := range arcxCensusReasons {
+		if arcxCensusReasons[i] == reason {
+			arcxCensusCounts[i].Add(1)
+			return
+		}
+	}
+	arcxCensusInvalid.Add(1)
+}
+
+// ArcxCensusReasons returns a copy of the closed label set, in slot order.
+// Exists so arcxrouter's tests can pin its reason table to this one — the two
+// are unexported in their own packages, and silent divergence would re-label
+// dashboard history (see the append-only note above).
+func ArcxCensusReasons() []string {
+	out := make([]string, len(arcxCensusReasons))
+	copy(out, arcxCensusReasons[:])
+	return out
+}
+
+// arcxCensusSnapshot returns every counter (zeros included, so the closed set
+// is visible on the dashboard and a stock build reads as all-zero rather than
+// absent). Consumed by Snapshot() for /api/v1/metrics.
+func (m *Metrics) arcxCensusSnapshot() map[string]int64 {
+	out := make(map[string]int64, len(arcxCensusReasons)+1)
+	for i, name := range arcxCensusReasons {
+		out[name] = arcxCensusCounts[i].Load()
+	}
+	out["invalid"] = arcxCensusInvalid.Load()
+	return out
+}

--- a/internal/metrics/arcx_census_test.go
+++ b/internal/metrics/arcx_census_test.go
@@ -1,0 +1,25 @@
+package metrics
+
+import "testing"
+
+// The closed set is enforced at THIS boundary too: an unknown reason — e.g. a
+// future caller passing an input-derived string — is counted as invalid and its
+// text is never stored or emitted. This is the second half of the no-user-bytes
+// guarantee (the first is the producer's constant-only table).
+func TestArcxCensusRejectsUnknownReasons(t *testing.T) {
+	m := Get()
+	before := arcxCensusInvalid.Load()
+	m.IncArcxShapeCensus("zzsentinelzz")
+	if got := arcxCensusInvalid.Load(); got != before+1 {
+		t.Fatalf("invalid counter: got %d, want %d", got, before+1)
+	}
+	snap := m.arcxCensusSnapshot()
+	if _, leaked := snap["zzsentinelzz"]; leaked {
+		t.Fatal("unknown reason string leaked into the snapshot as a key")
+	}
+	// And a valid reason lands in its slot.
+	m.IncArcxShapeCensus("group_by")
+	if snap := m.arcxCensusSnapshot(); snap["group_by"] < 1 {
+		t.Fatal("valid reason not counted")
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -447,10 +447,14 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 	return map[string]interface{}{
 		// Process info
 		"uptime_seconds": time.Since(m.startTime).Seconds(),
-		"goroutines":     runtime.NumGoroutine(),
-		"go_version":     runtime.Version(),
-		"num_cpu":        runtime.NumCPU(),
-		"gomaxprocs":     runtime.GOMAXPROCS(0),
+
+		// arcx decline census (closed label set; all-zero in stock builds —
+		// only the arcx_engine-tagged census path increments these).
+		"arcx_shape_census": m.arcxCensusSnapshot(),
+		"goroutines":        runtime.NumGoroutine(),
+		"go_version":        runtime.Version(),
+		"num_cpu":           runtime.NumCPU(),
+		"gomaxprocs":        runtime.GOMAXPROCS(0),
 
 		// Memory (Go runtime)
 		"memory_alloc_bytes":       memStats.Alloc,


### PR DESCRIPTION
Answers *"which query shapes does the arcx router decline, and how often?"* from a running dev
instance. Counters ride the existing `/api/v1/metrics` and `/metrics` surfaces — **no new
endpoint** (GHSA-m3qr-fvp4-78xj is exactly the routes-before-auth class a new route would risk).

## Design (shaped by a plan-stage adversarial review that killed the naive version)

**Post-hoc classifier over the full token stream, not the recognizer's bail point.** The
recognizer is a sequence matcher that stops at the first off-path token — measured, 16 of 18
structurally distinct decline shapes collapse into one bucket there. The classifier scans
everything the lexer produced and picks from a **closed 18-label compile-time set**
(`group_by`, `join`, `cte`, `window`, `set_op`, `distinct`, `agg_fn`, …, plus `eligible`, so the
census shows the whole distribution).

**Placed before the parallel dispatch in `handleQuery`.** The parallel executor selects exactly
the simple single-table population the arcx router targets; a census taken at the arcx hook
(else-branch only) would systematically under-count the shapes most worth building next.

**No query text, anywhere — hard constraint, enforced twice.** Every emitted label is a
compile-time constant; identifiers are **counted, never named** (`fn_other`, never
`fn_other:<name>`); the DEBUG fingerprint is `reason` + token count. The producer can only
return members of its constant table, and `internal/metrics` independently rejects unknown
strings into a nameless `invalid` counter — so a future input-derived label can neither leak
user bytes nor mint metric cardinality.

**Tagged-only, stock Arc untouched.** The classifier is `cgo && arcx_engine`; the stub census
hook is deliberately **empty** so the recognizer stays linker-stripped from stock builds —
verified: **0 arcx/arcxrouter symbols** in the untagged binary. `ARC_ROUTER=off` keeps its
zero-cost kill-switch meaning (no census either). In stock builds the counters exist and read
as all-zero in the snapshot.

## Tests

- Shape-separation table over the adversarial's probe corpus
- **The load-bearing sentinel test**: sentinel-laden SQL (`zzsentinelzz(...)`,
  `'ZZSENTINELZZ'`, NUL bytes, hostile headers) through every path — the label must be in-set
  and sentinel-free, which covers the log and the metric since both receive only that string
- Cross-package pin of the two reason tables (index = storage slot; drift would silently
  re-label dashboard history)
- Metrics boundary rejection (unknown reason → `invalid`, string never stored)

## Verification (both build modes — the #644–#646 lesson)

- `go build`/`go vet -tags=duckdb_arrow ./...` (incl. tests) ✓
- `go vet -tags=duckdb_arrow,arcx_engine ./...` (incl. tests) ✓
- `-race` on touched packages, both modes ✓
- Stock binary: 0 arcx symbols ✓

One behavior worth knowing: `+`/`/` lex (arithmetic support), so plain-arithmetic shapes land
in `none_ineligible` rather than `unlexable` — pinned by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)