### PR TITLE
feat(arcxrouter): recognize ungrouped aggregation shapes (scan_agg)

### DIFF
--- a/internal/arcxrouter/agg_recognizer_test.go
+++ b/internal/arcxrouter/agg_recognizer_test.go
@@ -1,0 +1,106 @@
+// Recognizer tests for the agg-1 ungrouped-aggregation shape (scan_agg). Pure
+// tokenizer tests — no engine, no cgo, run in every build mode.
+
+package arcxrouter
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestScanAggRecognized(t *testing.T) {
+	cases := []struct {
+		sql       string
+		items     []string
+		whereText string
+	}{
+		// The headline shape: count(*) with a data-column WHERE.
+		{
+			"SELECT count(*) FROM cpu WHERE host = 'a'",
+			[]string{"count(*)"},
+			"host = 'a'",
+		},
+		// Multi-aggregate dashboard shape.
+		{
+			"SELECT count(*), avg(usage_user) FROM cpu WHERE host = 'a'",
+			[]string{"count(*)", "avg(usage_user)"},
+			"host = 'a'",
+		},
+		// sum/avg have no footer shape — recognized with or without WHERE.
+		{
+			"SELECT sum(value) FROM cpu",
+			[]string{"sum(value)"},
+			"",
+		},
+		// min/max with WHERE fall past the footer scalar matcher into scan_agg.
+		{
+			"SELECT min(time), max(time) FROM cpu WHERE host = 'a'",
+			[]string{"min(time)", "max(time)"},
+			"host = 'a'",
+		},
+		// Function name lowercased; ARGUMENT spelling preserved (client-visible
+		// derived name `sum(X)` — canonicalizing the arg would change it).
+		{
+			"SELECT SUM(X) FROM cpu WHERE X > 1",
+			[]string{"sum(X)"},
+			"X > 1",
+		},
+		// Boolean-tree WHERE reuses the scan's re-serialization.
+		{
+			"SELECT count(*), sum(x) FROM cpu WHERE host = 'a' OR x > 3",
+			[]string{"count(*)", "sum(x)"},
+			"host = 'a' OR x > 3",
+		},
+	}
+	for _, c := range cases {
+		m, ok := eligibleShape(c.sql)
+		if !ok {
+			t.Fatalf("should be eligible: %s", c.sql)
+		}
+		if m.shape != ShapeScanAgg {
+			t.Fatalf("shape = %q, want scan_agg: %s", m.shape, c.sql)
+		}
+		if !reflect.DeepEqual(m.aggItems, c.items) {
+			t.Fatalf("items = %v, want %v: %s", m.aggItems, c.items, c.sql)
+		}
+		if m.whereText != c.whereText {
+			t.Fatalf("whereText = %q, want %q: %s", m.whereText, c.whereText, c.sql)
+		}
+	}
+}
+
+func TestScanAggFooterShapesKeepFirstRefusal(t *testing.T) {
+	// No-WHERE single aggregates stay on their proven footer shapes; the engine
+	// itself routes footer-first for these.
+	for sql, shape := range map[string]string{
+		"SELECT count(*) FROM cpu":  ShapeCountStar,
+		"SELECT count(x) FROM cpu":  ShapeCountCol,
+		"SELECT min(time) FROM cpu": ShapeMinCol,
+		"SELECT max(time) FROM cpu": ShapeMaxCol,
+	} {
+		m, ok := eligibleShape(sql)
+		if !ok || m.shape != shape {
+			t.Fatalf("eligibleShape(%q) = (%q, %t), want (%q, true)", sql, m.shape, ok, shape)
+		}
+	}
+}
+
+func TestScanAggDeclines(t *testing.T) {
+	for _, sql := range []string{
+		// Later slices / engine-declined shapes must stay off the arcx path.
+		"SELECT count(*) FROM cpu GROUP BY host",
+		"SELECT count(*) FROM cpu WHERE x > 1 ORDER BY 1",
+		"SELECT count(*) FROM cpu WHERE x > 1 LIMIT 1",
+		"SELECT count(DISTINCT x) FROM cpu",
+		"SELECT sum(a * b) FROM cpu",
+		"SELECT sum(*) FROM cpu",
+		"SELECT host, count(*) FROM cpu",          // mixed list
+		"SELECT count(*) AS c FROM cpu WHERE x=1", // alias
+		"SELECT median(x) FROM cpu WHERE x > 1",   // unsupported aggregate
+		"SELECT sum(x) FROM cpu WHERE",            // dangling WHERE
+	} {
+		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScanAgg {
+			t.Fatalf("must not match scan_agg: %s", sql)
+		}
+	}
+}

