### PR TITLE
fix: await MQTT unsubscribe tokens during shutdown

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -55,6 +55,15 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 
 ## Bug fixes
 
+### MQTT shutdown waits for unsubscribe acknowledgements
+
+Stop and pause now wait for each unsubscribe token with a bounded timeout and
+always disconnect. The manager persists the stopped or paused status even if
+the broker rejects an unsubscribe or times out, and returns the shutdown error
+after attempting the status update.
+
+Contributed by [@mah1104ahm](https://github.com/mah1104ahm) in [#673](https://github.com/Basekick-Labs/arc/pull/673).
+
 ### S3 query paths now follow calendar days across DST ([#321](https://github.com/Basekick-Labs/arc/issues/321))
 
 S3 time-range path generation now builds one inclusive partition path per UTC

--- a/internal/mqtt/manager.go
+++ b/internal/mqtt/manager.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -367,14 +368,11 @@ func (m *SubscriptionManager) StopSubscription(ctx context.Context, id string) e
 	delete(m.subscribers, id)
 	m.mu.Unlock()
 
-	if err := subscriber.Stop(); err != nil {
-		return err
-	}
-
-	m.repo.UpdateStatus(ctx, id, StatusStopped, "")
+	stopErr := subscriber.Stop()
+	statusErr := m.repo.UpdateStatus(ctx, id, StatusStopped, "")
 	m.logger.Info().Str("id", id).Msg("Stopped MQTT subscription")
 
-	return nil
+	return errors.Join(stopErr, statusErr)
 }
 
 // PauseSubscription pauses a subscription (stops without clearing error state)
@@ -388,14 +386,11 @@ func (m *SubscriptionManager) PauseSubscription(ctx context.Context, id string) 
 	delete(m.subscribers, id)
 	m.mu.Unlock()
 
-	if err := subscriber.Stop(); err != nil {
-		return err
-	}
-
-	m.repo.UpdateStatus(ctx, id, StatusPaused, "")
+	stopErr := subscriber.Stop()
+	statusErr := m.repo.UpdateStatus(ctx, id, StatusPaused, "")
 	m.logger.Info().Str("id", id).Msg("Paused MQTT subscription")
 
-	return nil
+	return errors.Join(stopErr, statusErr)
 }
 
 // RestartSubscription stops and starts a subscription

--- a/internal/mqtt/manager_stop_test.go
+++ b/internal/mqtt/manager_stop_test.go
@@ -1,0 +1,81 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+	"github.com/rs/zerolog"
+)
+
+type stoppingClient struct {
+	paho.Client
+	token        *unsubscribeToken
+	disconnected bool
+}
+
+func (c *stoppingClient) IsConnected() bool                { return !c.disconnected }
+func (c *stoppingClient) Unsubscribe(...string) paho.Token { return c.token }
+func (c *stoppingClient) Disconnect(uint)                  { c.disconnected = true }
+
+func TestManagerShutdownPersistsStatusOnUnsubscribeFailure(t *testing.T) {
+	brokerErr := errors.New("broker rejected unsubscribe")
+	for _, pause := range []bool{false, true} {
+		for _, timeout := range []bool{false, true} {
+			name := "stop"
+			if pause {
+				name = "pause"
+			}
+			if timeout {
+				name += "/timeout"
+			} else {
+				name += "/broker-error"
+			}
+			t.Run(name, func(t *testing.T) {
+				mgr := newTestManager(t)
+				ctx := context.Background()
+				sub := &Subscription{Name: "stop-test", Broker: "tcp://localhost:1883", ClientID: "test", Topics: []string{"sensors/#"}, Database: "iot", Status: StatusRunning}
+				sub.SetDefaults()
+				if err := mgr.repo.Create(ctx, sub); err != nil {
+					t.Fatal(err)
+				}
+				client := &stoppingClient{token: &unsubscribeToken{finished: !timeout, err: brokerErr, done: make(chan struct{})}}
+				_, cancel := context.WithCancel(ctx)
+				defer cancel()
+				mgr.subscribers[sub.ID] = &Subscriber{id: sub.ID, config: sub, running: true, client: client, cancel: cancel, logger: zerolog.Nop()}
+				want := StatusStopped
+				var err error
+				if pause {
+					want = StatusPaused
+					err = mgr.PauseSubscription(ctx, sub.ID)
+				} else {
+					err = mgr.StopSubscription(ctx, sub.ID)
+				}
+				if err == nil {
+					t.Fatal("expected unsubscribe failure")
+				}
+				if timeout && !strings.Contains(err.Error(), "timed out") {
+					t.Fatalf("expected timeout: %v", err)
+				}
+				if !timeout && !errors.Is(err, brokerErr) {
+					t.Fatalf("lost broker error: %v", err)
+				}
+				got, getErr := mgr.repo.Get(ctx, sub.ID)
+				if getErr != nil {
+					t.Fatal(getErr)
+				}
+				if got.Status != want {
+					t.Fatalf("persisted status = %v, want %v", got.Status, want)
+				}
+				if !client.disconnected {
+					t.Fatal("client still connected")
+				}
+				if _, exists := mgr.subscribers[sub.ID]; exists {
+					t.Fatal("subscriber still registered")
+				}
+			})
+		}
+	}
+}

