### PR TITLE
feat(arcxrouter): the epoch-math (Grafana $__timeGroup) bucket form joins the allow-list

### DIFF
--- a/internal/arcxrouter/agg_recognizer_test.go
+++ b/internal/arcxrouter/agg_recognizer_test.go
@@ -191,3 +191,59 @@ func TestGroupedAggDeclines(t *testing.T) {
 		}
 	}
 }
+
+func TestEpochMathBucketRecognized(t *testing.T) {
+	// agg-3b: the exact Grafana $__timeGroup emission (mandatory alias; the
+	// time-series frame needs a column named `time`).
+	em := "to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time"
+	cases := []struct {
+		sql        string
+		orderByKey bool
+	}{
+		{"SELECT " + em + ", avg(cpu_user) FROM cpu WHERE time >= '2026-08-13T00:00:00Z' AND time < '2026-08-14T00:00:00Z' GROUP BY 1 ORDER BY time", true},
+		{"SELECT " + em + ", count(*), avg(cpu_user) FROM cpu GROUP BY 1 ORDER BY 1", true},
+		{"SELECT " + em + ", avg(cpu_user) FROM cpu GROUP BY 1 ORDER BY time ASC", true},
+		{"SELECT " + em + ", avg(cpu_user) FROM cpu GROUP BY 1", false},
+	}
+	for _, c := range cases {
+		m, ok := eligibleShape(c.sql)
+		if !ok || m.shape != ShapeScanAggGrouped {
+			t.Fatalf("should be scan_agg_grouped: %s (got %q, %t)", c.sql, m.shape, ok)
+		}
+		if m.epochWidthSecs != 300 || m.bucketCol != "time" || m.bucketAlias != "time" {
+			t.Fatalf("parts = %d/%q/%q: %s", m.epochWidthSecs, m.bucketCol, m.bucketAlias, c.sql)
+		}
+		if m.orderByKey != c.orderByKey {
+			t.Fatalf("orderByKey = %t, want %t: %s", m.orderByKey, c.orderByKey, c.sql)
+		}
+	}
+}
+
+func TestEpochMathBucketDeclines(t *testing.T) {
+	for _, sql := range []string{
+		// A SPACED `/ /` is a DuckDB Parser Error — must never lex as `//` (the
+		// 2e `--` comment adjacency class; greedy lexer pin).
+		"SELECT to_timestamp((epoch_ns(time) / / 1000000000 // 300) * 300) AS time, avg(x) FROM cpu GROUP BY 1",
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 / / 300) * 300) AS time, avg(x) FROM cpu GROUP BY 1",
+		// Width literals must match (a different, legal expression otherwise).
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 600) AS time, avg(x) FROM cpu GROUP BY 1",
+		// Unaliased form declines (derived-name reproduction not worth it).
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300), avg(x) FROM cpu GROUP BY 1",
+		// GROUP BY <alias>: DuckDB binds the RAW column there (oracle-probed) —
+		// only positional GROUP BY is safe.
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS b, avg(x) FROM cpu GROUP BY b",
+		// Width out of range / zero.
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 0) * 0) AS time, avg(x) FROM cpu GROUP BY 1",
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 99999999) * 99999999) AS time, avg(x) FROM cpu GROUP BY 1",
+		// Wrong ns divisor.
+		"SELECT to_timestamp((epoch_ns(time) // 1000000 // 300) * 300) AS time, avg(x) FROM cpu GROUP BY 1",
+		// Two bucket items.
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS a, date_trunc('minute', time), avg(x) FROM cpu GROUP BY 1, 2",
+		// ORDER BY DESC still declines.
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time, avg(x) FROM cpu GROUP BY 1 ORDER BY time DESC",
+	} {
+		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScanAggGrouped {
+			t.Fatalf("must not match scan_agg_grouped: %s", sql)
+		}
+	}
+}

