### PR TITLE
feat(arcxrouter): allow-list the first grouped shape (single-key count(*), no WHERE)

### DIFF
--- a/internal/arcxrouter/agg_recognizer_test.go
+++ b/internal/arcxrouter/agg_recognizer_test.go
@@ -104,3 +104,47 @@ func TestScanAggDeclines(t *testing.T) {
 		}
 	}
 }
+
+func TestGroupedCountOnlyRecognized(t *testing.T) {
+	cases := []struct {
+		sql   string
+		items []string
+		key   string
+	}{
+		{"SELECT host, count(*) FROM cpu GROUP BY host", []string{"host", "count(*)"}, "host"},
+		{"SELECT count(*), host FROM cpu GROUP BY host", []string{"count(*)", "host"}, "host"},
+		{"SELECT host, count(*) FROM cpu GROUP BY 1", []string{"host", "count(*)"}, "host"},
+		{"SELECT count(*), host FROM cpu GROUP BY 2", []string{"count(*)", "host"}, "host"},
+		{"SELECT host, count(*), count(*) FROM cpu GROUP BY host", []string{"host", "count(*)", "count(*)"}, "host"},
+	}
+	for _, c := range cases {
+		m, ok := eligibleShape(c.sql)
+		if !ok || m.shape != ShapeScanAggGroupedCount {
+			t.Fatalf("should be scan_agg_grouped_count: %s (got %q, %t)", c.sql, m.shape, ok)
+		}
+		if !reflect.DeepEqual(m.aggItems, c.items) || m.groupKey != c.key {
+			t.Fatalf("items/key = %v/%q, want %v/%q: %s", m.aggItems, m.groupKey, c.items, c.key, c.sql)
+		}
+	}
+}
+
+func TestGroupedCountOnlyDeclines(t *testing.T) {
+	for _, sql := range []string{
+		// Outside the allow-listed subclass — the engine serves wider grouped
+		// shapes but they have NOT cleared the perf gate (agg-2b record).
+		"SELECT host, count(*) FROM cpu WHERE x > 1 GROUP BY host", // WHERE-bearing
+		"SELECT host, sum(x) FROM cpu GROUP BY host",               // value aggregate
+		"SELECT host, count(x) FROM cpu GROUP BY host",             // count(col)
+		"SELECT host, region, count(*) FROM cpu GROUP BY host, region", // multi-key
+		"SELECT host FROM cpu GROUP BY host",                       // no count
+		"SELECT count(*) FROM cpu GROUP BY host",                   // key not projected
+		"SELECT host, count(*) FROM cpu GROUP BY region",           // wrong key
+		"SELECT host, count(*) FROM cpu GROUP BY 2",                // position at count
+		"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY 1",  // trailing
+		"SELECT host, count(*) FROM cpu GROUP BY host LIMIT 5",
+	} {
+		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScanAggGroupedCount {
+			t.Fatalf("must not match scan_agg_grouped_count: %s", sql)
+		}
+	}
+}

