### PR TITLE
fix(backup): make live SQLite backup and restore safe

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -53,13 +53,6 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 `interval2` can never be misread as time bounds; compound quoted intervals like
 `'1 day 12 hours'` remain unpruned (never mis-pruned as their first component).
 
-## Fixed: Live SQLite backups and restores no longer risk torn database state
-
-Backups now snapshot live SQLite databases before copying them, so concurrent
-WAL writers cannot interleave pages into a backup. Restores replace the database
-by rename, remove stale WAL/SHM sidecars, and report that a restart is required
-before further writes. Temporary snapshots are restricted to the owner.
-
 ## Bug fixes
 
 ### Iceberg version hints no longer advance before metadata copies publish ([#636](https://github.com/Basekick-Labs/arc/issues/636))
@@ -113,3 +106,12 @@ of a custom single-Unwrap loop, so an `azcore.ResponseError` is correctly identi
 even when wrapped inside joined multi-errors (`errors.Join`).
 
 Contributed by [@Thundercloud12](https://github.com/Thundercloud12) in [#670](https://github.com/Basekick-Labs/arc/pull/670).
+
+### Live SQLite backups and restores no longer risk torn database state ([#635](https://github.com/Basekick-Labs/arc/issues/635))
+
+Backups now snapshot live SQLite databases before copying them, so concurrent
+WAL writers cannot interleave pages into a backup. Restores replace the database
+by rename, remove stale WAL/SHM sidecars, and report that a restart is required
+before further writes. Temporary snapshots are restricted to the owner.
+
+Contributed by [@atirna](https://github.com/atirna) in [#678](https://github.com/Basekick-Labs/arc/pull/678).

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -53,6 +53,13 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 `interval2` can never be misread as time bounds; compound quoted intervals like
 `'1 day 12 hours'` remain unpruned (never mis-pruned as their first component).
 
+## Fixed: Live SQLite backups and restores no longer risk torn database state
+
+Backups now snapshot live SQLite databases before copying them, so concurrent
+WAL writers cannot interleave pages into a backup. Restores replace the database
+by rename, remove stale WAL/SHM sidecars, and report that a restart is required
+before further writes. Temporary snapshots are restricted to the owner.
+
 ## Bug fixes
 
 ### Iceberg version hints no longer advance before metadata copies publish ([#636](https://github.com/Basekick-Labs/arc/issues/636))

--- a/internal/api/backup_routes.go
+++ b/internal/api/backup_routes.go
@@ -262,11 +262,17 @@ func (h *BackupHandler) RestoreBackup(c *fiber.Ctx) error {
 		}
 	}()
 
-	return c.Status(fiber.StatusAccepted).JSON(fiber.Map{
+	resp := fiber.Map{
 		"message":   "Restore started",
 		"backup_id": req.BackupID,
 		"status":    "running",
-	})
+	}
+	if opts.RestoreMetadata {
+		// Restored databases replace the live files by rename; open
+		// connections keep the pre-restore content until the server restarts.
+		resp["restart_required"] = true
+	}
+	return c.Status(fiber.StatusAccepted).JSON(resp)
 }
 
 // acquireOperation atomically reserves the handler's shared backup/restore slot.

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -433,33 +433,55 @@ func (m *Manager) backupSQLite(ctx context.Context, backupID string) error {
 	return m.backupSQLiteFile(ctx, backupID, m.sqliteDBPath, "arc.db")
 }
 
-// backupSQLiteFile copies one SQLite database file into the backup under
-// metadata/<destName>. It performs a WAL checkpoint first so the copy is
-// consistent, and streams via the storage backend rather than reading the whole
-// database into memory.
-func (m *Manager) backupSQLiteFile(ctx context.Context, backupID, dbPath, destName string) error {
-	// Checkpoint WAL to ensure all data is flushed to the main DB file.
+// snapshotSQLite writes a consistent snapshot of the live database at dbPath to
+// a fresh temporary file and returns its path. The caller must remove it.
+//
+// VACUUM INTO reads the database (including un-checkpointed WAL frames) under
+// one read transaction, so concurrently committing writers cannot interleave
+// pages into the snapshot — the failure mode of checkpoint-then-copy, where a
+// checkpoint between the copy's start and end rewrites the main file mid-read
+// once the WAL passes the auto-checkpoint threshold.
+func snapshotSQLite(ctx context.Context, dbPath string) (string, error) {
+	dir, err := os.MkdirTemp(filepath.Dir(dbPath), ".arc-snapshot-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create snapshot directory: %w", err)
+	}
+	snapshotPath := filepath.Join(dir, "snapshot.db")
+
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
-		return fmt.Errorf("failed to open SQLite for checkpoint: %w", err)
+		os.RemoveAll(dir)
+		return "", fmt.Errorf("failed to open SQLite for snapshot: %w", err)
 	}
