### PR TITLE
feat(arcxrouter): bucket+tag composite grouped shapes join the allow-list (the per-host panel)

### DIFF
--- a/internal/arcxrouter/agg_recognizer_test.go
+++ b/internal/arcxrouter/agg_recognizer_test.go
@@ -135,16 +135,34 @@ func TestGroupedAggRecognized(t *testing.T) {
 			"SELECT host, sum(f), min(f) FROM cpu WHERE f > 1.5 OR host = 'b' GROUP BY 1",
 			[]string{"host", "sum(f)", "min(f)"}, "host", "f > 1.5 OR host = 'b'",
 		},
-		// agg-3: the time-bucket key + ORDER BY on the key.
+		// agg-3: the time-bucket key + ORDER BY on the key. Since agg-3c,
+		// groupKey carries only the TAG key — "" for bucket-only queries (the
+		// bucket travels as validated parts).
 		{
 			"SELECT date_trunc('minute', time), count(*), avg(cpu_user) FROM cpu WHERE time >= '2026-01-01T00:00:00Z' GROUP BY 1 ORDER BY 1",
 			[]string{"date_trunc('minute', time)", "count(*)", "avg(cpu_user)"},
-			"date_trunc('minute', time)", "time >= '2026-01-01T00:00:00Z'",
+			"", "time >= '2026-01-01T00:00:00Z'",
 		},
 		{
 			"SELECT count(*), date_trunc('hour', Time) FROM cpu GROUP BY 2",
 			[]string{"count(*)", "date_trunc('hour', Time)"},
-			"date_trunc('hour', Time)", "",
+			"", "",
+		},
+		// agg-3c: the per-host panel — bucket + tag composite key.
+		{
+			"SELECT date_trunc('hour', time), host, count(*), avg(cpu_user) FROM cpu GROUP BY 1, 2",
+			[]string{"date_trunc('hour', time)", "host", "count(*)", "avg(cpu_user)"},
+			"host", "",
+		},
+		{
+			"SELECT host, date_trunc('hour', time), avg(cpu_user) FROM cpu GROUP BY 1, 2 ORDER BY 2",
+			[]string{"host", "date_trunc('hour', time)", "avg(cpu_user)"},
+			"host", "",
+		},
+		{
+			"SELECT date_trunc('hour', time), host, count(*) FROM cpu GROUP BY 1, host",
+			[]string{"date_trunc('hour', time)", "host", "count(*)"},
+			"host", "",
 		},
 		{
 			"SELECT host, count(*) FROM cpu GROUP BY host ORDER BY host ASC",
@@ -197,13 +215,13 @@ func TestEpochMathBucketRecognized(t *testing.T) {
 	// time-series frame needs a column named `time`).
 	em := "to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time"
 	cases := []struct {
-		sql        string
-		orderByKey bool
+		sql         string
+		orderByItem int
 	}{
-		{"SELECT " + em + ", avg(cpu_user) FROM cpu WHERE time >= '2026-08-13T00:00:00Z' AND time < '2026-08-14T00:00:00Z' GROUP BY 1 ORDER BY time", true},
-		{"SELECT " + em + ", count(*), avg(cpu_user) FROM cpu GROUP BY 1 ORDER BY 1", true},
-		{"SELECT " + em + ", avg(cpu_user) FROM cpu GROUP BY 1 ORDER BY time ASC", true},
-		{"SELECT " + em + ", avg(cpu_user) FROM cpu GROUP BY 1", false},
+		{"SELECT " + em + ", avg(cpu_user) FROM cpu WHERE time >= '2026-08-13T00:00:00Z' AND time < '2026-08-14T00:00:00Z' GROUP BY 1 ORDER BY time", 1},
+		{"SELECT " + em + ", count(*), avg(cpu_user) FROM cpu GROUP BY 1 ORDER BY 1", 1},
+		{"SELECT " + em + ", avg(cpu_user) FROM cpu GROUP BY 1 ORDER BY time ASC", 1},
+		{"SELECT " + em + ", avg(cpu_user) FROM cpu GROUP BY 1", 0},
 	}
 	for _, c := range cases {
 		m, ok := eligibleShape(c.sql)
@@ -213,8 +231,8 @@ func TestEpochMathBucketRecognized(t *testing.T) {
 		if m.epochWidthSecs != 300 || m.bucketCol != "time" || m.bucketAlias != "time" {
 			t.Fatalf("parts = %d/%q/%q: %s", m.epochWidthSecs, m.bucketCol, m.bucketAlias, c.sql)
 		}
-		if m.orderByKey != c.orderByKey {
-			t.Fatalf("orderByKey = %t, want %t: %s", m.orderByKey, c.orderByKey, c.sql)
+		if m.orderByItem != c.orderByItem {
+			t.Fatalf("orderByItem = %d, want %d: %s", m.orderByItem, c.orderByItem, c.sql)
 		}
 	}
 }
@@ -241,6 +259,30 @@ func TestEpochMathBucketDeclines(t *testing.T) {
 		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS a, date_trunc('minute', time), avg(x) FROM cpu GROUP BY 1, 2",
 		// ORDER BY DESC still declines.
 		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time, avg(x) FROM cpu GROUP BY 1 ORDER BY time DESC",
+	} {
+		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScanAggGrouped {
+			t.Fatalf("must not match scan_agg_grouped: %s", sql)
+		}
+	}
+}
+
+func TestCompositeKeyDeclines(t *testing.T) {
+	for _, sql := range []string{
+		// Two TAG keys ride the generic engine path that measured 1.4-2.4x
+		// BEHIND at corpus scale — off the list until its own bench (agg-3c).
+		"SELECT host, region, count(*) FROM cpu GROUP BY 1, 2",
+		"SELECT date_trunc('hour', time), host, region, count(*) FROM cpu GROUP BY 1, 2, 3",
+		// Two buckets.
+		"SELECT date_trunc('hour', time), date_trunc('minute', time), count(*) FROM cpu GROUP BY 1, 2",
+		// A projected key missing from GROUP BY (closure both ways).
+		"SELECT date_trunc('hour', time), host, count(*) FROM cpu GROUP BY 1",
+		"SELECT date_trunc('hour', time), host, count(*) FROM cpu GROUP BY 2",
+		// Duplicate refs.
+		"SELECT date_trunc('hour', time), host, count(*) FROM cpu GROUP BY 1, 1",
+		// GROUP BY naming the bucket ALIAS (binds the raw column in DuckDB).
+		"SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS b, host, count(*) FROM cpu GROUP BY b, host",
+		// ORDER BY an aggregate position.
+		"SELECT date_trunc('hour', time), host, count(*) FROM cpu GROUP BY 1, 2 ORDER BY 3",
 	} {
 		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScanAggGrouped {
 			t.Fatalf("must not match scan_agg_grouped: %s", sql)

--- a/internal/arcxrouter/build_agg_sql_test.go
+++ b/internal/arcxrouter/build_agg_sql_test.go
@@ -79,12 +79,11 @@ func TestBuildGroupedSQL(t *testing.T) {
 	// agg-3 bucket key + ORDER BY: the bucket text is REBUILT from the validated
 	// parts (BucketUnit/BucketCol), never taken from GroupKey.
 	got, ok = buildGroupedSQL(Decision{
-		AggItems:   []string{"date_trunc('minute', time)", "count(*)", "avg(cpu_user)"},
-		GroupKey:   "date_trunc('minute', time)",
-		BucketUnit: "minute",
-		BucketCol:  "time",
-		WhereText:  "time >= '2026-01-01T00:00:00Z'",
-		OrderByKey: true,
+		AggItems:    []string{"date_trunc('minute', time)", "count(*)", "avg(cpu_user)"},
+		BucketUnit:  "minute",
+		BucketCol:   "time",
+		WhereText:   "time >= '2026-01-01T00:00:00Z'",
+		OrderByItem: 1,
 	}, paths)
 	want = "SELECT date_trunc('minute', time), count(*), avg(cpu_user) FROM read_parquet(['/p.parquet']) WHERE time >= '2026-01-01T00:00:00Z' GROUP BY 1 ORDER BY 1"
 	if !ok || got != want {
@@ -93,11 +92,10 @@ func TestBuildGroupedSQL(t *testing.T) {
 	// agg-3b epoch-math bucket: rebuilt from validated parts, alias included.
 	got, ok = buildGroupedSQL(Decision{
 		AggItems:       []string{"to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time", "avg(cpu_user)"},
-		GroupKey:       "to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time",
 		EpochWidthSecs: 300,
 		BucketCol:      "time",
 		BucketAlias:    "time",
-		OrderByKey:     true,
+		OrderByItem:    1,
 	}, paths)
 	want = "SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time, avg(cpu_user) FROM read_parquet(['/p.parquet']) GROUP BY 1 ORDER BY 1"
 	if !ok || got != want {
@@ -106,22 +104,18 @@ func TestBuildGroupedSQL(t *testing.T) {
 	for _, d := range []Decision{
 		{ // epoch-math with unsafe parts must never be emitted
 			AggItems:       []string{"to_timestamp((epoch_ns(t; DROP) // 1000000000 // 300) * 300) AS time", "count(*)"},
-			GroupKey:       "to_timestamp((epoch_ns(t; DROP) // 1000000000 // 300) * 300) AS time",
 			EpochWidthSecs: 300, BucketCol: "t; DROP", BucketAlias: "time",
 		},
 		{
 			AggItems:       []string{"to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS x; DROP", "count(*)"},
-			GroupKey:       "to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS x; DROP",
 			EpochWidthSecs: 300, BucketCol: "time", BucketAlias: "x; DROP",
 		},
 		{ // unsafe bucket parts must never be emitted
 			AggItems:   []string{"date_trunc('week', time)", "count(*)"},
-			GroupKey:   "date_trunc('week', time)",
 			BucketUnit: "week", BucketCol: "time",
 		},
 		{
 			AggItems:   []string{"date_trunc('minute', x)", "count(*)"},
-			GroupKey:   "date_trunc('minute', x)",
 			BucketUnit: "minute", BucketCol: "x; DROP",
 		},
 		{AggItems: []string{"count(*)"}, GroupKey: "host"},                 // no key item
@@ -132,5 +126,35 @@ func TestBuildGroupedSQL(t *testing.T) {
 		if got, ok := buildGroupedSQL(d, paths); ok {
 			t.Fatalf("must decline unsafe decision %v, got %q", d, got)
 		}
+	}
+}
+
+func TestBuildGroupedSQLComposite(t *testing.T) {
+	paths := "['/p.parquet']"
+	// Bucket + tag: positional GROUP BY list; ORDER BY validated as a key pos.
+	got, ok := buildGroupedSQL(Decision{
+		AggItems: []string{
+			"to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time",
+			"host", "avg(cpu_user)",
+		},
+		GroupKey:       "host",
+		EpochWidthSecs: 300,
+		BucketCol:      "time",
+		BucketAlias:    "time",
+		OrderByItem:    1,
+	}, paths)
+	want := "SELECT to_timestamp((epoch_ns(time) // 1000000000 // 300) * 300) AS time, host, avg(cpu_user) FROM read_parquet(['/p.parquet']) GROUP BY 1, 2 ORDER BY 1"
+	if !ok || got != want {
+		t.Fatalf("got (%q, %t), want %q", got, ok, want)
+	}
+	// ORDER BY pointing at a NON-key position must decline.
+	if _, ok := buildGroupedSQL(Decision{
+		AggItems:    []string{"date_trunc('hour', time)", "host", "count(*)"},
+		GroupKey:    "host",
+		BucketUnit:  "hour",
+		BucketCol:   "time",
+		OrderByItem: 3,
+	}, paths); ok {
+		t.Fatal("ORDER BY on an aggregate position must decline")
 	}
 }

--- a/internal/arcxrouter/compare_grouped.go
+++ b/internal/arcxrouter/compare_grouped.go
@@ -1,10 +1,11 @@
-// Shadow comparison for the allow-listed grouped class (agg-2b/2c): N rows of
-// (single group key, agg-1 aggregate columns). Both sides sort by the TYPED key
-// part (plan F5: never a joined string; a single key makes this one part — Utf8
-// or Int64, NULL ordered first), then compare row-wise with the per-item agg
-// policy: keys and counts/min/max exact (float min/max ±0.0-equal, two NaNs
-// equal), float sum/avg within the documented 1e-9 tolerance, integer sums via
-// big.Int. Diffs stay value-free.
+// Shadow comparison for the allow-listed grouped class (agg-2b/2c → agg-3c
+// multi-key): N rows of (key part(s), agg-1 aggregate columns). Both sides sort
+// by the TYPED key-part TUPLE (plan F5: never a joined string; parts compare
+// element-wise in key-column order, NULL parts ordered first), then compare
+// row-wise with the per-item agg policy: keys and counts/min/max exact (float
+// min/max ±0.0-equal, two NaNs equal), float sum/avg within the documented
+// 1e-9 tolerance, integer sums via big.Int. Timestamp key parts (agg-3 buckets)
+// compare as typed epoch-µs on both sides. Diffs stay value-free.
 
 //go:build cgo && arcx_engine
 
@@ -22,75 +23,123 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 )
 
-// groupedRow is one comparable row: the key part (typed) plus the aggregate
-// cells in column order (reusing compare_agg's aggCell + policies).
+// keyPart is one typed component of a group key tuple: a Utf8 tag value or an
+// Int64/epoch-µs bucket. NULL is distinct from ”/0 (isNull); NULL parts are
+// normalized to isI=false on BOTH sides before comparison (the DuckDB side
+// cannot observe a NULL's column type).
+type keyPart struct {
+	isNull bool
+	isI    bool
+	s      string
+	i      int64
+}
+
+// groupedRow is one comparable row: the key parts in KEY-COLUMN order plus the
+// aggregate cells in column order (reusing compare_agg's aggCell + policies).
 type groupedRow struct {
-	keyNull bool
-	keyStr  string
-	keyInt  int64
-	keyIsI  bool
-	cells   []aggCell
+	keys  []keyPart
+	cells []aggCell
+}
+
+func keyPartLess(a, b *keyPart) bool {
+	if a.isNull != b.isNull {
+		return a.isNull
+	}
+	if a.isNull {
+		return false
+	}
+	if a.isI {
+		return a.i < b.i
+	}
+	return a.s < b.s
+}
+
+func keyPartEq(a, b *keyPart) bool {
+	if a.isNull != b.isNull || a.isI != b.isI {
+		return false
+	}
+	if a.isNull {
+		return true
+	}
+	if a.isI {
+		return a.i == b.i
+	}
+	return a.s == b.s
 }
 
 func groupedLess(a, b *groupedRow) bool {
-	if a.keyNull != b.keyNull {
-		return a.keyNull
+	for k := range a.keys {
+		if k >= len(b.keys) {
+			return false
+		}
+		if !keyPartEq(&a.keys[k], &b.keys[k]) {
+			return keyPartLess(&a.keys[k], &b.keys[k])
+		}
 	}
-	if a.keyIsI {
-		return a.keyInt < b.keyInt
-	}
-	return a.keyStr < b.keyStr
+	return false
 }
 
 func groupedKeyEq(a, b *groupedRow) bool {
-	if a.keyNull != b.keyNull || a.keyIsI != b.keyIsI {
+	if len(a.keys) != len(b.keys) {
 		return false
 	}
-	if a.keyNull {
-		return true
+	for k := range a.keys {
+		if !keyPartEq(&a.keys[k], &b.keys[k]) {
+			return false
+		}
 	}
-	if a.keyIsI {
-		return a.keyInt == b.keyInt
-	}
-	return a.keyStr == b.keyStr
+	return true
 }
 
-func groupedFromArcx(rec arrow.Record, keyCol int) ([]groupedRow, error) {
+func isKeyCol(keyCols []int, c int) bool {
+	for _, k := range keyCols {
+		if k == c {
+			return true
+		}
+	}
+	return false
+}
+
+func groupedFromArcx(rec arrow.Record, keyCols []int) ([]groupedRow, error) {
 	ncols := int(rec.NumCols())
-	if keyCol >= ncols {
-		return nil, fmt.Errorf("arcx grouped: key col %d out of %d", keyCol, ncols)
+	for _, k := range keyCols {
+		if k >= ncols {
+			return nil, fmt.Errorf("arcx grouped: key col %d out of %d", k, ncols)
+		}
 	}
 	out := make([]groupedRow, rec.NumRows())
 	for r := range out {
 		row := &out[r]
 		for c := 0; c < ncols; c++ {
-			if c == keyCol {
+			if isKeyCol(keyCols, c) {
+				var p keyPart
 				switch col := rec.Column(c).(type) {
 				case *array.String:
 					if col.IsNull(r) {
-						row.keyNull = true
+						p.isNull = true
 					} else {
-						row.keyStr = col.Value(r)
+						p.s = col.Value(r)
 					}
 				case *array.Int64:
-					row.keyIsI = true
+					p.isI = true
 					if col.IsNull(r) {
-						row.keyNull = true
+						p.isNull = true
 					} else {
-						row.keyInt = col.Value(r)
+						p.i = col.Value(r)
 					}
 				// agg-3 bucket key: compare as epoch µs (typed, never a string).
 				case *array.Timestamp:
-					row.keyIsI = true
+					p.isI = true
 					if col.IsNull(r) {
-						row.keyNull = true
+						p.isNull = true
 					} else {
 						unit := col.DataType().(*arrow.TimestampType).Unit
-						row.keyInt = toMicros(int64(col.Value(r)), unit)
+						p.i = toMicros(int64(col.Value(r)), unit)
 					}
 				default:
 					return nil, fmt.Errorf("arcx grouped key: unexpected type %T", rec.Column(c))
 				}
+				row.keys = append(row.keys, p)
 				continue
 			}
 			switch col := rec.Column(c).(type) {
@@ -124,7 +173,7 @@ func groupedFromArcx(rec arrow.Record, keyCol int) ([]groupedRow, error) {
 	return out, nil
 }
 
-func groupedFromRows(rows *sql.Rows, keyCol int) ([]groupedRow, error) {
+func groupedFromRows(rows *sql.Rows, keyCols []int) ([]groupedRow, error) {
 	cols, err := rows.Columns()
 	if err != nil {
 		return nil, err
@@ -141,23 +190,25 @@ func groupedFromRows(rows *sql.Rows, keyCol int) ([]groupedRow, error) {
 		}
 		var row groupedRow
 		for c, v := range raw {
-			if c == keyCol {
+			if isKeyCol(keyCols, c) {
+				var p keyPart
 				switch x := v.(type) {
 				case nil:
-					row.keyNull = true
+					p.isNull = true
 				case string:
-					row.keyStr = x
+					p.s = x
 				case []byte:
-					row.keyStr = string(x)
+					p.s = string(x)
 				case int64:
-					row.keyIsI = true
-					row.keyInt = x
+					p.isI = true
+					p.i = x
 				case time.Time:
-					row.keyIsI = true
-					row.keyInt = x.UnixMicro()
+					p.isI = true
+					p.i = x.UnixMicro()
 				default:
 					return nil, fmt.Errorf("duckdb grouped key: unexpected type %T", v)
 				}
+				row.keys = append(row.keys, p)
 				continue
 			}
 			switch x := v.(type) {
@@ -180,25 +231,40 @@ func groupedFromRows(rows *sql.Rows, keyCol int) ([]groupedRow, error) {
 	return out, rows.Err()
 }
 
+// normalizeNullParts forces every NULL key part's isI to false on BOTH sides so
+// keyPartEq/Less never see a type mismatch on NULLs (the DuckDB side cannot
+// observe a NULL's column type; the arcx side can — align them).
+func normalizeNullParts(rows []groupedRow) {
+	for i := range rows {
+		for k := range rows[i].keys {
+			if rows[i].keys[k].isNull {
+				rows[i].keys[k].isI = false
+			}
+		}
+	}
+}
+
 // compareGrouped returns "" on match, else a short VALUE-FREE diff. `items` is
-// the select list in column order (the key item marks the key column; the rest
-// pick the per-cell policy — tolerance only for float sum/avg).
-func compareGrouped(rec arrow.Record, oracle []groupedRow, items []string, keyCol int) string {
-	got, err := groupedFromArcx(rec, keyCol)
+// the select list in column order (keyCols mark the key columns; the rest pick
+// the per-cell policy — tolerance only for float sum/avg).
+func compareGrouped(rec arrow.Record, oracle []groupedRow, items []string, keyCols []int) string {
+	got, err := groupedFromArcx(rec, keyCols)
 	if err != nil {
 		return "arcx grouped decode error: " + err.Error()
 	}
 	if len(got) != len(oracle) {
 		return fmt.Sprintf("grouped row count differs (arcx=%d duckdb=%d)", len(got), len(oracle))
 	}
-	// Cell policies in CELL order (items minus the key, order preserved).
+	// Cell policies in CELL order (items minus the keys, order preserved).
 	var tolerant []bool
 	for i, item := range items {
-		if i == keyCol {
+		if isKeyCol(keyCols, i) {
 			continue
 		}
 		tolerant = append(tolerant, aggItemTolerant(item))
 	}
+	normalizeNullParts(got)
+	normalizeNullParts(oracle)
 	sort.Slice(got, func(i, j int) bool { return groupedLess(&got[i], &got[j]) })
 	sort.Slice(oracle, func(i, j int) bool { return groupedLess(&oracle[i], &oracle[j]) })
 	for i := range got {

--- a/internal/arcxrouter/eligibility.go
+++ b/internal/arcxrouter/eligibility.go
@@ -157,8 +157,12 @@ type matchResult struct {
 	// The SQL builder re-emits from THESE, never from groupKey's text.
 	bucketUnit string
 	bucketCol  string
-	// agg-3: emit `ORDER BY <key position>` (ascending) in the engine SQL.
-	orderByKey bool
+	// agg-3c: the ordered KEY's 1-based select position (0 = no ORDER BY);
+	// the builder emits `ORDER BY <this position>` ascending.
+	orderByItem int
+	// agg-3c: rebuilt bucket item text ("" = no bucket key). groupKey holds
+	// the TAG key's spelling ("" = no tag key); at least one is set.
+	bucketText string
 	// agg-3b epoch-math bucket: width secs (0 = not this form) + mandatory alias.
 	epochWidthSecs int
 	bucketAlias    string
@@ -223,12 +227,13 @@ func eligibleShape(sql string) (matchResult, bool) {
 		return matchResult{
 			shape:          ShapeScanAggGrouped,
 			aggItems:       gm.items,
-			groupKey:       gm.key,
+			groupKey:       gm.tagKey,
+			bucketText:     gm.bucketText,
 			bucketUnit:     gm.bucketUnit,
 			bucketCol:      gm.bucketCol,
 			epochWidthSecs: gm.epochWidthSecs,
 			bucketAlias:    gm.bucketAlias,
-			orderByKey:     gm.orderByKey,
+			orderByItem:    gm.orderByItem,
 			whereText:      gm.whereText,
 			measurement:    gm.meas,
 		}, true

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -113,7 +113,13 @@ type Decision struct {
 	// these validated parts, never from GroupKey's text.
 	BucketUnit string
 	BucketCol  string
-	OrderByKey bool // agg-3: append `ORDER BY <key position>` (ascending)
+	// agg-3c: the ordered KEY's 1-based select position (0 = no ORDER BY);
+	// the builder emits `ORDER BY <this position>` ascending after validating
+	// it points at a key item.
+	OrderByItem int
+	// agg-3c: the rebuilt bucket item text is NOT carried — the builder
+	// rebuilds it from the validated parts below; GroupKey holds the TAG key
+	// ("" = no tag key).
 	// agg-3b epoch-math bucket: width in whole seconds (0 = not this form) and
 	// the mandatory alias — the builder re-emits from these validated parts.
 	EpochWidthSecs int
@@ -162,7 +168,7 @@ func Decide(sql, headerDB string, h Handler) Decision {
 		GroupKey:       m.groupKey,
 		BucketUnit:     m.bucketUnit,
 		BucketCol:      m.bucketCol,
-		OrderByKey:     m.orderByKey,
+		OrderByItem:    m.orderByItem,
 		EpochWidthSecs: m.epochWidthSecs,
 		BucketAlias:    m.bucketAlias,
 	}
@@ -352,44 +358,52 @@ func buildScanAggSQL(d Decision, pathArray string) (string, bool) {
 // builders. WhereText is reserializeWhere's rebuilt-from-validated-tokens text,
 // the same already-reviewed injection surface the scan/agg builders emit.
 func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
-	// The key is either a bare tag column, or (agg-3) a time bucket REBUILT here
-	// from the validated parts — unit from the fixed-width allow-set, column via
-	// isBareIdent — never from GroupKey's text.
-	var keyText string
-	var keyPos int
+	// agg-3c key set: at most one BUCKET (rebuilt here from validated parts —
+	// unit/width allow-set, bare-ident col/alias — never from source text) and
+	// at most one bare TAG key; at least one of either. Per-key matched flags
+	// (the single-flag logic breaks at two keys — adversarial #7).
+	var bucketText string
 	switch {
 	case d.EpochWidthSecs != 0:
-		// agg-3b: rebuild the exact Grafana emission + alias from validated
-		// parts (width in range, bare-ident col and alias) — never source text.
 		if d.EpochWidthSecs < 1 || d.EpochWidthSecs > 31_622_400 ||
 			!isBareIdent(d.BucketCol) || !isBareIdent(d.BucketAlias) {
 			return "", false
 		}
 		w := strconv.Itoa(d.EpochWidthSecs)
-		keyText = "to_timestamp((epoch_ns(" + d.BucketCol + ") // 1000000000 // " + w + ") * " + w + ") AS " + d.BucketAlias
+		bucketText = "to_timestamp((epoch_ns(" + d.BucketCol + ") // 1000000000 // " + w + ") * " + w + ") AS " + d.BucketAlias
 	case d.BucketUnit != "":
 		if !fixedWidthUnits[strings.ToLower(d.BucketUnit)] || !isBareIdent(d.BucketCol) {
 			return "", false
 		}
-		keyText = "date_trunc('" + d.BucketUnit + "', " + d.BucketCol + ")"
-	case isBareIdent(d.GroupKey):
-		keyText = d.GroupKey
-	default:
+		bucketText = "date_trunc('" + d.BucketUnit + "', " + d.BucketCol + ")"
+	}
+	tagText := ""
+	if d.GroupKey != "" {
+		if !isBareIdent(d.GroupKey) {
+			return "", false
+		}
+		tagText = d.GroupKey
+	}
+	if bucketText == "" && tagText == "" {
 		return "", false
 	}
 	if len(d.AggItems) < 2 {
 		return "", false
 	}
-	sawKey, sawAgg := false, false
+	sawBucket, sawTag, sawAgg := false, false, false
+	keyPositions := []int{}
 	var b strings.Builder
 	b.WriteString("SELECT ")
 	for i, item := range d.AggItems {
 		switch {
 		case isAggItem(item):
 			sawAgg = true
-		case item == keyText && !sawKey:
-			sawKey = true
-			keyPos = i + 1
+		case bucketText != "" && item == bucketText && !sawBucket:
+			sawBucket = true
+			keyPositions = append(keyPositions, i+1)
+		case tagText != "" && item == tagText && !sawTag:
+			sawTag = true
+			keyPositions = append(keyPositions, i+1)
 		default:
 			return "", false
 		}
@@ -398,7 +412,7 @@ func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
 		}
 		b.WriteString(item)
 	}
-	if !sawKey || !sawAgg {
+	if !sawAgg || (bucketText != "" && !sawBucket) || (tagText != "" && !sawTag) {
 		return "", false
 	}
 	b.WriteString(" FROM read_parquet(")
@@ -408,13 +422,27 @@ func buildGroupedSQL(d Decision, pathArray string) (string, bool) {
 		b.WriteString(" WHERE ")
 		b.WriteString(d.WhereText)
 	}
-	// GROUP BY / ORDER BY by POSITION: valid for both key forms and emits no
-	// identifier text at all.
+	// GROUP BY / ORDER BY by POSITION: valid for every key form and emits no
+	// identifier text at all. ORDER BY must point at a KEY position.
 	b.WriteString(" GROUP BY ")
-	b.WriteString(strconv.Itoa(keyPos))
-	if d.OrderByKey {
+	for i, kp := range keyPositions {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(strconv.Itoa(kp))
+	}
+	if d.OrderByItem != 0 {
+		ok := false
+		for _, kp := range keyPositions {
+			if d.OrderByItem == kp {
+				ok = true
+			}
+		}
+		if !ok {
+			return "", false
+		}
 		b.WriteString(" ORDER BY ")
-		b.WriteString(strconv.Itoa(keyPos))
+		b.WriteString(strconv.Itoa(d.OrderByItem))
 	}
 	return b.String(), true
 }
@@ -766,18 +794,20 @@ func (h Deps) compareToOracle(ctx context.Context, d Decision, rec arrow.Record)
 		return compareAgg(rec, oracle, d.AggItems), nil
 	}
 	if d.Shape == ShapeScanAggGrouped {
-		keyCol := 0
+		// agg-3c: keys are every NON-aggregate item (a bare tag and/or a bucket
+		// — the item texts were re-serialized by the recognizer, so isAggItem
+		// is the robust discriminator; no bucket-text reconstruction needed).
+		var keyCols []int
 		for i, item := range d.AggItems {
-			if item == d.GroupKey {
-				keyCol = i
-				break
+			if !isAggItem(item) {
+				keyCols = append(keyCols, i)
 			}
 		}
-		oracle, err := groupedFromRows(rows, keyCol)
+		oracle, err := groupedFromRows(rows, keyCols)
 		if err != nil {
 			return "", err
 		}
-		return compareGrouped(rec, oracle, d.AggItems, keyCol), nil
+		return compareGrouped(rec, oracle, d.AggItems, keyCols), nil
 	}
 	if isScalarShape(d.Shape) {
 		oracle, err := scalarFromRows(rows)

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -747,9 +747,10 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 	}
 	fail := func() (groupedMatch, bool) { return groupedMatch{}, false }
 	var items []string
-	var key, whereText, meas string
+	var bucketText, tagKey, whereText, meas string
 
-	keyItem := -1
+	bucketItem := -1
+	tagItem := -1
 	nAggs := 0
 	for {
 		t, tok := c.next()
@@ -765,7 +766,7 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 			// MANDATORY (Grafana's time-series frame needs a column named `time`;
 			// the unaliased form would need DuckDB's mangled derived name
 			// reproduced). The builder re-emits from the validated parts.
-			if keyItem >= 0 {
+			if bucketItem >= 0 {
 				return fail()
 			}
 			c.i++ // consume '('
@@ -820,13 +821,13 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 			m.epochWidthSecs = secs
 			m.bucketCol = bc.orig
 			m.bucketAlias = al.orig
-			keyItem = len(items)
-			key = "to_timestamp((epoch_ns(" + bc.orig + ") // 1000000000 // " + wt.orig + ") * " + wt.orig + ") AS " + al.orig
-			items = append(items, key)
+			bucketItem = len(items)
+			bucketText = "to_timestamp((epoch_ns(" + bc.orig + ") // 1000000000 // " + wt.orig + ") * " + wt.orig + ") AS " + al.orig
+			items = append(items, bucketText)
 		} else if isCall && t.lower == "date_trunc" {
 			// The time-bucket KEY item (agg-3). One per query; fixed-width units
 			// only (the engine declines calendar units).
-			if keyItem >= 0 {
+			if bucketItem >= 0 {
 				return fail()
 			}
 			c.i++ // consume '('
@@ -846,9 +847,9 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 			}
 			m.bucketUnit = ut.str
 			m.bucketCol = bc.orig
-			keyItem = len(items)
-			key = "date_trunc('" + ut.str + "', " + bc.orig + ")"
-			items = append(items, key)
+			bucketItem = len(items)
+			bucketText = "date_trunc('" + ut.str + "', " + bc.orig + ")"
+			items = append(items, bucketText)
 		} else if isCall {
 			switch t.lower {
 			case "count", "sum", "min", "max", "avg":
@@ -874,13 +875,15 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 			}
 			nAggs++
 		} else {
-			// A bare column — the single group key; a second (or repeated) bare
-			// column is outside the allow-listed class.
-			if keyItem >= 0 {
+			// A bare column — the TAG key. agg-3c allows at most ONE tag key
+			// (alongside an optional bucket): a second tag would ride the
+			// generic engine path that measured 1.4-2.4x BEHIND at corpus
+			// scale — allow-listing it routes a known loss (gotcha #5).
+			if tagItem >= 0 {
 				return fail()
 			}
-			keyItem = len(items)
-			key = t.orig
+			tagItem = len(items)
+			tagKey = t.orig
 			items = append(items, t.orig)
 		}
 		if c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == ',' {
@@ -889,7 +892,8 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 		}
 		break
 	}
-	if keyItem < 0 || nAggs == 0 {
+	// At least one key of either kind + at least one aggregate.
+	if (bucketItem < 0 && tagItem < 0) || nAggs == 0 {
 		return fail()
 	}
 	if !c.ident("from") {
@@ -916,66 +920,108 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 	}
 	// Key references are ASYMMETRIC (oracle-probed at agg-3b): in GROUP BY,
 	// DuckDB binds a bare ident to the RAW COLUMN (so an alias never resolves
-	// there — position or bare-key name only); in ORDER BY it binds the ALIAS.
-	groupRef := func(kt token) bool {
+	// there — position, or the TAG key's bare name only); in ORDER BY it binds
+	// the ALIAS. Each ref resolves to a key ITEM index, or -1.
+	groupRef := func(kt token) int {
 		switch kt.kind {
 		case tokIdent:
-			return m.bucketUnit == "" && m.epochWidthSecs == 0 && strings.EqualFold(kt.orig, key)
+			if tagItem >= 0 && strings.EqualFold(kt.orig, tagKey) {
+				return tagItem
+			}
 		case tokNum:
-			return kt.orig == strconv.Itoa(keyItem+1)
+			if bucketItem >= 0 && kt.orig == strconv.Itoa(bucketItem+1) {
+				return bucketItem
+			}
+			if tagItem >= 0 && kt.orig == strconv.Itoa(tagItem+1) {
+				return tagItem
+			}
 		}
-		return false
+		return -1
 	}
-	orderRef := func(kt token) bool {
-		if kt.kind == tokIdent && m.bucketAlias != "" {
-			return strings.EqualFold(kt.orig, m.bucketAlias)
+	orderRef := func(kt token) int {
+		if kt.kind == tokIdent && m.bucketAlias != "" && strings.EqualFold(kt.orig, m.bucketAlias) {
+			return bucketItem
 		}
 		return groupRef(kt)
 	}
-	kt, tok := c.next()
-	if !tok || !groupRef(kt) {
-		return fail()
+	// GROUP BY: a comma-list of key refs covering EVERY key exactly once
+	// (agg-3c: bucket + tag panels say `GROUP BY 1, 2` or `GROUP BY 1, host`).
+	seen := map[int]bool{}
+	for {
+		kt, tok := c.next()
+		if !tok {
+			return fail()
+		}
+		ki := groupRef(kt)
+		if ki < 0 || seen[ki] {
+			return fail()
+		}
+		seen[ki] = true
+		if c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == ',' {
+			c.i++
+			continue
+		}
+		break
 	}
-	// Optional `ORDER BY <key ref> [ASC]` (agg-3): the engine sorts the single
-	// key ascending, NULLS LAST. DESC / LIMIT / anything else after declines.
+	nKeys := 0
+	if bucketItem >= 0 {
+		nKeys++
+	}
+	if tagItem >= 0 {
+		nKeys++
+	}
+	if len(seen) != nKeys {
+		return fail() // every projected key must be grouped exactly once
+	}
+	// Optional `ORDER BY <key ref> [ASC]` (agg-3): the engine sorts that single
+	// key ascending, NULLS LAST. DESC / LIMIT / multi-key ORDER decline.
 	if c.peekIdentLower() == "order" {
 		c.next()
 		if !c.ident("by") {
 			return fail()
 		}
 		ot, tok := c.next()
-		if !tok || !orderRef(ot) {
+		if !tok {
+			return fail()
+		}
+		oi := orderRef(ot)
+		if oi < 0 {
 			return fail()
 		}
 		if c.peekIdentLower() == "asc" {
 			c.next()
 		}
-		m.orderByKey = true
+		m.orderByItem = oi + 1 // 1-based select-list position
 	}
 	if !c.atEnd() {
 		return fail()
 	}
 	m.items = items
-	m.key = key
-	m.keyItem = keyItem
+	m.bucketText = bucketText
+	m.bucketItem = bucketItem
+	m.tagKey = tagKey
+	m.tagItem = tagItem
 	m.whereText = whereText
 	m.meas = meas
 	return m, true
 }
 
 // groupedMatch is matchGroupedAgg's result: the re-serialized select items, the
-// key (a bare column, or the rebuilt bucket text when bucketUnit != ""), the
-// key's select-list index, and the validated bucket parts the SQL builder
-// re-emits (never source text).
+// key set (agg-3c: at most one BUCKET — date_trunc or epoch-math — and at most
+// one bare TAG key, at least one of either), their select-list indices, and the
+// validated bucket parts the SQL builder re-emits (never source text).
 type groupedMatch struct {
 	items      []string
-	key        string
-	keyItem    int
+	bucketText string // rebuilt bucket item text ("" = no bucket key)
+	bucketItem int    // select-list index of the bucket (-1 = none)
+	tagKey     string // the bare tag key's spelling ("" = no tag key)
+	tagItem    int    // select-list index of the tag key (-1 = none)
 	whereText  string
 	meas       string
 	bucketUnit string
 	bucketCol  string
-	orderByKey bool
+	// ORDER BY: the ordered KEY's 1-based select-list position (0 = none).
+	orderByItem int
 	// agg-3b epoch-math bucket: width in whole seconds (0 = not this form) and
 	// the MANDATORY alias — validated parts the builder re-emits.
 	epochWidthSecs int


### PR DESCRIPTION
## What

The grouped recognizer widens to the agg-3c key set: at most one time bucket (`date_trunc` or the epoch-math `$__timeGroup` form) **plus at most ONE bare tag key**, at least one of either — the per-host Grafana panel shape (`$__timeGroup(time,5m) AS time, host, avg(...) GROUP BY 1, 2`).

Exactly one tag is deliberate: a second tag rides the engine's generic composite path that measured **1.4–2.4× behind** at corpus scale — allow-listing it would route a known loss (gotcha #5). Two tags go behind their own bench. The engine's composite fast path (arcX #65) flips the one-tag class to 1.16–2.03× wins.

## How

- **GROUP BY** accepts a comma-list of key refs covering every projected key exactly once — positions for both key forms; a bare *name* binds the tag key only (in GROUP BY DuckDB binds bare idents to the raw column, so the bucket alias never resolves there; oracle-probed at agg-3b).
- **ORDER BY** resolves to a single key (position, tag name, or bucket alias); `Decision` carries the ordered key's select position, and the builder validates it points at a key before emitting positional `GROUP BY`/`ORDER BY` lists (no identifier text in emitted clauses). Per-key matched flags replace the single-flag item validation that breaks at two keys.
- **Shadow compare goes multi-key**: the single typed key becomes a typed key-part **tuple** (never a joined string), part-wise sort/equality, NULL parts normalized on both sides, Timestamp parts as epoch-µs. Tie-agnostic by construction — DuckDB's arbitrary within-bucket ORDER BY tie order never false-alarms.

## End-to-end (serve vs off, same tagged binary, the exact per-host 5m panel, 1-day window, 3000 groups)

**1231 ms vs 2098 ms — 1.7× at the wire**, identical row counts and per-(bucket, host) values. Stock build carries zero engine symbols; vet and tests green in both build modes.

## Tests

Composite accepts (both item orders, `GROUP BY 1, host`, ORDER BY bucket-alias/position), declines (two tags, two buckets, missing/duplicate key refs, `GROUP BY <alias>`, ORDER BY an aggregate position), builder emission + ORDER-BY-non-key decline, and the multi-key comparator paths exercised through both build modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)