### PR TITLE
feat(arcxrouter): arg_max/arg_min/max_by/min_by join the allow-list; shadow arg-tie WARN policy

### DIFF
--- a/internal/api/arcx_hook.go
+++ b/internal/api/arcx_hook.go
@@ -372,6 +372,9 @@ type arcxMetrics struct {
 func (m arcxMetrics) ArcxShadowMatch(shape string) {
 	m.logger.Debug().Str("shape", shape).Msg("arcx shadow: match")
 }
+func (m arcxMetrics) ArcxShadowArgDivergence(shape string) {
+	m.logger.Warn().Str("shape", shape).Msg("arcx shadow: arg-item divergence metric (tie candidate)")
+}
 func (m arcxMetrics) ArcxShadowMismatch(shape string) {
 	m.logger.Warn().Str("shape", shape).Msg("arcx shadow: mismatch metric")
 }

--- a/internal/arcxrouter/agg_recognizer_test.go
+++ b/internal/arcxrouter/agg_recognizer_test.go
@@ -289,3 +289,58 @@ func TestCompositeKeyDeclines(t *testing.T) {
 		}
 	}
 }
+
+func TestArgMinMaxRecognized(t *testing.T) {
+	// agg-4: the two-arg by-time aggregates, ungrouped and grouped.
+	cases := []struct {
+		sql   string
+		shape string
+		items []string
+	}{
+		{
+			"SELECT arg_max(cpu_user, time) FROM cpu WHERE host = 'a'",
+			ShapeScanAgg, []string{"arg_max(cpu_user, time)"},
+		},
+		{
+			"SELECT count(*), max_by(Value, Time) FROM cpu",
+			ShapeScanAgg, []string{"count(*)", "max_by(Value, Time)"},
+		},
+		{
+			"SELECT host, arg_max(cpu_user, time) FROM cpu GROUP BY host",
+			ShapeScanAggGrouped, []string{"host", "arg_max(cpu_user, time)"},
+		},
+		{
+			"SELECT date_trunc('hour', time), host, arg_min(cpu_user, time) FROM cpu GROUP BY 1, 2",
+			ShapeScanAggGrouped,
+			[]string{"date_trunc('hour', time)", "host", "arg_min(cpu_user, time)"},
+		},
+	}
+	for _, c := range cases {
+		m, ok := eligibleShape(c.sql)
+		if !ok || m.shape != c.shape {
+			t.Fatalf("shape = (%q, %t), want %q: %s", m.shape, ok, c.shape, c.sql)
+		}
+		if !reflect.DeepEqual(m.aggItems, c.items) {
+			t.Fatalf("items = %v, want %v: %s", m.aggItems, c.items, c.sql)
+		}
+	}
+}
+
+func TestArgMinMaxDeclines(t *testing.T) {
+	for _, sql := range []string{
+		// The 3-arg top-N form EXISTS on DuckDB (returns LIST) — must not match.
+		"SELECT arg_max(cpu_user, time, 2) FROM cpu",
+		// NULL-keeping variant and no-underscore spellings exist too.
+		"SELECT arg_max_null(cpu_user, time) FROM cpu",
+		"SELECT argmax(cpu_user, time) FROM cpu",
+		"SELECT argmin(cpu_user, time) FROM cpu",
+		// One arg / expression args decline.
+		"SELECT arg_max(cpu_user) FROM cpu",
+		"SELECT arg_max(cpu_user * 2, time) FROM cpu",
+		"SELECT host, arg_max(cpu_user, time, 3) FROM cpu GROUP BY host",
+	} {
+		if m, ok := eligibleShape(sql); ok && (m.shape == ShapeScanAgg || m.shape == ShapeScanAggGrouped) {
+			t.Fatalf("must not match: %s", sql)
+		}
+	}
+}

--- a/internal/arcxrouter/build_agg_sql_test.go
+++ b/internal/arcxrouter/build_agg_sql_test.go
@@ -158,3 +158,19 @@ func TestBuildGroupedSQLComposite(t *testing.T) {
 		t.Fatal("ORDER BY on an aggregate position must decline")
 	}
 }