--- a/internal/arcxrouter/build_agg_sql_test.go
+++ b/internal/arcxrouter/build_agg_sql_test.go
@@ -1,0 +1,54 @@
+// Engine-SQL construction tests for the agg-1 shape. Tagged: buildScanAggSQL
+// lives in the engine-linked router.
+
+//go:build cgo && arcx_engine
+
+package arcxrouter
+
+import "testing"
+
+func TestBuildScanAggSQL(t *testing.T) {
+	paths := "['/base/db/cpu/2026/01/01/a.parquet']"
+	cases := []struct {
+		d    Decision
+		want string
+	}{
+		{
+			Decision{AggItems: []string{"count(*)"}, WhereText: "host = 'a'"},
+			"SELECT count(*) FROM read_parquet(['/base/db/cpu/2026/01/01/a.parquet']) WHERE host = 'a'",
+		},
+		{
+			Decision{AggItems: []string{"count(*)", "avg(usage_user)"}, WhereText: ""},
+			"SELECT count(*), avg(usage_user) FROM read_parquet(['/base/db/cpu/2026/01/01/a.parquet'])",
+		},
+		{
+			// Argument spelling preserved end-to-end (derived name parity).
+			Decision{AggItems: []string{"sum(X)"}, WhereText: "X > 1"},
+			"SELECT sum(X) FROM read_parquet(['/base/db/cpu/2026/01/01/a.parquet']) WHERE X > 1",
+		},
+	}
+	for _, c := range cases {
+		got, ok := buildScanAggSQL(c.d, paths)
+		if !ok || got != c.want {
+			t.Fatalf("buildScanAggSQL = (%q, %t), want %q", got, ok, c.want)
+		}
+	}
+}
+
+func TestBuildScanAggSQLDeclinesUnsafeItems(t *testing.T) {
+	paths := "['/p.parquet']"
+	for _, items := range [][]string{
+		{},                              // empty list
+		{"count(*) --"},                 // trailing junk
+		{"sum(x); DROP TABLE t"},        // injection attempt
+		{"sum(x')"},                     // non-ident arg
+		{"median(x)"},                   // unknown fn
+		{"sum(a, b)"},                   // arity
+		{"SUM(x)"},                      // fn not lowercased = not our serialization
+		{"sum(x)", "count(*) OR 1 = 1"}, // second item unsafe
+	} {
+		if got, ok := buildScanAggSQL(Decision{AggItems: items}, paths); ok {
+			t.Fatalf("must decline unsafe items %v, got %q", items, got)
+		}
+	}
+}

