### PR TITLE
fix(tiering): prune partitions per tier in multi-tier queries

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -130,3 +130,18 @@ were created. It is now capped at 1,024 entries with eviction on insert; a cache
 miss just repeats an idempotent directory creation.
 
 Contributed by [@mah1104ahm](https://github.com/mah1104ahm) in [#674](https://github.com/Basekick-Labs/arc/pull/674).
+
+### Tiered queries now prune partitions per tier ([#662](https://github.com/Basekick-Labs/arc/issues/662))
+
+Since tiering shipped, a query over a measurement with an active cold tier
+bypassed partition pruning entirely: both tiers' full globs were scanned on
+every query, including S3/Azure LIST and GET calls on the cold archive. The
+multi-tier path now prunes each tier against its own backend: hour and day
+partitions are generated per tier, existence-filtered with backend-relative
+listings, and a tier verified to hold no data for the query's time range is
+dropped from the query outright — a recent-range dashboard query no longer
+touches cold object storage at all. File-level time pruning (26.09.2's
+`query.file_time_pruning`) applies to the hot tier inside tiered queries too.
+Listing failures fail open to the tier's full glob, end-only time predicates
+never exclude cold data older than the assumed range start, and completed
+tier migrations now invalidate the query caches the same way compaction does.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -3472,6 +3472,10 @@ func main() {
 
 		// Wire tiering manager to query handler for multi-tier query routing
 		queryHandler.SetTieringManager(tieringManager)
+		// A completed migration moves files between tiers, so cached pruned
+		// partition paths (pruner + SQL transform caches) go stale and must
+		// be dropped — same reason compaction invalidates them (#662).
+		tieringManager.SetOnMigrationComplete(queryHandler.InvalidateCaches)
 		log.Info().Msg("Tiering manager wired to query handler for multi-tier queries")
 
 		// Wire tiering manager to databases handler for cold-tier database/measurement listing

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -2958,7 +2958,7 @@ func (h *QueryHandler) buildReadParquetExpr(ctx context.Context, path, originalS
 						Str("database", database).
 						Str("measurement", measurement).
 						Msg("Tiering enabled: building multi-tier query")
-					return h.buildMultiTierReadParquet(database, measurement, tieredPaths, keyword)
+					return h.buildMultiTierReadParquet(ctx, database, measurement, originalSQL, tieredPaths, keyword)
 				}
 			}
 		}
@@ -3011,7 +3011,7 @@ func (h *QueryHandler) buildReadParquetExprForMeasurement(ctx context.Context, d
 					Str("database", database).
 					Str("measurement", measurement).
 					Msg("Tiering enabled: building multi-tier query (fast path)")
-				return h.buildMultiTierReadParquet(database, measurement, tieredPaths, keyword)
+				return h.buildMultiTierReadParquet(ctx, database, measurement, originalSQL, tieredPaths, keyword)
 			}
 		}
 	}
