### PR TITLE
fix: prune expired tier cache entries

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -55,6 +55,14 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 
 ## Bug fixes
 
+### Expired tier-cache entries are pruned on store
+
+Each tier-cache insertion removes expired entries while holding the cache lock,
+preventing entries for old partitions from accumulating indefinitely. Expiry
+uses the same boundary as the read path and requires no background goroutine.
+
+Contributed by [@mah1104ahm](https://github.com/mah1104ahm) in [#675](https://github.com/Basekick-Labs/arc/pull/675).
+
 ### S3 query paths now follow calendar days across DST ([#321](https://github.com/Basekick-Labs/arc/issues/321))
 
 S3 time-range path generation now builds one inclusive partition path per UTC

--- a/internal/tiering/metadata.go
+++ b/internal/tiering/metadata.go
@@ -16,6 +16,14 @@ type tierCacheEntry struct {
 	expiresAt time.Time
 }
 
+func (s *MetadataStore) pruneExpiredTierCache(now time.Time) {
+	for key, entry := range s.tierCache {
+		if !now.Before(entry.expiresAt) {
+			delete(s.tierCache, key)
+		}
+	}
+}
+
 // tierCacheTTL is how long tier lookups are cached (30 seconds)
 const tierCacheTTL = 30 * time.Second
 
@@ -545,6 +553,7 @@ func (s *MetadataStore) GetTiersForMeasurement(ctx context.Context, database, me
 
 	// Update cache
 	s.tierCacheMu.Lock()
+	s.pruneExpiredTierCache(time.Now())
 	s.tierCache[cacheKey] = &tierCacheEntry{
 		tiers:     tiers,
 		expiresAt: time.Now().Add(tierCacheTTL),

--- a/internal/tiering/metadata.go
+++ b/internal/tiering/metadata.go
@@ -16,6 +16,7 @@ type tierCacheEntry struct {
 	expiresAt time.Time
 }
 
+// pruneExpiredTierCache removes expired entries. The caller must hold tierCacheMu.
 func (s *MetadataStore) pruneExpiredTierCache(now time.Time) {
 	for key, entry := range s.tierCache {
 		if !now.Before(entry.expiresAt) {

--- a/internal/tiering/metadata_test.go
+++ b/internal/tiering/metadata_test.go
@@ -90,6 +90,32 @@ func TestMetadataStore_RecordFile(t *testing.T) {
 	}
 }
 
+func TestMetadataStore_GetTiersForMeasurementPrunesExpiredCacheEntries(t *testing.T) {
+	store, cleanup := setupTestMetadataStore(t)
+	defer cleanup()
+
+	now := time.Now()
+	store.tierCache["expired/measurement"] = &tierCacheEntry{
+		tiers:     map[Tier]bool{TierHot: true},
+		expiresAt: now.Add(-time.Second),
+	}
+	store.tierCache["live/measurement"] = &tierCacheEntry{
+		tiers:     map[Tier]bool{TierCold: true},
+		expiresAt: now.Add(time.Minute),
+	}
+
+	if _, err := store.GetTiersForMeasurement(context.Background(), "new", "measurement"); err != nil {
+		t.Fatalf("GetTiersForMeasurement() error = %v", err)
+	}
+
+	if _, ok := store.tierCache["expired/measurement"]; ok {
+		t.Fatal("expired cache entry was not pruned")
+	}
+	if _, ok := store.tierCache["live/measurement"]; !ok {
+		t.Fatal("live cache entry was pruned")
+	}
+}
+
 func TestMetadataStore_UpdateTier(t *testing.T) {
 	store, cleanup := setupTestMetadataStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

- prune expired tier-cache entries whenever a fresh cache result is stored
- keep the scan under the existing cache mutex
- add a regression test proving expired entries are removed while live entries remain

## Verification

- `gofmt` on changed Go files
- `go test ./internal/tiering`
- `git diff --check`

Closes #343
