### PR TITLE
feat(arcxrouter): time-bucketed grouped shapes join the allow-list (the dashboard class)

### DIFF
--- a/internal/arcxrouter/agg_recognizer_test.go
+++ b/internal/arcxrouter/agg_recognizer_test.go
@@ -135,6 +135,21 @@ func TestGroupedAggRecognized(t *testing.T) {
 			"SELECT host, sum(f), min(f) FROM cpu WHERE f > 1.5 OR host = 'b' GROUP BY 1",
 			[]string{"host", "sum(f)", "min(f)"}, "host", "f > 1.5 OR host = 'b'",
 		},
+		// agg-3: the time-bucket key + ORDER BY on the key.
+		{
+			"SELECT date_trunc('minute', time), count(*), avg(cpu_user) FROM cpu WHERE time >= '2026-01-01T00:00:00Z' GROUP BY 1 ORDER BY 1",
+			[]string{"date_trunc('minute', time)", "count(*)", "avg(cpu_user)"},
+			"date_trunc('minute', time)", "time >= '2026-01-01T00:00:00Z'",
+		},
+		{
+			"SELECT count(*), date_trunc('hour', Time) FROM cpu GROUP BY 2",
+			[]string{"count(*)", "date_trunc('hour', Time)"},
+			"date_trunc('hour', Time)", "",
+		},
+		{
+			"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY host ASC",
+			[]string{"host", "count(*)"}, "host", "",
+		},
 	}
 	for _, c := range cases {
 		m, ok := eligibleShape(c.sql)
@@ -159,7 +174,10 @@ func TestGroupedAggDeclines(t *testing.T) {
 		"SELECT count(*) FROM cpu GROUP BY host",                       // key not projected
 		"SELECT host, count(*) FROM cpu GROUP BY region",               // wrong key
 		"SELECT host, count(*) FROM cpu GROUP BY 2",                    // position at count
-		"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY 1",      // trailing
+		// `ORDER BY 1` on the key became eligible at agg-3 (see the Recognized
+		// test); DESC and ORDER on an aggregate still decline.
+		"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY 1 DESC",
+		"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY 2",
 		"SELECT host, count(*) FROM cpu GROUP BY host LIMIT 5",
 		// WHERE joined the class (mimalloc slice) — but ONLY through the shared
 		// reserializeWhere vocabulary; anything it declines stays declined here.

--- a/internal/arcxrouter/build_agg_sql_test.go
+++ b/internal/arcxrouter/build_agg_sql_test.go
@@ -59,7 +59,9 @@ func TestBuildGroupedSQL(t *testing.T) {
 		AggItems: []string{"count(*)", "host"},
 		GroupKey: "host",
 	}, paths)
-	want := "SELECT count(*), host FROM read_parquet(['/p.parquet']) GROUP BY host"
+	// agg-3: GROUP BY (and ORDER BY) emit by POSITION — valid for bare keys and
+	// bucket keys alike, and no identifier text reaches the emitted clause.
+	want := "SELECT count(*), host FROM read_parquet(['/p.parquet']) GROUP BY 2"
 	if !ok || got != want {
 		t.Fatalf("got (%q, %t), want %q", got, ok, want)
 	}
@@ -70,11 +72,35 @@ func TestBuildGroupedSQL(t *testing.T) {
 		GroupKey:  "host",
 		WhereText: "cpu_user > 90",
 	}, paths)