--- a/internal/arcxrouter/build_agg_sql_test.go
+++ b/internal/arcxrouter/build_agg_sql_test.go
@@ -52,3 +52,25 @@ func TestBuildScanAggSQLDeclinesUnsafeItems(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildGroupedCountSQL(t *testing.T) {
+	paths := "['/p.parquet']"
+	got, ok := buildGroupedCountSQL(Decision{
+		AggItems: []string{"count(*)", "host"},
+		GroupKey: "host",
+	}, paths)
+	want := "SELECT count(*), host FROM read_parquet(['/p.parquet']) GROUP BY host"
+	if !ok || got != want {
+		t.Fatalf("got (%q, %t), want %q", got, ok, want)
+	}
+	for _, d := range []Decision{
+		{AggItems: []string{"count(*)"}, GroupKey: "host"},              // no key item
+		{AggItems: []string{"host", "count(*)"}, GroupKey: "h; DROP"},   // unsafe key
+		{AggItems: []string{"host", "sum(x)"}, GroupKey: "host"},        // non-count item
+		{AggItems: []string{"host", "host", "count(*)"}, GroupKey: "host"}, // repeated key
+	} {
+		if got, ok := buildGroupedCountSQL(d, paths); ok {
+			t.Fatalf("must decline unsafe decision %v, got %q", d, got)
+		}
+	}
+}

--- a/internal/arcxrouter/compare_grouped.go
+++ b/internal/arcxrouter/compare_grouped.go
@@ -1,0 +1,156 @@
+// Shadow comparison for the allow-listed grouped shape (agg-2b): N rows of
+// (single group key, count(*) columns). Both sides sort by the TYPED key part
+// (plan F5: never a joined string; a single key makes this one part — Utf8 or
+// Int64 — with NULL ordered first), then compare row-wise: keys and counts
+// EXACT. Diffs stay value-free.
+
+//go:build cgo && arcx_engine
+
+package arcxrouter
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// groupedRow is one comparable grouped-count row: the key part (typed) and the
+// remaining cells as int64 counts in column order.
+type groupedRow struct {
+	keyNull bool
+	keyStr  string
+	keyInt  int64
+	keyIsI  bool
+	counts  []int64
+}
+
+func groupedLess(a, b *groupedRow) bool {
+	if a.keyNull != b.keyNull {
+		return a.keyNull
+	}
+	if a.keyIsI {
+		return a.keyInt < b.keyInt
+	}
+	return a.keyStr < b.keyStr
+}
+
+// groupedFromArcx extracts rows from arcx's record. `keyCol` is the key's
+// column index within the select list (from Decision.AggItems order).
+func groupedFromArcx(rec arrow.Record, keyCol int) ([]groupedRow, error) {
+	ncols := int(rec.NumCols())
+	if keyCol >= ncols {
+		return nil, fmt.Errorf("arcx grouped: key col %d out of %d", keyCol, ncols)
+	}
+	out := make([]groupedRow, rec.NumRows())
+	for r := range out {
+		row := &out[r]
+		for c := 0; c < ncols; c++ {
+			if c == keyCol {
+				switch col := rec.Column(c).(type) {
+				case *array.String:
+					if col.IsNull(r) {
+						row.keyNull = true
+					} else {
+						row.keyStr = col.Value(r)
+					}
+				case *array.Int64:
+					row.keyIsI = true
+					if col.IsNull(r) {
+						row.keyNull = true
+					} else {
+						row.keyInt = col.Value(r)
+					}
+				default:
+					return nil, fmt.Errorf("arcx grouped key: unexpected type %T", rec.Column(c))
+				}
+				continue
+			}
+			col, ok := rec.Column(c).(*array.Int64)
+			if !ok || col.IsNull(r) {
+				return nil, fmt.Errorf("arcx grouped count col %d: unexpected type/null", c)
+			}
+			row.counts = append(row.counts, col.Value(r))
+		}
+	}
+	return out, nil
+}
+
+func groupedFromRows(rows *sql.Rows, keyCol int) ([]groupedRow, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	var out []groupedRow
+	for rows.Next() {
+		raw := make([]interface{}, len(cols))
+		ptrs := make([]interface{}, len(cols))
+		for i := range raw {
+			ptrs[i] = &raw[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+		var row groupedRow
+		for c, v := range raw {
+			if c == keyCol {
+				switch x := v.(type) {
+				case nil:
+					row.keyNull = true
+				case string:
+					row.keyStr = x
+				case []byte:
+					row.keyStr = string(x)
+				case int64:
+					row.keyIsI = true
+					row.keyInt = x
+				case time.Time:
+					return nil, fmt.Errorf("duckdb grouped key: unexpected timestamp")
+				default:
+					return nil, fmt.Errorf("duckdb grouped key: unexpected type %T", v)
+				}
+				continue
+			}
+			x, ok := v.(int64)
+			if !ok {
+				return nil, fmt.Errorf("duckdb grouped count col %d: unexpected type %T", c, v)
+			}
+			row.counts = append(row.counts, x)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// compareGroupedCount returns "" on match, else a short VALUE-FREE diff.
+func compareGroupedCount(rec arrow.Record, oracle []groupedRow, keyCol int) string {
+	got, err := groupedFromArcx(rec, keyCol)
+	if err != nil {
+		return "arcx grouped decode error: " + err.Error()
+	}
+	if len(got) != len(oracle) {
+		return fmt.Sprintf("grouped row count differs (arcx=%d duckdb=%d)", len(got), len(oracle))
+	}
+	sort.Slice(got, func(i, j int) bool { return groupedLess(&got[i], &got[j]) })
+	sort.Slice(oracle, func(i, j int) bool { return groupedLess(&oracle[i], &oracle[j]) })
+	for i := range got {
+		a, d := &got[i], &oracle[i]
+		if a.keyNull != d.keyNull || a.keyIsI != d.keyIsI ||
+			(!a.keyNull && a.keyIsI && a.keyInt != d.keyInt) ||
+			(!a.keyNull && !a.keyIsI && a.keyStr != d.keyStr) {
+			return fmt.Sprintf("grouped row %d of %d differs (key, values withheld)", i, len(got))
+		}
+		if len(a.counts) != len(d.counts) {
+			return fmt.Sprintf("grouped row %d differs (count-column arity)", i)
+		}
+		for c := range a.counts {
+			if a.counts[c] != d.counts[c] {
+				return fmt.Sprintf("grouped row %d of %d differs (count col %d, values withheld)", i, len(got), c)
+			}
+		}
+	}
+	return ""
+}

--- a/internal/arcxrouter/eligibility.go
+++ b/internal/arcxrouter/eligibility.go
@@ -36,6 +36,9 @@ const (
 	ShapeScan = "scan"
 	// Phase 3 agg-1 ungrouped aggregation: SELECT <agg list> FROM m [WHERE ...].
 	ShapeScanAgg = "scan_agg"
+	// Phase 3 agg-2b: the ONE grouped shape past the perf gate — single key,
+	// count(*)-only, no WHERE. Wider grouped shapes stay ineligible (DuckDB).
+	ShapeScanAggGroupedCount = "scan_agg_grouped_count"
 )
 
 // scanPred is one WHERE predicate `<col> <op> <literal>` from a scan. Exactly one
@@ -146,6 +149,9 @@ type matchResult struct {
 	// scan_agg only: re-serialized aggregate items ("count(*)", "sum(colAsWritten)"),
 	// in select-list order — validated token-by-token in matchScanAgg.
 	aggItems []string
+	// scan_agg_grouped_count only: the single group-key column (as written).
+	// aggItems then holds the select list ("count(*)" or the key), in order.
+	groupKey string
 }
 
 // eligibleShape recognizes the arcx shapes on the raw user SQL. ok=false means
@@ -198,6 +204,17 @@ func eligibleShape(sql string) (matchResult, bool) {
 	// sum/avg) — the engine's parse-level fall-through, mirrored.
 	if items, whereText, meas, ok := matchScanAgg(toks); ok {
 		return matchResult{shape: ShapeScanAgg, aggItems: items, whereText: whereText, measurement: meas}, true
+	}
+	// The allow-listed grouped shape (agg-2b): single key + count(*)-only, no
+	// WHERE. Tried before the scan (a bare-column-led grouped select would fail
+	// the scan anyway; count-led ones fall through the agg matchers above).
+	if items, key, meas, ok := matchGroupedCountOnly(toks); ok {
+		return matchResult{
+			shape:       ShapeScanAggGroupedCount,
+			aggItems:    items,
+			groupKey:    key,
+			measurement: meas,
+		}, true
 	}
 	// Scan is tried LAST: it's the broadest shape (a bare column list matches many
 	// SELECTs), so the specific aggregate shapes get first refusal.

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -108,6 +108,7 @@ type Decision struct {
 	OrderBy   []scanOrderKey // scan only: ORDER BY keys
 	Limit     int            // scan only: LIMIT n (0 = none)
 	AggItems  []string       // scan_agg only: re-serialized aggregate items, select-list order
+	GroupKey  string         // scan_agg_grouped_count only: the single group-key column
 }
 
 // Decide is the cheap per-query pre-filter. It never calls the engine; it only
@@ -149,6 +150,7 @@ func Decide(sql, headerDB string, h Handler) Decision {
 		OrderBy:   m.orderBy,
 		Limit:     m.limit,
 		AggItems:  m.aggItems,
+		GroupKey:  m.groupKey,
 	}
 }
 
@@ -289,6 +291,8 @@ func (h Deps) buildEngineSQL(ctx context.Context, d Decision) (string, bool) {
 		return buildScanSQL(d, arr.String())
 	case ShapeScanAgg:
 		return buildScanAggSQL(d, arr.String())
+	case ShapeScanAggGroupedCount:
+		return buildGroupedCountSQL(d, arr.String())
 	default:
 		return "", false
 	}
@@ -324,6 +328,41 @@ func buildScanAggSQL(d Decision, pathArray string) (string, bool) {
 		b.WriteString(" WHERE ")
 		b.WriteString(d.WhereText)
 	}
+	return b.String(), true
+}
+
+// buildGroupedCountSQL constructs the engine SQL for the allow-listed grouped
+// shape: `SELECT <items> FROM read_parquet([...]) GROUP BY <key>`. Items are
+// re-validated (each is `count(*)` or exactly the bare key); decline rather
+// than emit unsafe SQL — same defense-in-depth as the other builders.
+func buildGroupedCountSQL(d Decision, pathArray string) (string, bool) {
+	if len(d.AggItems) < 2 || !isBareIdent(d.GroupKey) {
+		return "", false
+	}
+	sawKey, sawCount := false, false
+	var b strings.Builder
+	b.WriteString("SELECT ")
+	for i, item := range d.AggItems {
+		switch {
+		case item == "count(*)":
+			sawCount = true
+		case item == d.GroupKey && !sawKey:
+			sawKey = true
+		default:
+			return "", false
+		}
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(item)
+	}
+	if !sawKey || !sawCount {
+		return "", false
+	}
+	b.WriteString(" FROM read_parquet(")
+	b.WriteString(pathArray)
+	b.WriteString(") GROUP BY ")
+	b.WriteString(d.GroupKey)
 	return b.String(), true
 }
 
@@ -672,6 +711,20 @@ func (h Deps) compareToOracle(ctx context.Context, d Decision, rec arrow.Record)
 			return "", err
 		}
 		return compareAgg(rec, oracle, d.AggItems), nil
+	}
+	if d.Shape == ShapeScanAggGroupedCount {
+		keyCol := 0
+		for i, item := range d.AggItems {
+			if item != "count(*)" {
+				keyCol = i
+				break
+			}
+		}
+		oracle, err := groupedFromRows(rows, keyCol)
+		if err != nil {
+			return "", err
+		}
+		return compareGroupedCount(rec, oracle, keyCol), nil
 	}
 	if isScalarShape(d.Shape) {
 		oracle, err := scalarFromRows(rows)

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -707,6 +707,90 @@ func matchScanAgg(toks []token) (items []string, whereText string, meas string, 
 	return items, whereText, meas, true
 }
 
+// matchGroupedCountOnly matches the ONE grouped shape the engine's perf gate has
+// cleared (agg-2b: parity at 7-run medians on the 1.47B-row corpus):
+//
+//	select {count(*) | <key>} [, ...]* from <measurement> group by {<key> | <pos>}
+//
+// EXACTLY one bare key column, ≥1 count(*), any item order, NO WHERE (the
+// WHERE-bearing grouped shapes are indistinguishable from the still-losing
+// broad-predicate class and stay on DuckDB), nothing after the GROUP BY. The
+// items are re-serialized from validated tokens; the key's spelling is
+// preserved (catalog naming happens engine-side).
+func matchGroupedCountOnly(toks []token) (items []string, key string, meas string, ok bool) {
+	c := &cursor{toks: toks}
+	if !c.ident("select") {
+		return nil, "", "", false
+	}
+	fail := func() ([]string, string, string, bool) { return nil, "", "", false }
+
+	keyItem := -1
+	for {
+		t, tok := c.next()
+		if !tok || t.kind != tokIdent || isScanKeyword(t.lower) {
+			return fail()
+		}
+		if t.lower == "count" && c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '(' {
+			c.i++
+			if !c.punct('*') || !c.punct(')') {
+				return fail()
+			}
+			items = append(items, "count(*)")
+		} else {
+			// A bare column — the group key. A second distinct bare column (or a
+			// repeat) is outside the allow-listed shape.
+			if keyItem >= 0 {
+				return fail()
+			}
+			keyItem = len(items)
+			key = t.orig
+			items = append(items, t.orig)
+		}
+		if c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == ',' {
+			c.i++
+			continue
+		}
+		break
+	}
+	if keyItem < 0 || len(items) < 2 {
+		// No key, or no count(*) beside it.
+		return fail()
+	}
+	if !c.ident("from") {
+		return fail()
+	}
+	mt, tok := c.next()
+	if !tok || mt.kind != tokIdent {
+		return fail()
+	}
+	meas = mt.orig
+
+	// NO WHERE in the allow-listed shape.
+	if !c.ident("group") || !c.ident("by") {
+		return fail()
+	}
+	kt, tok := c.next()
+	if !tok {
+		return fail()
+	}
+	switch kt.kind {
+	case tokIdent:
+		if !strings.EqualFold(kt.orig, key) {
+			return fail()
+		}
+	case tokNum:
+		if kt.orig != strconv.Itoa(keyItem+1) {
+			return fail()
+		}
+	default:
+		return fail()
+	}
+	if !c.atEnd() {
+		return fail()
+	}
+	return items, key, meas, true
+}
+
 func matchScan(toks []token) (cols []string, preds []scanPred, whereText string, orderBy []scanOrderKey, limit int, meas string, ok bool) {
 	c := &cursor{toks: toks}
 	if !c.ident("select") {


### PR DESCRIPTION
## What

Adds \`scan_agg_grouped_count\` to the engine router: \`SELECT {host|count(*)} [,…] FROM m GROUP BY host\` — exactly one bare key, count(*)-only, no WHERE, positional or named GROUP BY. A grouped shadow comparator (typed key sort, exact keys+counts, value-free diffs) covers it.

## Why this subclass only

The engine's grouped aggregation (arcX #57/#58) is differentially proven across the corpus, but the performance bar gates the allow-list per shape: only this subclass reached parity (7-run medians on the full corpus). Value-aggregate, WHERE-bearing, and multi-key grouped shapes remain ineligible and serve from DuckDB until they clear.

Behind \`cgo && arcx_engine\` as always; both build modes compile/vet/test clean; stock binary verified at 0 engine symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)