### PR TITLE
fix(api)+feat(arcxrouter): arcx serve UAF fix; widen grouped allow-list to WHERE-bearing shapes

### DIFF
--- a/internal/api/arcx_hook.go
+++ b/internal/api/arcx_hook.go
@@ -238,6 +238,12 @@ func (h *QueryHandler) serveArcxResult(
 	// `start` is the query's true start (captured BEFORE the engine ran) so
 	// execution_time_ms covers engine work, not just serialization.
 	timestamp := time.Now().UTC().Format(time.RFC3339)
+	// UAF trap (same class the Arrow-IPC path below documents): the pooled Fiber
+	// *Ctx is recycled once this handler returns, but SetBodyStreamWriter runs
+	// AFTER that — reading `c` inside the closure (getTokenName → UserValue on
+	// the released RequestCtx) segfaults the process. Capture every ctx-derived
+	// value the async writers need BEFORE committing the stream writer.
+	tokenName := getTokenName(c)
 
 	if isMsgPackWire(c) {
 		// MAJOR-4: msgpack must drain SYNCHRONOUSLY here — BEFORE committing headers —
@@ -292,7 +298,7 @@ func (h *QueryHandler) serveArcxResult(
 			if onComplete != nil {
 				onComplete(rowCount)
 			}
-			h.logSlowQuery(convertedSQL, start, rowCount, getTokenName(c))
+			h.logSlowQuery(convertedSQL, start, rowCount, tokenName)
 		})
 		return true
 	}
@@ -347,7 +353,7 @@ func (h *QueryHandler) serveArcxResult(
 			if onComplete != nil {
 				onComplete(rc)
 			}
-			h.logSlowQuery(convertedSQL, start, rc, getTokenName(c))
+			h.logSlowQuery(convertedSQL, start, rc, tokenName)
 		}
 		w.Flush()
 	})