-	want = "SELECT host, count(*), avg(cpu_user) FROM read_parquet(['/p.parquet']) WHERE cpu_user > 90 GROUP BY host"
+	want = "SELECT host, count(*), avg(cpu_user) FROM read_parquet(['/p.parquet']) WHERE cpu_user > 90 GROUP BY 1"
+	if !ok || got != want {
+		t.Fatalf("got (%q, %t), want %q", got, ok, want)
+	}
+	// agg-3 bucket key + ORDER BY: the bucket text is REBUILT from the validated
+	// parts (BucketUnit/BucketCol), never taken from GroupKey.
+	got, ok = buildGroupedSQL(Decision{
+		AggItems:   []string{"date_trunc('minute', time)", "count(*)", "avg(cpu_user)"},
+		GroupKey:   "date_trunc('minute', time)",
+		BucketUnit: "minute",
+		BucketCol:  "time",
+		WhereText:  "time >= '2026-01-01T00:00:00Z'",
+		OrderByKey: true,
+	}, paths)
+	want = "SELECT date_trunc('minute', time), count(*), avg(cpu_user) FROM read_parquet(['/p.parquet']) WHERE time >= '2026-01-01T00:00:00Z' GROUP BY 1 ORDER BY 1"
 	if !ok || got != want {
 		t.Fatalf("got (%q, %t), want %q", got, ok, want)
 	}
 	for _, d := range []Decision{
+		{ // unsafe bucket parts must never be emitted
+			AggItems:   []string{"date_trunc('week', time)", "count(*)"},
+			GroupKey:   "date_trunc('week', time)",
+			BucketUnit: "week", BucketCol: "time",
+		},
+		{
+			AggItems:   []string{"date_trunc('minute', x)", "count(*)"},
+			GroupKey:   "date_trunc('minute', x)",
+			BucketUnit: "minute", BucketCol: "x; DROP",
+		},
 		{AggItems: []string{"count(*)"}, GroupKey: "host"},                 // no key item
 		{AggItems: []string{"host", "count(*)"}, GroupKey: "h; DROP"},      // unsafe key
 		{AggItems: []string{"host", "median(x)"}, GroupKey: "host"},        // unknown fn item

--- a/internal/arcxrouter/compare_grouped.go
+++ b/internal/arcxrouter/compare_grouped.go
@@ -79,6 +79,15 @@ func groupedFromArcx(rec arrow.Record, keyCol int) ([]groupedRow, error) {
 					} else {
 						row.keyInt = col.Value(r)
 					}
+				// agg-3 bucket key: compare as epoch µs (typed, never a string).
+				case *array.Timestamp:
+					row.keyIsI = true
+					if col.IsNull(r) {
+						row.keyNull = true
+					} else {
+						unit := col.DataType().(*arrow.TimestampType).Unit
+						row.keyInt = toMicros(int64(col.Value(r)), unit)
+					}
 				default:
 					return nil, fmt.Errorf("arcx grouped key: unexpected type %T", rec.Column(c))
 				}
@@ -143,6 +152,9 @@ func groupedFromRows(rows *sql.Rows, keyCol int) ([]groupedRow, error) {
 				case int64:
 					row.keyIsI = true
 					row.keyInt = x
+				case time.Time:
+					row.keyIsI = true
+					row.keyInt = x.UnixMicro()
 				default:
 					return nil, fmt.Errorf("duckdb grouped key: unexpected type %T", v)
 				}

--- a/internal/arcxrouter/eligibility.go
+++ b/internal/arcxrouter/eligibility.go
@@ -153,6 +153,12 @@ type matchResult struct {
 	// scan_agg_grouped_count only: the single group-key column (as written).
 	// aggItems then holds the select list ("count(*)" or the key), in order.
 	groupKey string
+	// agg-3 bucket key: the validated date_trunc parts (empty = a bare tag key).
+	// The SQL builder re-emits from THESE, never from groupKey's text.
+	bucketUnit string
+	bucketCol  string
+	// agg-3: emit `ORDER BY <key position>` (ascending) in the engine SQL.
+	orderByKey bool
 }
 
 // eligibleShape recognizes the arcx shapes on the raw user SQL. ok=false means
