### PR TITLE
feat(arcxrouter): widen the grouped allow-list to the full aggregate set (no WHERE)

### DIFF
--- a/internal/arcxrouter/agg_recognizer_test.go
+++ b/internal/arcxrouter/agg_recognizer_test.go
@@ -105,7 +105,7 @@ func TestScanAggDeclines(t *testing.T) {
 	}
 }
 
-func TestGroupedCountOnlyRecognized(t *testing.T) {
+func TestGroupedNoWhereRecognized(t *testing.T) {
 	cases := []struct {
 		sql   string
 		items []string
@@ -116,10 +116,14 @@ func TestGroupedCountOnlyRecognized(t *testing.T) {
 		{"SELECT host, count(*) FROM cpu GROUP BY 1", []string{"host", "count(*)"}, "host"},
 		{"SELECT count(*), host FROM cpu GROUP BY 2", []string{"count(*)", "host"}, "host"},
 		{"SELECT host, count(*), count(*) FROM cpu GROUP BY host", []string{"host", "count(*)", "count(*)"}, "host"},
+		// agg-2c widened the class to agg-1's full aggregate set (no WHERE).
+		{"SELECT host, sum(x), avg(x) FROM cpu GROUP BY host", []string{"host", "sum(x)", "avg(x)"}, "host"},
+		{"SELECT host, count(*), avg(Usage), max(Usage) FROM cpu GROUP BY host", []string{"host", "count(*)", "avg(Usage)", "max(Usage)"}, "host"},
+		{"SELECT min(time), host FROM cpu GROUP BY 2", []string{"min(time)", "host"}, "host"},
 	}
 	for _, c := range cases {
 		m, ok := eligibleShape(c.sql)
-		if !ok || m.shape != ShapeScanAggGroupedCount {
+		if !ok || m.shape != ShapeScanAggGrouped {
 			t.Fatalf("should be scan_agg_grouped_count: %s (got %q, %t)", c.sql, m.shape, ok)
 		}
 		if !reflect.DeepEqual(m.aggItems, c.items) || m.groupKey != c.key {
@@ -128,13 +132,14 @@ func TestGroupedCountOnlyRecognized(t *testing.T) {
 	}
 }
 
-func TestGroupedCountOnlyDeclines(t *testing.T) {
+func TestGroupedNoWhereDeclines(t *testing.T) {
 	for _, sql := range []string{
 		// Outside the allow-listed subclass — the engine serves wider grouped
 		// shapes but they have NOT cleared the perf gate (agg-2b record).
 		"SELECT host, count(*) FROM cpu WHERE x > 1 GROUP BY host", // WHERE-bearing
-		"SELECT host, sum(x) FROM cpu GROUP BY host",               // value aggregate
-		"SELECT host, count(x) FROM cpu GROUP BY host",             // count(col)
+		"SELECT host, sum(x) FROM cpu WHERE x > 1 GROUP BY host",   // WHERE-bearing value agg
+		"SELECT host, sum(a * b) FROM cpu GROUP BY host",           // expression arg
+		"SELECT host, count(DISTINCT x) FROM cpu GROUP BY host",    // DISTINCT
 		"SELECT host, region, count(*) FROM cpu GROUP BY host, region", // multi-key
 		"SELECT host FROM cpu GROUP BY host",                       // no count
 		"SELECT count(*) FROM cpu GROUP BY host",                   // key not projected
@@ -143,7 +148,7 @@ func TestGroupedCountOnlyDeclines(t *testing.T) {
 		"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY 1",  // trailing
 		"SELECT host, count(*) FROM cpu GROUP BY host LIMIT 5",
 	} {
-		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScanAggGroupedCount {
+		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScanAggGrouped {
 			t.Fatalf("must not match scan_agg_grouped_count: %s", sql)
 		}
 	}

--- a/internal/arcxrouter/build_agg_sql_test.go
+++ b/internal/arcxrouter/build_agg_sql_test.go
@@ -53,9 +53,9 @@ func TestBuildScanAggSQLDeclinesUnsafeItems(t *testing.T) {
 	}
 }
 
-func TestBuildGroupedCountSQL(t *testing.T) {
+func TestBuildGroupedSQL(t *testing.T) {
 	paths := "['/p.parquet']"
-	got, ok := buildGroupedCountSQL(Decision{
+	got, ok := buildGroupedSQL(Decision{
 		AggItems: []string{"count(*)", "host"},
 		GroupKey: "host",
 	}, paths)
@@ -66,10 +66,10 @@ func TestBuildGroupedCountSQL(t *testing.T) {
 	for _, d := range []Decision{
 		{AggItems: []string{"count(*)"}, GroupKey: "host"},              // no key item
 		{AggItems: []string{"host", "count(*)"}, GroupKey: "h; DROP"},   // unsafe key
-		{AggItems: []string{"host", "sum(x)"}, GroupKey: "host"},        // non-count item
+		{AggItems: []string{"host", "median(x)"}, GroupKey: "host"},     // unknown fn item
 		{AggItems: []string{"host", "host", "count(*)"}, GroupKey: "host"}, // repeated key
 	} {
-		if got, ok := buildGroupedCountSQL(d, paths); ok {
+		if got, ok := buildGroupedSQL(d, paths); ok {
 			t.Fatalf("must decline unsafe decision %v, got %q", d, got)
 		}
 	}

--- a/internal/arcxrouter/compare_grouped.go
+++ b/internal/arcxrouter/compare_grouped.go
@@ -1,8 +1,10 @@
-// Shadow comparison for the allow-listed grouped shape (agg-2b): N rows of
-// (single group key, count(*) columns). Both sides sort by the TYPED key part
-// (plan F5: never a joined string; a single key makes this one part — Utf8 or
-// Int64 — with NULL ordered first), then compare row-wise: keys and counts
-// EXACT. Diffs stay value-free.
+// Shadow comparison for the allow-listed grouped class (agg-2b/2c): N rows of
+// (single group key, agg-1 aggregate columns). Both sides sort by the TYPED key
+// part (plan F5: never a joined string; a single key makes this one part — Utf8
+// or Int64, NULL ordered first), then compare row-wise with the per-item agg
+// policy: keys and counts/min/max exact (float min/max ±0.0-equal, two NaNs
+// equal), float sum/avg within the documented 1e-9 tolerance, integer sums via
+// big.Int. Diffs stay value-free.
 
 //go:build cgo && arcx_engine
 
@@ -11,6 +13,8 @@ package arcxrouter
 import (
 	"database/sql"
 	"fmt"
+	"math"
+	"math/big"
 	"sort"
 	"time"
 
@@ -18,14 +22,14 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 )
 
-// groupedRow is one comparable grouped-count row: the key part (typed) and the
-// remaining cells as int64 counts in column order.
+// groupedRow is one comparable row: the key part (typed) plus the aggregate
+// cells in column order (reusing compare_agg's aggCell + policies).
 type groupedRow struct {
 	keyNull bool
 	keyStr  string
 	keyInt  int64
 	keyIsI  bool
-	counts  []int64
+	cells   []aggCell
 }
 
 func groupedLess(a, b *groupedRow) bool {
@@ -38,8 +42,19 @@ func groupedLess(a, b *groupedRow) bool {
 	return a.keyStr < b.keyStr
 }
 
-// groupedFromArcx extracts rows from arcx's record. `keyCol` is the key's
-// column index within the select list (from Decision.AggItems order).
+func groupedKeyEq(a, b *groupedRow) bool {
+	if a.keyNull != b.keyNull || a.keyIsI != b.keyIsI {
+		return false
+	}
+	if a.keyNull {
+		return true
+	}
+	if a.keyIsI {
+		return a.keyInt == b.keyInt
+	}
+	return a.keyStr == b.keyStr
+}
+
 func groupedFromArcx(rec arrow.Record, keyCol int) ([]groupedRow, error) {
 	ncols := int(rec.NumCols())
 	if keyCol >= ncols {
@@ -69,11 +84,32 @@ func groupedFromArcx(rec arrow.Record, keyCol int) ([]groupedRow, error) {
 				}
 				continue
 			}
-			col, ok := rec.Column(c).(*array.Int64)
-			if !ok || col.IsNull(r) {
-				return nil, fmt.Errorf("arcx grouped count col %d: unexpected type/null", c)
+			switch col := rec.Column(c).(type) {
+			case *array.Int64:
+				if col.IsNull(r) {
+					row.cells = append(row.cells, aggCell{isNull: true})
+				} else {
+					row.cells = append(row.cells, aggCell{isInt: true, i: big.NewInt(col.Value(r))})
+				}
+			case *array.Float64:
+				if col.IsNull(r) {
+					row.cells = append(row.cells, aggCell{isNull: true})
+				} else {
+					row.cells = append(row.cells, aggCell{f: col.Value(r)})
+				}
+			case *array.Timestamp:
+				if col.IsNull(r) {
+					row.cells = append(row.cells, aggCell{isNull: true})
+				} else {
+					unit := col.DataType().(*arrow.TimestampType).Unit
+					row.cells = append(row.cells, aggCell{
+						isInt: true,
+						i:     big.NewInt(toMicros(int64(col.Value(r)), unit)),
+					})
+				}
+			default:
+				return nil, fmt.Errorf("arcx grouped agg col %d: unexpected type %T", c, rec.Column(c))
 			}
-			row.counts = append(row.counts, col.Value(r))
 		}
 	}
 	return out, nil
@@ -107,26 +143,35 @@ func groupedFromRows(rows *sql.Rows, keyCol int) ([]groupedRow, error) {
 				case int64:
 					row.keyIsI = true
 					row.keyInt = x
-				case time.Time:
-					return nil, fmt.Errorf("duckdb grouped key: unexpected timestamp")
 				default:
 					return nil, fmt.Errorf("duckdb grouped key: unexpected type %T", v)
 				}
 				continue
 			}
-			x, ok := v.(int64)
-			if !ok {
-				return nil, fmt.Errorf("duckdb grouped count col %d: unexpected type %T", c, v)
+			switch x := v.(type) {
+			case nil:
+				row.cells = append(row.cells, aggCell{isNull: true})
+			case int64:
+				row.cells = append(row.cells, aggCell{isInt: true, i: big.NewInt(x)})
+			case *big.Int:
+				row.cells = append(row.cells, aggCell{isInt: true, i: x})
+			case float64:
+				row.cells = append(row.cells, aggCell{f: x})
+			case time.Time:
+				row.cells = append(row.cells, aggCell{isInt: true, i: big.NewInt(x.UnixMicro())})
+			default:
+				return nil, fmt.Errorf("duckdb grouped agg col %d: unexpected type %T", c, v)
 			}
-			row.counts = append(row.counts, x)
 		}
 		out = append(out, row)
 	}
 	return out, rows.Err()
 }
 
-// compareGroupedCount returns "" on match, else a short VALUE-FREE diff.
-func compareGroupedCount(rec arrow.Record, oracle []groupedRow, keyCol int) string {
+// compareGrouped returns "" on match, else a short VALUE-FREE diff. `items` is
+// the select list in column order (the key item marks the key column; the rest
+// pick the per-cell policy — tolerance only for float sum/avg).
+func compareGrouped(rec arrow.Record, oracle []groupedRow, items []string, keyCol int) string {
 	got, err := groupedFromArcx(rec, keyCol)
 	if err != nil {
 		return "arcx grouped decode error: " + err.Error()
@@ -134,21 +179,54 @@ func compareGroupedCount(rec arrow.Record, oracle []groupedRow, keyCol int) stri
 	if len(got) != len(oracle) {
 		return fmt.Sprintf("grouped row count differs (arcx=%d duckdb=%d)", len(got), len(oracle))
 	}
+	// Cell policies in CELL order (items minus the key, order preserved).
+	var tolerant []bool
+	for i, item := range items {
+		if i == keyCol {
+			continue
+		}
+		tolerant = append(tolerant, aggItemTolerant(item))
+	}
 	sort.Slice(got, func(i, j int) bool { return groupedLess(&got[i], &got[j]) })
 	sort.Slice(oracle, func(i, j int) bool { return groupedLess(&oracle[i], &oracle[j]) })
 	for i := range got {
 		a, d := &got[i], &oracle[i]
-		if a.keyNull != d.keyNull || a.keyIsI != d.keyIsI ||
-			(!a.keyNull && a.keyIsI && a.keyInt != d.keyInt) ||
-			(!a.keyNull && !a.keyIsI && a.keyStr != d.keyStr) {
+		if !groupedKeyEq(a, d) {
 			return fmt.Sprintf("grouped row %d of %d differs (key, values withheld)", i, len(got))
 		}
-		if len(a.counts) != len(d.counts) {
-			return fmt.Sprintf("grouped row %d differs (count-column arity)", i)
+		if len(a.cells) != len(d.cells) || len(a.cells) != len(tolerant) {
+			return fmt.Sprintf("grouped row %d differs (agg-column arity)", i)
 		}
-		for c := range a.counts {
-			if a.counts[c] != d.counts[c] {
-				return fmt.Sprintf("grouped row %d of %d differs (count col %d, values withheld)", i, len(got), c)
+		for c := range a.cells {
+			ac, dc := &a.cells[c], &d.cells[c]
+			if ac.isNull != dc.isNull {
+				return fmt.Sprintf("grouped row %d differs (agg col %d null-ness)", i, c)
+			}
+			if ac.isNull {
+				continue
+			}
+			if ac.isInt != dc.isInt {
+				return fmt.Sprintf("grouped row %d differs (agg col %d kind)", i, c)
+			}
+			if ac.isInt {
+				if ac.i.Cmp(dc.i) != 0 {
+					return fmt.Sprintf("grouped row %d of %d differs (agg col %d, values withheld)", i, len(got), c)
+				}
+				continue
+			}
+			if math.IsNaN(ac.f) || math.IsNaN(dc.f) {
+				if math.IsNaN(ac.f) && math.IsNaN(dc.f) {
+					continue
+				}
+				return fmt.Sprintf("grouped row %d differs (agg col %d NaN-ness)", i, c)
+			}
+			if tolerant[c] {
+				scale := math.Max(math.Abs(ac.f), math.Abs(dc.f))
+				if math.Abs(ac.f-dc.f) > aggFloatRelTol*math.Max(scale, 1.0) {
+					return fmt.Sprintf("grouped row %d differs (agg col %d beyond 1e-9 tolerance, values withheld)", i, c)
+				}
+			} else if ac.f != dc.f {
+				return fmt.Sprintf("grouped row %d of %d differs (agg col %d float, values withheld)", i, len(got), c)
 			}
 		}
 	}

--- a/internal/arcxrouter/decline_test.go
+++ b/internal/arcxrouter/decline_test.go
@@ -16,7 +16,7 @@ func TestCensusClassifySeparatesShapes(t *testing.T) {
 	cases := []struct {
 		sql, want string
 	}{
-		{"SELECT host, avg(usage_idle) FROM cpu GROUP BY host", "group_by"},
+		{"SELECT host, avg(usage_idle) FROM cpu WHERE usage_idle > 1.0 GROUP BY host", "group_by"},
 		{"SELECT a.host FROM cpu a JOIN meta b ON a.host = b.host", "join"},
 		{"WITH t AS (SELECT host FROM cpu) SELECT host FROM t", "cte"},
 		{"SELECT host FROM cpu UNION SELECT host FROM mem", "set_op"},

--- a/internal/arcxrouter/eligibility.go
+++ b/internal/arcxrouter/eligibility.go
@@ -36,9 +36,10 @@ const (
 	ShapeScan = "scan"
 	// Phase 3 agg-1 ungrouped aggregation: SELECT <agg list> FROM m [WHERE ...].
 	ShapeScanAgg = "scan_agg"
-	// Phase 3 agg-2b: the ONE grouped shape past the perf gate — single key,
-	// count(*)-only, no WHERE. Wider grouped shapes stay ineligible (DuckDB).
-	ShapeScanAggGroupedCount = "scan_agg_grouped_count"
+	// Phase 3 agg-2b/2c: the grouped class past the perf gate — single key,
+	// agg-1's aggregate set, NO WHERE. WHERE-bearing grouped shapes stay
+	// ineligible (blocked by the broad-predicate bench; they share a shape).
+	ShapeScanAggGrouped = "scan_agg_grouped"
 )
 
 // scanPred is one WHERE predicate `<col> <op> <literal>` from a scan. Exactly one
@@ -208,9 +209,9 @@ func eligibleShape(sql string) (matchResult, bool) {
 	// The allow-listed grouped shape (agg-2b): single key + count(*)-only, no
 	// WHERE. Tried before the scan (a bare-column-led grouped select would fail
 	// the scan anyway; count-led ones fall through the agg matchers above).
-	if items, key, meas, ok := matchGroupedCountOnly(toks); ok {
+	if items, key, meas, ok := matchGroupedNoWhere(toks); ok {
 		return matchResult{
-			shape:       ShapeScanAggGroupedCount,
+			shape:       ShapeScanAggGrouped,
 			aggItems:    items,
 			groupKey:    key,
 			measurement: meas,

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -291,8 +291,8 @@ func (h Deps) buildEngineSQL(ctx context.Context, d Decision) (string, bool) {
 		return buildScanSQL(d, arr.String())
 	case ShapeScanAgg:
 		return buildScanAggSQL(d, arr.String())
-	case ShapeScanAggGroupedCount:
-		return buildGroupedCountSQL(d, arr.String())
+	case ShapeScanAggGrouped:
+		return buildGroupedSQL(d, arr.String())
 	default:
 		return "", false
 	}
@@ -331,21 +331,21 @@ func buildScanAggSQL(d Decision, pathArray string) (string, bool) {
 	return b.String(), true
 }
 
-// buildGroupedCountSQL constructs the engine SQL for the allow-listed grouped
-// shape: `SELECT <items> FROM read_parquet([...]) GROUP BY <key>`. Items are
-// re-validated (each is `count(*)` or exactly the bare key); decline rather
+// buildGroupedSQL constructs the engine SQL for the allow-listed grouped class:
+// `SELECT <items> FROM read_parquet([...]) GROUP BY <key>`. Items re-validate as
+// agg-1 aggregate items (`isAggItem`) or exactly the bare key; decline rather
 // than emit unsafe SQL — same defense-in-depth as the other builders.
-func buildGroupedCountSQL(d Decision, pathArray string) (string, bool) {
+func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
 	if len(d.AggItems) < 2 || !isBareIdent(d.GroupKey) {
 		return "", false
 	}
-	sawKey, sawCount := false, false
+	sawKey, sawAgg := false, false
 	var b strings.Builder
 	b.WriteString("SELECT ")
 	for i, item := range d.AggItems {
 		switch {
-		case item == "count(*)":
-			sawCount = true
+		case isAggItem(item):
+			sawAgg = true
 		case item == d.GroupKey && !sawKey:
 			sawKey = true
 		default:
@@ -356,7 +356,7 @@ func buildGroupedCountSQL(d Decision, pathArray string) (string, bool) {
 		}
 		b.WriteString(item)
 	}
-	if !sawKey || !sawCount {
+	if !sawKey || !sawAgg {
 		return "", false
 	}
 	b.WriteString(" FROM read_parquet(")
@@ -712,10 +712,10 @@ func (h Deps) compareToOracle(ctx context.Context, d Decision, rec arrow.Record)
 		}
 		return compareAgg(rec, oracle, d.AggItems), nil
 	}
-	if d.Shape == ShapeScanAggGroupedCount {
+	if d.Shape == ShapeScanAggGrouped {
 		keyCol := 0
 		for i, item := range d.AggItems {
-			if item != "count(*)" {
+			if item == d.GroupKey {
 				keyCol = i
 				break
 			}
@@ -724,7 +724,7 @@ func (h Deps) compareToOracle(ctx context.Context, d Decision, rec arrow.Record)
 		if err != nil {
 			return "", err
 		}
-		return compareGroupedCount(rec, oracle, keyCol), nil
+		return compareGrouped(rec, oracle, d.AggItems, keyCol), nil
 	}
 	if isScalarShape(d.Shape) {
 		oracle, err := scalarFromRows(rows)

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -707,17 +707,19 @@ func matchScanAgg(toks []token) (items []string, whereText string, meas string, 
 	return items, whereText, meas, true
 }
 
-// matchGroupedCountOnly matches the ONE grouped shape the engine's perf gate has
-// cleared (agg-2b: parity at 7-run medians on the 1.47B-row corpus):
+// matchGroupedNoWhere matches the grouped class the engine's perf gate has
+// cleared (agg-2c: every no-WHERE single-key grouped bench shape beats DuckDB
+// v1.5.5 on the 1.47B-row corpus):
 //
-//	select {count(*) | <key>} [, ...]* from <measurement> group by {<key> | <pos>}
+//	select {<agg>|<key>} [, ...]* from <measurement> group by {<key> | <pos>}
 //
-// EXACTLY one bare key column, ≥1 count(*), any item order, NO WHERE (the
-// WHERE-bearing grouped shapes are indistinguishable from the still-losing
-// broad-predicate class and stay on DuckDB), nothing after the GROUP BY. The
-// items are re-serialized from validated tokens; the key's spelling is
-// preserved (catalog naming happens engine-side).
-func matchGroupedCountOnly(toks []token) (items []string, key string, meas string, ok bool) {
+// EXACTLY one bare key column, ≥1 aggregate from agg-1's set (`count(*)` or
+// `count|sum|min|max|avg(<bare col>)`), any item order, NO WHERE (WHERE-bearing
+// grouped shapes share a recognizer shape with the still-losing broad-predicate
+// class and stay on DuckDB), nothing after the GROUP BY. Items are re-serialized
+// from validated tokens (fn lowercased, ARG spelling preserved — derived-name
+// parity); the key's spelling is preserved.
+func matchGroupedNoWhere(toks []token) (items []string, key string, meas string, ok bool) {
 	c := &cursor{toks: toks}
 	if !c.ident("select") {
 		return nil, "", "", false
@@ -725,20 +727,40 @@ func matchGroupedCountOnly(toks []token) (items []string, key string, meas strin
 	fail := func() ([]string, string, string, bool) { return nil, "", "", false }
 
 	keyItem := -1
+	nAggs := 0
 	for {
 		t, tok := c.next()
 		if !tok || t.kind != tokIdent || isScanKeyword(t.lower) {
 			return fail()
 		}
-		if t.lower == "count" && c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '(' {
-			c.i++
-			if !c.punct('*') || !c.punct(')') {
+		isCall := c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '('
+		if isCall {
+			switch t.lower {
+			case "count", "sum", "min", "max", "avg":
+			default:
 				return fail()
 			}
-			items = append(items, "count(*)")
+			c.i++ // consume '('
+			if t.lower == "count" && c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '*' {
+				c.i++
+				if !c.punct(')') {
+					return fail()
+				}
+				items = append(items, "count(*)")
+			} else {
+				arg, tok := c.next()
+				if !tok || arg.kind != tokIdent || isScanKeyword(arg.lower) {
+					return fail()
+				}
+				if !c.punct(')') {
+					return fail() // expression / DISTINCT / arity → decline
+				}
+				items = append(items, t.lower+"("+arg.orig+")")
+			}
+			nAggs++
 		} else {
-			// A bare column — the group key. A second distinct bare column (or a
-			// repeat) is outside the allow-listed shape.
+			// A bare column — the single group key; a second (or repeated) bare
+			// column is outside the allow-listed class.
 			if keyItem >= 0 {
 				return fail()
 			}
@@ -752,8 +774,7 @@ func matchGroupedCountOnly(toks []token) (items []string, key string, meas strin
 		}
 		break
 	}
-	if keyItem < 0 || len(items) < 2 {
-		// No key, or no count(*) beside it.
+	if keyItem < 0 || nAggs == 0 {
 		return fail()
 	}
 	if !c.ident("from") {
@@ -765,7 +786,7 @@ func matchGroupedCountOnly(toks []token) (items []string, key string, meas strin
 	}
 	meas = mt.orig
 
-	// NO WHERE in the allow-listed shape.
+	// NO WHERE in the allow-listed class.
 	if !c.ident("group") || !c.ident("by") {
 		return fail()
 	}


### PR DESCRIPTION
## What

Widens \`scan_agg_grouped\` from count(*)-only to agg-1's full aggregate set (single bare key, no WHERE): \`SELECT host, count(*), avg(x), max(x) … GROUP BY host\` now routes to the engine. The shadow comparator generalizes to mixed cells — keys and counts/min/max exact (NaN-both-equal, ±0.0-equal), float sum/avg within the documented 1e-9 tolerance, integer sums via big.Int. Value-free diffs preserved.

## Why now

arcX #59's increments flipped the remaining no-WHERE grouped shapes to wins over DuckDB v1.5.5 (count-only 0.53 vs 0.55; full-agg 1.30 vs 1.41 at 1.47B rows). WHERE-bearing grouped remains ineligible — the broad-predicate shape still trails and shares a recognizer shape with the selective one.

Both build modes compile/vet/test clean; stock binary at 0 engine symbols. One census pin updated (the widened shape moved from \`group_by\` to \`eligible\` by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)