### PR TITLE
fix(logging): mask query literals and error echoes in server logs

### DIFF
--- a/internal/api/continuous_query.go
+++ b/internal/api/continuous_query.go
@@ -805,7 +805,7 @@ func (h *ContinuousQueryHandler) executeAggregation(ctx context.Context, cq *Con
 		wrappedQuery = wrapSourceMeasurement(query, cq.Database, cq.SourceMeasurement, readParquetExpr)
 	}
 
-	h.logger.Debug().Str("query", wrappedQuery).Msg("Executing wrapped query")
+	h.logger.Debug().Str("query", sqlutil.ForLog(wrappedQuery)).Msg("Executing wrapped query")
 
 	// Execute query using DuckDB
 	rows, err := h.db.Query(wrappedQuery)

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"io"
 	"os"
 	"path/filepath"
@@ -310,7 +311,7 @@ func (h *DeleteHandler) handleDelete(c *fiber.Ctx) error {
 	h.logger.Info().
 		Str("database", req.Database).
 		Str("measurement", req.Measurement).
-		Str("where", req.Where).
+		Str("where", sqlutil.ForLog(req.Where)).
 		Bool("dry_run", req.DryRun).
 		Msg("Processing delete request")
 

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -918,9 +918,12 @@ func (h *QueryHandler) logSlowQuery(sql string, start time.Time, rowCount int, t
 		return
 	}
 	metrics.Get().IncSlowQueries()
-	maskedSQL, _ := sqlutil.MaskStringLiterals(sql, sqlutil.HasQuotes(sql))
+	// ForLog (DuckDB-exact literal scanner) supersedes the older
+	// MaskStringLiterals here: the round-trip masker treats backslash as an
+	// escape in plain strings, which DuckDB does not — a value ending in `\`
+	// would shift literal boundaries and log the NEXT literal in the clear.
 	h.logger.Warn().
-		Str("sql", maskedSQL).
+		Str("sql", sqlutil.ForLog(sql)).
 		Float64("execution_time_ms", float64(elapsed.Milliseconds())).
 		Int("row_count", rowCount).
 		Str("token_name", tokenName).
@@ -1307,7 +1310,7 @@ func (h *QueryHandler) checkQueryPermissions(c *fiber.Ctx, sql, permission strin
 
 	if h.debugEnabled {
 		h.logger.Debug().
-			Str("sql", sql).
+			Str("sql", sqlutil.ForLog(sql)).
 			Int("table_count", len(tableRefs)).
 			Msg("Checking RBAC permissions for query")
 	}
@@ -1624,8 +1627,8 @@ localProcessing:
 
 	if h.debugEnabled {
 		h.logger.Debug().
-			Str("original_sql", req.SQL).
-			Str("converted_sql", convertedSQL).
+			Str("original_sql", sqlutil.ForLog(req.SQL)).
+			Str("converted_sql", sqlutil.ForLog(convertedSQL)).
 			Bool("cache_hit", cached).
 			Bool("parallel", parallelInfo != nil).
 			Str("header_db", headerDB).
@@ -1702,7 +1705,7 @@ localProcessing:
 					h.queryRegistry.Fail(queryID, "Parallel query execution failed")
 				}
 			}
-			h.logger.Error().Err(err).Str("sql", req.SQL).Msg("Parallel query execution failed")
+			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(req.SQL)).Msg("Parallel query execution failed")
 			return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 				Success:         false,
 				Error:           err.Error(),
@@ -1744,8 +1747,9 @@ localProcessing:
 				if execCtx.Err() == context.DeadlineExceeded {
 					h.queryRegistry.TimedOut(queryID)
 				} else {
-					h.queryRegistry.Fail(queryID, fmt.Sprintf("%d/%d partitions failed: %v",
-						len(erroredPaths), len(results), firstPartitionErr))
+					h.queryRegistry.Fail(queryID, fmt.Sprintf("%d/%d partitions failed: %s",
+						len(erroredPaths), len(results),
+						sqlutil.SanitizeErrText(firstPartitionErr.Error())))
 				}
 			}
 			// Sample paths at log level — full list could be hundreds.
@@ -1758,7 +1762,7 @@ localProcessing:
 				Int("errored_partitions", len(erroredPaths)).
 				Int("total_partitions", len(results)).
 				Strs("sample_paths", samplePaths).
-				Str("sql", req.SQL).
+				Str("sql", sqlutil.ForLog(req.SQL)).
 				Msg("Parallel query: partition error(s) — failing whole request to avoid silent partial result")
 			return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 				Success: false,
@@ -1840,7 +1844,7 @@ localProcessing:
 					if errors.Is(streamErr, context.DeadlineExceeded) {
 						h.queryRegistry.TimedOut(queryID)
 					} else {
-						h.queryRegistry.Fail(queryID, streamErr.Error())
+						h.queryRegistry.Fail(queryID, sqlutil.SanitizeErrText(streamErr.Error()))
 					}
 				}
 				// Per-handler client-disconnect counter (#426).