--- a/internal/arcxrouter/compare_agg.go
+++ b/internal/arcxrouter/compare_agg.go
@@ -1,0 +1,181 @@
+// Agg-1 (Phase 3 slice 1) shadow comparison: one row, N aggregate columns.
+//
+// Policy (mirrors the engine's differential harness, arcx plan
+// 2026-08-26-phase3-agg1 F2/F6/F7):
+//   - count / count(*): exact int64.
+//   - min / max: exact numeric — float compares with == (which already treats
+//     -0.0 == 0.0, the DuckDB first-encountered-wins ±0.0 case that is not
+//     oracle-able), and two NaNs compare EQUAL (NaN is a legitimate shared
+//     answer, and NaN != NaN would false-alarm every NaN-bearing column).
+//   - sum / avg on floats: relative tolerance 1e-9 (absolute near zero). arcx's
+//     deterministic work-list-order combine and DuckDB's parallel reduction are
+//     different association orders; bit-matching is not a defined target.
+//   - sum on integers: DuckDB returns HUGEINT (the driver scans *big.Int); arcx
+//     returns int64 (Arc's decimal→int64 client contract). Compared exactly as
+//     big integers — a HUGEINT beyond int64 can't appear here, because the arcx
+//     side errors before a record exists.
+//
+// Diffs are VALUE-FREE (class only), same as every other comparator in this
+// package — mismatch logs must never leak query results.
+
+//go:build cgo && arcx_engine
+
+package arcxrouter
+
+import (
+	"database/sql"
+	"fmt"
+	"math"
+	"math/big"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+const aggFloatRelTol = 1e-9
+
+// aggCell is one oracle cell reduced to a comparable form. Exactly one of
+// (i, f, isNull) is meaningful per kind.
+type aggCell struct {
+	isNull bool
+	isInt  bool
+	i      *big.Int // isInt: count, integer sum, timestamp µs
+	f      float64  // !isInt: float sum/avg/min/max
+}
+
+// aggFromRows scans DuckDB's single aggregate row. The driver hands back int64
+// (count, int min/max), float64 (double aggs), time.Time (timestamp min/max),
+// *big.Int (HUGEINT integer sums), or nil (NULL aggregates over an empty set).
+func aggFromRows(rows *sql.Rows) ([]aggCell, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("duckdb agg returned no rows")
+	}
+	raw := make([]interface{}, len(cols))
+	ptrs := make([]interface{}, len(cols))
+	for i := range raw {
+		ptrs[i] = &raw[i]
+	}
+	if err := rows.Scan(ptrs...); err != nil {
+		return nil, err
+	}
+	if rows.Next() {
+		return nil, fmt.Errorf("duckdb agg returned more than one row")
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]aggCell, len(cols))
+	for i, v := range raw {
+		switch x := v.(type) {
+		case nil:
+			out[i] = aggCell{isNull: true}
+		case int64:
+			out[i] = aggCell{isInt: true, i: big.NewInt(x)}
+		case *big.Int:
+			out[i] = aggCell{isInt: true, i: x}
+		case float64:
+			out[i] = aggCell{f: x}
+		case time.Time:
+			out[i] = aggCell{isInt: true, i: big.NewInt(x.UnixMicro())}
+		default:
+			return nil, fmt.Errorf("duckdb agg col %d: unexpected type %T", i, v)
+		}
+	}
+	return out, nil
+}
+
+// aggFromArcx reduces arcx's 1×N record to the same cell form.
+func aggFromArcx(rec arrow.Record) ([]aggCell, error) {
+	if rec.NumRows() != 1 {
+		return nil, fmt.Errorf("arcx agg expected 1 row, got %d", rec.NumRows())
+	}
+	out := make([]aggCell, rec.NumCols())
+	for c := 0; c < int(rec.NumCols()); c++ {
+		switch col := rec.Column(c).(type) {
+		case *array.Int64:
+			if col.IsNull(0) {
+				out[c] = aggCell{isNull: true}
+			} else {
+				out[c] = aggCell{isInt: true, i: big.NewInt(col.Value(0))}
+			}
+		case *array.Float64:
+			if col.IsNull(0) {
+				out[c] = aggCell{isNull: true}
+			} else {
+				out[c] = aggCell{f: col.Value(0)}
+			}
+		case *array.Timestamp:
+			if col.IsNull(0) {
+				out[c] = aggCell{isNull: true}
+			} else {
+				unit := col.DataType().(*arrow.TimestampType).Unit
+				out[c] = aggCell{isInt: true, i: big.NewInt(toMicros(int64(col.Value(0)), unit))}
+			}
+		default:
+			return nil, fmt.Errorf("arcx agg col %d: unexpected type %T", c, rec.Column(c))
+		}
+	}
+	return out, nil
+}
+
+// aggItemTolerant reports whether the item's float result carries the documented
+// tolerance (sum/avg — order-dependent reductions). min/max/count stay exact.
+func aggItemTolerant(item string) bool {
+	return len(item) > 4 && (item[:4] == "sum(" || item[:4] == "avg(")
+}
+
+// compareAgg returns "" on match, else a short VALUE-FREE diff.
+func compareAgg(rec arrow.Record, oracle []aggCell, items []string) string {
+	got, err := aggFromArcx(rec)
+	if err != nil {
+		return "arcx agg decode error: " + err.Error()
+	}
+	if len(got) != len(oracle) {
+		return fmt.Sprintf("agg column count differs (arcx=%d duckdb=%d)", len(got), len(oracle))
+	}
+	for c := range got {
+		a, d := got[c], oracle[c]
+		if a.isNull != d.isNull {
+			return fmt.Sprintf("agg col %d differs (null-ness: arcx_null=%t duckdb_null=%t)", c, a.isNull, d.isNull)
+		}
+		if a.isNull {
+			continue
+		}
+		if a.isInt != d.isInt {
+			// One side numeric-int, the other float — a type divergence (e.g. a
+			// shape mapping bug), not a value difference.
+			return fmt.Sprintf("agg col %d differs (kind: arcx_int=%t duckdb_int=%t)", c, a.isInt, d.isInt)
+		}
+		if a.isInt {
+			if a.i.Cmp(d.i) != 0 {
+				return fmt.Sprintf("agg col %d differs (int values withheld from log)", c)
+			}
+			continue
+		}
+		// Float cell. Two NaNs agree; one-sided NaN is a real divergence.
+		if math.IsNaN(a.f) || math.IsNaN(d.f) {
+			if math.IsNaN(a.f) && math.IsNaN(d.f) {
+				continue
+			}
+			return fmt.Sprintf("agg col %d differs (NaN-ness: arcx_nan=%t duckdb_nan=%t)", c, math.IsNaN(a.f), math.IsNaN(d.f))
+		}
+		tolerant := c < len(items) && aggItemTolerant(items[c])
+		if tolerant {
+			scale := math.Max(math.Abs(a.f), math.Abs(d.f))
+			if math.Abs(a.f-d.f) > aggFloatRelTol*math.Max(scale, 1.0) {
+				return fmt.Sprintf("agg col %d differs (float beyond 1e-9 tolerance, values withheld)", c)
+			}
+		} else if a.f != d.f {
+			return fmt.Sprintf("agg col %d differs (float values withheld from log)", c)
+		}
+	}
+	return ""
+}

