### PR TITLE
docs: add pre-26.06.1 token upgrade runbook

### DIFF
--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -619,6 +619,21 @@ Before 26.06.1, every Arc Enterprise cluster node carried its **own** SQLite aut
 
 **No migration of pre-existing tokens.** Tokens created on a pre-26.06.1 node by the local-only API path remain valid **only on that node** after upgrade. Operators are expected to re-issue API tokens through the new replicated path so they take effect cluster-wide. Bootstrap tokens set via `ARC_AUTH_BOOTSTRAP_TOKEN` are unaffected if the same value was used on every node (which the previous workaround required).
 
+#### Upgrade runbook for pre-26.06.1 API tokens
+
+Use this procedure during the maintenance window for every Arc Enterprise cluster that has API-created tokens from before 26.06.1:
+
+1. **Inventory before the upgrade.** On every node, record each active token's name, permissions, owner, and downstream consumers. The local databases can differ, so do not treat any one node as authoritative. Do not copy bcrypt hashes or plaintext token values into the inventory.
+2. **Back up each local auth database.** Stop Arc on the node before copying the file configured by `auth.db_path`; include its SQLite `-wal` and `-shm` sidecars when present.
+3. **Upgrade every node to 26.06.1 or later** and wait for the Raft cluster to regain a stable leader and full membership.
+4. **Verify the replicated write path.** Create one short-lived validation token through `POST /api/v1/auth/tokens`, then confirm that `arc_cluster_auth_apply_create_total` advances by the same amount on every node and that the token authenticates against every node. Revoke the validation token when the check passes.
+5. **Re-issue each inventoried token.** Create a replacement through `POST /api/v1/auth/tokens` on any node, using the original scope and permissions. Capture the returned plaintext once; Arc cannot display it again.
+6. **Rotate downstream consumers.** Update CI secrets, SDK configuration, dashboards, and other clients to the replacement value. Verify each consumer against more than one cluster node before continuing.
+7. **Revoke the old per-node token** through `POST /api/v1/auth/tokens/:id/revoke`, then verify that it fails on every node. Repeat steps 5-7 one token at a time to keep rollback scope small.
+8. **Resolve divergence alerts before rejoining a node.** If `arc_cluster_auth_rejected_total` grows or the logs report an ID collision, stop the affected node, preserve its auth database backup, and remove only the conflicting legacy rows (or rebuild the local auth database from the FSM) before rejoining. Never delete an auth database while Arc is running.
+
+The migration is complete when every active consumer uses a replacement token, the apply counters converge across nodes, the rejected counter is stable, and every legacy token fails against every node.
+
 **Divergence detection on upgrade.** Pre-26.06.1 tokens were stamped with `AUTOINCREMENT` IDs (1, 2, 3…). Cluster-replicated tokens land at `ID = Raft log index`, which can be 5+ for a freshly-bootstrapped cluster. An operator with many pre-existing tokens may have a pre-existing AUTOINCREMENT row whose ID happens to match the new cluster row's ID — silent `INSERT OR IGNORE` would mask the new row on that node while applying on every other node, leaving `VerifyToken` results divergent across the cluster. 26.06.1 detects this at materialise time: if a row at the same ID exists with a DIFFERENT token hash or name, `ApplyCreateToken` returns an error rather than overwriting silently, the `arc_cluster_auth_rejected_total` counter increments, and the cluster Apply path logs the divergence at `Error` level. Operator action: drop the diverging local `auth.db` rows (or the whole local auth DB and let the FSM repopulate) before re-joining. Identical hash + name is treated as idempotent log replay (no-op, no error), so a restart of a healthy cluster does not surface this.
 
 **Operator-facing changes.**

--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -619,20 +619,9 @@ Before 26.06.1, every Arc Enterprise cluster node carried its **own** SQLite aut
 
 **No migration of pre-existing tokens.** Tokens created on a pre-26.06.1 node by the local-only API path remain valid **only on that node** after upgrade. Operators are expected to re-issue API tokens through the new replicated path so they take effect cluster-wide. Bootstrap tokens set via `ARC_AUTH_BOOTSTRAP_TOKEN` are unaffected if the same value was used on every node (which the previous workaround required).
 