@@ -1984,7 +1988,7 @@ localProcessing:
 			// This happens when querying a measurement that has no data on storage yet
 			// (e.g., new measurement, or DuckDB's httpfs cache is stale).
 			if isNoFilesFoundError(err) {
-				h.logger.Info().Str("sql", req.SQL).Msg("No files found for measurement, returning empty result")
+				h.logger.Info().Str("sql", sqlutil.ForLog(req.SQL)).Msg("No files found for measurement, returning empty result")
 				m.IncQuerySuccess()
 				if h.queryRegistry != nil && queryID != "" {
 					h.queryRegistry.Complete(queryID, 0)
@@ -2006,7 +2010,7 @@ localProcessing:
 				if h.queryRegistry != nil && queryID != "" {
 					h.queryRegistry.TimedOut(queryID)
 				}
-				h.logger.Error().Err(err).Str("sql", req.SQL).Dur("timeout", effectiveTimeout).Msg("Query timed out")
+				h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(req.SQL)).Dur("timeout", effectiveTimeout).Msg("Query timed out")
 				return c.Status(fiber.StatusGatewayTimeout).JSON(QueryResponse{
 					Success:         false,
 					Error:           "Query timed out",
@@ -2021,7 +2025,7 @@ localProcessing:
 					h.queryRegistry.Fail(queryID, "Query execution failed")
 				}
 			}
-			h.logger.Error().Err(err).Str("sql", req.SQL).Msg("Query execution failed")
+			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(req.SQL)).Msg("Query execution failed")
 			return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 				Success:         false,
 				Error:           err.Error(),
@@ -2090,7 +2094,7 @@ localProcessing:
 					if errors.Is(streamErr, context.DeadlineExceeded) {
 						h.queryRegistry.TimedOut(queryID)
 					} else {
-						h.queryRegistry.Fail(queryID, streamErr.Error())
+						h.queryRegistry.Fail(queryID, sqlutil.SanitizeErrText(streamErr.Error()))
 					}
 				}
 				// Per-handler client-disconnect counter (#426).
@@ -3964,8 +3968,8 @@ func (h *QueryHandler) estimateQuery(c *fiber.Ctx) error {
 	countSQL := "SELECT COUNT(*) FROM (" + convertedSQL + ") AS t"
 
 	h.logger.Debug().
-		Str("original_sql", req.SQL).
-		Str("count_sql", countSQL).
+		Str("original_sql", sqlutil.ForLog(req.SQL)).
+		Str("count_sql", sqlutil.ForLog(countSQL)).
 		Msg("Estimating query")
 
 	m := metrics.Get()
@@ -3984,7 +3988,7 @@ func (h *QueryHandler) estimateQuery(c *fiber.Ctx) error {
 		// Check if it was a timeout
 		if h.queryTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
 			m.IncQueryTimeouts()
-			h.logger.Error().Err(err).Str("sql", countSQL).Dur("timeout", h.queryTimeout).Msg("Estimate query timed out")
+			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(countSQL)).Dur("timeout", h.queryTimeout).Msg("Estimate query timed out")
 			return c.Status(fiber.StatusGatewayTimeout).JSON(EstimateResponse{
 				Success:         false,
 				Error:           "Query timed out",
@@ -3992,7 +3996,7 @@ func (h *QueryHandler) estimateQuery(c *fiber.Ctx) error {
 				ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 			})
 		}
-		h.logger.Error().Err(err).Str("sql", countSQL).Msg("Estimate query failed")
+		h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(countSQL)).Msg("Estimate query failed")
 		return c.JSON(EstimateResponse{
 			Success:         false,
 			Error:           "Cannot estimate query: " + err.Error(),
@@ -4354,7 +4358,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	h.logger.Debug().
 		Str("measurement", measurement).
 		Str("database", database).
-		Str("sql", convertedSQL).
+		Str("sql", sqlutil.ForLog(convertedSQL)).
 		Msg("Querying measurement")
 
 	timestamp := time.Now().UTC().Format(time.RFC3339)
@@ -4373,7 +4377,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	rows, err := h.db.Query(convertedSQL)
 	if err != nil {
 		m.IncQueryErrors()
-		h.logger.Error().Err(err).Str("sql", sql).Msg("Measurement query failed")
+		h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(sql)).Msg("Measurement query failed")
 		return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 			Success:         false,
 			Error:           err.Error(),

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"strconv"
 	"strings"
 	"sync"
@@ -163,8 +164,8 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 	convertedSQL, _ := h.getTransformedSQL(c.Context(), req.SQL, headerDB)
 
 	h.logger.Debug().
-		Str("original_sql", req.SQL).
-		Str("converted_sql", convertedSQL).
+		Str("original_sql", sqlutil.ForLog(req.SQL)).
+		Str("converted_sql", sqlutil.ForLog(convertedSQL)).
 		Str("header_db", headerDB).
 		Msg("Executing Arrow query")
 
@@ -200,14 +201,14 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		}
 		if h.queryTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
 			m.IncQueryTimeouts()
-			h.logger.Error().Err(err).Str("sql", req.SQL).Dur("timeout", h.queryTimeout).Msg("Arrow query timed out")
+			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(req.SQL)).Dur("timeout", h.queryTimeout).Msg("Arrow query timed out")
 			return c.Status(fiber.StatusGatewayTimeout).JSON(fiber.Map{
 				"success": false,
 				"error":   "Query timed out",
 			})
 		}
 		m.IncQueryErrors()
-		h.logger.Error().Err(err).Str("sql", req.SQL).Msg("Arrow query execution failed")
+		h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(req.SQL)).Msg("Arrow query execution failed")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"success": false,
 			"error":   err.Error(),

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"math"
 	"strconv"
 	"strings"