+
+func TestIsAggItemTwoArg(t *testing.T) {
+	for item, want := range map[string]bool{
+		"arg_max(v, time)":    true,
+		"min_by(Value, Time)": true,
+		"arg_max(v, time, 2)": false, // 3-arg re-serialization can't exist, but the validator must still reject
+		"arg_max(v)":          false,
+		"argmax(v, time)":     false,
+		"arg_max(a b, time)":  false,
+		"arg_max(v; DROP, t)": false,
+	} {
+		if got := isAggItem(item); got != want {
+			t.Fatalf("isAggItem(%q) = %t, want %t", item, got, want)
+		}
+	}
+}

--- a/internal/arcxrouter/compare_agg.go
+++ b/internal/arcxrouter/compare_agg.go
@@ -141,6 +141,21 @@ func compareAgg(rec arrow.Record, oracle []aggCell, items []string) string {
 	if len(got) != len(oracle) {
 		return fmt.Sprintf("agg column count differs (arcx=%d duckdb=%d)", len(got), len(oracle))
 	}
+	// agg-4 tie policy: a VALUE diff on an arg_max/arg_min cell is deferred —
+	// only if NO non-arg cell differs does it surface, tagged "argdiff:" so
+	// the caller WARNs instead of alarming (DuckDB's tie pick is
+	// nondeterministic; arcx's is pinned). Structural diffs (null-ness/kind)
+	// on arg cells still alarm: ties can't change a cell's type.
+	argDiff := ""
+	deferArg := func(c int, msg string) bool {
+		if c < len(items) && isArgItem(items[c]) {
+			if argDiff == "" {
+				argDiff = msg
+			}
+			return true
+		}
+		return false
+	}
 	for c := range got {
 		a, d := got[c], oracle[c]
 		if a.isNull != d.isNull {
@@ -156,16 +171,26 @@ func compareAgg(rec arrow.Record, oracle []aggCell, items []string) string {
 		}
 		if a.isInt {
 			if a.i.Cmp(d.i) != 0 {
-				return fmt.Sprintf("agg col %d differs (int values withheld from log)", c)
+				msg := fmt.Sprintf("agg col %d differs (int values withheld from log)", c)
+				if deferArg(c, msg) {
+					continue
+				}
+				return msg
 			}
 			continue
 		}
-		// Float cell. Two NaNs agree; one-sided NaN is a real divergence.
+		// Float cell. Two NaNs agree; one-sided NaN is a real divergence —
+		// EXCEPT on an arg cell, where a tie between a NaN payload and a real
+		// one legitimately diverges (defer like a value diff).
 		if math.IsNaN(a.f) || math.IsNaN(d.f) {
 			if math.IsNaN(a.f) && math.IsNaN(d.f) {
 				continue
 			}
-			return fmt.Sprintf("agg col %d differs (NaN-ness: arcx_nan=%t duckdb_nan=%t)", c, math.IsNaN(a.f), math.IsNaN(d.f))
+			msg := fmt.Sprintf("agg col %d differs (NaN-ness: arcx_nan=%t duckdb_nan=%t)", c, math.IsNaN(a.f), math.IsNaN(d.f))
+			if deferArg(c, msg) {
+				continue
+			}
+			return msg
 		}
 		tolerant := c < len(items) && aggItemTolerant(items[c])
 		if tolerant {
@@ -174,8 +199,15 @@ func compareAgg(rec arrow.Record, oracle []aggCell, items []string) string {
 				return fmt.Sprintf("agg col %d differs (float beyond 1e-9 tolerance, values withheld)", c)
 			}
 		} else if a.f != d.f {
-			return fmt.Sprintf("agg col %d differs (float values withheld from log)", c)
+			msg := fmt.Sprintf("agg col %d differs (float values withheld from log)", c)
+			if deferArg(c, msg) {
+				continue
+			}
+			return msg
 		}
+	}
+	if argDiff != "" {
+		return "argdiff:" + argDiff
 	}
 	return ""
 }

--- a/internal/arcxrouter/compare_grouped.go
+++ b/internal/arcxrouter/compare_grouped.go
@@ -256,12 +256,30 @@ func compareGrouped(rec arrow.Record, oracle []groupedRow, items []string, keyCo
 		return fmt.Sprintf("grouped row count differs (arcx=%d duckdb=%d)", len(got), len(oracle))
 	}
 	// Cell policies in CELL order (items minus the keys, order preserved).
+	// cellItems carries the item text per cell for the agg-4 arg-tie deferral.
 	var tolerant []bool
+	var cellItems []string
 	for i, item := range items {
 		if isKeyCol(keyCols, i) {
 			continue
 		}
 		tolerant = append(tolerant, aggItemTolerant(item))
+		cellItems = append(cellItems, item)
+	}
+	// agg-4 tie policy: VALUE (and NaN-ness) diffs on arg cells are deferred —
+	// surfaced tagged "argdiff:" only when nothing else differs, so the caller
+	// WARNs instead of alarming. Structural diffs (row count, keys, null-ness,
+	// kind) always alarm: ties cannot cause them (a NULL payload never wins in
+	// either engine — the both-non-NULL participation rule).
+	argDiff := ""
+	deferArg := func(c int, msg string) bool {
+		if c < len(cellItems) && isArgItem(cellItems[c]) {
+			if argDiff == "" {
+				argDiff = msg
+			}
+			return true
+		}
+		return false
 	}
 	normalizeNullParts(got)
 	normalizeNullParts(oracle)
@@ -288,7 +306,11 @@ func compareGrouped(rec arrow.Record, oracle []groupedRow, items []string, keyCo
 			}
 			if ac.isInt {
 				if ac.i.Cmp(dc.i) != 0 {
-					return fmt.Sprintf("grouped row %d of %d differs (agg col %d, values withheld)", i, len(got), c)
+					msg := fmt.Sprintf("grouped row %d of %d differs (agg col %d, values withheld)", i, len(got), c)
+					if deferArg(c, msg) {
+						continue
+					}
+					return msg
 				}
 				continue
 			}
@@ -296,7 +318,11 @@ func compareGrouped(rec arrow.Record, oracle []groupedRow, items []string, keyCo
 				if math.IsNaN(ac.f) && math.IsNaN(dc.f) {
 					continue
 				}
-				return fmt.Sprintf("grouped row %d differs (agg col %d NaN-ness)", i, c)
+				msg := fmt.Sprintf("grouped row %d differs (agg col %d NaN-ness)", i, c)
+				if deferArg(c, msg) {
+					continue
+				}
+				return msg
 			}
 			if tolerant[c] {
 				scale := math.Max(math.Abs(ac.f), math.Abs(dc.f))
@@ -304,9 +330,16 @@ func compareGrouped(rec arrow.Record, oracle []groupedRow, items []string, keyCo
 					return fmt.Sprintf("grouped row %d differs (agg col %d beyond 1e-9 tolerance, values withheld)", i, c)
 				}
 			} else if ac.f != dc.f {
-				return fmt.Sprintf("grouped row %d of %d differs (agg col %d float, values withheld)", i, len(got), c)
+				msg := fmt.Sprintf("grouped row %d of %d differs (agg col %d float, values withheld)", i, len(got), c)
+				if deferArg(c, msg) {
+					continue
+				}
+				return msg
 			}
 		}
