### PR TITLE
fix: bound the local directory cache

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -121,3 +121,12 @@ Contributed by [@atirna](https://github.com/atirna) in [#678](https://github.com
 When compaction history trims to its newest 100 jobs, the retained map references are now copied into fresh slice backing storage. This prevents an older history slice from sharing the manager's current array and retaining evicted pointer-containing entries; the retained maps are intentionally not deep-copied.
 
 Contributed by [@bferanmi806-sketch](https://github.com/bferanmi806-sketch) in [#679](https://github.com/Basekick-Labs/arc/pull/679).
+
+### Local storage directory cache is bounded ([#318](https://github.com/Basekick-Labs/arc/issues/318))
+
+The local backend's directory cache, which avoids redundant `MkdirAll` calls under
+sustained ingest load, previously grew without bound as new partition directories
+were created. It is now capped at 1,024 entries with eviction on insert; a cache
+miss just repeats an idempotent directory creation.
+
+Contributed by [@mah1104ahm](https://github.com/mah1104ahm) in [#674](https://github.com/Basekick-Labs/arc/pull/674).

--- a/internal/storage/backend_test.go
+++ b/internal/storage/backend_test.go
@@ -127,6 +127,23 @@ func TestLocalBackend_BasicOperations(t *testing.T) {
 	})
 }
 
+func TestLocalBackend_DirectoryCacheIsBounded(t *testing.T) {
+	backend, err := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend() error = %v", err)
+	}
+
+	for i := 0; i < maxDirCacheEntries+25; i++ {
+		if err := backend.ensureDir(filepath.Join(backend.basePath, fmt.Sprintf("dir-%d", i))); err != nil {
+			t.Fatalf("ensureDir() error = %v", err)
+		}
+	}
+
+	if got := len(backend.dirCache); got > maxDirCacheEntries {
+		t.Fatalf("directory cache size = %d, want at most %d", got, maxDirCacheEntries)
+	}
+}
+
 // TestLocalBackend_DirectoryLister tests the DirectoryLister interface
 func TestLocalBackend_DirectoryLister(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "arc-storage-test-*")

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -15,6 +15,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const maxDirCacheEntries = 1024
+
 // LocalBackend implements the Backend interface for local filesystem storage
 type LocalBackend struct {
 	basePath string
@@ -68,6 +70,12 @@ func (b *LocalBackend) ensureDir(dir string) error {
 		// Use 0700 for owner-only access (security best practice)
 		if err := os.MkdirAll(dir, 0700); err != nil {
 			return fmt.Errorf("failed to create directory: %w", err)
+		}
+		if len(b.dirCache) >= maxDirCacheEntries {
+			for cachedDir := range b.dirCache {
+				delete(b.dirCache, cachedDir)
+				break
+			}
 		}
 		b.dirCache[dir] = true
 	}


### PR DESCRIPTION
## Summary

- cap the local backend's directory cache at 1,024 entries
- evict a cached directory before inserting a new entry at capacity
- add a regression test that creates more directories than the bound

## Verification

- `gofmt` on changed Go files
- `go test ./internal/storage`
- `git diff --check`

Closes #318