-	if _, err := db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
-		db.Close()
-		return fmt.Errorf("WAL checkpoint failed: %w", err)
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, "VACUUM INTO ?", snapshotPath); err != nil {
+		os.RemoveAll(dir)
+		return "", fmt.Errorf("SQLite snapshot failed: %w", err)
 	}
-	db.Close()
+	return snapshotPath, nil
+}
+
+// backupSQLiteFile copies one SQLite database file into the backup under
+// metadata/<destName>, as a consistent snapshot of the live database streamed
+// via the storage backend rather than a file read of the live path.
+func (m *Manager) backupSQLiteFile(ctx context.Context, backupID, dbPath, destName string) error {
+	snapshotPath, err := snapshotSQLite(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(filepath.Dir(snapshotPath))
 
 	// Get file size for WriteReader
-	info, err := os.Stat(dbPath)
+	info, err := os.Stat(snapshotPath)
 	if err != nil {
-		return fmt.Errorf("failed to stat SQLite database: %w", err)
+		return fmt.Errorf("failed to stat SQLite snapshot: %w", err)
 	}
 	size := info.Size()
 
-	// Stream via temp file to avoid loading entire DB into memory
-	f, err := os.Open(dbPath)
+	// Stream via temp file to avoid loading entire DB in memory
+	f, err := os.Open(snapshotPath)
 	if err != nil {
-		return fmt.Errorf("failed to open SQLite database: %w", err)
+		return fmt.Errorf("failed to open SQLite snapshot: %w", err)
 	}
 	defer f.Close()
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -458,6 +458,10 @@ func snapshotSQLite(ctx context.Context, dbPath string) (string, error) {
 		os.RemoveAll(dir)
 		return "", fmt.Errorf("SQLite snapshot failed: %w", err)
 	}
+	if err := os.Chmod(snapshotPath, 0600); err != nil {
+		os.RemoveAll(dir)
+		return "", fmt.Errorf("failed to restrict SQLite snapshot: %w", err)
+	}
 	return snapshotPath, nil
 }
 

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -3,12 +3,15 @@ package backup
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/rs/zerolog"
@@ -637,4 +640,106 @@ func mustLocalBackend(t *testing.T, dir string, logger zerolog.Logger) storage.B
 		t.Fatalf("failed to create local backend at %s: %v", dir, err)
 	}
 	return b