@@ -3150,11 +3150,10 @@ func (h *QueryHandler) extractDBMeasurementFromPath(path string) (database, meas
 // buildMultiTierReadParquet builds a read_parquet expression that queries tiers with actual data.
 // Queries the tiering metadata to determine which tiers have files for this database/measurement,
 // then only includes paths for tiers that actually have data.
-func (h *QueryHandler) buildMultiTierReadParquet(database, measurement string, tieredPaths map[tiering.Tier]string, keyword string) string {
+func (h *QueryHandler) buildMultiTierReadParquet(ctx context.Context, database, measurement, originalSQL string, tieredPaths map[tiering.Tier]string, keyword string) string {
 	options := buildReadParquetOptions()
 
 	// Query metadata to find which tiers actually have data for this measurement
-	ctx := context.Background()
 	actualTiers, err := h.tieringManager.GetMetadata().GetTiersForMeasurement(ctx, database, measurement)
 	if err != nil {
 		h.logger.Warn().Err(err).
@@ -3174,14 +3173,18 @@ func (h *QueryHandler) buildMultiTierReadParquet(database, measurement string, t
 		return keyword + " read_parquet(" + quotePath(h.getStoragePath(database, measurement)) + ", " + options + ")"
 	}
 
-	// Collect paths only for tiers that actually have data
-	var paths []string
+	// Collect the full glob and backend for each tier that actually has data
+	type tierSource struct {
+		tier    tiering.Tier
+		glob    string
+		backend storage.Backend
+	}
+	var sources []tierSource
 
 	// Hot tier (local) - only if metadata says there's hot data
 	if actualTiers[tiering.TierHot] {
 		if _, ok := tieredPaths[tiering.TierHot]; ok {
-			fullHotPath := h.getStoragePath(database, measurement)
-			paths = append(paths, fullHotPath)
+			sources = append(sources, tierSource{tiering.TierHot, h.getStoragePath(database, measurement), h.storage})
 		}
 	}
 
@@ -3190,10 +3193,55 @@ func (h *QueryHandler) buildMultiTierReadParquet(database, measurement string, t
 		if _, ok := tieredPaths[tiering.TierCold]; ok {
 			coldBackend := h.tieringManager.GetBackendForTier(tiering.TierCold)
 			if coldBackend != nil {
-				coldPath := storage.GetStoragePath(coldBackend, database, measurement)
-				paths = append(paths, coldPath)
+				sources = append(sources, tierSource{tiering.TierCold, storage.GetStoragePath(coldBackend, database, measurement), coldBackend})
 			}
 		}
+	}
+
+	// Per-tier partition pruning (#662). Each tier's hour/day paths are
+	// generated against its own base and existence-filtered against its own
+	// backend; a tier verified to hold no data for the time range is dropped
+	// entirely (a recent-range dashboard query never lists or reads cold
+	// object storage beyond the cached parent listings).
+	timeRange := h.pruner.ExtractTimeRange(originalSQL)
+	var paths []string
+	prunedTiers := 0
+	for _, src := range sources {
+		if src.tier == tiering.TierCold && timeRange != nil && timeRange.StartAssumed {
+			// An end-only predicate's assumed start (2020-01-01) must not
+			// exclude cold-archive data that can legitimately be older; scan
+			// the full cold glob instead.
+			paths = append(paths, src.glob)
+			continue
+		}
+		tierPaths, outcome := h.pruner.PruneTierPaths(ctx, src.glob, database, measurement, timeRange, src.backend, src.tier == tiering.TierHot)
+		switch outcome {
+		case pruning.TierPrunePruned:
+			paths = append(paths, tierPaths...)
+			prunedTiers++
+		case pruning.TierPruneEmpty:
+			prunedTiers++
+		default:
+			paths = append(paths, src.glob)
+		}
+	}
+	if len(paths) == 0 && len(sources) > 0 {
+		// Every tier pruned to verified-empty. Mirror the single-tier
+		// zero-survivor behavior and fall back to the full tier globs rather
+		// than fabricating an empty relation.
+		for _, src := range sources {
+			paths = append(paths, src.glob)
+		}
+		prunedTiers = 0
+	}
+	if prunedTiers > 0 {
+		h.logger.Info().
+			Str("database", database).
+			Str("measurement", measurement).
+			Int("tiers", len(sources)).
+			Int("pruned_tiers", prunedTiers).
+			Int("path_count", len(paths)).
+			Msg("Multi-tier partition pruning applied")
 	}
 
 	if len(paths) == 0 {
@@ -3316,7 +3364,7 @@ func (h *QueryHandler) convertSingleTableQueryForParallel(ctx context.Context, s
 			tieredPaths := router.GetGlobPathsForQuery(database, tableName)
 			if _, hasCold := tieredPaths[tiering.TierCold]; hasCold {
 				// Use tiering-aware method - parallel not supported for multi-tier queries
-				replacement := h.buildMultiTierReadParquet(database, tableName, tieredPaths, "FROM")
+				replacement := h.buildMultiTierReadParquet(ctx, database, tableName, sql, tieredPaths, "FROM")
 				return sql[:idx] + replacement + sql[end:], nil
 			}
 		}

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1084,7 +1084,7 @@ func (h *QueryHandler) SetFileTimePruning(enabled bool, margin time.Duration) {
 func (h *QueryHandler) InvalidateCaches() {
 	h.pruner.InvalidateAllCaches()
 	h.queryCache.Invalidate()
-	h.logger.Info().Msg("Query caches invalidated after compaction")
+	h.logger.Info().Msg("Query caches invalidated (compaction or tier migration)")
 }
 
 // StartBackgroundWorkers spawns the long-lived goroutines the handler

--- a/internal/pruning/partition_pruner.go
+++ b/internal/pruning/partition_pruner.go
@@ -402,6 +402,11 @@ type PrunerStats struct {
 type TimeRange struct {
 	Start time.Time
 	End   time.Time
+	// StartAssumed marks a range whose Start was not extracted from the query
+	// but assumed (an end-only predicate defaults Start to 2020-01-01). A
+	// consumer pruning storage that can legitimately hold data older than the
+	// assumption (a cold archive tier) must not trust Start for exclusion.
+	StartAssumed bool
 }
 
 // evaluateRelativeTime converts a relative time expression to an absolute time.
@@ -580,7 +585,7 @@ func (p *PartitionPruner) ExtractTimeRange(sqlStr string) *TimeRange {
 	} else if endTime != nil {
 		// Only end time - assume from beginning of data
 		start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-		return &TimeRange{Start: start, End: *endTime}
+		return &TimeRange{Start: start, End: *endTime, StartAssumed: true}
 	}
 
 	return nil

--- a/internal/pruning/tier_pruning.go
+++ b/internal/pruning/tier_pruning.go
@@ -1,0 +1,227 @@
+package pruning
+
+// Per-tier partition pruning for tiered storage (#662).
+//
+// The single-tier OptimizeTablePath existence-filters against the pruner's one
+// configured backend (p.storage). A tiered query spans TWO backends — the hot
+// (usually local) primary and the cold archive — so its paths must be filtered
+// against the tier's OWN backend, with listing keys relative to that backend's
+// root. Filtering a cold s3://bucket/prefix/... path through the hot backend,
+// or listing it with a bucket-relative key that the backend then re-prefixes,
+// silently reports every cold partition as absent — which under a
+// drop-empty-tiers policy would be data loss, not a performance bug.
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+)
+
+// TierPruneOutcome classifies the result of PruneTierPaths for one tier.
+type TierPruneOutcome int
+
+const (
+	// TierPruneFallback: the tier could not be pruned (pruning disabled, no
+	// time range, unrecognized glob shape, the path cap tripped, or a listing
+	// error left existence unverified with nothing surviving). The caller must
+	// scan the tier's full glob.
+	TierPruneFallback TierPruneOutcome = iota
+	// TierPrunePruned: the returned paths are the tier's partitions for the
+	// time range, existence-verified against the tier's backend.
+	TierPrunePruned
+	// TierPruneEmpty: every generated partition path was verified absent on
+	// the tier's backend with no listing errors. The tier holds no data for
+	// the time range and may be dropped from the query entirely.
+	TierPruneEmpty
+)
+
+// PruneTierPaths prunes one storage tier's partition paths for a query time
+// range, existence-filtering against the tier's own backend.
+//
+// tierGlob is the tier's full glob ({base}/{db}/{measurement}/**/*.parquet,
+// where base may be local, s3://bucket/prefix, or azure://container).
+// allowFileTime additionally applies file-level time pruning (#660) — hot tier
+// only: the live hour that feature targets exists only on the hot tier, and
+// the feature is documented for the local backend.
+//
+// Results are NOT cached at this layer (unlike OptimizeTablePath's
+// partitionCache): the SQL transform cache already dedupes repeated queries,
+// and the remote directory/file listings below are individually cached in
+// globCache, so a re-prune costs no extra backend calls within the TTL.
+func (p *PartitionPruner) PruneTierPaths(ctx context.Context, tierGlob, database, measurement string, timeRange *TimeRange, backend storage.Backend, allowFileTime bool) ([]string, TierPruneOutcome) {
+	if !p.enabled || timeRange == nil {
+		return nil, TierPruneFallback
+	}
+	suffix := database + "/" + measurement + "/**/*.parquet"
+	if !strings.HasSuffix(tierGlob, suffix) {
+		p.logger.Debug().Str("glob", tierGlob).Msg("Tier glob shape not recognized; not pruning")
+		return nil, TierPruneFallback
+	}
+	// rootURL keeps its trailing separator so TrimPrefix yields clean
+	// backend-relative keys; basePath drops it for path generation.
+	rootURL := strings.TrimSuffix(tierGlob, suffix)
+	basePath := strings.TrimSuffix(rootURL, "/")
+
+	paths := p.GeneratePartitionPaths(ctx, basePath, database, measurement, timeRange)
+	if len(paths) == 0 {
+		// Range too wide for the path cap, or generation cancelled.
+		return nil, TierPruneFallback
+	}
+
+	verified := true
+	if strings.HasPrefix(tierGlob, "s3://") || strings.HasPrefix(tierGlob, "azure://") {
+		paths, verified = p.filterTierRemotePaths(ctx, paths, backend, rootURL)
+	} else {
+		paths = p.filterExistingLocalPaths(paths)
+	}
+
+	if len(paths) == 0 {
+		if verified {
+			return nil, TierPruneEmpty
+		}
+		return nil, TierPruneFallback
+	}
+
+	if allowFileTime {
+		paths, _ = p.applyFileTimePruning(ctx, paths, timeRange)
+		if len(paths) == 0 {
+			return nil, TierPruneFallback
+		}
+	}
+	return paths, TierPrunePruned
+}
+
+// filterTierRemotePaths existence-filters remote partition paths against the
+// given backend, using keys relative to rootURL (the tier glob's base,
+// scheme+bucket+configured-prefix inclusive) so the backend's own key
+// prefixing applies exactly once.
+//
+// Every listing failure fails OPEN — the path is kept and verified is
+// returned false, so the caller can never mistake "could not check" for
+// "verified absent". (The single-tier filter fails closed on day-level List
+// errors; that is tolerable there because a dropped path still has the
+// unpruned-glob fallback, which a dropped TIER would not.)
+func (p *PartitionPruner) filterTierRemotePaths(ctx context.Context, paths []string, backend storage.Backend, rootURL string) ([]string, bool) {
+	lister, canList := backend.(storage.DirectoryLister)
+	if backend == nil || !canList {
+		p.logger.Debug().Msg("Tier backend cannot list directories; keeping all paths unverified")
+		return paths, false
+	}
+
+	verified := true
+	// hourDirs groups hour-level paths by their backend-relative parent (day)
+	// directory, listed once each.
+	type hourEntry struct {
+		path   string
+		target string // hour segment, e.g. "14"
+	}
+	hourDirs := make(map[string][]hourEntry)
+	var dayPaths []string // day-level compacted-file globs, checked individually
+
+	existing := make([]string, 0, len(paths))
+	for _, path := range paths {
+		rel := strings.TrimPrefix(path, rootURL)
+		if rel == path {
+			// Path does not share the tier root — cannot derive a
+			// backend-relative key; keep it unverified.
+			p.logger.Debug().Str("path", path).Msg("Tier path outside tier root; keeping unverified")
+			existing = append(existing, path)
+			verified = false
+			continue
+		}
+		dir := strings.TrimSuffix(rel, "/*.parquet")
+		segs := strings.Split(dir, "/")
+		switch len(segs) {
+		case 6: // db/measurement/year/month/day/hour
+			parent := strings.Join(segs[:5], "/")
+			hourDirs[parent] = append(hourDirs[parent], hourEntry{path: path, target: segs[5]})
+		case 5: // db/measurement/year/month/day (daily compacted files)
+			dayPaths = append(dayPaths, path)
+		default:
+			existing = append(existing, path)
+			verified = false
+		}
+	}
+
+	// Hour-level: one ListDirectories per covered day.
+	for parent, entries := range hourDirs {
+		cacheKey := "tier:dirs:" + rootURL + parent
+		var children []string
+		if cached, ok := p.globCache.get(cacheKey); ok {
+			children = cached
+		} else {
+			listCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			subdirs, err := lister.ListDirectories(listCtx, parent+"/")
+			cancel()
+			if err != nil {
+				p.logger.Debug().Err(err).Str("prefix", parent).Msg("Tier directory listing failed; keeping paths unverified")
+				for _, e := range entries {
+					existing = append(existing, e.path)
+				}
+				verified = false
+				continue
+			}
+			children = make([]string, 0, len(subdirs))
+			for _, subdir := range subdirs {
+				subdir = strings.TrimSuffix(subdir, "/")
+				if idx := strings.LastIndex(subdir, "/"); idx != -1 {
+					subdir = subdir[idx+1:]
+				}
+				children = append(children, subdir)
+			}
+			p.globCache.set(cacheKey, children)
+		}
+		childSet := make(map[string]bool, len(children))
+		for _, c := range children {
+			childSet[c] = true
+		}
+		for _, e := range entries {
+			if childSet[e.target] {
+				existing = append(existing, e.path)
+			}
+		}
+	}
+
+	// Day-level: files must exist directly at the day directory (daily
+	// compaction output), not only in hour subdirectories.
+	for _, path := range dayPaths {
+		rel := strings.TrimPrefix(path, rootURL)
+		prefix := strings.TrimSuffix(rel, "*.parquet")
+		cacheKey := "tier:dayfiles:" + rootURL + prefix
+		var hasFiles bool
+		if cached, ok := p.globCache.get(cacheKey); ok {
+			hasFiles = len(cached) > 0
+		} else {
+			listCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			files, err := backend.List(listCtx, prefix)
+			cancel()
+			if err != nil {
+				p.logger.Debug().Err(err).Str("prefix", prefix).Msg("Tier day-level listing failed; keeping path unverified")
+				existing = append(existing, path)
+				verified = false
+				continue
+			}
+			var directFiles []string
+			for _, f := range files {
+				remaining := strings.TrimPrefix(f, prefix)
+				if remaining != "" && !strings.Contains(remaining, "/") && strings.HasSuffix(remaining, ".parquet") {
+					directFiles = append(directFiles, remaining)
+				}
+			}
+			p.globCache.set(cacheKey, directFiles)
+			hasFiles = len(directFiles) > 0
+		}
+		if hasFiles {
+			existing = append(existing, path)
+		}
+	}
+
+	p.logger.Debug().
+		Int("original_count", len(paths)).
+		Int("existing_count", len(existing)).
+		Bool("verified", verified).
+		Msg("Filtered tier remote paths")
+	return existing, verified
+}

--- a/internal/pruning/tier_pruning_s3_manual_test.go
+++ b/internal/pruning/tier_pruning_s3_manual_test.go
@@ -1,0 +1,92 @@
+package pruning
+
+// Manual integration test for per-tier pruning against REAL S3 (#662).
+//
+// Skipped unless ARC_S3_MANUAL_TEST_BUCKET names a bucket the ambient AWS
+// credentials can list. Expected fixture layout (zero-byte objects suffice —
+// only listings are exercised):
+//
+//	tenant1/db/cpu/2024/03/15/14/cpu_a.parquet
+//	tenant1/db/cpu/2024/03/15/15/cpu_b.parquet
+//	tenant1/db/cpu/2024/03/16/09/cpu_c.parquet
+//	tenant1/db/cpu/2024/03/10/cpu_daily.parquet   (day-level compacted)
+//	db/mem/2024/03/15/14/mem_a.parquet            (empty-prefix case)
+//
+// This exists because the highest-risk failure mode of #662 — prefix
+// double-application producing false "verified empty" — is a property of the
+// real backend's key handling, which mocks can only approximate.
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+func manualS3Backend(t *testing.T, prefix string) storage.Backend {
+	t.Helper()
+	bucket := os.Getenv("ARC_S3_MANUAL_TEST_BUCKET")
+	if bucket == "" {
+		t.Skip("ARC_S3_MANUAL_TEST_BUCKET not set; skipping real-S3 manual test")
+	}
+	backend, err := storage.NewS3Backend(&storage.S3Config{
+		Bucket: bucket,
+		Region: os.Getenv("AWS_REGION"),
+		Prefix: prefix,
+		UseSSL: true,
+	}, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewS3Backend: %v", err)
+	}
+	return backend
+}
+
+func TestManualS3_PruneTierPaths_PrefixedBackend(t *testing.T) {
+	backend := manualS3Backend(t, "tenant1/")
+	p := NewPartitionPruner(zerolog.Nop())
+	glob := storage.GetStoragePath(backend, "db", "cpu")
+
+	// In-range: hours 14-15 exist on 03-15; hour 16 does not.
+	paths, outcome := p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T17:00:00Z"), backend, false)
+	if outcome != TierPrunePruned {
+		t.Fatalf("in-range outcome = %v, want TierPrunePruned (paths=%v)", outcome, paths)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("in-range paths = %v, want exactly hours 14 and 15", paths)
+	}
+	for _, path := range paths {
+		if !strings.Contains(path, "/tenant1/db/cpu/2024/03/15/1") {
+			t.Fatalf("unexpected pruned path %q", path)
+		}
+	}
+
+	// Day-level compacted file on 03-10 must survive; its hours must not.
+	paths, outcome = p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2024-03-10T00:00:00Z", "2024-03-10T04:00:00Z"), backend, false)
+	if outcome != TierPrunePruned || len(paths) != 1 || !strings.HasSuffix(paths[0], "/tenant1/db/cpu/2024/03/10/*.parquet") {
+		t.Fatalf("day-level: outcome=%v paths=%v, want only the 03/10 day glob", outcome, paths)
+	}
+
+	// Out-of-range: the tier is verified empty — the cold-tier-elimination win.
+	_, outcome = p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2025-06-01T00:00:00Z", "2025-06-01T02:00:00Z"), backend, false)
+	if outcome != TierPruneEmpty {
+		t.Fatalf("out-of-range outcome = %v, want TierPruneEmpty", outcome)
+	}
+}
+
+func TestManualS3_PruneTierPaths_EmptyPrefixBackend(t *testing.T) {
+	backend := manualS3Backend(t, "")
+	p := NewPartitionPruner(zerolog.Nop())
+	glob := storage.GetStoragePath(backend, "db", "mem")
+
+	paths, outcome := p.PruneTierPaths(context.Background(), glob, "db", "mem",
+		tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T15:00:00Z"), backend, false)
+	if outcome != TierPrunePruned || len(paths) != 1 {
+		t.Fatalf("empty-prefix: outcome=%v paths=%v, want the one existing hour", outcome, paths)
+	}
+}

--- a/internal/pruning/tier_pruning_test.go
+++ b/internal/pruning/tier_pruning_test.go
@@ -186,3 +186,26 @@ func TestExtractTimeRange_MarksAssumedStart(t *testing.T) {
 		t.Fatalf("two-sided range = %+v, want StartAssumed=false", twoSided)
 	}
 }
+
+// A day with only a daily-compacted file (no hour subdirectories) must keep
+// its day-level glob and drop the hour globs, and vice versa.
+func TestPruneTierPaths_MixedHourAndDayExistence(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+	backend := &tierMock{
+		mockS3Backend: &mockS3Backend{existingDirs: map[string][]string{}},
+		files: map[string][]string{
+			"db/cpu/2024/03/15/": {"db/cpu/2024/03/15/cpu_daily.parquet"},
+		},
+	}
+	glob := "s3://bucket/db/cpu/**/*.parquet"
+
+	paths, outcome := p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T16:00:00Z"), backend, false)
+
+	if outcome != TierPrunePruned {
+		t.Fatalf("outcome = %v, want TierPrunePruned", outcome)
+	}
+	if len(paths) != 1 || paths[0] != "s3://bucket/db/cpu/2024/03/15/*.parquet" {
+		t.Fatalf("paths = %v, want only the day-level glob", paths)
+	}
+}

--- a/internal/pruning/tier_pruning_test.go
+++ b/internal/pruning/tier_pruning_test.go
@@ -1,0 +1,188 @@
+package pruning
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// tierMock embeds mockS3Backend and adds error injection, day-file listings,
+// and recording of every requested prefix — the recording is the regression
+// harness for the prefix double-application bug (#662 review finding): the
+// pruner must hand the backend keys relative to the backend's own root, never
+// keys that still carry the configured bucket prefix.
+type tierMock struct {
+	*mockS3Backend
+	files       map[string][]string // List(prefix) -> object keys
+	errPrefixes map[string]bool     // prefixes whose listings fail
+	requested   []string
+}
+
+func (m *tierMock) ListDirectories(ctx context.Context, prefix string) ([]string, error) {
+	m.requested = append(m.requested, prefix)
+	if m.errPrefixes[prefix] {
+		return nil, fmt.Errorf("injected listing error for %s", prefix)
+	}
+	return m.mockS3Backend.ListDirectories(ctx, prefix)
+}
+
+func (m *tierMock) List(ctx context.Context, prefix string) ([]string, error) {
+	m.requested = append(m.requested, prefix)
+	if m.errPrefixes[prefix] {
+		return nil, fmt.Errorf("injected listing error for %s", prefix)
+	}
+	return m.files[prefix], nil
+}
+
+func tierRange(t *testing.T, start, end string) *TimeRange {
+	t.Helper()
+	s, err := time.Parse(time.RFC3339, start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, err := time.Parse(time.RFC3339, end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &TimeRange{Start: s, End: e}
+}
+
+// The cold glob embeds the backend's configured prefix; listings must go out
+// backend-relative so the backend's own prefixing applies exactly once.
+func TestPruneTierPaths_RemoteUsesBackendRelativeKeys(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+	backend := &tierMock{
+		mockS3Backend: &mockS3Backend{existingDirs: map[string][]string{
+			"db/cpu/2024/03/15/": {"14"},
+		}},
+		files: map[string][]string{},
+	}
+	glob := "s3://bucket/tenant1/db/cpu/**/*.parquet"
+
+	paths, outcome := p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T16:00:00Z"), backend, false)
+
+	if outcome != TierPrunePruned {
+		t.Fatalf("outcome = %v, want TierPrunePruned", outcome)
+	}
+	want := []string{"s3://bucket/tenant1/db/cpu/2024/03/15/14/*.parquet"}
+	if len(paths) != 1 || paths[0] != want[0] {
+		t.Fatalf("paths = %v, want %v", paths, want)
+	}
+	for _, prefix := range backend.requested {
+		if strings.HasPrefix(prefix, "tenant1/") || strings.Contains(prefix, "bucket") {
+			t.Fatalf("backend asked to list %q — key must be relative to the backend root (double-prefix bug)", prefix)
+		}
+	}
+}
+
+func TestPruneTierPaths_VerifiedEmptyDropsTier(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+	backend := &tierMock{
+		mockS3Backend: &mockS3Backend{existingDirs: map[string][]string{}},
+		files:         map[string][]string{},
+	}
+	glob := "s3://bucket/db/cpu/**/*.parquet"
+
+	paths, outcome := p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T16:00:00Z"), backend, false)
+
+	if outcome != TierPruneEmpty {
+		t.Fatalf("outcome = %v, want TierPruneEmpty", outcome)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("paths = %v, want none", paths)
+	}
+}
+
+// A listing failure must fail OPEN: keep the unverifiable paths, and never
+// let an all-error result read as "verified empty".
+func TestPruneTierPaths_ListingErrorFailsOpen(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+	backend := &tierMock{
+		mockS3Backend: &mockS3Backend{existingDirs: map[string][]string{}},
+		files:         map[string][]string{},
+		errPrefixes:   map[string]bool{"db/cpu/2024/03/15/": true},
+	}
+	glob := "s3://bucket/db/cpu/**/*.parquet"
+
+	paths, outcome := p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T16:00:00Z"), backend, false)
+
+	if outcome != TierPrunePruned {
+		t.Fatalf("outcome = %v, want TierPrunePruned (fail-open keeps unverifiable paths)", outcome)
+	}
+	// The hour paths under the erroring parent AND the day-level path (same
+	// erroring prefix) must all survive.
+	if len(paths) != 3 {
+		t.Fatalf("paths = %v, want the 2 hour paths and 1 day path kept", paths)
+	}
+}
+
+func TestPruneTierPaths_LocalTier(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+	base := t.TempDir()
+	hourDir := filepath.Join(base, "db", "cpu", "2024", "03", "15", "14")
+	if err := os.MkdirAll(hourDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hourDir, "x.parquet"), []byte("p"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	glob := base + "/db/cpu/**/*.parquet"
+
+	paths, outcome := p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T16:00:00Z"), nil, false)
+
+	if outcome != TierPrunePruned {
+		t.Fatalf("outcome = %v, want TierPrunePruned", outcome)
+	}
+	if len(paths) != 1 || paths[0] != filepath.Join(base, "db", "cpu", "2024", "03", "15", "14", "*.parquet") {
+		t.Fatalf("paths = %v, want the one existing hour glob", paths)
+	}
+
+	// A range with no local data at all is a verified-empty tier.
+	_, outcome = p.PruneTierPaths(context.Background(), glob, "db", "cpu",
+		tierRange(t, "2030-01-01T00:00:00Z", "2030-01-01T02:00:00Z"), nil, false)
+	if outcome != TierPruneEmpty {
+		t.Fatalf("future-range outcome = %v, want TierPruneEmpty", outcome)
+	}
+}
+
+func TestPruneTierPaths_FallbackCases(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+	r := tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T16:00:00Z")
+
+	if _, outcome := p.PruneTierPaths(context.Background(), "s3://bucket/db/cpu/**/*.parquet", "db", "cpu", nil, nil, false); outcome != TierPruneFallback {
+		t.Fatalf("nil range: outcome = %v, want TierPruneFallback", outcome)
+	}
+	if _, outcome := p.PruneTierPaths(context.Background(), "s3://bucket/other/shape.parquet", "db", "cpu", r, nil, false); outcome != TierPruneFallback {
+		t.Fatalf("bad glob shape: outcome = %v, want TierPruneFallback", outcome)
+	}
+	// A range wide enough to trip the path cap must fall back, not drop.
+	wide := &TimeRange{Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), End: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)}
+	if _, outcome := p.PruneTierPaths(context.Background(), "s3://bucket/db/cpu/**/*.parquet", "db", "cpu", wide, nil, false); outcome != TierPruneFallback {
+		t.Fatalf("capped range: outcome = %v, want TierPruneFallback", outcome)
+	}
+}
+
+// End-only predicates get an assumed 2020 start; the range must say so, so
+// the query layer can refuse to prune a cold archive with it.
+func TestExtractTimeRange_MarksAssumedStart(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+
+	endOnly := p.ExtractTimeRange("SELECT * FROM cpu WHERE time < '2024-01-01 00:00:00'")
+	if endOnly == nil || !endOnly.StartAssumed {
+		t.Fatalf("end-only range = %+v, want StartAssumed=true", endOnly)
+	}
+	twoSided := p.ExtractTimeRange("SELECT * FROM cpu WHERE time >= '2023-01-01' AND time < '2024-01-01'")
+	if twoSided == nil || twoSided.StartAssumed {
+		t.Fatalf("two-sided range = %+v, want StartAssumed=false", twoSided)
+	}
+}

--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -24,10 +24,13 @@ type Manager struct {
 	coldBackend storage.Backend
 
 	// onMigrationComplete, when set, runs after a migration cycle that moved
-	// at least one file. The query layer uses it to invalidate pruner and SQL
-	// transform caches, whose cached partition paths go stale the moment a
-	// file changes tier (a cached hot hour glob that no longer matches any
-	// file makes DuckDB error on the next query within the cache TTL).
+	// or deleted at least one tier file. The query layer uses it to invalidate
+	// pruner and SQL transform caches, whose cached partition paths go stale
+	// the moment a file changes tier (a cached hot hour glob that no longer
+	// matches any file makes DuckDB error on the next query within the cache
+	// TTL). Guarded by callbackMu: it is wired from main after the scheduler
+	// goroutine already runs.
+	callbackMu          sync.Mutex
 	onMigrationComplete func()
 
 	// Data stores
@@ -246,18 +249,35 @@ func (m *Manager) RunMigrationCycle(ctx context.Context) error {
 		Dur("duration", duration).
 		Msg("Migration cycle completed")
 
-	if totalMigrated > 0 && m.onMigrationComplete != nil {
-		m.onMigrationComplete()
-	}
+	m.notifyMigrationComplete(totalMigrated, orphansDeleted)
 
 	return nil
 }
 
+// notifyMigrationComplete fires the registered callback when a cycle changed
+// which files live on which tier. Orphan deletions count: crash-recovery
+// reconciliation can delete hot files in a cycle that migrated nothing, and a
+// cached pruned hot glob matching zero files makes DuckDB error until TTL.
+func (m *Manager) notifyMigrationComplete(migrated, orphansDeleted int) {
+	if migrated <= 0 && orphansDeleted <= 0 {
+		return
+	}
+	m.callbackMu.Lock()
+	fn := m.onMigrationComplete
+	m.callbackMu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
 // SetOnMigrationComplete registers a callback invoked after any migration
-// cycle that moved files between tiers. See the field comment for why the
-// query caches need it.
+// cycle that moved or deleted tier files. See the field comment for why the
+// query caches need it. Safe to call after Start: the scheduler goroutine
+// reads the callback under the same lock.
 func (m *Manager) SetOnMigrationComplete(fn func()) {
+	m.callbackMu.Lock()
 	m.onMigrationComplete = fn
+	m.callbackMu.Unlock()
 }
 
 // cleanupOldMigrations deletes migration history records older than the configured retention.

--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -23,6 +23,13 @@ type Manager struct {
 	hotBackend  storage.Backend
 	coldBackend storage.Backend
 
+	// onMigrationComplete, when set, runs after a migration cycle that moved
+	// at least one file. The query layer uses it to invalidate pruner and SQL
+	// transform caches, whose cached partition paths go stale the moment a
+	// file changes tier (a cached hot hour glob that no longer matches any
+	// file makes DuckDB error on the next query within the cache TTL).
+	onMigrationComplete func()
+
 	// Data stores
 	metadata *MetadataStore
 	policies *PolicyStore
@@ -239,7 +246,18 @@ func (m *Manager) RunMigrationCycle(ctx context.Context) error {
 		Dur("duration", duration).
 		Msg("Migration cycle completed")
 
+	if totalMigrated > 0 && m.onMigrationComplete != nil {
+		m.onMigrationComplete()
+	}
+
 	return nil
+}
+
+// SetOnMigrationComplete registers a callback invoked after any migration
+// cycle that moved files between tiers. See the field comment for why the
+// query caches need it.
+func (m *Manager) SetOnMigrationComplete(fn func()) {
+	m.onMigrationComplete = fn
 }
 
 // cleanupOldMigrations deletes migration history records older than the configured retention.

--- a/internal/tiering/migration_callback_test.go
+++ b/internal/tiering/migration_callback_test.go
@@ -1,0 +1,28 @@
+package tiering
+
+import "testing"
+
+// notifyMigrationComplete must fire when files moved OR when orphan
+// reconciliation deleted hot files (a zero-migration crash-recovery cycle
+// still changes which globs match), and stay quiet on a no-op cycle.
+func TestNotifyMigrationComplete(t *testing.T) {
+	m := &Manager{}
+	fired := 0
+	m.SetOnMigrationComplete(func() { fired++ })
+
+	m.notifyMigrationComplete(0, 0)
+	if fired != 0 {
+		t.Fatal("no-op cycle must not fire the callback")
+	}
+	m.notifyMigrationComplete(3, 0)
+	if fired != 1 {
+		t.Fatalf("migrated>0: fired = %d, want 1", fired)
+	}
+	m.notifyMigrationComplete(0, 2)
+	if fired != 2 {
+		t.Fatalf("orphansDeleted>0: fired = %d, want 2", fired)
+	}
+
+	var nilCallback *Manager = &Manager{}
+	nilCallback.notifyMigrationComplete(1, 1) // must not panic
+}


### PR DESCRIPTION
## Summary

- fixes #662: the multi-tier query builder returned both tiers' full globs before the pruner ever ran, so any deployment with an active cold tier scanned everything on every query, including S3/Azure LIST+GET on the archive
- prune each tier against its own backend: hour/day partitions generated per tier, existence-filtered with backend-relative listing keys (a configured bucket prefix applies exactly once), and a tier verified empty for the query's time range is dropped outright — recent-range dashboard queries no longer touch cold storage
- end-only time predicates (assumed 2020 range start) never prune the cold archive; listing errors fail open to the tier's full glob and can never read as verified-empty; file-level time pruning (#660) applies to the hot tier only; single-tier and non-tiered paths are byte-identical to before
- completed migration cycles (including orphan-only reconciliation deletes) invalidate the pruner and SQL transform caches, same as compaction, so cached pruned globs cannot go stale into DuckDB errors

## Process

Plan was adversarially reviewed before implementation (surfaced the prefix double-application hazard, the mandatory backend parameterization, and the end-only-range regression), and the implementation got an independent adversarial review whose findings (orphan-delete invalidation, callback wiring race, coverage gaps) are addressed in the second commit.

## Verification

- new unit tests: backend-relative key regression (recorded-prefix assertion), verified-empty tier drop, fail-open listing errors, local tier, path-cap and shape fallbacks, StartAssumed extraction, mixed hour/day existence, migration-callback trigger conditions
- env-guarded manual test against REAL S3 (`ARC_S3_MANUAL_TEST_BUCKET`): prefixed and unprefixed backends, live ListObjectsV2 semantics — in-range pruning to exact hours, day-compacted detection, out-of-range TierPruneEmpty; run and passed against a scratch bucket, then the bucket was deleted
- `go build ./...`, `go vet`, full `internal/pruning` + `internal/tiering` + `internal/api` suites pass
- release notes entry added under Bug fixes in 26.09.2

Closes #662