--- a/internal/mqtt/subscriber.go
+++ b/internal/mqtt/subscriber.go
@@ -21,6 +21,8 @@ import (
 	"github.com/basekick-labs/arc/pkg/models"
 )
 
+const unsubscribeTimeout = time.Second
+
 // Subscriber handles MQTT connection and message processing for a single subscription
 type Subscriber struct {
 	id             string
@@ -125,11 +127,14 @@ func (s *Subscriber) Stop() error {
 	s.mu.Unlock()
 
 	s.cancel()
+	var unsubscribeErr error
 
 	if s.client != nil && s.client.IsConnected() {
 		// Unsubscribe from topics
 		for _, topic := range s.config.Topics {
-			s.client.Unsubscribe(topic)
+			if err := waitForUnsubscribe(topic, s.client.Unsubscribe(topic)); err != nil && unsubscribeErr == nil {
+				unsubscribeErr = err
+			}
 		}
 
 		// Disconnect with 1 second timeout
@@ -139,6 +144,16 @@ func (s *Subscriber) Stop() error {
 	s.logger.Info().Msg("Disconnected from MQTT broker")
 	s.updateStatus(StatusStopped, "")
 
+	return unsubscribeErr
+}
+
+func waitForUnsubscribe(topic string, token pahomqtt.Token) error {
+	if !token.WaitTimeout(unsubscribeTimeout) {
+		return fmt.Errorf("unsubscribe from %q timed out after %s", topic, unsubscribeTimeout)
+	}
+	if err := token.Error(); err != nil {
+		return fmt.Errorf("unsubscribe from %q failed: %w", topic, err)
+	}
 	return nil
 }
 

--- a/internal/mqtt/subscriber_test.go
+++ b/internal/mqtt/subscriber_test.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -118,4 +119,52 @@ func BenchmarkOnMessageStatUpdate(b *testing.B) {
 			s.lastMessageAtNanos.Store(time.Now().UnixNano())
 		}
 	})
+}
+
+type unsubscribeToken struct {
+	err      error
+	finished bool
+	done     chan struct{}
+}
+
+func (t *unsubscribeToken) Wait() bool {
+	return t.finished
+}
+
+func (t *unsubscribeToken) WaitTimeout(time.Duration) bool {
+	return t.finished
+}
+
+func (t *unsubscribeToken) Done() <-chan struct{} {
+	return t.done
+}
+
+func (t *unsubscribeToken) Error() error {
+	return t.err
+}
+
+func TestWaitForUnsubscribe(t *testing.T) {
+	sentinel := errors.New("broker rejected unsubscribe")
+	tests := []struct {
+		name        string
+		token       *unsubscribeToken
+		wantWrapped error
+		wantErr     bool
+	}{
+		{name: "completed", token: &unsubscribeToken{finished: true, done: make(chan struct{})}},
+		{name: "broker error", token: &unsubscribeToken{finished: true, err: sentinel, done: make(chan struct{})}, wantWrapped: sentinel, wantErr: true},
+		{name: "timeout", token: &unsubscribeToken{done: make(chan struct{})}, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := waitForUnsubscribe("events", test.token)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("waitForUnsubscribe() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if test.wantWrapped != nil && !errors.Is(err, test.wantWrapped) {
+				t.Fatalf("waitForUnsubscribe() error = %v, want wrapped %v", err, test.wantWrapped)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- await each MQTT unsubscribe token during subscriber shutdown
- bound each wait with a one-second timeout and preserve the first failure
- always disconnect after unsubscribe attempts
- cover success, broker-error, and timeout paths

## Verification

- `gofmt` on changed Go files
- `go test ./internal/mqtt`
- `git diff --check`

Closes #303