--- a/internal/arcxengine/arcxengine_test.go
+++ b/internal/arcxengine/arcxengine_test.go
@@ -75,7 +75,11 @@ func TestBridgeCountStar(t *testing.T) {
 
 func TestBridgeUnsupportedDeclines(t *testing.T) {
 	// A shape the engine doesn't handle → ErrUnsupported (caller falls back).
-	_, err := Query("SELECT sum(x) FROM read_parquet('/x.parquet')", Context{})
+	// A JOIN is safely outside the engine's surface for the foreseeable phases;
+	// the original `sum(x)` probe became a SUPPORTED shape at Phase 3 agg-1 and
+	// started returning a sandbox Execution error instead (stale-test find,
+	// 2026-08-27 mimalloc adversarial).
+	_, err := Query("SELECT a.x FROM read_parquet('/x.parquet') a JOIN read_parquet('/y.parquet') b ON a.x = b.x", Context{})
 	var un ErrUnsupported
 	if !errors.As(err, &un) {
 		t.Fatalf("expected ErrUnsupported, got %v", err)

--- a/internal/arcxrouter/agg_recognizer_test.go
+++ b/internal/arcxrouter/agg_recognizer_test.go
@@ -105,51 +105,71 @@ func TestScanAggDeclines(t *testing.T) {
 	}
 }
 
-func TestGroupedNoWhereRecognized(t *testing.T) {
+func TestGroupedAggRecognized(t *testing.T) {
 	cases := []struct {
-		sql   string
-		items []string
-		key   string
+		sql       string
+		items     []string
+		key       string
+		whereText string
 	}{
-		{"SELECT host, count(*) FROM cpu GROUP BY host", []string{"host", "count(*)"}, "host"},
-		{"SELECT count(*), host FROM cpu GROUP BY host", []string{"count(*)", "host"}, "host"},
-		{"SELECT host, count(*) FROM cpu GROUP BY 1", []string{"host", "count(*)"}, "host"},
-		{"SELECT count(*), host FROM cpu GROUP BY 2", []string{"count(*)", "host"}, "host"},
-		{"SELECT host, count(*), count(*) FROM cpu GROUP BY host", []string{"host", "count(*)", "count(*)"}, "host"},
+		{"SELECT host, count(*) FROM cpu GROUP BY host", []string{"host", "count(*)"}, "host", ""},
+		{"SELECT count(*), host FROM cpu GROUP BY host", []string{"count(*)", "host"}, "host", ""},
+		{"SELECT host, count(*) FROM cpu GROUP BY 1", []string{"host", "count(*)"}, "host", ""},
+		{"SELECT count(*), host FROM cpu GROUP BY 2", []string{"count(*)", "host"}, "host", ""},
+		{"SELECT host, count(*), count(*) FROM cpu GROUP BY host", []string{"host", "count(*)", "count(*)"}, "host", ""},
 		// agg-2c widened the class to agg-1's full aggregate set (no WHERE).
-		{"SELECT host, sum(x), avg(x) FROM cpu GROUP BY host", []string{"host", "sum(x)", "avg(x)"}, "host"},
-		{"SELECT host, count(*), avg(Usage), max(Usage) FROM cpu GROUP BY host", []string{"host", "count(*)", "avg(Usage)", "max(Usage)"}, "host"},
-		{"SELECT min(time), host FROM cpu GROUP BY 2", []string{"min(time)", "host"}, "host"},
+		{"SELECT host, sum(x), avg(x) FROM cpu GROUP BY host", []string{"host", "sum(x)", "avg(x)"}, "host", ""},
+		{"SELECT host, count(*), avg(Usage), max(Usage) FROM cpu GROUP BY host", []string{"host", "count(*)", "avg(Usage)", "max(Usage)"}, "host", ""},
+		{"SELECT min(time), host FROM cpu GROUP BY 2", []string{"min(time)", "host"}, "host", ""},
+		// mimalloc slice: the WHERE-bearing shapes cleared the perf gate (both the
+		// selective and broad arms + the masked dashboard pair win vs v1.5.5).
+		{
+			"SELECT host, count(*), avg(cpu_user) FROM cpu WHERE cpu_user > 90 GROUP BY host",
+			[]string{"host", "count(*)", "avg(cpu_user)"}, "host", "cpu_user > 90",
+		},
+		{
+			"SELECT host, sum(x) FROM cpu WHERE host = 'a' GROUP BY host",
+			[]string{"host", "sum(x)"}, "host", "host = 'a'",
+		},
+		{
+			"SELECT host, sum(f), min(f) FROM cpu WHERE f > 1.5 OR host = 'b' GROUP BY 1",
+			[]string{"host", "sum(f)", "min(f)"}, "host", "f > 1.5 OR host = 'b'",
+		},
 	}
 	for _, c := range cases {
 		m, ok := eligibleShape(c.sql)
 		if !ok || m.shape != ShapeScanAggGrouped {
-			t.Fatalf("should be scan_agg_grouped_count: %s (got %q, %t)", c.sql, m.shape, ok)
+			t.Fatalf("should be scan_agg_grouped: %s (got %q, %t)", c.sql, m.shape, ok)
 		}
-		if !reflect.DeepEqual(m.aggItems, c.items) || m.groupKey != c.key {
-			t.Fatalf("items/key = %v/%q, want %v/%q: %s", m.aggItems, m.groupKey, c.items, c.key, c.sql)
+		if !reflect.DeepEqual(m.aggItems, c.items) || m.groupKey != c.key || m.whereText != c.whereText {
+			t.Fatalf("items/key/where = %v/%q/%q, want %v/%q/%q: %s",
+				m.aggItems, m.groupKey, m.whereText, c.items, c.key, c.whereText, c.sql)
 		}
 	}
 }
 
-func TestGroupedNoWhereDeclines(t *testing.T) {
+func TestGroupedAggDeclines(t *testing.T) {
 	for _, sql := range []string{
 		// Outside the allow-listed subclass — the engine serves wider grouped
-		// shapes but they have NOT cleared the perf gate (agg-2b record).
-		"SELECT host, count(*) FROM cpu WHERE x > 1 GROUP BY host", // WHERE-bearing
-		"SELECT host, sum(x) FROM cpu WHERE x > 1 GROUP BY host",   // WHERE-bearing value agg
-		"SELECT host, sum(a * b) FROM cpu GROUP BY host",           // expression arg
-		"SELECT host, count(DISTINCT x) FROM cpu GROUP BY host",    // DISTINCT
+		// shapes but they have NOT cleared the perf gate.
+		"SELECT host, sum(a * b) FROM cpu GROUP BY host",               // expression arg
+		"SELECT host, count(DISTINCT x) FROM cpu GROUP BY host",        // DISTINCT
 		"SELECT host, region, count(*) FROM cpu GROUP BY host, region", // multi-key
-		"SELECT host FROM cpu GROUP BY host",                       // no count
-		"SELECT count(*) FROM cpu GROUP BY host",                   // key not projected
-		"SELECT host, count(*) FROM cpu GROUP BY region",           // wrong key
-		"SELECT host, count(*) FROM cpu GROUP BY 2",                // position at count
-		"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY 1",  // trailing
+		"SELECT host FROM cpu GROUP BY host",                           // no count
+		"SELECT count(*) FROM cpu GROUP BY host",                       // key not projected
+		"SELECT host, count(*) FROM cpu GROUP BY region",               // wrong key
+		"SELECT host, count(*) FROM cpu GROUP BY 2",                    // position at count
+		"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY 1",      // trailing
 		"SELECT host, count(*) FROM cpu GROUP BY host LIMIT 5",
+		// WHERE joined the class (mimalloc slice) — but ONLY through the shared
+		// reserializeWhere vocabulary; anything it declines stays declined here.
+		"SELECT host, count(*) FROM cpu WHERE GROUP BY host",                   // empty WHERE
+		"SELECT host, count(*) FROM cpu WHERE x > GROUP BY host",               // dangling atom
+		"SELECT host, count(*) FROM cpu WHERE lower(host) = 'a' GROUP BY host", // fn call in WHERE
+		"SELECT host, count(*) FROM cpu WHERE x > 1 GROUP BY host LIMIT 5",     // trailing after GROUP BY
 	} {
 		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScanAggGrouped {
-			t.Fatalf("must not match scan_agg_grouped_count: %s", sql)
+			t.Fatalf("must not match scan_agg_grouped: %s", sql)
 		}
 	}
 }

--- a/internal/arcxrouter/build_agg_sql_test.go
+++ b/internal/arcxrouter/build_agg_sql_test.go
@@ -63,10 +63,21 @@ func TestBuildGroupedSQL(t *testing.T) {
 	if !ok || got != want {
 		t.Fatalf("got (%q, %t), want %q", got, ok, want)
 	}
+	// WHERE-bearing (mimalloc slice): the reserialized tree lands between the
+	// path array and GROUP BY, mirroring buildScanAggSQL.
+	got, ok = buildGroupedSQL(Decision{
+		AggItems:  []string{"host", "count(*)", "avg(cpu_user)"},
+		GroupKey:  "host",
+		WhereText: "cpu_user > 90",
+	}, paths)
+	want = "SELECT host, count(*), avg(cpu_user) FROM read_parquet(['/p.parquet']) WHERE cpu_user > 90 GROUP BY host"
+	if !ok || got != want {
+		t.Fatalf("got (%q, %t), want %q", got, ok, want)
+	}
 	for _, d := range []Decision{
-		{AggItems: []string{"count(*)"}, GroupKey: "host"},              // no key item
-		{AggItems: []string{"host", "count(*)"}, GroupKey: "h; DROP"},   // unsafe key
-		{AggItems: []string{"host", "median(x)"}, GroupKey: "host"},     // unknown fn item
+		{AggItems: []string{"count(*)"}, GroupKey: "host"},                 // no key item
+		{AggItems: []string{"host", "count(*)"}, GroupKey: "h; DROP"},      // unsafe key
+		{AggItems: []string{"host", "median(x)"}, GroupKey: "host"},        // unknown fn item
 		{AggItems: []string{"host", "host", "count(*)"}, GroupKey: "host"}, // repeated key
 	} {
 		if got, ok := buildGroupedSQL(d, paths); ok {

--- a/internal/arcxrouter/decline_test.go
+++ b/internal/arcxrouter/decline_test.go
@@ -16,7 +16,9 @@ func TestCensusClassifySeparatesShapes(t *testing.T) {
 	cases := []struct {
 		sql, want string
 	}{
-		{"SELECT host, avg(usage_idle) FROM cpu WHERE usage_idle > 1.0 GROUP BY host", "group_by"},
+		// A WHERE-bearing single-key grouped agg became ELIGIBLE at the mimalloc
+		// slice; multi-key grouping remains the census representative.
+		{"SELECT host, core, avg(usage_idle) FROM cpu WHERE usage_idle > 1.0 GROUP BY host, core", "group_by"},
 		{"SELECT a.host FROM cpu a JOIN meta b ON a.host = b.host", "join"},
 		{"WITH t AS (SELECT host FROM cpu) SELECT host FROM t", "cte"},
 		{"SELECT host FROM cpu UNION SELECT host FROM mem", "set_op"},

--- a/internal/arcxrouter/eligibility.go
+++ b/internal/arcxrouter/eligibility.go
@@ -206,14 +206,16 @@ func eligibleShape(sql string) (matchResult, bool) {
 	if items, whereText, meas, ok := matchScanAgg(toks); ok {
 		return matchResult{shape: ShapeScanAgg, aggItems: items, whereText: whereText, measurement: meas}, true
 	}
-	// The allow-listed grouped shape (agg-2b): single key + count(*)-only, no
-	// WHERE. Tried before the scan (a bare-column-led grouped select would fail
-	// the scan anyway; count-led ones fall through the agg matchers above).
-	if items, key, meas, ok := matchGroupedNoWhere(toks); ok {
+	// The allow-listed grouped shape (agg-2b → agg-2c full agg set → mimalloc
+	// slice optional WHERE). Tried before the scan (a bare-column-led grouped
+	// select would fail the scan anyway; count-led ones fall through the agg
+	// matchers above).
+	if items, key, whereText, meas, ok := matchGroupedAgg(toks); ok {
 		return matchResult{
 			shape:       ShapeScanAggGrouped,
 			aggItems:    items,
 			groupKey:    key,
+			whereText:   whereText,
 			measurement: meas,
 		}, true
 	}

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -332,9 +332,11 @@ func buildScanAggSQL(d Decision, pathArray string) (string, bool) {
 }
 
 // buildGroupedSQL constructs the engine SQL for the allow-listed grouped class:
-// `SELECT <items> FROM read_parquet([...]) GROUP BY <key>`. Items re-validate as
-// agg-1 aggregate items (`isAggItem`) or exactly the bare key; decline rather
-// than emit unsafe SQL — same defense-in-depth as the other builders.
+// `SELECT <items> FROM read_parquet([...]) [WHERE <tree>] GROUP BY <key>`. Items
+// re-validate as agg-1 aggregate items (`isAggItem`) or exactly the bare key;
+// decline rather than emit unsafe SQL — same defense-in-depth as the other
+// builders. WhereText is reserializeWhere's rebuilt-from-validated-tokens text,
+// the same already-reviewed injection surface the scan/agg builders emit.
 func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
 	if len(d.AggItems) < 2 || !isBareIdent(d.GroupKey) {
 		return "", false
@@ -361,7 +363,12 @@ func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
 	}
 	b.WriteString(" FROM read_parquet(")
 	b.WriteString(pathArray)
-	b.WriteString(") GROUP BY ")
+	b.WriteString(")")
+	if d.WhereText != "" {
+		b.WriteString(" WHERE ")
+		b.WriteString(d.WhereText)
+	}
+	b.WriteString(" GROUP BY ")
 	b.WriteString(d.GroupKey)
 	return b.String(), true
 }

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -707,24 +707,27 @@ func matchScanAgg(toks []token) (items []string, whereText string, meas string, 
 	return items, whereText, meas, true
 }
 
-// matchGroupedNoWhere matches the grouped class the engine's perf gate has
-// cleared (agg-2c: every no-WHERE single-key grouped bench shape beats DuckDB
-// v1.5.5 on the 1.47B-row corpus):
+// matchGroupedAgg matches the grouped class the engine's perf gate has cleared
+// (agg-2c: every no-WHERE single-key grouped bench shape beats DuckDB v1.5.5 on
+// the 1.47B-row corpus; mimalloc slice 2026-08-27: the WHERE-bearing shapes —
+// selective AND broad, incl. the masked dashboard pair — flipped to wins too,
+// so the optional WHERE joined the class):
 //
-//	select {<agg>|<key>} [, ...]* from <measurement> group by {<key> | <pos>}
+//	select {<agg>|<key>} [, ...]* from <measurement> [where <tree>] group by {<key> | <pos>}
 //
 // EXACTLY one bare key column, ≥1 aggregate from agg-1's set (`count(*)` or
-// `count|sum|min|max|avg(<bare col>)`), any item order, NO WHERE (WHERE-bearing
-// grouped shapes share a recognizer shape with the still-losing broad-predicate
-// class and stay on DuckDB), nothing after the GROUP BY. Items are re-serialized
+// `count|sum|min|max|avg(<bare col>)`), any item order, an optional WHERE
+// through the same `reserializeWhere` boolean-tree surface the scan/agg shapes
+// use (injection-proof: emitted text is rebuilt from validated tokens, never
+// sliced from the source), nothing after the GROUP BY. Items are re-serialized
 // from validated tokens (fn lowercased, ARG spelling preserved — derived-name
 // parity); the key's spelling is preserved.
-func matchGroupedNoWhere(toks []token) (items []string, key string, meas string, ok bool) {
+func matchGroupedAgg(toks []token) (items []string, key string, whereText string, meas string, ok bool) {
 	c := &cursor{toks: toks}
 	if !c.ident("select") {
-		return nil, "", "", false
+		return nil, "", "", "", false
 	}
-	fail := func() ([]string, string, string, bool) { return nil, "", "", false }
+	fail := func() ([]string, string, string, string, bool) { return nil, "", "", "", false }
 
 	keyItem := -1
 	nAggs := 0
@@ -786,7 +789,16 @@ func matchGroupedNoWhere(toks []token) (items []string, key string, meas string,
 	}
 	meas = mt.orig
 
-	// NO WHERE in the allow-listed class.
+	// Optional WHERE — the same boolean-tree re-serialization the scan and
+	// ungrouped-agg shapes route through (one shared surface, one shared review).
+	if c.peekIdentLower() == "where" {
+		c.next()
+		wt, wok := reserializeWhere(c)
+		if !wok {
+			return fail()
+		}
+		whereText = wt
+	}
 	if !c.ident("group") || !c.ident("by") {
 		return fail()
 	}
@@ -809,7 +821,7 @@ func matchGroupedNoWhere(toks []token) (items []string, key string, meas string,
 	if !c.atEnd() {
 		return fail()
 	}
-	return items, key, meas, true
+	return items, key, whereText, meas, true
 }
 
 func matchScan(toks []token) (cols []string, preds []scanPred, whereText string, orderBy []scanOrderKey, limit int, meas string, ok bool) {


### PR DESCRIPTION
## What

Two fixes and one allow-list expansion for the arcx router path (dev-only: built behind `cgo && arcx_engine`; stock builds are unaffected and carry zero arcx symbols — verified).

### 1. UAF fix (critical)

`serveArcxResult`'s async body-stream writers (msgpack + JSON arms) called `getTokenName(c)` on the pooled Fiber `Ctx`, which is recycled once the handler returns — an arcx-served HTTP query on those wires dereferenced a released `RequestCtx` and crashed the server. The token name is now captured **before** `SetBodyStreamWriter`, matching the capture discipline the Arrow-IPC arm already documents. Verified end-to-end: repeated arcx-served queries over HTTP; server stays up; results correct.

### 2. Stale decline test

`TestBridgeUnsupportedDeclines` probed with `sum(x)`, which the engine now supports — the test was passing for the wrong reason paths and failing in tagged CI-less builds. The probe is now a JOIN (durably outside the engine surface), so the decline contract is actually exercised again.

### 3. Grouped allow-list: optional WHERE

The grouped recognizer accepts an optional WHERE through the same `reserializeWhere` boolean-tree surface the scan/agg shapes already use (injection-proof: emitted text is rebuilt from validated tokens, never sliced from the source). `whereText` threads through `Decision` into `buildGroupedSQL`. Gated per the standing discipline: the engine-side differential fixtures for WHERE-bearing grouped shapes are green and the perf gate cleared (all benched grouped shapes now at or ahead of the baseline). A/B attribution on a selective shape: serve 14 ms vs off 67 ms median.

Census: the `group_by` representative moves to a multi-key query (single-key WHERE-bearing grouped is now eligible).

## Verification

- `go test ./internal/api ./internal/arcxrouter` (stock) and `-tags=duckdb_arrow,arcx_engine` for `arcxengine`/`arcxrouter`/`api` — all green.
- `CGO_ENABLED=1 go vet -tags=duckdb_arrow,arcx_engine` clean; stock `go build ./...` clean; stock binary has 0 arcx symbols.
- End-to-end serve run over HTTP: correct rows, server alive across repeated queries, serve-vs-off attribution confirms the arcx path is exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)