--- a/internal/arcxrouter/compare_agg_test.go
+++ b/internal/arcxrouter/compare_agg_test.go
@@ -1,0 +1,141 @@
+//go:build cgo && arcx_engine
+
+package arcxrouter
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// aggRec builds a 1-row record: each cell is nil (NULL), int64, or float64.
+func aggRec(t *testing.T, cells ...interface{}) arrow.Record {
+	t.Helper()
+	pool := memory.NewGoAllocator()
+	fields := make([]arrow.Field, len(cells))
+	cols := make([]arrow.Array, len(cells))
+	for i, c := range cells {
+		switch v := c.(type) {
+		case int64:
+			b := array.NewInt64Builder(pool)
+			b.Append(v)
+			cols[i] = b.NewArray()
+			fields[i] = arrow.Field{Name: "c", Type: arrow.PrimitiveTypes.Int64, Nullable: true}
+		case float64:
+			b := array.NewFloat64Builder(pool)
+			b.Append(v)
+			cols[i] = b.NewArray()
+			fields[i] = arrow.Field{Name: "c", Type: arrow.PrimitiveTypes.Float64, Nullable: true}
+		case nil:
+			b := array.NewFloat64Builder(pool)
+			b.AppendNull()
+			cols[i] = b.NewArray()
+			fields[i] = arrow.Field{Name: "c", Type: arrow.PrimitiveTypes.Float64, Nullable: true}
+		default:
+			t.Fatalf("unsupported cell %T", c)
+		}
+	}
+	return array.NewRecord(arrow.NewSchema(fields, nil), cols, 1)
+}
+
+func TestCompareAggMatches(t *testing.T) {
+	cases := []struct {
+		name   string
+		rec    arrow.Record
+		oracle []aggCell
+		items  []string
+	}{
+		{
+			"count and int sum exact (HUGEINT big.Int path)",
+			aggRec(t, int64(5), int64(1500)),
+			[]aggCell{{isInt: true, i: big.NewInt(5)}, {isInt: true, i: big.NewInt(1500)}},
+			[]string{"count(*)", "sum(x)"},
+		},
+		{
+			"float sum within 1e-9 relative tolerance",
+			aggRec(t, 73469570793.69745),
+			[]aggCell{{f: 73469570793.63945}},
+			[]string{"sum(value)"},
+		},
+		{
+			"min/max signed zero: -0.0 == 0.0 numerically",
+			aggRec(t, math.Copysign(0, -1), 0.0),
+			[]aggCell{{f: 0.0}, {f: math.Copysign(0, -1)}},
+			[]string{"min(f)", "max(f)"},
+		},
+		{
+			"both NaN agree",
+			aggRec(t, math.NaN()),
+			[]aggCell{{f: math.NaN()}},
+			[]string{"sum(f)"},
+		},
+		{
+			"empty-set NULLs agree",
+			aggRec(t, nil),
+			[]aggCell{{isNull: true}},
+			[]string{"avg(x)"},
+		},
+	}
+	for _, c := range cases {
+		if diff := compareAgg(c.rec, c.oracle, c.items); diff != "" {
+			t.Fatalf("%s: unexpected diff %q", c.name, diff)
+		}
+	}
+}
+
+func TestCompareAggMismatches(t *testing.T) {
+	cases := []struct {
+		name   string
+		rec    arrow.Record
+		oracle []aggCell
+		items  []string
+	}{
+		{
+			"int value differs",
+			aggRec(t, int64(5)),
+			[]aggCell{{isInt: true, i: big.NewInt(6)}},
+			[]string{"count(*)"},
+		},
+		{
+			"min/max floats are EXACT (no tolerance)",
+			aggRec(t, 1.0000000000001),
+			[]aggCell{{f: 1.0}},
+			[]string{"min(f)"},
+		},
+		{
+			"float sum beyond tolerance",
+			aggRec(t, 1.001),
+			[]aggCell{{f: 1.0}},
+			[]string{"sum(f)"},
+		},
+		{
+			"one-sided NaN is a divergence",
+			aggRec(t, math.NaN()),
+			[]aggCell{{f: 1.0}},
+			[]string{"sum(f)"},
+		},
+		{
+			"null-ness differs",
+			aggRec(t, nil),
+			[]aggCell{{f: 1.0}},
+			[]string{"avg(f)"},
+		},
+	}
+	for _, c := range cases {
+		diff := compareAgg(c.rec, c.oracle, c.items)
+		if diff == "" {
+			t.Fatalf("%s: expected a diff, got match", c.name)
+		}
+		// Value-free discipline: the diff class may name kinds, never values.
+		for _, leak := range []string{"5", "6", "1.0", "73469"} {
+			if strings.Contains(diff, leak) {
+				t.Fatalf("%s: diff leaks a value: %q", c.name, diff)
+			}
+		}
+	}
+}