-#### Upgrade runbook for pre-26.06.1 API tokens
-
-Use this procedure during the maintenance window for every Arc Enterprise cluster that has API-created tokens from before 26.06.1:
-
-1. **Inventory before the upgrade.** On every node, record each active token's name, permissions, owner, and downstream consumers. The local databases can differ, so do not treat any one node as authoritative. Do not copy bcrypt hashes or plaintext token values into the inventory.
-2. **Back up each local auth database.** Stop Arc on the node before copying the file configured by `auth.db_path`; include its SQLite `-wal` and `-shm` sidecars when present.
-3. **Upgrade every node to 26.06.1 or later** and wait for the Raft cluster to regain a stable leader and full membership.
-4. **Verify the replicated write path.** Create one short-lived validation token through `POST /api/v1/auth/tokens`, then confirm that `arc_cluster_auth_apply_create_total` advances by the same amount on every node and that the token authenticates against every node. Revoke the validation token when the check passes.
-5. **Re-issue each inventoried token.** Create a replacement through `POST /api/v1/auth/tokens` on any node, using the original scope and permissions. Capture the returned plaintext once; Arc cannot display it again.
-6. **Rotate downstream consumers.** Update CI secrets, SDK configuration, dashboards, and other clients to the replacement value. Verify each consumer against more than one cluster node before continuing.
-7. **Revoke the old per-node token** through `POST /api/v1/auth/tokens/:id/revoke`, then verify that it fails on every node. Repeat steps 5-7 one token at a time to keep rollback scope small.
-8. **Resolve divergence alerts before rejoining a node.** If `arc_cluster_auth_rejected_total` grows or the logs report an ID collision, stop the affected node, preserve its auth database backup, and remove only the conflicting legacy rows (or rebuild the local auth database from the FSM) before rejoining. Never delete an auth database while Arc is running.
-
-The migration is complete when every active consumer uses a replacement token, the apply counters converge across nodes, the rejected counter is stable, and every legacy token fails against every node.
+For the durable operator procedure, see [Upgrading pre-26.06.1 API tokens](operations/pre-26.06.1-token-upgrade.md).
+Legacy tokens require offline cleanup on each node; the replicated revoke API
+must only be used for tokens created through the replicated path after upgrade.
 
 **Divergence detection on upgrade.** Pre-26.06.1 tokens were stamped with `AUTOINCREMENT` IDs (1, 2, 3…). Cluster-replicated tokens land at `ID = Raft log index`, which can be 5+ for a freshly-bootstrapped cluster. An operator with many pre-existing tokens may have a pre-existing AUTOINCREMENT row whose ID happens to match the new cluster row's ID — silent `INSERT OR IGNORE` would mask the new row on that node while applying on every other node, leaving `VerifyToken` results divergent across the cluster. 26.06.1 detects this at materialise time: if a row at the same ID exists with a DIFFERENT token hash or name, `ApplyCreateToken` returns an error rather than overwriting silently, the `arc_cluster_auth_rejected_total` counter increments, and the cluster Apply path logs the divergence at `Error` level. Operator action: drop the diverging local `auth.db` rows (or the whole local auth DB and let the FSM repopulate) before re-joining. Identical hash + name is treated as idempotent log replay (no-op, no error), so a restart of a healthy cluster does not surface this.
 