@@ -210,13 +216,16 @@ func eligibleShape(sql string) (matchResult, bool) {
 	// slice optional WHERE). Tried before the scan (a bare-column-led grouped
 	// select would fail the scan anyway; count-led ones fall through the agg
 	// matchers above).
-	if items, key, whereText, meas, ok := matchGroupedAgg(toks); ok {
+	if gm, ok := matchGroupedAgg(toks); ok {
 		return matchResult{
 			shape:       ShapeScanAggGrouped,
-			aggItems:    items,
-			groupKey:    key,
-			whereText:   whereText,
-			measurement: meas,
+			aggItems:    gm.items,
+			groupKey:    gm.key,
+			bucketUnit:  gm.bucketUnit,
+			bucketCol:   gm.bucketCol,
+			orderByKey:  gm.orderByKey,
+			whereText:   gm.whereText,
+			measurement: gm.meas,
 		}, true
 	}
 	// Scan is tried LAST: it's the broadest shape (a bare column list matches many

--- a/internal/arcxrouter/eligibility_test.go
+++ b/internal/arcxrouter/eligibility_test.go
@@ -128,21 +128,24 @@ func TestEligibleShape_Declines(t *testing.T) {
 		{"select star", "SELECT * FROM cpu"},
 
 		// --- agg declines ---
-		{"agg wrong column", "SELECT date_trunc('day', ts), count(*) FROM cpu GROUP BY 1"},
+		// "agg wrong column" (ts instead of time): since agg-3 this routes via the
+		// grouped bucket path; the ENGINE settles it (FooterAgg col-mismatch →
+		// Unsupported → silent fallback). Covered in TestGroupedAggRecognized.
 		{"agg column expr", "SELECT date_trunc('day', time + 1), count(*) FROM cpu GROUP BY 1"},
 		{"agg unsupported unit", "SELECT date_trunc('week', time), count(*) FROM cpu GROUP BY 1"},
 		// minute/second ARE supported, but ONLY with a time-range WHERE — unfiltered
 		// sub-hour declines (would miss DuckDB's NULL bucket). Covered in detail by
 		// TestEligibleShape_FilteredDateTrunc.
-		{"agg minute no where declines", "SELECT date_trunc('minute', time), count(*) FROM cpu GROUP BY 1"},
-		{"agg second no where declines", "SELECT date_trunc('second', time), count(*) FROM cpu GROUP BY 1"},
+		// minute/second count-only WITHOUT a WHERE: since agg-3 these route via the
+		// grouped bucket path (the engine's footer path keeps first refusal and
+		// declines them; the fallback contract handles it). Moved to eligible.
 		{"agg group by expr", "SELECT date_trunc('day', time), count(*) FROM cpu GROUP BY date_trunc('day', time)"},
 		{"agg group by 2", "SELECT date_trunc('day', time), count(*) FROM cpu GROUP BY 2"},
 		{"agg no group by", "SELECT date_trunc('day', time), count(*) FROM cpu"},
 		{"agg extra projection", "SELECT date_trunc('day', time), host, count(*) FROM cpu GROUP BY 1"},
 		{"agg having", "SELECT date_trunc('day', time), count(*) FROM cpu GROUP BY 1 HAVING count(*) > 1"},
 		{"agg order by 2", "SELECT date_trunc('day', time), count(*) FROM cpu GROUP BY 1 ORDER BY 2"},
-		{"agg sum not count", "SELECT date_trunc('day', time), sum(x) FROM cpu GROUP BY 1"},
+		// "agg sum not count": the agg-3 surface itself — now eligible (grouped).
 
 		// --- TZ-injection declines (M3) ---
 		{"set timezone", "SET TimeZone='America/New_York'; SELECT count(*) FROM cpu"},
@@ -213,22 +216,35 @@ func TestEligibleShape_FilteredDateTrunc(t *testing.T) {
 		})
 	}
 
-	declines := []struct{ name, sql string }{
-		{"= on time (not a range)", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time = '2024-01-01T00:00:00Z' GROUP BY 1"},
+	// Since agg-3, the non-footer WHERE forms route via the GROUPED bucket path
+	// (ShapeScanAggGrouped) instead of declining outright — the engine serves the
+	// forms its differential fixtures pinned (=, !=, OR, IS NULL trees,
+	// data-column atoms) and Unsupported-declines the rest (BETWEEN, numeric RHS
+	// vs timestamp) with a silent fallback (unsupported ≠ error).
+	regrouped := []struct{ name, sql string }{
+		{"= on time", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time = '2024-01-01T00:00:00Z' GROUP BY 1"},
 		{"!= on time", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time != '2024-01-01T00:00:00Z' GROUP BY 1"},
 		{"OR", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time >= '2024-01-01T00:00:00Z' OR time < '2024-01-02T00:00:00Z' GROUP BY 1"},
 		{"non-time column", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE host = 'web1' GROUP BY 1"},
-		{"BETWEEN", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time BETWEEN '2024-01-01T00:00:00Z' AND '2024-01-02T00:00:00Z' GROUP BY 1"},
-		{"numeric RHS", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time >= 5 GROUP BY 1"},
 		{"IS NULL", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time IS NULL GROUP BY 1"},
-		{"in-query default_null_order", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time >= '2024-01-01T00:00:00Z' GROUP BY 1 /* default_null_order */"},
-		// Sub-hour units REQUIRE a time range: unfiltered would miss DuckDB's NULL
-		// bucket (the engine's per-row decode counts only non-null in-range rows).
 		{"minute no where", "SELECT date_trunc('minute', time), count(*) FROM cpu GROUP BY 1"},
 		{"second no where", "SELECT date_trunc('second', time), count(*) FROM cpu GROUP BY 1"},
-		// A sub-hour WHERE that isn't a pure time range still declines (same as hour).
-		{"minute IS NULL OR range (grammar guardrail)", "SELECT date_trunc('minute', time), count(*) FROM cpu WHERE time IS NULL OR time >= '2024-01-01T00:00:00Z' GROUP BY 1"},
+		{"minute IS NULL OR range", "SELECT date_trunc('minute', time), count(*) FROM cpu WHERE time IS NULL OR time >= '2024-01-01T00:00:00Z' GROUP BY 1"},
 		{"minute non-time predicate", "SELECT date_trunc('minute', time), count(*) FROM cpu WHERE host = 'web1' GROUP BY 1"},
+		{"BETWEEN", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time BETWEEN '2024-01-01T00:00:00Z' AND '2024-01-02T00:00:00Z' GROUP BY 1"},
+		{"numeric RHS", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time >= 5 GROUP BY 1"},
+	}
+	for _, tc := range regrouped {
+		t.Run("regrouped/"+tc.name, func(t *testing.T) {
+			m, ok := eligibleShape(tc.sql)
+			if !ok || m.shape != ShapeScanAggGrouped {
+				t.Fatalf("expected grouped-bucket eligibility, got (%q, %t) for %q", m.shape, ok, tc.sql)
+			}
+		})
+	}
+	declines := []struct{ name, sql string }{
+		// Comments never pass the tokenizer (the 2e `--` CRITICAL class).
+		{"in-query default_null_order", "SELECT date_trunc('hour', time), count(*) FROM cpu WHERE time >= '2024-01-01T00:00:00Z' GROUP BY 1 /* default_null_order */"},
 	}
 	for _, tc := range declines {
 		t.Run("decline/"+tc.name, func(t *testing.T) {

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -108,7 +108,12 @@ type Decision struct {
 	OrderBy   []scanOrderKey // scan only: ORDER BY keys
 	Limit     int            // scan only: LIMIT n (0 = none)
 	AggItems  []string       // scan_agg only: re-serialized aggregate items, select-list order
-	GroupKey  string         // scan_agg_grouped_count only: the single group-key column
+	GroupKey  string         // scan_agg_grouped only: the single group-key column (or the rebuilt bucket text)
+	// agg-3 bucket key parts (empty = bare tag key) — the builder re-emits from
+	// these validated parts, never from GroupKey's text.
+	BucketUnit string
+	BucketCol  string
+	OrderByKey bool // agg-3: append `ORDER BY <key position>` (ascending)
 }
 
 // Decide is the cheap per-query pre-filter. It never calls the engine; it only
@@ -141,16 +146,19 @@ func Decide(sql, headerDB string, h Handler) Decision {
 			// would be a bypass around Arc's CVE fix.
 			AllowedDirs: h.AllowedDirs,
 		},
-		Shape:     m.shape,
-		Unit:      m.unit,
-		Col:       m.col,
-		Cols:      m.cols,
-		Preds:     m.preds,
-		WhereText: m.whereText,
-		OrderBy:   m.orderBy,
-		Limit:     m.limit,
-		AggItems:  m.aggItems,
-		GroupKey:  m.groupKey,
+		Shape:      m.shape,
+		Unit:       m.unit,
+		Col:        m.col,
+		Cols:       m.cols,
+		Preds:      m.preds,
+		WhereText:  m.whereText,
+		OrderBy:    m.orderBy,
+		Limit:      m.limit,
+		AggItems:   m.aggItems,
+		GroupKey:   m.groupKey,
+		BucketUnit: m.bucketUnit,
+		BucketCol:  m.bucketCol,
+		OrderByKey: m.orderByKey,
 	}
 }
 
@@ -338,7 +346,23 @@ func buildScanAggSQL(d Decision, pathArray string) (string, bool) {
 // builders. WhereText is reserializeWhere's rebuilt-from-validated-tokens text,
 // the same already-reviewed injection surface the scan/agg builders emit.
 func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
-	if len(d.AggItems) < 2 || !isBareIdent(d.GroupKey) {
+	// The key is either a bare tag column, or (agg-3) a time bucket REBUILT here
+	// from the validated parts — unit from the fixed-width allow-set, column via
+	// isBareIdent — never from GroupKey's text.
+	var keyText string
+	var keyPos int
+	switch {
+	case d.BucketUnit != "":
+		if !fixedWidthUnits[strings.ToLower(d.BucketUnit)] || !isBareIdent(d.BucketCol) {
+			return "", false
+		}
+		keyText = "date_trunc('" + d.BucketUnit + "', " + d.BucketCol + ")"
+	case isBareIdent(d.GroupKey):
+		keyText = d.GroupKey
+	default:
+		return "", false
+	}
+	if len(d.AggItems) < 2 {
 		return "", false
 	}
 	sawKey, sawAgg := false, false
@@ -348,8 +372,9 @@ func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
 		switch {
 		case isAggItem(item):
 			sawAgg = true
-		case item == d.GroupKey && !sawKey:
+		case item == keyText && !sawKey:
 			sawKey = true
+			keyPos = i + 1
 		default:
 			return "", false
 		}
@@ -368,8 +393,14 @@ func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
 		b.WriteString(" WHERE ")
 		b.WriteString(d.WhereText)
 	}
+	// GROUP BY / ORDER BY by POSITION: valid for both key forms and emits no
+	// identifier text at all.
 	b.WriteString(" GROUP BY ")
-	b.WriteString(d.GroupKey)
+	b.WriteString(strconv.Itoa(keyPos))
+	if d.OrderByKey {
+		b.WriteString(" ORDER BY ")
+		b.WriteString(strconv.Itoa(keyPos))
+	}
 	return b.String(), true
 }
 

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -719,15 +719,25 @@ func matchScanAgg(toks []token) (items []string, whereText string, meas string, 
 // `count|sum|min|max|avg(<bare col>)`), any item order, an optional WHERE
 // through the same `reserializeWhere` boolean-tree surface the scan/agg shapes
 // use (injection-proof: emitted text is rebuilt from validated tokens, never
-// sliced from the source), nothing after the GROUP BY. Items are re-serialized
-// from validated tokens (fn lowercased, ARG spelling preserved — derived-name
-// parity); the key's spelling is preserved.
-func matchGroupedAgg(toks []token) (items []string, key string, whereText string, meas string, ok bool) {
+// sliced from the source). Items are re-serialized from validated tokens (fn
+// lowercased, ARG spelling preserved — derived-name parity); the key's spelling
+// is preserved.
+//
+// agg-3 widened the key: EITHER a bare tag column OR one time-bucket item
+// `date_trunc('<unit>', <bare col>)` with unit in the engine's fixed-width set
+// (second/minute/hour/day — bucketUnit/bucketCol return the validated parts and
+// the builder re-emits them, never the source text). An optional trailing
+// `ORDER BY <key pos|key name> [ASC]` is accepted (the engine sorts ascending,
+// NULLS LAST); DESC/LIMIT/multi-key ORDER decline. Non-UTC sessions never get
+// here — the M3 tz-injection gate runs before shape matching (gotcha #3).
+func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 	c := &cursor{toks: toks}
 	if !c.ident("select") {
-		return nil, "", "", "", false
+		return groupedMatch{}, false
 	}
-	fail := func() ([]string, string, string, string, bool) { return nil, "", "", "", false }
+	fail := func() (groupedMatch, bool) { return groupedMatch{}, false }
+	var items []string
+	var key, whereText, meas string
 
 	keyItem := -1
 	nAggs := 0
@@ -737,7 +747,33 @@ func matchGroupedAgg(toks []token) (items []string, key string, whereText string
 			return fail()
 		}
 		isCall := c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '('
-		if isCall {
+		if isCall && t.lower == "date_trunc" {
+			// The time-bucket KEY item (agg-3). One per query; fixed-width units
+			// only (the engine declines calendar units).
+			if keyItem >= 0 {
+				return fail()
+			}
+			c.i++ // consume '('
+			ut, tok := c.next()
+			if !tok || ut.kind != tokStr || !fixedWidthUnits[strings.ToLower(ut.str)] {
+				return fail()
+			}
+			if !c.punct(',') {
+				return fail()
+			}
+			bc, tok := c.next()
+			if !tok || bc.kind != tokIdent || isScanKeyword(bc.lower) || !isBareIdent(bc.orig) {
+				return fail()
+			}
+			if !c.punct(')') {
+				return fail()
+			}
+			m.bucketUnit = ut.str
+			m.bucketCol = bc.orig
+			keyItem = len(items)
+			key = "date_trunc('" + ut.str + "', " + bc.orig + ")"
+			items = append(items, key)
+		} else if isCall {
 			switch t.lower {
 			case "count", "sum", "min", "max", "avg":
 			default:
@@ -802,26 +838,71 @@ func matchGroupedAgg(toks []token) (items []string, key string, whereText string
 	if !c.ident("group") || !c.ident("by") {
 		return fail()
 	}
+	// A key reference: the key's position, or (bare keys only — a bucket's text
+	// is not an identifier) its name.
+	keyRef := func(kt token) bool {
+		switch kt.kind {
+		case tokIdent:
+			return m.bucketUnit == "" && strings.EqualFold(kt.orig, key)
+		case tokNum:
+			return kt.orig == strconv.Itoa(keyItem+1)
+		}
+		return false
+	}
 	kt, tok := c.next()
-	if !tok {
+	if !tok || !keyRef(kt) {
 		return fail()
 	}
-	switch kt.kind {
-	case tokIdent:
-		if !strings.EqualFold(kt.orig, key) {
+	// Optional `ORDER BY <key ref> [ASC]` (agg-3): the engine sorts the single
+	// key ascending, NULLS LAST. DESC / LIMIT / anything else after declines.
+	if c.peekIdentLower() == "order" {
+		c.next()
+		if !c.ident("by") {
 			return fail()
 		}
-	case tokNum:
-		if kt.orig != strconv.Itoa(keyItem+1) {
+		ot, tok := c.next()
+		if !tok || !keyRef(ot) {
 			return fail()
 		}
-	default:
-		return fail()
+		if c.peekIdentLower() == "asc" {
+			c.next()
+		}
+		m.orderByKey = true
 	}
 	if !c.atEnd() {
 		return fail()
 	}
-	return items, key, whereText, meas, true
+	m.items = items
+	m.key = key
+	m.keyItem = keyItem
+	m.whereText = whereText
+	m.meas = meas
+	return m, true
+}
+
+// groupedMatch is matchGroupedAgg's result: the re-serialized select items, the
+// key (a bare column, or the rebuilt bucket text when bucketUnit != ""), the
+// key's select-list index, and the validated bucket parts the SQL builder
+// re-emits (never source text).
+type groupedMatch struct {
+	items      []string
+	key        string
+	keyItem    int
+	whereText  string
+	meas       string
+	bucketUnit string
+	bucketCol  string
+	orderByKey bool
+}
+
+// fixedWidthUnits is the engine's agg-3 bucket set — pure UTC epoch division
+// (day = 86,400s; no DST in UTC). Calendar units (week/month/year) decline;
+// count-only month/year stays on the footer date_trunc_count shape.
+var fixedWidthUnits = map[string]bool{
+	"second": true,
+	"minute": true,
+	"hour":   true,
+	"day":    true,
 }
 
 func matchScan(toks []token) (cols []string, preds []scanPred, whereText string, orderBy []scanOrderKey, limit int, meas string, ok bool) {


### PR DESCRIPTION
## What

The grouped recognizer learns the time-bucketed aggregation surface the engine cleared its perf gate on (all three dashboard bench shapes ahead of the baseline; differential fixtures green engine-side):

- **Time-bucket key item**: `date_trunc('<unit>', <bare col>)` with unit in the fixed-width set (second/minute/hour/day). The SQL builder re-emits the bucket from **validated parts** (unit allow-set + `isBareIdent` column) — never from source text, the same injection discipline as every emitted clause.
- **Optional `ORDER BY <key ref> [ASC]`** (engine sorts ascending, NULLS LAST); DESC / LIMIT / ORDER-on-aggregate decline.
- `GROUP BY` / `ORDER BY` now emit **by position** — valid for both key forms, and no identifier text reaches the emitted clause.
- Shadow compare handles **Timestamp group keys as typed epoch-µs** on both sides (arrow `Timestamp` / Go `time.Time`), never strings.

## Dispatch notes

The footer `date_trunc_count` shape keeps first refusal (count-only + pure time-range WHERE, ~1 ms). Previously-declined forms — `=`/`!=` on time, OR / IS NULL trees, data-column atoms under buckets, sub-hour without WHERE — now route via the grouped tree: the engine serves the differential-pinned forms and Unsupported-declines the rest with the standing silent fallback (unsupported ≠ error). The M3 tz-injection gate runs before shape matching, so non-UTC sessions never route.

## End-to-end (serve vs off, same binary, 1-day minute-bucket query, real corpus)

arcx ~1000 ms vs DuckDB path ~1830 ms; identical rows and values. A visible bonus: arcx preserves the user's derived column name (`date_trunc('minute', "time")`) where the current DuckDB path leaks the epoch-math rewrite's mangled name (`to_timestamp(((CAST(epoch("time")...`).

Known caveat on record: pre-1970 buckets would shadow-mismatch because the existing epoch rewrite truncates toward zero where `date_trunc` floors — a pre-existing rewrite semantic, and telemetry data is post-1970.

## Verification

- `go test ./internal/arcxrouter ./internal/api` in stock and `-tags=duckdb_arrow,arcx_engine` modes — green; vet clean both modes; stock binary carries no engine symbols.
- Recognizer/builder/eligibility tests updated: flipped decline-pins converted to shape assertions (`regrouped/` cases), new accept cases for bucket + ORDER BY, unsafe-bucket-part builder declines (`week`, injection in the column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)