--- a/internal/arcxrouter/eligibility.go
+++ b/internal/arcxrouter/eligibility.go
@@ -34,6 +34,8 @@ const (
 	ShapeCountCol = "count_col"
 	// Phase 2a general single-table scan: SELECT <cols> FROM m [WHERE <preds>].
 	ShapeScan = "scan"
+	// Phase 3 agg-1 ungrouped aggregation: SELECT <agg list> FROM m [WHERE ...].
+	ShapeScanAgg = "scan_agg"
 )
 
 // scanPred is one WHERE predicate `<col> <op> <literal>` from a scan. Exactly one
@@ -141,6 +143,9 @@ type matchResult struct {
 	// the tree authority.
 	orderBy []scanOrderKey // scan only: ORDER BY keys
 	limit   int            // scan only: LIMIT n (0 = none)
+	// scan_agg only: re-serialized aggregate items ("count(*)", "sum(colAsWritten)"),
+	// in select-list order — validated token-by-token in matchScanAgg.
+	aggItems []string
 }
 
 // eligibleShape recognizes the arcx shapes on the raw user SQL. ok=false means
@@ -186,6 +191,13 @@ func eligibleShape(sql string) (matchResult, bool) {
 	if fn, col, meas, ok := matchScalarAgg(toks); ok {
 		shape := map[string]string{"min": ShapeMinCol, "max": ShapeMaxCol, "count": ShapeCountCol}[fn]
 		return matchResult{shape: shape, col: col, measurement: meas}, true
+	}
+	// Agg-1 ungrouped aggregation: tried after the footer shapes (they keep first
+	// refusal — the engine itself routes footer-first) and before the scan. Catches
+	// the shapes the footer matchers just declined (a WHERE, a multi-agg list,
+	// sum/avg) — the engine's parse-level fall-through, mirrored.
+	if items, whereText, meas, ok := matchScanAgg(toks); ok {
+		return matchResult{shape: ShapeScanAgg, aggItems: items, whereText: whereText, measurement: meas}, true
 	}
 	// Scan is tried LAST: it's the broadest shape (a bare column list matches many
 	// SELECTs), so the specific aggregate shapes get first refusal.

--- a/internal/arcxrouter/eligibility_test.go
+++ b/internal/arcxrouter/eligibility_test.go
@@ -76,14 +76,13 @@ func TestEligibleShape_ScalarAggregates(t *testing.T) {
 
 func TestEligibleShape_ScalarDeclines(t *testing.T) {
 	for _, sql := range []string{
-		"SELECT min(time) FROM cpu WHERE x > 1",
 		"SELECT max(time) FROM cpu GROUP BY 1",
 		"SELECT min(time) AS m FROM cpu",
 		"SELECT min(time + 1) FROM cpu",
 		"SELECT min(*) FROM cpu",
-		"SELECT sum(value) FROM cpu",        // sum not supported (footers lack sums)
-		"SELECT avg(value) FROM cpu",        // avg not supported
-		"SELECT min(a), max(b) FROM cpu",    // two aggregates
+		// NOTE: `sum(value)`, `avg(value)`, `min(a), max(b)`, and WHERE-bearing
+		// scalar aggs are now ELIGIBLE (ShapeScanAgg, agg-1) — covered by
+		// TestScanAggRecognized. Only the still-declined forms remain here.
 		"SELECT min(time) FROM cpu, mem",    // two tables
 		"SELECT min(time) FROM cpu LIMIT 1", // trailing clause
 	} {
@@ -115,7 +114,8 @@ func TestEligibleShape_Declines(t *testing.T) {
 		{"date_trunc suffix", "SELECT date_truncx('day', time), count(*) FROM cpu GROUP BY 1"},
 
 		// --- count(*) declines ---
-		{"count with where", "SELECT count(*) FROM cpu WHERE x > 1"},
+		// NOTE: `count(*) ... WHERE` is now ELIGIBLE (ShapeScanAgg, agg-1) —
+		// the headline filtered-aggregation shape.
 		{"count with groupby", "SELECT count(*) FROM cpu GROUP BY host"},
 		{"count with limit", "SELECT count(*) FROM cpu LIMIT 10"},
 		{"count with join", "SELECT count(*) FROM cpu JOIN mem ON cpu.time = mem.time"},
@@ -123,7 +123,8 @@ func TestEligibleShape_Declines(t *testing.T) {
 		// decline. Its acceptance is covered by TestEligibleShape_ScalarAggregates.
 		{"count alias", "SELECT count(*) AS n FROM cpu"},
 		{"count two tables", "SELECT count(*) FROM cpu, mem"},
-		{"not count", "SELECT sum(x) FROM cpu"},
+		// NOTE: `sum(x)` is now ELIGIBLE (ShapeScanAgg, agg-1) — no longer a
+		// decline. Its acceptance is covered by TestScanAggRecognized.
 		{"select star", "SELECT * FROM cpu"},
 
 		// --- agg declines ---

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -107,6 +107,7 @@ type Decision struct {
 	WhereText string         // re-serialized WHERE: boolean tree for scan (2b-2), or a time-range filter for date_trunc agg (PR-A)
 	OrderBy   []scanOrderKey // scan only: ORDER BY keys
 	Limit     int            // scan only: LIMIT n (0 = none)
+	AggItems  []string       // scan_agg only: re-serialized aggregate items, select-list order
 }
 
 // Decide is the cheap per-query pre-filter. It never calls the engine; it only
@@ -147,6 +148,7 @@ func Decide(sql, headerDB string, h Handler) Decision {
 		WhereText: m.whereText,
 		OrderBy:   m.orderBy,
 		Limit:     m.limit,
+		AggItems:  m.aggItems,
 	}
 }
 
@@ -285,9 +287,63 @@ func (h Deps) buildEngineSQL(ctx context.Context, d Decision) (string, bool) {
 		return "SELECT " + fn + "(" + d.Col + ") FROM read_parquet(" + arr.String() + ")", true
 	case ShapeScan:
 		return buildScanSQL(d, arr.String())
+	case ShapeScanAgg:
+		return buildScanAggSQL(d, arr.String())
 	default:
 		return "", false
 	}
+}
+
+// buildScanAggSQL constructs the engine SQL for an ungrouped aggregation (agg-1):
+//
+//	SELECT <agg items> FROM read_parquet([<paths>]) [WHERE <tree>]
+//
+// Every item came from matchScanAgg's token-validated re-serialization; re-validate
+// the exact form here anyway (defense in depth vs a hand-built Decision) — decline
+// rather than emit unsafe SQL. The WHERE text was built by reserializeWhere (every
+// token re-validated, strings re-escaped), same as the scan's tree path.
+func buildScanAggSQL(d Decision, pathArray string) (string, bool) {
+	if len(d.AggItems) == 0 {
+		return "", false
+	}
+	var b strings.Builder
+	b.WriteString("SELECT ")
+	for i, item := range d.AggItems {
+		if !isAggItem(item) {
+			return "", false
+		}
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(item)
+	}
+	b.WriteString(" FROM read_parquet(")
+	b.WriteString(pathArray)
+	b.WriteByte(')')
+	if d.WhereText != "" {
+		b.WriteString(" WHERE ")
+		b.WriteString(d.WhereText)
+	}
+	return b.String(), true
+}
+
+// isAggItem re-validates one re-serialized aggregate item: `count(*)`, or
+// `{count|sum|min|max|avg}(<bare ident>)` with the fn lowercased — exactly what
+// matchScanAgg emits.
+func isAggItem(item string) bool {
+	if item == "count(*)" {
+		return true
+	}
+	open := strings.IndexByte(item, '(')
+	if open < 0 || !strings.HasSuffix(item, ")") {
+		return false
+	}
+	switch item[:open] {
+	case "count", "sum", "min", "max", "avg":
+	default:
+		return false
+	}
+	return isBareIdent(item[open+1 : len(item)-1])
 }
 
 // buildScanSQL constructs the engine SQL for a general single-table scan:
@@ -609,6 +665,13 @@ func (h Deps) compareToOracle(ctx context.Context, d Decision, rec arrow.Record)
 			return "", err
 		}
 		return compareScan(rec, oracle), nil
+	}
+	if d.Shape == ShapeScanAgg {
+		oracle, err := aggFromRows(rows)
+		if err != nil {
+			return "", err
+		}
+		return compareAgg(rec, oracle, d.AggItems), nil
 	}
 	if isScalarShape(d.Shape) {
 		oracle, err := scalarFromRows(rows)

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -619,6 +619,94 @@ func matchProjFunc(c *cursor, fnLower string) (string, bool) {
 	}
 }
 
+// matchScanAgg matches the agg-1 ungrouped-aggregation shape (Phase 3 slice 1):
+//
+//	select <agg> [, <agg>]* from <measurement> [where <pred tree>]
+//
+// where <agg> is `count(*)` or `{count|sum|min|max|avg}(<bare column>)`. Each item
+// is re-serialized from its VALIDATED tokens as `fn(colAsWritten)` — the function
+// name lowercased (both engines lowercase it in the derived output name anyway),
+// the argument's typed spelling preserved (DuckDB and arcx both echo it verbatim
+// in the derived name, so canonicalizing the arg would change the client-visible
+// column name). The WHERE reuses the scan's boolean-tree re-serialization — the
+// same injection-proof construction, the engine is the tree authority. Anything
+// after the WHERE (GROUP BY / ORDER BY / LIMIT / aliases) declines: those are
+// later slices and the engine declines them too.
+//
+// Tried AFTER the footer matchers (count(*)/scalar agg get first refusal — the
+// engine routes footer-first for those) and BEFORE matchScan.
+func matchScanAgg(toks []token) (items []string, whereText string, meas string, ok bool) {
+	c := &cursor{toks: toks}
+	if !c.ident("select") {
+		return nil, "", "", false
+	}
+	fail := func() ([]string, string, string, bool) { return nil, "", "", false }
+
+	for {
+		f, ok := c.next()
+		if !ok || f.kind != tokIdent {
+			return fail()
+		}
+		switch f.lower {
+		case "count", "sum", "min", "max", "avg":
+		default:
+			return fail()
+		}
+		if !c.punct('(') {
+			return fail()
+		}
+		// `count(*)` — the only star form. `sum(*)` etc. fall through to the
+		// bare-column requirement and decline.
+		if f.lower == "count" && c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '*' {
+			c.i++
+			if !c.punct(')') {
+				return fail()
+			}
+			items = append(items, "count(*)")
+		} else {
+			arg, ok := c.next()
+			if !ok || arg.kind != tokIdent || isScanKeyword(arg.lower) || arg.lower == "distinct" {
+				return fail()
+			}
+			// The immediately-following `)` requirement declines expressions
+			// (`sum(a*b)`) and DISTINCT — mirroring the engine's matcher.
+			if !c.punct(')') {
+				return fail()
+			}
+			items = append(items, f.lower+"("+arg.orig+")")
+		}
+		if c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == ',' {
+			c.i++
+			continue
+		}
+		break
+	}
+
+	if !c.ident("from") {
+		return fail()
+	}
+	mt, ok := c.next()
+	if !ok || mt.kind != tokIdent {
+		return fail()
+	}
+	meas = mt.orig
+
+	// Optional WHERE — ALWAYS the boolean-tree re-serialization (a flat AND is a
+	// tree too; the agg path has no flat-preds representation to maintain).
+	if c.peekIdentLower() == "where" {
+		c.next()
+		wt, ok := reserializeWhere(c)
+		if !ok {
+			return fail()
+		}
+		whereText = wt
+	}
+	if !c.atEnd() {
+		return fail()
+	}
+	return items, whereText, meas, true
+}
+
 func matchScan(toks []token) (cols []string, preds []scanPred, whereText string, orderBy []scanOrderKey, limit int, meas string, ok bool) {
 	c := &cursor{toks: toks}
 	if !c.ident("select") {


### PR DESCRIPTION
## What

Extends the engine router's recognizer with an aggregate select-list shape (\`scan_agg\`): \`count(*)\` / \`count|sum|min|max|avg(col)\` over the existing WHERE surface. The existing single-aggregate shapes keep first refusal. Adds a one-row shadow comparator for aggregate results (integer sums compared exactly via big.Int, a documented tolerance for float sum/avg, NaN/signed-zero handling) — diffs stay value-free.

Dev-only as before: everything is behind the \`cgo && arcx_engine\` build tags. Stock builds are unchanged — verified 0 engine symbols in the untagged binary, and both build modes compile, vet, and test clean (incl. tagged test files).

## Why

The engine side (arcX #56) proved these shapes against the oracle across its fixture corpus; this is the matching allow-list growth, derived from that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)