--- a/operations/pre-26.06.1-token-upgrade.md
+++ b/operations/pre-26.06.1-token-upgrade.md
@@ -1,0 +1,66 @@
+# Upgrading pre-26.06.1 API tokens
+
+Applies to Arc Enterprise clusters with API-created tokens from before 26.06.1.
+Plan a maintenance window and preserve administrative access. Bootstrap tokens
+configured identically on every node are unaffected.
+
+## Why legacy tokens need local cleanup
+
+Legacy tokens exist only in individual nodes' SQLite auth databases. They were
+not migrated into the replicated FSM. The cluster revoke endpoint looks up the
+ID in the FSM: an unknown ID is an idempotent no-op even if the API returns
+success. If a legacy AUTOINCREMENT ID collides with a replicated token ID, the
+same request can revoke the replacement token instead. Never use the replicated
+revoke endpoint to remove a legacy token.
+
+## Maintenance procedure
+
+1. Inventory active tokens on **every node** before upgrade: record node, local
+   token identity, name, permissions, owner and consumers. Preserve enough
+   non-secret identity to distinguish legacy rows from replacements; a numeric
+   ID alone is insufficient. Do not export hashes or plaintext into the inventory.
+2. Stop each node before backing up the file configured by `auth.db_path`,
+   including SQLite `-wal` and `-shm` sidecars when present. Preserve the backup
+   with restricted access. Never copy or delete the live database during writes.
+3. Upgrade all nodes to 26.06.1 or later. Restore stable leadership and full
+   membership before issuing replicated tokens.
+4. Create a short-lived validation token through `POST /api/v1/auth/tokens`.
+   Confirm authentication on every node and matching increments of
+   `arc_cluster_auth_apply_create_total` on every node. Revoke **this new token**
+   through `POST /api/v1/auth/tokens/:id/revoke`; verify rejection on every node.
+5. Re-issue each inventoried token through `POST /api/v1/auth/tokens` on any node,
+   preserving its scope and permissions. Capture the returned plaintext once
+   into the approved secret store. Verify it on every node before rotating any
+   consumer. If an ID collision prevents materialisation, stop and resolve the
+   divergence as described below before proceeding.
+6. Rotate downstream CI secrets, SDKs, dashboards and other consumers to the
+   replacement. Verify each consumer against multiple nodes.
+7. Remove the old token **locally on every node that holds it**. Stop the node,
+   take a fresh backup, and remove only the positively identified legacy rows
+   from its local auth database, or use the supported rebuild from replicated
+   FSM state. Do not select rows by ID alone or remove a replicated replacement.
+   If identity cannot be established, stop and seek operator support rather than
+   guessing. Restart and verify that replacement tokens still authenticate and
+   legacy tokens do not. Keep quorum available during node maintenance, or use
+   a planned full-cluster outage. Repeat steps 5–7 one token at a time.
+8. Verify completion: every active consumer uses a replacement, all apply
+   counters converge, `arc_cluster_auth_rejected_total` is stable, and every
+   legacy token is rejected on every node.
+
+## Divergence and rollback
+
+On a collision or growing rejected counter, stop the affected node and preserve
+its backup. Reconcile only the conflicting legacy rows, or rebuild its local
+auth database from authoritative FSM state before rejoining. Never remove the
+Raft state to repair the SQLite cache. Do not invent SQL cleanup by token ID.
+
+Restoring a pre-upgrade database can re-enable legacy credentials and diverge
+from replicated state. Treat rollback as a coordinated maintenance operation:
+keep the affected node out of client traffic until its state and credentials
+have been reconciled and verified. Retain backups until the operator accepts
+the completed migration.
+
+See [26.06.1 release notes](../RELEASE_NOTES_2026.06.1.md) for replication,
+collision handling and metrics. The source issue is
+[#457](https://github.com/Basekick-Labs/arc/issues/457); its original suggestion
+to revoke legacy tokens through the API does not apply to unmigrated rows.


### PR DESCRIPTION
## Summary

- add a staged upgrade runbook for clusters with pre-26.06.1 API tokens
- cover inventory, backup, rolling upgrade, token re-issue, consumer rotation, and revocation
- include divergence recovery and explicit completion criteria

## Verification

- reviewed the documented endpoints and upgrade sequence against the current token routes
- `git diff --check`

Closes #457
