### PR TITLE
feat(arcxrouter): lift the flat-scan ±0.0 float-literal gates (the engine now serves them)

### DIFF
--- a/internal/arcxrouter/build_scan_sql_test.go
+++ b/internal/arcxrouter/build_scan_sql_test.go
@@ -96,8 +96,9 @@ func TestBuildScanSQL_DeclinesUnsafe(t *testing.T) {
 		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "LIKE", num: "1"}}},                // bad op
 		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "=", num: "1x"}}},                  // bad int literal
 		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "=", num: "1.2x", isFloat: true}}}, // bad float literal
-		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "=", num: "0.0", isFloat: true}}},  // ±0.0 float (declines defense-in-depth)
-		{Shape: ShapeScan, Cols: []string{"code"}, Preds: []scanPred{{col: "a", op: "<", num: "0.0", isFloat: true}}},  // ±0.0 inequality still declines (2b-4)
+		// ±0.0 emit-time rejection LIFTED (int-coercion slice: the engine
+		// normalizes both operands) — the ±0.0 Decisions now emit; covered by
+		// the routing pins in scan_recognizer_test.
 	}
 	for i, d := range bad {
 		if _, ok := buildScanSQL(d, "['/a.parquet']"); ok {

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -533,11 +533,11 @@ func buildScanSQL(d Decision, pathArray string) (string, bool) {
 				b.WriteString(escapeStringLiteral(p.str))
 				b.WriteByte('\'')
 			} else if p.isFloat {
-				// DOUBLE comparison literal — validate the `digit.digit` shape and reject
-				// `±0.0` again at emit time (defense in depth vs a hand-built Decision).
-				// As of 2b-4 all six ops are allowed (arrow total_cmp == DuckDB); only the
-				// ±0.0 literal stays rejected (signed-zero divergence, all ops).
-				if !isFloatLiteral(p.num) || isZeroFloatLiteral(p.num) {
+				// DOUBLE comparison literal — validate the `digit.digit` shape at emit
+				// time (defense in depth vs a hand-built Decision). The former ±0.0
+				// rejection is lifted (int-coercion slice: the engine normalizes both
+				// operands, oracle-matched on the full specials matrix).
+				if !isFloatLiteral(p.num) {
 					return "", false
 				}
 				b.WriteString(p.num)

--- a/internal/arcxrouter/scan_recognizer_test.go
+++ b/internal/arcxrouter/scan_recognizer_test.go
@@ -314,21 +314,27 @@ func TestMatchScan_DoubleEquality(t *testing.T) {
 		!m.preds[1].isFloat || m.preds[1].op != "<=" || m.preds[1].num != "2.0" {
 		t.Fatalf("float BETWEEN should desugar to 2 float preds (2b-4): ok=%v %+v", ok, m.preds)
 	}
-	// A ±0.0 float BETWEEN bound declines (the desugared `>= 0.0` fires the guard).
-	if m, ok := eligibleShape("SELECT a FROM cpu WHERE value BETWEEN 0.0 AND 2.0"); ok && m.shape == ShapeScan {
-		t.Fatalf("±0.0 float BETWEEN bound should decline: %+v", m.preds)
+	// ±0.0 bounds and literals ROUTE since the int-coercion slice — the engine
+	// binds any zero spelling as the normalized compare (oracle-matched on the
+	// full specials matrix), so the 2b-4 router mirror is lifted.
+	for _, sql := range []string{
+		"SELECT a FROM cpu WHERE value BETWEEN 0.0 AND 2.0",
+		"SELECT a FROM cpu WHERE value = 0.0",
+		"SELECT a FROM cpu WHERE value = -0.0",
+		"SELECT a FROM cpu WHERE value != 0.0",
+		"SELECT a FROM cpu WHERE value < 0.0",
+		"SELECT a FROM cpu WHERE value >= -0.0",
+		"SELECT a FROM cpu WHERE value = 00.000",
+	} {
+		if m, ok := eligibleShape(sql); !ok || m.shape != ShapeScan {
+			t.Fatalf("±0.0 should route since the coercion slice: %q (ok=%v)", sql, ok)
+		}
 	}
 
 	// Declines the router must STILL make (mirror the engine so it never routes a decline):
 	decline := []string{
-		"SELECT a FROM cpu WHERE value = 0.0",    // ±0.0 (signed-zero divergence) — all ops
-		"SELECT a FROM cpu WHERE value = -0.0",   // "
-		"SELECT a FROM cpu WHERE value != 0.0",   // "
-		"SELECT a FROM cpu WHERE value < 0.0",    // ±0.0 inequality (2b-4 widened the guard)
-		"SELECT a FROM cpu WHERE value >= -0.0",  // "
-		"SELECT a FROM cpu WHERE value = 00.000", // ±0.0 alt spelling
-		"SELECT a FROM cpu WHERE value = 5.",     // `digit.` not a float token → junk
-		"SELECT a FROM cpu WHERE value = .5",     // `.digit` not a float token → junk
+		"SELECT a FROM cpu WHERE value = 5.", // `digit.` not a float token → junk
+		"SELECT a FROM cpu WHERE value = .5", // `.digit` not a float token → junk
 	}
 	for _, sql := range decline {
 		if m, ok := eligibleShape(sql); ok && m.shape == ShapeScan {

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -1135,12 +1135,10 @@ func matchScan(toks []token) (cols []string, preds []scanPred, whereText string,
 				if !ok || (hiT.kind != tokNum && hiT.kind != tokStr && hiT.kind != tokFloat) {
 					return fail()
 				}
-				// A `±0.0` float bound declines for the same signed-zero reason as a bare
-				// float inequality (the desugared `>= 0.0` / `<= 0.0` diverges) — 2b-4.
-				if (loT.kind == tokFloat && isZeroFloatLiteral(loT.orig)) ||
-					(hiT.kind == tokFloat && isZeroFloatLiteral(hiT.orig)) {
-					return fail()
-				}
+				// A `±0.0` float bound SERVES since the int-coercion slice: the
+				// engine binds any zero spelling as the normalized compare
+				// `(col + 0.0) <op> +0.0` (the 2e machinery), oracle-matched on
+				// the full specials matrix — the 2b-4 decline is lifted.
 				lo := scanPred{col: colT.orig, op: ">="}
 				hi := scanPred{col: colT.orig, op: "<="}
 				switch loT.kind {
@@ -1174,13 +1172,9 @@ func matchScan(toks []token) (cols []string, preds []scanPred, whereText string,
 					preds = append(preds, scanPred{col: colT.orig, op: opStr, num: litT.orig, isStr: false})
 				case tokFloat:
 					// DOUBLE comparison. As of 2b-4 the engine serves all six ops on a
-					// finite float (arrow total_cmp == DuckDB ordering), so the flat path
-					// no longer restricts to Eq/Ne. The one guard that stays: a `±0.0`
-					// literal declines (arrow total_cmp separates -0.0/0.0, DuckDB treats
-					// them equal — diverges for `< 0.0`/`>= 0.0` too, not just equality).
-					if isZeroFloatLiteral(litT.orig) {
-						return fail()
-					}
+					// finite float (arrow total_cmp == DuckDB ordering). Since the
+					// int-coercion slice the `±0.0` literal also serves (the engine
+					// normalizes both operands — the signed-zero divergence is gone).
 					preds = append(preds, scanPred{col: colT.orig, op: opStr, num: litT.orig, isFloat: true})
 				case tokStr:
 					preds = append(preds, scanPred{col: colT.orig, op: opStr, str: litT.str, isStr: true})


### PR DESCRIPTION
## What

The engine's int-coercion slice (arcX #66) binds any zero-spelled literal as the normalized compare `(col + 0.0) <op> +0.0` — oracle-matched on the full `{−0.0, +0.0, ±1, NaN, ±inf, NULL}` × six-ops × three-spellings matrix — so the router's 2b-4 signed-zero mirror is obsolete. Lifted at **all three sites together** (lifting only the tokenizer gates would have silently killed the Decision at emit-time defense): the flat-path compare gate, the BETWEEN bound gate, and `buildScanSQL`'s emit check. Float-literal *shape* validation stays.

The int-literal and tree/agg paths needed no change — they never had a zero gate; the engine was the decline there, lifted engine-side in #66.

## Verification

- Pins flipped to routing assertions (`BETWEEN 0.0 AND 2.0`, `=`/`!=`/`<`/`>=` with `0.0`/`-0.0`/`00.000`); junk-literal declines (`5.`, `.5`) stay.
- E2E serve on the real corpus: `WHERE cpu_user > 90` (int) and `WHERE cpu_user > 0` both served with correct counts (146,934,286 / 1,469,844,958).
- Both build modes green; stock binary carries zero engine symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)