### PR TITLE
fix(compaction): avoid retaining evicted job history entries (#315)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -52,3 +52,7 @@ require a word boundary after the unit, so interval-lookalike text inside string
 literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such as
 `interval2` can never be misread as time bounds; compound quoted intervals like
 `'1 day 12 hours'` remain unpruned (never mis-pruned as their first component).
+
+## Fixed: Compaction job history no longer retains evicted entries ([#315](https://github.com/Basekick-Labs/arc/issues/315))
+
+When compaction history trims to its newest 100 jobs, the retained map references are now copied into fresh slice backing storage. This prevents an older history slice from sharing the manager's current array and retaining evicted pointer-containing entries; the retained maps are intentionally not deep-copied.

--- a/internal/compaction/manager.go
+++ b/internal/compaction/manager.go
@@ -211,6 +211,21 @@ func NewManager(cfg *ManagerConfig) *Manager {
 	return m
 }
 
+// appendJobHistory keeps the newest 100 job-stat maps. When trimming is
+// required, copy the retained map references into fresh slice storage so the
+// current history does not keep an older backing array that may retain evicted
+// pointer-containing entries. The maps themselves are intentionally shared.
+func appendJobHistory(history []map[string]interface{}, jobStats map[string]interface{}) []map[string]interface{} {
+	history = append(history, jobStats)
+	if len(history) <= 100 {
+		return history
+	}
+
+	retained := make([]map[string]interface{}, 100)
+	copy(retained, history[len(history)-100:])
+	return retained
+}
+
 // SetOnCompactionComplete sets the callback invoked after each successful compaction job.
 // This is used to invalidate DuckDB and query caches in the parent process after
 // the compaction subprocess deletes old parquet files.
@@ -595,12 +610,8 @@ func (m *Manager) CompactPartition(ctx context.Context, candidate Candidate) err
 		jobStats["success"] = false
 	}
 
-	// Add to history
-	m.jobHistory = append(m.jobHistory, jobStats)
-	// Keep last 100 jobs
-	if len(m.jobHistory) > 100 {
-		m.jobHistory = m.jobHistory[len(m.jobHistory)-100:]
-	}
+	// Add to history while holding m.mu so Stats sees a consistent history.
+	m.jobHistory = appendJobHistory(m.jobHistory, jobStats)
 	// Copy the callback while still holding the lock — main.go wires it via
 	// SetOnCompactionComplete after the schedulers have started (#351).
 	onComplete := m.onCompactionComplete

--- a/internal/compaction/manager_test.go
+++ b/internal/compaction/manager_test.go
@@ -426,6 +426,36 @@ func TestManager_JobHistory(t *testing.T) {
 	}
 }
 
+func TestAppendJobHistory_TrimsWithFreshBackingArray(t *testing.T) {
+	// Leave one spare slot so append uses the pre-trim backing array. A reslice-only
+	// trim would then make preTrim[1] and trimmed[0] the same storage.
+	history := make([]map[string]interface{}, 100, 101)
+	for i := range history {
+		history[i] = map[string]interface{}{"id": i}
+	}
+	preTrim := history
+
+	trimmed := appendJobHistory(history, map[string]interface{}{"id": 100})
+
+	if len(trimmed) != 100 {
+		t.Fatalf("trimmed history length = %d, want 100", len(trimmed))
+	}
+	for i, job := range trimmed {
+		if got, want := job["id"], i+1; got != want {
+			t.Fatalf("trimmed history[%d] = %v, want %d", i, got, want)
+		}
+	}
+	if &preTrim[1] == &trimmed[0] {
+		t.Fatal("trimmed history shares backing-array storage with the pre-trim slice")
+	}
+
+	// Retain the map references without deep-copying the individual maps.
+	history[1]["marker"] = "shared"
+	if got := trimmed[0]["marker"]; got != "shared" {
+		t.Fatalf("trimmed history copied a job map instead of retaining its reference: got %v", got)
+	}
+}
+
 // TestCandidate tests the Candidate struct
 func TestCandidate(t *testing.T) {
 	candidate := Candidate{


### PR DESCRIPTION
Closes #315.

Trimming now copies the newest 100 job-history entries into fresh slice storage instead of reslicing the old backing array. Adds a deterministic regression test that asserts backing-array separation while preserving ordering and map references. Includes the 26.09.2 release-note entry.

Local tagged/race validation is blocked by the Windows DuckDB/cgo environment; Linux CI is the authoritative full validation.