+	}
+	if argDiff != "" {
+		return "argdiff:" + argDiff
 	}
 	return ""
 }

--- a/internal/arcxrouter/router.go
+++ b/internal/arcxrouter/router.go
@@ -84,6 +84,9 @@ type OracleDB interface {
 type Metrics interface {
 	ArcxShadowMatch(shape string)
 	ArcxShadowMismatch(shape string)
+	// agg-4: a shadow diff confined to arg_max/arg_min cells (tie-divergence
+	// candidate — WARN-class, never the mismatch alarm).
+	ArcxShadowArgDivergence(shape string)
 	ArcxShadowError(shape string)
 	// ArcxShadowSkipped: a shadow sample was deliberately not taken (at the concurrency
 	// cap, or the result exceeded ShadowMaxRows). NOT an error and NOT a mismatch —
@@ -458,12 +461,33 @@ func isAggItem(item string) bool {
 	if open < 0 || !strings.HasSuffix(item, ")") {
 		return false
 	}
+	inner := item[open+1 : len(item)-1]
 	switch item[:open] {
 	case "count", "sum", "min", "max", "avg":
-	default:
-		return false
+		return isBareIdent(inner)
+	// agg-4: the two-arg by-time aggregates — EXACTLY two bare idents,
+	// re-serialized as `fn(a, b)`. The 3-arg top-N form, arg_max_null, and
+	// no-underscore argmax/argmin exist on DuckDB and must NOT match.
+	case "arg_max", "arg_min", "max_by", "min_by":
+		a, b, ok := strings.Cut(inner, ", ")
+		return ok && isBareIdent(a) && isBareIdent(b)
 	}
-	return isBareIdent(item[open+1 : len(item)-1])
+	return false
+}
+
+// isArgItem reports whether a re-serialized item is an agg-4 by-time aggregate
+// — the shadow compare treats a mismatch confined to these cells as an
+// arg-tie divergence candidate (WARN), never the ERROR alarm: DuckDB's tie
+// choice is run-to-run nondeterministic at high thread counts (oracle-probed)
+// while arcx is pinned deterministic, so ambiguous ties diverge legitimately
+// (~0.1% of groups on real data).
+func isArgItem(item string) bool {
+	for _, p := range []string{"arg_max(", "arg_min(", "max_by(", "min_by("} {
+		if strings.HasPrefix(item, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // buildScanSQL constructs the engine SQL for a general single-table scan:
@@ -756,6 +780,22 @@ func (h Deps) runShadow(ctx context.Context, d Decision, engineSQL string) {
 	h.Metrics.ArcxLatency("duckdb", d.Shape, oracleMicros)
 
 	if diff != "" {
+		// agg-4 tie policy: a mismatch confined to arg_max/arg_min CELLS is a
+		// tie-divergence CANDIDATE (DuckDB nondeterministic, arcx pinned) —
+		// WARN + its own metric, never the ERROR alarm. The comparators tag
+		// such diffs with the "argdiff:" prefix after verifying no non-arg
+		// cell differs. Residual risk (a real arg bug on tie-free data lands
+		// here too) is recorded in the agg-4 plan doc; a WARN-rate spike is
+		// itself the signal, and the differential harness carries the strict
+		// membership checks.
+		if strings.HasPrefix(diff, "argdiff:") {
+			h.Logger.Warn().
+				Str("shape", d.Shape).
+				Str("diff", strings.TrimPrefix(diff, "argdiff:")).
+				Msg("arcx shadow: arg-item divergence (tie candidate, values withheld)")
+			h.Metrics.ArcxShadowArgDivergence(d.Shape)
+			return
+		}
 		h.Logger.Error().
 			Str("shape", d.Shape).
 			Str("engine_sql", sqlutil.ForLog(engineSQL)).

--- a/internal/arcxrouter/tokenize.go
+++ b/internal/arcxrouter/tokenize.go
@@ -659,31 +659,42 @@ func matchScanAgg(toks []token) (items []string, whereText string, meas string, 
 		}
 		switch f.lower {
 		case "count", "sum", "min", "max", "avg":
+			if !c.punct('(') {
+				return fail()
+			}
+			// `count(*)` — the only star form. `sum(*)` etc. fall through to the
+			// bare-column requirement and decline.
+			if f.lower == "count" && c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '*' {
+				c.i++
+				if !c.punct(')') {
+					return fail()
+				}
+				items = append(items, "count(*)")
+			} else {
+				arg, ok := c.next()
+				if !ok || arg.kind != tokIdent || isScanKeyword(arg.lower) || arg.lower == "distinct" {
+					return fail()
+				}
+				// The immediately-following `)` requirement declines expressions
+				// (`sum(a*b)`) and DISTINCT — mirroring the engine's matcher.
+				if !c.punct(')') {
+					return fail()
+				}
+				items = append(items, f.lower+"("+arg.orig+")")
+			}
+		case "arg_max", "arg_min", "max_by", "min_by":
+			// agg-4 two-arg by-time aggregates: `fn(payload, orderkey)` — both
+			// bare idents, re-serialized `fn(a, b)` (fn lowercased, spellings
+			// preserved). The 3-arg top-N form and any other arg-shape fall to
+			// the `)` requirement and decline; `arg_max_null`/`argmax` are
+			// unknown fn names and decline in the default arm.
+			item, ok := parseTwoArgAggItem(c, f.lower)
+			if !ok {
+				return fail()
+			}
+			items = append(items, item)
 		default:
 			return fail()
-		}
-		if !c.punct('(') {
-			return fail()
-		}
-		// `count(*)` — the only star form. `sum(*)` etc. fall through to the
-		// bare-column requirement and decline.
-		if f.lower == "count" && c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == '*' {
-			c.i++
-			if !c.punct(')') {
-				return fail()
-			}
-			items = append(items, "count(*)")
-		} else {
-			arg, ok := c.next()
-			if !ok || arg.kind != tokIdent || isScanKeyword(arg.lower) || arg.lower == "distinct" {
-				return fail()
-			}
-			// The immediately-following `)` requirement declines expressions
-			// (`sum(a*b)`) and DISTINCT — mirroring the engine's matcher.
-			if !c.punct(')') {
-				return fail()
-			}
-			items = append(items, f.lower+"("+arg.orig+")")
 		}
 		if c.i < len(c.toks) && c.toks[c.i].kind == tokPunct && c.toks[c.i].punct == ',' {
 			c.i++
@@ -850,6 +861,14 @@ func matchGroupedAgg(toks []token) (m groupedMatch, ok bool) {
 			bucketItem = len(items)
 			bucketText = "date_trunc('" + ut.str + "', " + bc.orig + ")"
 			items = append(items, bucketText)
+		} else if isCall && (t.lower == "arg_max" || t.lower == "arg_min" || t.lower == "max_by" || t.lower == "min_by") {
+			// agg-4 two-arg by-time aggregates (see matchScanAgg's arm).
+			item, iok := parseTwoArgAggItem(c, t.lower)
+			if !iok {
+				return fail()
+			}
+			items = append(items, item)
+			nAggs++
 		} else if isCall {
 			switch t.lower {
 			case "count", "sum", "min", "max", "avg":
@@ -1026,6 +1045,30 @@ type groupedMatch struct {
 	// the MANDATORY alias — validated parts the builder re-emits.
 	epochWidthSecs int
 	bucketAlias    string
+}
+
+// parseTwoArgAggItem consumes `( <bare ident> , <bare ident> )` after an agg-4
+// function name and re-serializes it as `fn(a, b)` — validated tokens only,
+// never source text. Anything else (star, expression, a third argument) fails.
+func parseTwoArgAggItem(c *cursor, fnLower string) (string, bool) {
+	if !c.punct('(') {
+		return "", false
+	}
+	a1, ok := c.next()
+	if !ok || a1.kind != tokIdent || isScanKeyword(a1.lower) || !isBareIdent(a1.orig) {
+		return "", false
+	}
+	if !c.punct(',') {
+		return "", false
+	}
+	a2, ok := c.next()
+	if !ok || a2.kind != tokIdent || isScanKeyword(a2.lower) || !isBareIdent(a2.orig) {
+		return "", false
+	}
+	if !c.punct(')') {
+		return "", false
+	}
+	return fnLower + "(" + a1.orig + ", " + a2.orig + ")", true
 }
 
 // fixedWidthUnits is the engine's agg-3 bucket set — pure UTC epoch division


### PR DESCRIPTION
## What

The agg-4 two-arg by-time aggregates (arcX #67) join both recognizers (scan_agg + grouped) via a shared `parseTwoArgAggItem` — exactly two bare idents, re-serialized `fn(a, b)` from validated tokens. The DuckDB-real half-match traps decline by construction: the 3-arg top-N form (extra arg fails the paren requirement), `arg_max_null`/`argmax`/`argmin` (unknown fn names). `isAggItem` grows the matching two-arg validation for the emit path.

## Shadow tie policy

DuckDB's tie pick is **run-to-run nondeterministic at high thread counts** (oracle-probed at plan stage) while arcx's is pinned deterministic — so a shadow diff confined to arg-item **cells** (value or NaN-ness; ties between NaN and real payloads are legitimate) is deferred by the comparators and surfaced tagged `argdiff:`, which the caller logs as **WARN + a distinct `ArcxShadowArgDivergence` metric** — never the ERROR alarm. Structural diffs (row count, keys, null-ness, kind) always alarm: ties cannot cause them (the both-non-NULL participation rule means a NULL payload never wins in either engine), and any non-arg cell difference still alarms even when arg cells also differ. Residual risk recorded in the agg-4 plan doc; a WARN-rate spike is itself the signal.

## E2E (serve vs off, same tagged binary, 1.47B rows)

`SELECT host, arg_max(cpu_user, time) FROM cpu GROUP BY host` — **688 ms vs 1129 ms (1.6× at the wire)**, 1000 rows both sides. Both build modes green; stock binary carries zero engine symbols.

## Tests

Recognizer accepts (ungrouped, mixed lists, grouped, bucket+tag composite with an arg item), declines (3-arg top-N, `arg_max_null`, no-underscore spellings, single-arg, expression args), two-arg `isAggItem` validation incl. injection-shaped parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)