+}
+
+// The issue's backup defect: between the pre-copy checkpoint and the end of
+// the file copy, live writers keep committing, and once their WAL passes the
+// auto-checkpoint threshold a checkpoint rewrites the main file mid-copy,
+// leaving a torn backup. The test drives that race deterministically: the
+// storage backend commits and checkpoints the live database partway through
+// reading the backup source. Against the live file the backup is torn; against
+// the VACUUM INTO snapshot it cannot be, because the snapshot is frozen before
+// the copy starts.
+func TestBackupSQLiteFile_SnapshotIsImmuneToMidCopyWriters(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	dbPath := filepath.Join(t.TempDir(), "arc.db")
+	writer, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	if _, err := writer.Exec("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE t (v TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 500; i++ {
+		if _, err := writer.Exec("INSERT INTO t (v) VALUES (?)", fmt.Sprintf("row-%03d-padding-padding-padding", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The racing backend commits and checkpoints the live database after the
+	// backup has streamed past the first page — the mid-copy writer.
+	hook := func() {
+		if _, err := writer.Exec("UPDATE t SET v = 'overwritten-' || v"); err != nil {
+			t.Error(err)
+		}
+		if _, err := writer.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+			t.Error(err)
+		}
+	}
+	backupDir := t.TempDir()
+	real, err := storage.NewLocalBackend(backupDir, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		dataStorage:   mustLocalBackend(t, t.TempDir(), logger),
+		backupStorage: &hookAfterFirstPage{Backend: real, hook: hook},
+		logger:        logger,
+	}
+	if err := m.backupSQLiteFile(ctx, "backup-1", dbPath, "arc.db"); err != nil {
+		t.Fatalf("backupSQLiteFile: %v", err)
+	}
+
+	backup, err := sql.Open("sqlite3", filepath.Join(backupDir, "backup-1", "metadata", "arc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backup.Close()
+	var integrity string
+	if err := backup.QueryRow("PRAGMA integrity_check").Scan(&integrity); err != nil {
+		t.Fatalf("backup is not a readable database (torn copy): %v", err)
+	}
+	if integrity != "ok" {
+		t.Fatalf("backup integrity_check = %q, want ok (torn copy)", integrity)
+	}
+	var overwritten int
+	if err := backup.QueryRow("SELECT count(*) FROM t WHERE v LIKE 'overwritten-%'").Scan(&overwritten); err != nil {
+		t.Fatal(err)
+	}
+	if overwritten != 0 {
+		t.Fatalf("mid-copy write leaked into backup: %d rows", overwritten)
+	}
+	var rows int
+	if err := backup.QueryRow("SELECT count(*) FROM t").Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 500 {
+		t.Fatalf("backup holds %d rows, want 500", rows)
+	}
+}
+
+// hookAfterFirstPage wraps a storage backend and runs hook once the backup has
+// streamed past the first pages of the source, simulating a concurrent writer
+// checkpointing mid-copy.
+type hookAfterFirstPage struct {
+	storage.Backend
+	hook  func()
+	fired bool
+}
+
+func (b *hookAfterFirstPage) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	if b.fired {
+		return b.Backend.WriteReader(ctx, path, reader, size)
+	}
+	b.fired = true
+	first := make([]byte, 8192+2048)
+	n, err := io.ReadFull(reader, first)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return err
+	}
+	b.hook()
+	return b.Backend.WriteReader(ctx, path, io.MultiReader(bytes.NewReader(first[:n]), reader), size)
 }

--- a/internal/backup/iceberg_backup_test.go
+++ b/internal/backup/iceberg_backup_test.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"os"
@@ -325,5 +326,166 @@ func TestRestore_SeparateIcebergCatalogIsRestored(t *testing.T) {
 	var name string
 	if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name='marker'`).Scan(&name); err != nil {
 		t.Fatalf("restored catalog is missing its contents: %v", err)
+	}
+}
+
+// The issue's restore defect: the pre-restore -wal is salted against the old
+// database, so replaying it over the restored file mixes stale frames into new
+// pages. restoreSQLiteFile must remove both sidecars after the write, and the
+// .before-restore safety copy must itself be a complete database — a plain
+// file read of the old database would miss its un-checkpointed WAL commits.
+func TestRestoreSQLiteFile_RemovesStaleSidecarsAndSnapshotsLiveState(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	// Live database with a WAL holding un-checkpointed commits.
+	liveDir := t.TempDir()
+	dbPath := filepath.Join(liveDir, "arc.db")
+	live, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer live.Close()
+	if _, err := live.Exec("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE t (v INTEGER)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := live.Exec("INSERT INTO t (v) VALUES (1), (2)"); err != nil {
+		t.Fatal(err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   mustLocalBackend(t, t.TempDir(), logger),
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+	// The backup holds a one-row database, older than the live one.
+	older, err := sql.Open("sqlite3", filepath.Join(backupDir, "older.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := older.Exec("CREATE TABLE t (v INTEGER); INSERT INTO t (v) VALUES (7)"); err != nil {
+		t.Fatal(err)
+	}
+	older.Close()
+	olderData, err := os.ReadFile(filepath.Join(backupDir, "older.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.backupStorage.Write(ctx, "backup-1/metadata/arc.db", olderData); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.restoreSQLiteFile(ctx, "backup-1", "arc.db", dbPath); err != nil {
+		t.Fatalf("restoreSQLiteFile: %v", err)
+	}
+
+	for _, sidecar := range []string{dbPath + "-wal", dbPath + "-shm"} {
+		if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+			t.Errorf("stale sidecar %s still present after restore", sidecar)
+		}
+	}
+
+	restored, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restored.Close()
+	var got int
+	if err := restored.QueryRow("SELECT count(*) FROM t").Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Fatalf("restored database holds %d rows, want the backup's 1", got)
+	}
+
+	// The pre-restore safety copy must contain the live WAL-resident commits.
+	safety, err := sql.Open("sqlite3", dbPath+".before-restore")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer safety.Close()
+	var safetyRows int
+	if err := safety.QueryRow("SELECT count(*) FROM t").Scan(&safetyRows); err != nil {
+		t.Fatal(err)
+	}
+	if safetyRows != 2 {
+		t.Fatalf(".before-restore copy holds %d rows, want the live database's 2 (WAL-resident commits included)", safetyRows)
+	}
+}
+
+// The restored file must be beyond the reach of pre-restore connections: the
+// swap is a rename, so a handle opened before the restore keeps writing the
+// old (now unlinked) inode and cannot tear or corrupt the restored database.
+func TestRestoreSQLiteFile_RestoredFileIsImmuneToPreRestoreHandles(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	liveDir := t.TempDir()
+	dbPath := filepath.Join(liveDir, "arc.db")
+	old, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer old.Close()
+	if _, err := old.Exec("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE t (v INTEGER); INSERT INTO t (v) VALUES (1)"); err != nil {
+		t.Fatal(err)
+	}
+
+	backupDir := t.TempDir()
+	m := &Manager{
+		dataStorage:   mustLocalBackend(t, t.TempDir(), logger),
+		backupStorage: mustLocalBackend(t, backupDir, logger),
+		logger:        logger,
+	}
+	backupDB, err := sql.Open("sqlite3", filepath.Join(backupDir, "backup.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backupDB.Exec("CREATE TABLE t (v INTEGER); INSERT INTO t (v) VALUES (41)"); err != nil {
+		t.Fatal(err)
+	}
+	backupDB.Close()
+	backupData, err := os.ReadFile(filepath.Join(backupDir, "backup.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.backupStorage.Write(ctx, "backup-1/metadata/arc.db", backupData); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.restoreSQLiteFile(ctx, "backup-1", "arc.db", dbPath); err != nil {
+		t.Fatalf("restoreSQLiteFile: %v", err)
+	}
+
+	// A pre-restore connection commits and checkpoints after the swap. Its
+	// writes may land in a sidecar or the unlinked inode, never in the
+	// restored file's bytes.
+	if _, err := old.Exec("INSERT INTO t (v) VALUES (2)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := old.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, backupData) {
+		t.Error("restored database file changed after a pre-restore connection wrote — restore is not immune to live handles")
+	}
+
+	fresh, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Close()
+	var rows int
+	if err := fresh.QueryRow("SELECT count(*) FROM t").Scan(&rows); err != nil {
+		t.Skipf("sidecar from the pre-restore writer shadows the restored file until restart: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("fresh connection read %d rows, want the backup's 1 (pre-restore writes leaked)", rows)
 	}
 }

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -2,8 +2,11 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -225,24 +228,65 @@ func (m *Manager) restoreSQLiteFile(ctx context.Context, backupID, srcName, dest
 		return fmt.Errorf("failed to read SQLite backup: %w", err)
 	}
 
-	// Safety: backup the current database before overwriting
+	// Safety: snapshot the current database before overwriting. A plain file
+	// read would miss un-checkpointed WAL commits; the snapshot reads through
+	// the WAL, so the pre-restore copy is itself a usable database.
 	if _, statErr := os.Stat(destPath); statErr == nil {
-		preRestorePath := destPath + ".before-restore"
-		currentData, err := os.ReadFile(destPath)
-		if err == nil {
-			if err := os.WriteFile(preRestorePath, currentData, 0600); err != nil {
-				m.logger.Warn().Err(err).Msg("Failed to create pre-restore backup of SQLite database")
-			} else {
-				m.logger.Info().Str("path", preRestorePath).Msg("Created pre-restore backup of SQLite database")
+		if snapshotPath, snapErr := snapshotSQLite(ctx, destPath); snapErr == nil {
+			if currentData, readErr := os.ReadFile(snapshotPath); readErr == nil {
+				preRestorePath := destPath + ".before-restore"
+				if err := os.WriteFile(preRestorePath, currentData, 0600); err != nil {
+					m.logger.Warn().Err(err).Msg("Failed to create pre-restore backup of SQLite database")
+				} else {
+					m.logger.Info().Str("path", preRestorePath).Msg("Created pre-restore backup of SQLite database")
+				}
 			}
+			os.RemoveAll(filepath.Dir(snapshotPath))
+		} else {
+			m.logger.Warn().Err(snapErr).Msg("Failed to snapshot database before restore")
 		}
 	}
 
-	if err := os.WriteFile(destPath, data, 0600); err != nil {
+	// Swap the file in by rename rather than overwriting the live inode: an
+	// open connection keeps reading and writing the old (now unlinked) inode,
+	// so pre-restore writers cannot tear or corrupt the restored file itself.
+	// They still see the pre-restore content until restart.
+	staging, err := os.CreateTemp(filepath.Dir(destPath), ".restore-staging-*")
+	if err != nil {
+		return fmt.Errorf("failed to create restore staging file: %w", err)
+	}
+	stagingPath := staging.Name()
+	if _, err := staging.Write(data); err != nil {
+		staging.Close()
+		os.Remove(stagingPath)
 		return fmt.Errorf("failed to write SQLite database: %w", err)
 	}
+	if err := staging.Close(); err != nil {
+		os.Remove(stagingPath)
+		return fmt.Errorf("failed to close restore staging file: %w", err)
+	}
+	if err := os.Chmod(stagingPath, 0600); err != nil {
+		os.Remove(stagingPath)
+		return fmt.Errorf("failed to restrict restore staging file: %w", err)
+	}
+	if err := os.Rename(stagingPath, destPath); err != nil {
+		os.Remove(stagingPath)
+		return fmt.Errorf("failed to move restored SQLite database into place: %w", err)
+	}
 
-	m.logger.Info().Str("backup_id", backupID).Str("database", srcName).Msg("SQLite database restored")
+	// A pre-restore -wal is salted against the old database: SQLite replaying
+	// it over the restored file would mix old frames into new pages, and -shm
+	// is the index for exactly that WAL. Neither belongs to the restored file.
+	for _, sidecar := range []string{destPath + "-wal", destPath + "-shm"} {
+		if err := os.Remove(sidecar); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to remove stale SQLite sidecar %s: %w", sidecar, err)
+		}
+	}
+
+	m.logger.Warn().
+		Str("backup_id", backupID).
+		Str("database", srcName).
+		Msg("SQLite database restored; restart required — open connections still hold the pre-restore database")
 	return nil
 }
 

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -247,10 +247,10 @@ func (m *Manager) restoreSQLiteFile(ctx context.Context, backupID, srcName, dest
 		}
 	}
 
-	// Swap the file in by rename rather than overwriting the live inode: an
-	// open connection keeps reading and writing the old (now unlinked) inode,
-	// so pre-restore writers cannot tear or corrupt the restored file itself.
-	// They still see the pre-restore content until restart.
+	// Swap the file in by rename rather than overwriting the live inode. Existing
+	// connections keep reading and writing the old (now unlinked) inode, while a
+	// pool may open new connections against the restored file, so restart before
+	// further writes to avoid splitting state across both files.
 	staging, err := os.CreateTemp(filepath.Dir(destPath), ".restore-staging-*")
 	if err != nil {
 		return fmt.Errorf("failed to create restore staging file: %w", err)


### PR DESCRIPTION
## Summary

- snapshot live SQLite databases with `VACUUM INTO` before streaming them into a backup
- replace restored database files by rename and remove stale SQLite WAL/SHM sidecars
- mark metadata restores as requiring a server restart so open database connections are released

Refs #635

## Test plan

- `go test ./internal/backup -run 'Test(BackupSQLiteFile_SnapshotIsImmuneToMidCopyWriters|RestoreSQLiteFile_RemovesStaleSidecarsAndSnapshotsLiveState|RestoreSQLiteFile_RestoredFileIsImmuneToPreRestoreHandles)' -count=1 -v`