@@ -118,7 +119,7 @@ func executeArrowJSONQuery(
 		if onFail != nil {
 			onFail(err.Error())
 		}
-		h.logger.Error().Err(err).Str("sql", convertedSQL).Msg("Arrow JSON query failed")
+		h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(convertedSQL)).Msg("Arrow JSON query failed")
 		c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 			Success:         false,
 			Error:           err.Error(),

--- a/internal/api/query_msgpack.go
+++ b/internal/api/query_msgpack.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"strings"
 	"time"
 
@@ -130,7 +131,7 @@ func executeArrowMsgPackQuery(
 		if onFail != nil {
 			onFail(err.Error())
 		}
-		h.logger.Error().Err(err).Str("format", "msgpack").Str("sql", convertedSQL).Msg("Arrow MsgPack query failed")
+		h.logger.Error().Err(err).Str("format", "msgpack").Str("sql", sqlutil.ForLog(convertedSQL)).Msg("Arrow MsgPack query failed")
 		_ = respondError(c, fiber.StatusInternalServerError, err.Error(), timestamp, start)
 		return -1, true
 	}
@@ -197,7 +198,7 @@ func executeArrowMsgPackQuery(
 			onFail(drainErr.Error())
 		}
 		h.logger.Error().Err(drainErr).Str("format", "msgpack").
-			Str("sql", convertedSQL).Msg("Arrow MsgPack drain failed")
+			Str("sql", sqlutil.ForLog(convertedSQL)).Msg("Arrow MsgPack drain failed")
 		_ = respondError(c, fiber.StatusInternalServerError, drainErr.Error(), timestamp, start)
 		return -1, true
 	}

--- a/internal/arcxrouter/compare.go
+++ b/internal/arcxrouter/compare.go
@@ -159,8 +159,17 @@ func compareResults(rec arrow.Record, oracle canonicalResult) string {
 	sortRows(b)
 	for i := range a {
 		if a[i] != b[i] {
-			return fmt.Sprintf("row %d differs: arcx=(bucket=%d,count=%d) duckdb=(bucket=%d,count=%d)",
-				i, a[i].bucketMicros, a[i].count, b[i].bucketMicros, b[i].count)
+			// NO VALUES in the diff: bucket timestamps and counts are result
+			// DATA, and this string lands in an ERROR log. What a responder
+			// actually needs is WHICH KIND of divergence — a missing bucket
+			// (pruning/path bug) vs a differing count (aggregation bug) — plus
+			// where; the values themselves come from re-running the comparison
+			// locally, a deliberate act.
+			kind := "count_differs"
+			if a[i].bucketMicros != b[i].bucketMicros {
+				kind = "bucket_differs"
+			}
+			return fmt.Sprintf("canonical row %d of %d differs (%s)", i, len(a), kind)
 		}
 	}
 	return ""
@@ -289,7 +298,11 @@ func compareScalar(rec arrow.Record, oracle scalarValue) string {
 		return "arcx scalar decode error: " + err.Error()
 	}
 	if got.isNull != oracle.isNull || (!got.isNull && got.v != oracle.v) {
-		return fmt.Sprintf("scalar differs: arcx=%s duckdb=%s", got, oracle)
+		// NO VALUES (see compareCanonical): report the divergence CLASS only.
+		if got.isNull != oracle.isNull {
+			return fmt.Sprintf("scalar differs (null-ness: arcx_null=%t duckdb_null=%t)", got.isNull, oracle.isNull)
+		}
+		return "scalar differs (both non-null, values withheld from log)"
 	}
 	return ""
 }

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"runtime"
 	"strconv"
 	"strings"
