### PR TITLE
fix(storage): use errors.As for azure response error inspection (#319)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -52,3 +52,8 @@ require a word boundary after the unit, so interval-lookalike text inside string
 literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such as
 `interval2` can never be misread as time bounds; compound quoted intervals like
 `'1 day 12 hours'` remain unpruned (never mis-pruned as their first component).
+
+## Fixed: Azure not-found error detection handling joined multi-errors
+
+Azure not-found error detection (`isAzureNotFoundError`) now uses `errors.As` instead of a custom single-Unwrap loop, ensuring `azcore.ResponseError` is correctly identified even when wrapped inside joined multi-errors (`errors.Join`). ([#319](https://github.com/Basekick-Labs/arc/issues/319))
+

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -573,9 +573,9 @@ func isAzureNotFoundError(err error) bool {
 		return false
 	}
 
-	// Check for Azure-specific error response
+	// Check for Azure-specific error response using standard errors.As (handles multi-errors/errors.Join)
 	var respErr *azcore.ResponseError
-	if ok := isResponseError(err, &respErr); ok {
+	if errors.As(err, &respErr) {
 		return respErr.StatusCode == 404
 	}
 
@@ -586,23 +586,3 @@ func isAzureNotFoundError(err error) bool {
 		strings.Contains(errStr, "NotFound")
 }
 
-// isResponseError checks if err is an azcore.ResponseError
-func isResponseError(err error, target **azcore.ResponseError) bool {
-	if err == nil {
-		return false
-	}
-	// Use errors.As pattern
-	for err != nil {
-		if re, ok := err.(*azcore.ResponseError); ok {
-			*target = re
-			return true
-		}
-		// Try to unwrap
-		if unwrapper, ok := err.(interface{ Unwrap() error }); ok {
-			err = unwrapper.Unwrap()
-		} else {
-			break
-		}
-	}
-	return false
-}

--- a/internal/storage/azure_test.go
+++ b/internal/storage/azure_test.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestIsAzureNotFoundError(t *testing.T) {
+	respErr404 := &azcore.ResponseError{StatusCode: 404}
+	respErr500 := &azcore.ResponseError{StatusCode: 500}
+	otherErr := errors.New("other error")
+
+	tests := []struct {
+		name   string
+		err    error
+		expect bool
+	}{
+		{
+			name:   "nil error",
+			err:    nil,
+			expect: false,
+		},
+		{
+			name:   "bare ResponseError 404",
+			err:    respErr404,
+			expect: true,
+		},
+		{
+			name:   "wrapped ResponseError 404",
+			err:    fmt.Errorf("wrapped error: %w", respErr404),
+			expect: true,
+		},
+		{
+			name:   "joined ResponseError 404 via errors.Join",
+			err:    errors.Join(otherErr, respErr404),
+			expect: true,
+		},
+		{
+			name:   "bare ResponseError 500",
+			err:    respErr500,
+			expect: false,
+		},
+		{
+			name:   "string fallback BlobNotFound",
+			err:    errors.New("BlobNotFound"),
+			expect: true,
+		},
+		{
+			name:   "string fallback 404",
+			err:    errors.New("HTTP 404"),
+			expect: true,
+		},
+		{
+			name:   "unrelated error",
+			err:    otherErr,
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAzureNotFoundError(tt.err)
+			if got != tt.expect {
+				t.Errorf("isAzureNotFoundError() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
Replaces the hand-rolled `isResponseError` unwrapping loop in `internal/storage/azure.go` with Go's standard `errors.As(err, &respErr)`.

### Motivation & Background
* Arc's manual error unwrapping loop only traversed single wrapped errors (`Unwrap() error`). If an `azcore.ResponseError` was contained inside a joined multi-error (`errors.Join` / `Unwrap() []error`), the loop failed to find it.
* The Azure SDK (`azcore`) documentation explicitly specifies using `errors.As()` to inspect errors in the error chain.

### Changes Made
- Updated `isAzureNotFoundError` to directly call `errors.As(err, &respErr)`.
- Removed redundant `isResponseError` helper function.

Fixes #319