--- a/internal/arcxrouter/build_agg_sql_test.go
+++ b/internal/arcxrouter/build_agg_sql_test.go
@@ -90,7 +90,30 @@ func TestBuildGroupedSQL(t *testing.T) {
 	if !ok || got != want {
 		t.Fatalf("got (%q, %t), want %q", got, ok, want)
 	}
+	// agg-3b epoch-math bucket: rebuilt from validated parts, alias included.
+	got, ok = buildGroupedSQL(Decision{
+		AggItems:       []string{"to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time", "avg(cpu_user)"},
+		GroupKey:       "to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time",
+		EpochWidthSecs: 300,
+		BucketCol:      "time",
+		BucketAlias:    "time",
+		OrderByKey:     true,
+	}, paths)
+	want = "SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time, avg(cpu_user) FROM read_parquet(['/p.parquet']) GROUP BY 1 ORDER BY 1"
+	if !ok || got != want {
+		t.Fatalf("got (%q, %t), want %q", got, ok, want)
+	}
 	for _, d := range []Decision{
+		{ // epoch-math with unsafe parts must never be emitted
+			AggItems:       []string{"to_timestamp((epoch_ns(t; DROP) // 1000000000 // 300) * 300) AS time", "count(*)"},
+			GroupKey:       "to_timestamp((epoch_ns(t; DROP) // 1000000000 // 300) * 300) AS time",
+			EpochWidthSecs: 300, BucketCol: "t; DROP", BucketAlias: "time",
+		},
+		{
+			AggItems:       []string{"to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS x; DROP", "count(*)"},
+			GroupKey:       "to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS x; DROP",
+			EpochWidthSecs: 300, BucketCol: "time", BucketAlias: "x; DROP",
+		},
 		{ // unsafe bucket parts must never be emitted
 			AggItems:   []string{"date_trunc('week', time)", "count(*)"},
 			GroupKey:   "date_trunc('week', time)",

--- a/internal/arcxrouter/eligibility.go
+++ b/internal/arcxrouter/eligibility.go
@@ -159,6 +159,9 @@ type matchResult struct {
 	bucketCol  string
 	// agg-3: emit `ORDER BY <key position>` (ascending) in the engine SQL.
 	orderByKey bool
+	// agg-3b epoch-math bucket: width secs (0 = not this form) + mandatory alias.
+	epochWidthSecs int
+	bucketAlias    string
 }
 
 // eligibleShape recognizes the arcx shapes on the raw user SQL. ok=false means
@@ -218,14 +221,16 @@ func eligibleShape(sql string) (matchResult, bool) {
 	// matchers above).
 	if gm, ok := matchGroupedAgg(toks); ok {
 		return matchResult{
-			shape:       ShapeScanAggGrouped,
-			aggItems:    gm.items,
-			groupKey:    gm.key,
-			bucketUnit:  gm.bucketUnit,
-			bucketCol:   gm.bucketCol,
-			orderByKey:  gm.orderByKey,
-			whereText:   gm.whereText,
-			measurement: gm.meas,
+			shape:          ShapeScanAggGrouped,
+			aggItems:       gm.items,
+			groupKey:       gm.key,
+			bucketUnit:     gm.bucketUnit,
+			bucketCol:      gm.bucketCol,
+			epochWidthSecs: gm.epochWidthSecs,
+			bucketAlias:    gm.bucketAlias,
+			orderByKey:     gm.orderByKey,
+			whereText:      gm.whereText,
+			measurement:    gm.meas,
 		}, true
 	}
 	// Scan is tried LAST: it's the broadest shape (a bare column list matches many

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -114,6 +114,10 @@ type Decision struct {
 	BucketUnit string
 	BucketCol  string
 	OrderByKey bool // agg-3: append `ORDER BY <key position>` (ascending)
+	// agg-3b epoch-math bucket: width in whole seconds (0 = not this form) and
+	// the mandatory alias — the builder re-emits from these validated parts.
+	EpochWidthSecs int
+	BucketAlias    string
 }
 
 // Decide is the cheap per-query pre-filter. It never calls the engine; it only
@@ -146,19 +150,21 @@ func Decide(sql, headerDB string, h Handler) Decision {
 			// would be a bypass around Arc's CVE fix.
 			AllowedDirs: h.AllowedDirs,
 		},
-		Shape:      m.shape,
-		Unit:       m.unit,
-		Col:        m.col,
-		Cols:       m.cols,
-		Preds:      m.preds,
-		WhereText:  m.whereText,
-		OrderBy:    m.orderBy,
-		Limit:      m.limit,
-		AggItems:   m.aggItems,
-		GroupKey:   m.groupKey,
-		BucketUnit: m.bucketUnit,
-		BucketCol:  m.bucketCol,
-		OrderByKey: m.orderByKey,
+		Shape:          m.shape,
+		Unit:           m.unit,
+		Col:            m.col,
+		Cols:           m.cols,
+		Preds:          m.preds,
+		WhereText:      m.whereText,
+		OrderBy:        m.orderBy,
+		Limit:          m.limit,
+		AggItems:       m.aggItems,
+		GroupKey:       m.groupKey,
+		BucketUnit:     m.bucketUnit,
+		BucketCol:      m.bucketCol,
+		OrderByKey:     m.orderByKey,
+		EpochWidthSecs: m.epochWidthSecs,
+		BucketAlias:    m.bucketAlias,
 	}
 }
 
@@ -352,6 +358,15 @@ func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
 	var keyText string
 	var keyPos int
 	switch {
+	case d.EpochWidthSecs != 0:
+		// agg-3b: rebuild the exact Grafana emission + alias from validated
+		// parts (width in range, bare-ident col and alias) — never source text.
+		if d.EpochWidthSecs < 1 || d.EpochWidthSecs > 31_622_400 ||
+			!isBareIdent(d.BucketCol) || !isBareIdent(d.BucketAlias) {
+			return "", false
+		}
+		w := strconv.Itoa(d.EpochWidthSecs)
+		keyText = "to_timestamp((epoch_ns(" + d.BucketCol + ") // 1000000000 // " + w + ") * " + w + ") AS " + d.BucketAlias
 	case d.BucketUnit != "":
 		if !fixedWidthUnits[strings.ToLower(d.BucketUnit)] || !isBareIdent(d.BucketCol) {
 			return "", false

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -20,12 +20,13 @@ import (
 type tokKind int
 
 const (
-	tokIdent tokKind = iota // keyword or identifier, incl. dotted db.measurement
-	tokStr                  // single-quoted string literal (date_trunc unit, WHERE string literal)
-	tokNum                  // integer literal (GROUP BY 1, WHERE numeric literal, optional leading -)
-	tokFloat                // decimal float literal `digit.digit` (WHERE DOUBLE eq, optional leading -)
-	tokPunct                // one of ( ) * ,
-	tokOp                   // comparison operator: = != <> < <= > >= (scan WHERE)
+	tokIdent  tokKind = iota // keyword or identifier, incl. dotted db.measurement
+	tokStr                   // single-quoted string literal (date_trunc unit, WHERE string literal)
+	tokNum                   // integer literal (GROUP BY 1, WHERE numeric literal, optional leading -)
+	tokFloat                 // decimal float literal `digit.digit` (WHERE DOUBLE eq, optional leading -)
+	tokPunct                 // one of ( ) * ,
+	tokOp                    // comparison operator: = != <> < <= > >= (scan WHERE)
+	tokIntDiv                // `//` — DuckDB integer (trunc) division, lexed GREEDILY (agg-3b)
 )
 
 type token struct {
@@ -59,6 +60,15 @@ func tokenize(sql string) ([]token, bool) {
 				return nil, false
 			}
 			i = n
+		case c == '/' && i+1 < n && b[i+1] == '/':
+			// `//` (ADJACENT) is DuckDB's integer-trunc division — one token
+			// (agg-3b). A spaced `/ /` is a DuckDB Parser Error (oracle-probed),
+			// and whitespace is otherwise discarded here, so greedy lexing is the
+			// only place adjacency can be enforced — the same lesson as the 2e
+			// `--` comment CRITICAL. The spaced form stays two Puncts and no
+			// shape consumes them, so it declines.
+			toks = append(toks, token{kind: tokIntDiv})
+			i += 2
 		case c == '(' || c == ')' || c == '*' || c == ',' || c == '+' || c == '/':
 			// `+`/`/` for 2e DOUBLE arith in WHERE (`*` was already here for SELECT *
 			// / count(*) AND doubles as arith-multiply by position, same as the engine).
@@ -747,7 +757,73 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 			return fail()
 		}
 		isCall := c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '('
-		if isCall && t.lower == "date_trunc" {
+		if isCall && t.lower == "to_timestamp" {
+			// The epoch-math time-bucket KEY item (agg-3b) — EXACTLY the Grafana
+			// `$__timeGroup` emission, token for token:
+			//   to_timestamp((epoch_ns(<col>) // 1000000000 // N) * N) AS <alias>
+			// Both N literals must match, N ∈ [1, 31_622_400]; the alias is
+			// MANDATORY (Grafana's time-series frame needs a column named `time`;
+			// the unaliased form would need DuckDB's mangled derived name
+			// reproduced). The builder re-emits from the validated parts.
+			if keyItem >= 0 {
+				return fail()
+			}
+			c.i++ // consume '('
+			if !c.punct('(') || !c.ident("epoch_ns") || !c.punct('(') {
+				return fail()
+			}
+			bc, tok := c.next()
+			if !tok || bc.kind != tokIdent || isScanKeyword(bc.lower) || !isBareIdent(bc.orig) {
+				return fail()
+			}
+			if !c.punct(')') {
+				return fail()
+			}
+			if c.i >= len(c.toks) || c.toks[c.i].kind != tokIntDiv {
+				return fail()
+			}
+			c.i++
+			nt, tok := c.next()
+			if !tok || nt.kind != tokNum || nt.orig != "1000000000" {
+				return fail()
+			}
+			if c.i >= len(c.toks) || c.toks[c.i].kind != tokIntDiv {
+				return fail()
+			}
+			c.i++
+			wt, tok := c.next()
+			if !tok || wt.kind != tokNum {
+				return fail()
+			}
+			secs, err := strconv.Atoi(wt.orig)
+			if err != nil || secs < 1 || secs > 31_622_400 {
+				return fail()
+			}
+			if !c.punct(')') {
+				return fail()
+			}
+			if c.i >= len(c.toks) || c.toks[c.i].kind != tokPunct || c.toks[c.i].punct != '*' {
+				return fail()
+			}
+			c.i++
+			wt2, tok := c.next()
+			if !tok || wt2.kind != tokNum || wt2.orig != wt.orig {
+				return fail() // width literals must MATCH — else a different expression
+			}
+			if !c.punct(')') || !c.ident("as") {
+				return fail()
+			}
+			al, tok := c.next()
+			if !tok || al.kind != tokIdent || isScanKeyword(al.lower) || !isBareIdent(al.orig) {
+				return fail()
+			}
+			m.epochWidthSecs = secs
+			m.bucketCol = bc.orig
+			m.bucketAlias = al.orig
+			keyItem = len(items)
+			key = "to_timestamp((epoch_ns(" + bc.orig + ") // 1000000000 // " + wt.orig + ") * " + wt.orig + ") AS " + al.orig
+			items = append(items, key)
+		} else if isCall && t.lower == "date_trunc" {
 			// The time-bucket KEY item (agg-3). One per query; fixed-width units
 			// only (the engine declines calendar units).
 			if keyItem >= 0 {
@@ -838,19 +914,26 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 	if !c.ident("group") || !c.ident("by") {
 		return fail()
 	}
-	// A key reference: the key's position, or (bare keys only — a bucket's text
-	// is not an identifier) its name.
-	keyRef := func(kt token) bool {
+	// Key references are ASYMMETRIC (oracle-probed at agg-3b): in GROUP BY,
+	// DuckDB binds a bare ident to the RAW COLUMN (so an alias never resolves
+	// there — position or bare-key name only); in ORDER BY it binds the ALIAS.
+	groupRef := func(kt token) bool {
 		switch kt.kind {
 		case tokIdent:
-			return m.bucketUnit == "" && strings.EqualFold(kt.orig, key)
+			return m.bucketUnit == "" && m.epochWidthSecs == 0 && strings.EqualFold(kt.orig, key)
 		case tokNum:
 			return kt.orig == strconv.Itoa(keyItem+1)
 		}
 		return false
 	}
+	orderRef := func(kt token) bool {
+		if kt.kind == tokIdent && m.bucketAlias != "" {
+			return strings.EqualFold(kt.orig, m.bucketAlias)
+		}
+		return groupRef(kt)
+	}
 	kt, tok := c.next()
-	if !tok || !keyRef(kt) {
+	if !tok || !groupRef(kt) {
 		return fail()
 	}
 	// Optional `ORDER BY <key ref> [ASC]` (agg-3): the engine sorts the single
@@ -861,7 +944,7 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 			return fail()
 		}
 		ot, tok := c.next()
-		if !tok || !keyRef(ot) {
+		if !tok || !orderRef(ot) {
 			return fail()
 		}
 		if c.peekIdentLower() == "asc" {
@@ -893,6 +976,10 @@ type groupedMatch struct {
 	bucketUnit string
 	bucketCol  string
 	orderByKey bool
+	// agg-3b epoch-math bucket: width in whole seconds (0 = not this form) and
+	// the MANDATORY alias — validated parts the builder re-emits.
+	epochWidthSecs int
+	bucketAlias    string
 }
 
 // fixedWidthUnits is the engine's agg-3 bucket set — pure UTC epoch division


### PR DESCRIPTION
## What

The grouped recognizer learns the exact Grafana datasource emission — `to_timestamp((epoch_ns(col) // 1000000000 // N) * N) AS <alias>` — as the time-bucket key, carried as **validated parts** (width in range, bare-ident column and alias) that the builder re-emits verbatim; source text is never sliced. This is the unlock for real `$__timeGroup` dashboard traffic (single-series panels; the per-host multi-key widening is the named follow-up).

## CRITICAL fixed alongside (plan-stage adversarial find)

`//` now lexes **greedily** as one token. A spaced `/ /` is a DuckDB Parser Error, and the tokenizer discards whitespace — so without greedy lexing, a post-lex "two slashes" match would serve SQL DuckDB rejects. Same adjacency class as the `--` comment CRITICAL; the spaced form stays two Puncts and is decline-pinned. (The engine-side twin of this fix ships in its own PR.)

## Binding rules (oracle-probed, asymmetric)

- **GROUP BY** binds a bare ident to the **raw column** — only positional GROUP BY is accepted; `GROUP BY <alias>` declines.
- **ORDER BY** binds the **alias** — `ORDER BY time`, `ORDER BY time ASC`, and `ORDER BY 1` all resolve to the key.

## End-to-end (serve vs off, same tagged binary, the exact Grafana 5m query, 1-day window)

994 ms vs 1716 ms — **1.7× at the wire**, identical buckets and values, and the `time` alias preserved on both paths. Stock build carries zero engine symbols; vet and tests green in both build modes.

## Tests

Recognizer accepts (emission + ORDER BY alias/ASC/positional, parts extraction) and declines (spaced `/ /` in both positions, width-literal mismatch, unaliased form, `GROUP BY <alias>`, width 0/out-of-range, wrong ns divisor, two bucket items, DESC); builder emission + injection-shaped part declines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)