@@ -197,7 +198,7 @@ func RunArrow(ctx context.Context, d Decision, h Handler, mode Mode) (reader arr
 		r, err := arcxengine.QueryStream(engineSQL, d.Ctx)
 		if err != nil {
 			if _, unsupported := err.(arcxengine.ErrUnsupported); !unsupported {
-				h.Logger.Error().Err(err).Str("shape", d.Shape).Str("sql", engineSQL).
+				h.Logger.Error().Err(err).Str("shape", d.Shape).Str("sql", sqlutil.ForLog(engineSQL)).
 					Msg("arcx serve (arrow): engine ERROR; falling back to DuckDB")
 				h.Metrics.ArcxShadowError(d.Shape)
 			}
@@ -533,13 +534,13 @@ func (h Deps) runShadow(ctx context.Context, d Decision, engineSQL string) {
 		if _, unsupported := err.(arcxengine.ErrUnsupported); unsupported {
 			// Expected engine decline (e.g. hour-over-daily, F2). Not an alarm —
 			// eligibility over-claimed; a tightening signal.
-			h.Logger.Warn().Str("shape", d.Shape).Str("sql", engineSQL).
+			h.Logger.Warn().Str("shape", d.Shape).Str("sql", sqlutil.ForLog(engineSQL)).
 				Msg("arcx shadow: engine declined an eligible shape")
 			h.Metrics.ArcxShadowDeclined(d.Shape)
 			return
 		}
 		// Real engine error — alarm.
-		h.Logger.Error().Err(err).Str("shape", d.Shape).Str("sql", engineSQL).
+		h.Logger.Error().Err(err).Str("shape", d.Shape).Str("sql", sqlutil.ForLog(engineSQL)).
 			Msg("arcx shadow: engine ERROR")
 		h.Metrics.ArcxShadowError(d.Shape)
 		return
@@ -559,7 +560,7 @@ func (h Deps) runShadow(ctx context.Context, d Decision, engineSQL string) {
 		return
 	}
 	if err != nil {
-		h.Logger.Error().Err(err).Str("shape", d.Shape).Str("sql", engineSQL).
+		h.Logger.Error().Err(err).Str("shape", d.Shape).Str("sql", sqlutil.ForLog(engineSQL)).
 			Msg("arcx shadow: stream drain ERROR")
 		h.Metrics.ArcxShadowError(d.Shape)
 		return
@@ -581,8 +582,8 @@ func (h Deps) runShadow(ctx context.Context, d Decision, engineSQL string) {
 	if diff != "" {
 		h.Logger.Error().
 			Str("shape", d.Shape).
-			Str("engine_sql", engineSQL).
-			Str("oracle_sql", h.ConvertedSQL).
+			Str("engine_sql", sqlutil.ForLog(engineSQL)).
+			Str("oracle_sql", sqlutil.ForLog(h.ConvertedSQL)).
 			Str("diff", diff).
 			Msg("arcx shadow: MISMATCH vs DuckDB")
 		h.Metrics.ArcxShadowMismatch(d.Shape)
@@ -632,7 +633,7 @@ func (h Deps) runServe(c *fiber.Ctx, ctx context.Context, d Decision, engineSQL 
 		if _, unsupported := err.(arcxengine.ErrUnsupported); unsupported {
 			return false // silent fallback — normal router contract
 		}
-		h.Logger.Error().Err(err).Str("shape", d.Shape).Str("sql", engineSQL).
+		h.Logger.Error().Err(err).Str("shape", d.Shape).Str("sql", sqlutil.ForLog(engineSQL)).
 			Msg("arcx serve: engine ERROR; falling back to DuckDB")
 		h.Metrics.ArcxShadowError(d.Shape)
 		return false

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1668,14 +1669,14 @@ func (d *DuckDB) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	if err != nil {
 		d.logger.Error().
 			Err(err).
-			Str("query", query).
+			Str("query", sqlutil.ForLog(query)).
 			Dur("elapsed", elapsed).
 			Msg("Query failed")
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
 
 	d.logger.Debug().
-		Str("query", query).
+		Str("query", sqlutil.ForLog(query)).
 		Dur("elapsed", elapsed).
 		Msg("Query executed")
 
@@ -1691,14 +1692,14 @@ func (d *DuckDB) QueryContext(ctx context.Context, query string, args ...interfa
 	if err != nil {
 		d.logger.Error().
 			Err(err).
-			Str("query", query).
+			Str("query", sqlutil.ForLog(query)).
 			Dur("elapsed", elapsed).
 			Msg("Query failed")
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
 
 	d.logger.Debug().
-		Str("query", query).
+		Str("query", sqlutil.ForLog(query)).
 		Dur("elapsed", elapsed).
 		Msg("Query executed")
 
@@ -1714,14 +1715,14 @@ func (d *DuckDB) Exec(query string, args ...interface{}) (sql.Result, error) {
 	if err != nil {
 		d.logger.Error().
 			Err(err).
-			Str("query", query).
+			Str("query", sqlutil.ForLog(query)).
 			Dur("elapsed", elapsed).
 			Msg("Exec failed")
 		return nil, fmt.Errorf("exec failed: %w", err)
 	}
 
 	d.logger.Debug().
-		Str("query", query).
+		Str("query", sqlutil.ForLog(query)).
 		Dur("elapsed", elapsed).
 		Msg("Exec completed")
 
@@ -1855,7 +1856,7 @@ func (d *DuckDB) QueryWithProfileContext(ctx context.Context, query string) (*sq
 	profile := d.parseProfileOutput(profilePath, totalTime)
 
 	d.logger.Debug().
-		Str("query", query).
+		Str("query", sqlutil.ForLog(query)).
 		Float64("total_ms", profile.TotalMs).
 		Float64("planner_ms", profile.PlannerMs).
 		Float64("execution_ms", profile.ExecutionMs).
@@ -1892,12 +1893,12 @@ func (d *DuckDB) parseProfileOutput(path string, totalTime time.Duration) *Query
 		return profile
 	}
 
-	// Debug: log raw JSON to understand structure
-	d.logger.Debug().Str("raw_json", string(data[:min(500, len(data))])).Msg("DuckDB profile JSON")
-
+	// NOTE: no raw-JSON debug dump here. The profile JSON embeds the full query
+	// text ("query_name": <sql>) within its first bytes, so even a truncated dump
+	// leaks query content into logs. Log sizes/errors, never the payload.
 	var output duckdbProfileOutput
 	if err := json.Unmarshal(data, &output); err != nil {
-		d.logger.Debug().Err(err).Str("raw", string(data[:min(200, len(data))])).Msg("Failed to parse profile JSON")
+		d.logger.Debug().Err(err).Int("profile_bytes", len(data)).Msg("Failed to parse profile JSON")
 		return profile
 	}
 

--- a/internal/database/duckdb_arrow.go
+++ b/internal/database/duckdb_arrow.go
@@ -8,6 +8,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"os"
 	"path/filepath"
 	"time"
@@ -59,7 +60,7 @@ func (d *DuckDB) ArrowQueryContext(ctx context.Context, query string) (array.Rec
 	}
 
 	d.logger.Debug().
-		Str("query", query).
+		Str("query", sqlutil.ForLog(query)).
 		Msg("Arrow query executed")
 
 	return reader, conn, nil

--- a/internal/logger/errsanitize.go
+++ b/internal/logger/errsanitize.go
@@ -1,0 +1,43 @@
+package logger
+
+import (
+	"github.com/rs/zerolog"
+
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
+)
+
+// installErrSanitizer sets the process-wide zerolog error marshaller so that
+// EVERY `Err(err)` log field is sanitized before it reaches a log line.
+//
+// Why this exists: the DuckDB driver's error strings echo user data back —
+// every Parser/Binder/Conversion error quotes the offending literal in its
+// message AND appends the full query text verbatim in a "LINE 1: …" context
+// block. There are ~77 `Err(err)` sites on the query paths alone, so masking
+// the `sql=` log fields while logging errors unmasked would achieve nothing on
+// exactly the paths (failures) where those logs fire. One hook here covers all
+// of them, plus every future `Err(err)` site, plus arcx-engine errors crossing
+// the FFI (whose messages echo user-supplied paths).
+//
+// What it does, in order:
+//  1. Cut everything from the first "\nLINE " onward — that block is a verbatim
+//     copy of the query, pure duplication of the (masked) `sql=` field.
+//  2. Keep only the first line of what remains (drops "Candidate bindings" and
+//     raw-value echo lines some error classes append).
+//  3. Mask quoted spans in BOTH styles ('…' and "…"): engine messages quote
+//     offending values with either. The message CLASS ("Could not convert
+//     string '…' to INT64") survives; the value does not.
+//
+// Trade-off, accepted deliberately: the hook is global, so quoted spans in
+// non-query errors (config values, filenames) are masked too. Uniform posture
+// — "every logged error is sanitized" — is a one-sentence claim a reviewer can
+// verify; a per-site wrapper would be a convention that erodes.
+func installErrSanitizer() {
+	zerolog.ErrorMarshalFunc = func(err error) interface{} {
+		if err == nil {
+			return nil
+		}
+		return sanitizeErrText(err.Error())
+	}
+}
+
+func sanitizeErrText(s string) string { return sqlutil.SanitizeErrText(s) }

--- a/internal/logger/errsanitize_test.go
+++ b/internal/logger/errsanitize_test.go
@@ -1,0 +1,42 @@
+package logger
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// A fabricated DuckDB-shaped error: quoted value + LINE echo of the full query.
+func TestSanitizeErrTextStripsQueryEchoAndValues(t *testing.T) {
+	raw := "Conversion Error: Could not convert string 'ZZSENTINELZZ' to INT64\n" +
+		"\nLINE 1: SELECT v FROM cpu WHERE host = 'ZZSENTINELZZ'\n" +
+		"                                        ^"
+	got := sanitizeErrText(raw)
+	if strings.Contains(got, "ZZSENTINELZZ") {
+		t.Fatalf("sentinel leaked: %q", got)
+	}
+	if strings.Contains(got, "LINE 1") || strings.Contains(got, "SELECT") {
+		t.Fatalf("query echo survived: %q", got)
+	}
+	if !strings.Contains(got, "Could not convert string") {
+		t.Fatalf("message class lost: %q", got)
+	}
+}
+
+// The hook must actually be installed by Setup, and fire on Err(err).
+func TestErrSanitizerInstalledBySetup(t *testing.T) {
+	Setup("info", "json")
+	var buf strings.Builder
+	// zerolog's ErrorMarshalFunc is package-global; any logger picks it up.
+	l := zerolog.New(&buf)
+	l.Error().Err(errors.New("bad value 'ZZSENTINELZZ' here\nLINE 1: SELECT 'ZZSENTINELZZ'")).Msg("x")
+	out := buf.String()
+	if strings.Contains(out, "ZZSENTINELZZ") {
+		t.Fatalf("Err(err) leaked the sentinel: %s", out)
+	}
+	if !strings.Contains(out, "bad value") {
+		t.Fatalf("error text vanished entirely: %s", out)
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -16,6 +16,10 @@ func Setup(level, format string) {
 	logLevel := parseLevel(level)
 	zerolog.SetGlobalLevel(logLevel)
 
+	// Sanitize every Err(err) field process-wide BEFORE any logger exists —
+	// engine error strings echo user query text (see errsanitize.go).
+	installErrSanitizer()
+
 	// Set output format
 	var baseOutput io.Writer = os.Stdout
 	if strings.ToLower(format) == "console" {

--- a/internal/pruning/partition_pruner.go
+++ b/internal/pruning/partition_pruner.go
@@ -464,7 +464,10 @@ func (p *PartitionPruner) ExtractTimeRange(sqlStr string) *TimeRange {
 	// Get the masked WHERE clause, then unmask it to get actual time values
 	maskedWhereClause := matches[1]
 	whereClause := sql.UnmaskStringLiterals(maskedWhereClause, masks)
-	p.logger.Debug().Str("where_clause", whereClause[:min(100, len(whereClause))]).Msg("Analyzing WHERE clause")
+	// The clause was just deliberately UNMASKED for analysis, so mask it for the
+	// log. Truncating before masking is safe: a cut mid-literal leaves it
+	// unterminated, and ForLog masks unterminated literals to the end.
+	p.logger.Debug().Str("where_clause", sql.ForLog(whereClause[:min(200, len(whereClause))])).Msg("Analyzing WHERE clause")
 
 	var startTime, endTime *time.Time
 

--- a/internal/sql/forlog.go
+++ b/internal/sql/forlog.go
@@ -1,0 +1,212 @@
+package sql
+
+import "strings"
+
+// ForLog returns sql with every string-literal BODY replaced by `...`, for use
+// in log fields. The statement's shape stays diagnosable (`WHERE host = '...'`);
+// the values are gone. This is the log-side counterpart of the slow-query log's
+// masking precedent, with one deliberate difference:
+//
+// It does NOT reuse MaskStringLiterals. That scanner treats backslash as an
+// escape inside plain '...' strings; DuckDB does not (backslash is a literal
+// character there — only E'...' strings honor it). Reusing it would mean a
+// value legitimately ending in `\` (a Windows path, a regex) shifts every
+// subsequent literal boundary and logs alternating literal CONTENTS in the
+// clear — an under-mask leak on benign input. The scanner below follows
+// DuckDB's actual rules. MaskStringLiterals itself is left untouched: it is
+// hardened round-trip code on the query-rewrite path, and its escape rule is
+// load-bearing there.
+//
+// Rules:
+//   - '...'   standard string: only ” escapes a quote; backslash is literal.
+//     Body → `...`.
+//   - E'...'  escape string: backslash escapes (incl. \'), ” also escapes.
+//     Body → `...`.
+//   - $tag$...$tag$ dollar-quoted string: body → `...`, emitted as $$...$$.
+//   - "..."   quoted IDENTIFIER: kept verbatim (operators need names to act on
+//     a log line; identifiers are schema vocabulary, not row data) —
+//     but scanned properly ("" escape) so a quote inside an identifier
+//     cannot derail literal detection.
+//   - -- and /* */ comment BODIES are masked too: they are arbitrary user text,
+//     same class as a literal.
+//   - Anything unterminated is masked to end of input (fail closed).
+func ForLog(sql string) string {
+	var b strings.Builder
+	b.Grow(len(sql))
+	i := 0
+	n := len(sql)
+	for i < n {
+		c := sql[i]
+		switch {
+		case c == '\'':
+			// Standard string. E-string is handled below before we get here.
+			b.WriteString("'...'")
+			i = skipStdString(sql, i+1)
+		case (c == 'E' || c == 'e') && i+1 < n && sql[i+1] == '\'' && !identChar(prevByte(sql, i)):
+			b.WriteString("E'...'")
+			i = skipEscString(sql, i+2)
+		case c == '$':
+			if end, tagLen, ok := scanDollarQuote(sql, i); ok {
+				b.WriteString("$$...$$")
+				i = end
+				_ = tagLen
+			} else {
+				b.WriteByte(c)
+				i++
+			}
+		case c == '"':
+			// Quoted identifier: copy verbatim, honoring "" escapes.
+			j := skipQuotedIdent(sql, i+1)
+			b.WriteString(sql[i:min(j, n)])
+			i = j
+		case c == '-' && i+1 < n && sql[i+1] == '-':
+			b.WriteString("--...")
+			for i < n && sql[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < n && sql[i+1] == '*':
+			b.WriteString("/*...*/")
+			i += 2
+			for i+1 < n && !(sql[i] == '*' && sql[i+1] == '/') {
+				i++
+			}
+			if i+1 < n {
+				i += 2
+			} else {
+				i = n
+			}
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// skipStdString returns the index just past the closing quote of a standard
+// '...' string whose opening quote is at i-1. Only ” escapes; backslash is a
+// literal character (DuckDB semantics).
+func skipStdString(sql string, i int) int {
+	n := len(sql)
+	for i < n {
+		if sql[i] == '\'' {
+			if i+1 < n && sql[i+1] == '\'' {
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return n // unterminated: consume the rest (fail closed)
+}
+
+// skipEscString is skipStdString for E'...' strings, where backslash escapes.
+func skipEscString(sql string, i int) int {
+	n := len(sql)
+	for i < n {
+		switch sql[i] {
+		case '\\':
+			i += 2
+			continue
+		case '\'':
+			if i+1 < n && sql[i+1] == '\'' {
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return n
+}
+
+// skipQuotedIdent returns the index just past the closing double quote, with
+// "" as the escape.
+func skipQuotedIdent(sql string, i int) int {
+	n := len(sql)
+	for i < n {
+		if sql[i] == '"' {
+			if i+1 < n && sql[i+1] == '"' {
+				i += 2
+				continue
+			}
+			return i + 1
+		}
+		i++
+	}
+	return n
+}
+
+// scanDollarQuote matches $tag$...$tag$ starting at i (sql[i] == '$'). Returns
+// (index past the closing delimiter, tag length, true) on a match.
+func scanDollarQuote(sql string, i int) (int, int, bool) {
+	n := len(sql)
+	j := i + 1
+	for j < n && identChar(sql[j]) {
+		j++
+	}
+	if j >= n || sql[j] != '$' {
+		return 0, 0, false
+	}
+	delim := sql[i : j+1] // "$tag$" (or "$$")
+	body := j + 1
+	end := strings.Index(sql[body:], delim)
+	if end < 0 {
+		return n, len(delim) - 2, true // unterminated: consume the rest
+	}
+	return body + end + len(delim), len(delim) - 2, true
+}
+
+func identChar(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// prevByte is shared with mask.go.
+
+// SanitizeErrText prepares an ERROR STRING for logging or storage: cut the
+// engine's "LINE 1: <query>" echo block (verbatim user query text), keep only
+// the first line (drops candidate-binding and raw-value echo lines), then mask
+// quoted values. Used by the global zerolog Err() hook AND by call sites that
+// PERSIST error strings (the query registry), which the log hook cannot reach.
+func SanitizeErrText(s string) string {
+	if i := strings.Index(s, "\nLINE "); i >= 0 {
+		s = s[:i]
+	}
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return MaskErrText(s)
+}
+
+// MaskErrText masks quoted spans in ERROR TEXT (not SQL): both '...' and "..."
+// spans are masked, because engine error messages quote offending VALUES with
+// either style ("Could not convert string 'x' …", `invalid timestamp "y"`).
+// This deliberately differs from ForLog, which keeps double-quoted identifiers
+// — an error message's double-quoted span is usually a value or a name copied
+// from user input, and the message class survives without it.
+func MaskErrText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	n := len(s)
+	for i < n {
+		c := s[i]
+		if c == '\'' || c == '"' {
+			b.WriteByte(c)
+			b.WriteString("...")
+			b.WriteByte(c)
+			i++
+			for i < n && s[i] != c {
+				i++
+			}
+			if i < n {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
+}

--- a/internal/sql/forlog_guard_test.go
+++ b/internal/sql/forlog_guard_test.go
@@ -1,0 +1,123 @@
+package sql
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The guard: no log field carrying SQL-shaped content may be emitted without
+// passing through ForLog (or SanitizeErrText for error strings). This is what
+// keeps "site #34" from regressing after the sweep — a grep-shaped review
+// missed `where`, `engine_sql`, `raw_json` and `diff` in this very tree, so the
+// rule is AST-based and two-sided:
+//
+//	(a) key denylist  — Str("sql"|"query"|"where"|…, …)
+//	(b) value taint   — any identifier in the value ending in sql/query/where/
+//	                    clause (case-insensitive), whatever the key is called
+//
+// Exemptions: identifiers ending in ID/Id/Name (query_id, query_name), and an
+// explicit allowlist with written justifications.
+var guardKeyDenylist = map[string]bool{
+	"sql": true, "query": true, "converted_sql": true, "engine_sql": true,
+	"oracle_sql": true, "where": true, "statement": true, "stmt": true,
+	"raw": true, "raw_json": true, "diff": true,
+}
+
+var guardValueTaint = regexp.MustCompile(`(?i)(sql|query|where|clause)$`)
+var guardValueExempt = regexp.MustCompile(`(Id|ID|Name|Timeout|Count)$`)
+
+// file:key → justification. Keep this SHORT; every entry is a reviewed decision.
+var guardAllowlist = map[string]string{
+	"internal/arcxrouter/router.go:diff": "value-free by construction — compare.go producers emit divergence class/position only, never values",
+}
+
+func TestNoUnmaskedSQLLogFields(t *testing.T) {
+	root := filepath.Join("..", "..") // repo root from internal/sql
+	var violations []string
+	err := filepath.WalkDir(filepath.Join(root, "internal"), func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil // files behind build tags we can't satisfy still parse; real parse errors are CI's problem
+		}
+		rel, _ := filepath.Rel(root, path)
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) != 2 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Str" {
+				return true
+			}
+			keyLit, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || keyLit.Kind != token.STRING {
+				return true
+			}
+			key := strings.Trim(keyLit.Value, `"`)
+			tainted := guardKeyDenylist[key]
+			if !tainted {
+				ast.Inspect(call.Args[1], func(vn ast.Node) bool {
+					if id, ok := vn.(*ast.Ident); ok {
+						if guardValueTaint.MatchString(id.Name) && !guardValueExempt.MatchString(id.Name) {
+							tainted = true
+						}
+					}
+					return true
+				})
+			}
+			if !tainted {
+				return true
+			}
+			if _, ok := guardAllowlist[rel+":"+key]; ok {
+				return true
+			}
+			masked := false
+			ast.Inspect(call.Args[1], func(vn ast.Node) bool {
+				if id, ok := vn.(*ast.Ident); ok && (id.Name == "ForLog" || id.Name == "SanitizeErrText") {
+					masked = true
+				}
+				return true
+			})
+			if !masked {
+				pos := fset.Position(call.Pos())
+				violations = append(violations,
+					pos.Filename+":"+itoa(pos.Line)+" Str(\""+key+"\", …) without sqlutil.ForLog")
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range violations {
+		t.Error(v)
+	}
+	if len(violations) > 0 {
+		t.Fatalf("%d unmasked SQL log field(s); wrap with sqlutil.ForLog or add a justified allowlist entry", len(violations))
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [12]byte
+	p := len(b)
+	for i > 0 {
+		p--
+		b[p] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[p:])
+}

--- a/internal/sql/forlog_test.go
+++ b/internal/sql/forlog_test.go
@@ -1,0 +1,69 @@
+package sql
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestForLogMasksLiterals(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`SELECT v FROM cpu WHERE host = 'prod-db-07'`,
+			`SELECT v FROM cpu WHERE host = '...'`},
+		// Doubled-quote escape stays inside ONE literal.
+		{`WHERE note = 'It''s secret'`, `WHERE note = '...'`},
+		// THE BACKSLASH CASE (the shared masker's leak): backslash is a literal
+		// char in standard strings, so the first literal ends at the next quote
+		// and the second literal's content must NOT surface.
+		{`WHERE a = 'x\' AND password = 'secret123'`,
+			`WHERE a = '...' AND password = '...'`},
+		// E-strings DO honor backslash: \' stays inside.
+		{`WHERE a = E'x\' still inside' AND b = 'v'`,
+			`WHERE a = E'...' AND b = '...'`},
+		// Dollar quoting.
+		{`WHERE a = $$raw secret$$`, `WHERE a = $$...$$`},
+		{`WHERE a = $tag$raw ' secret$tag$ AND b='v'`, `WHERE a = $$...$$ AND b='...'`},
+		// Quoted identifiers survive; a quote inside one can't derail scanning.
+		{`SELECT "weird""col" FROM t WHERE x='v'`, `SELECT "weird""col" FROM t WHERE x='...'`},
+		// Comments are user text.
+		{"SELECT v FROM t -- note: acme-corp\nWHERE x='v'", "SELECT v FROM t --...\nWHERE x='...'"},
+		{`SELECT v /* acme */ FROM t`, `SELECT v /*...*/ FROM t`},
+		// Unterminated masks to the end (fail closed).
+		{`WHERE a = 'never closed and secret`, `WHERE a = '...'`},
+		// Identifier ending in E is not an E-string prefix.
+		{`SELECT CASE WHEN mode='x' THEN 1 END`, `SELECT CASE WHEN mode='...' THEN 1 END`},
+	}
+	for _, c := range cases {
+		if got := ForLog(c.in); got != c.want {
+			t.Errorf("ForLog(%q)\n  got  %q\n  want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestForLogSentinels(t *testing.T) {
+	probes := []string{
+		`SELECT v FROM cpu WHERE host = 'ZZSENTINELZZ' AND t = 'ZZ2'`,
+		`WHERE a = 'x\' AND b = 'ZZSENTINELZZ'`,
+		`WHERE a = E'\' ZZSENTINELZZ'`,
+		`WHERE a = $q$ZZSENTINELZZ$q$`,
+		"-- ZZSENTINELZZ\nSELECT 1",
+		`WHERE a = 'ZZSENTINELZZ`, // unterminated
+	}
+	for _, p := range probes {
+		if got := ForLog(p); strings.Contains(got, "ZZSENTINELZZ") {
+			t.Errorf("sentinel leaked: ForLog(%q) = %q", p, got)
+		}
+	}
+}
+
+func TestMaskErrTextMasksBothQuoteStyles(t *testing.T) {
+	in := `Conversion Error: Could not convert string 'secret-host-42' to INT64 near "2026-99-99"`
+	got := MaskErrText(in)
+	for _, leak := range []string{"secret-host-42", "2026-99-99"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("leaked %q in %q", leak, got)
+		}
+	}
+	if !strings.Contains(got, "Could not convert string") {
+		t.Errorf("message class lost: %q", got)
+	}
+}


### PR DESCRIPTION
Server logs captured user data on two channels (verified live on a stock build):

1. **Failed queries logged full SQL** — literals included — in `sql=` fields at ERROR, plus one
   Info-level DELETE `where=` field on the healthy path.
2. **The DuckDB driver's error strings echo the offending value and the entire query line**
   (`LINE 1: …`) through every `Err(err)` call — so masking the `sql=` fields alone would have
   been cosmetic. This channel (~77 sites) was the majority of the surface.

Client responses are unchanged: the requester already has their own query.

## Mechanisms

**`sqlutil.ForLog`** — a DuckDB-exact literal masker for log fields. Deliberately does *not*
reuse `MaskStringLiterals`: that scanner treats backslash as an escape in plain strings, which
DuckDB does not — a value legitimately ending in `\` shifts literal boundaries and logs the
*next* literal in the clear (reproduced in review). Statement shape stays diagnosable
(`WHERE host = '...'`): operators keep identifiers, lose values. The slow-query log migrates to
it.

**A process-wide `zerolog.ErrorMarshalFunc`** — cuts the `LINE` query echo, keeps the first
line, masks quoted spans in both styles. One ~20-line hook covers all `Err(err)` sites and every
future one. `SanitizeErrText` is also applied where error strings are *persisted* (query
registry), which the log hook cannot reach.

**An AST guard test** — key denylist + value-taint rule (any identifier ending in
sql/query/where/clause); passes only via `ForLog`/`SanitizeErrText` or a justified allowlist
entry. On its **first run it caught 7 sites the manual survey missed**, including one introduced
by this very change in a two-step form — exactly the regression class it exists to block.

Also: shadow-compare mismatch diagnostics no longer print result values (divergence class +
position only), and the profile raw-JSON debug dumps are removed (the profile embeds the full
query in its first bytes).

## Before / after (same failing-query repro, stock build)

```
before: error="…LINE 1: SELECT … WHERE host = 'SECRET…'…" sql="… WHERE host = 'SECRET…'"
after:  error="…Binder Error: Referenced column \"...\" not found!" sql="… WHERE host = '...'"
```

Sentinel occurrences in the log: **2 → 0**, on both JSON and msgpack endpoints.

## Scope, decided explicitly

- Numeric literals stay unmasked in v1: Arc pre-rewrites time functions to epoch math, so
  masking numbers destroys the time-range diagnostics that make slow/failed-query logs useful;
  the domain's sensitive vocabulary (hosts, tenants, tokens, paths) is strings.
- Client-visible error echo accepted (requester's own query).

## Verification

- `go build`/`go vet -tags=duckdb_arrow ./...` clean; tagged vet clean
- `-race` green on all touched packages, including `internal/api`
- Guard + sentinel tests green (incl. the backslash boundary-shift case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)