### PR TITLE
fix(query): pin DuckDB session TimeZone to UTC

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -154,7 +154,7 @@ UTC-hour partition layout, arcxrouter, and JSON output all assume UTC. On a
 non-UTC host, a naive timestamp literal (`WHERE time >= '2024-03-15 14:00:00'`)
 meant one instant to the pruner and a different one to the engine, so pruned
 queries could silently miss matching rows. Every Arc session now runs with
-`TimeZone='UTC'`.
+`TimeZone='UTC'` — the query engine and the compaction subprocess alike.
 
 What changes on non-UTC hosts: naive timestamp literals are always UTC;
 `date_trunc`, `time_bucket`, and `::DATE` casts on `TIMESTAMPTZ` bucket at UTC

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -145,3 +145,21 @@ touches cold object storage at all. File-level time pruning (26.09.2's
 Listing failures fail open to the tier's full glob, end-only time predicates
 never exclude cold data older than the assumed range start, and completed
 tier migrations now invalidate the query caches the same way compaction does.
+
+### Query time zone is now pinned to UTC ([#682](https://github.com/Basekick-Labs/arc/issues/682))
+
+**Behavior change on servers whose host time zone is not UTC.** DuckDB
+defaulted its session zone to the host's zone, while Arc's partition pruner,
+UTC-hour partition layout, arcxrouter, and JSON output all assume UTC. On a
+non-UTC host, a naive timestamp literal (`WHERE time >= '2024-03-15 14:00:00'`)
+meant one instant to the pruner and a different one to the engine, so pruned
+queries could silently miss matching rows. Every Arc session now runs with
+`TimeZone='UTC'`.
+
+What changes on non-UTC hosts: naive timestamp literals are always UTC;
+`date_trunc`, `time_bucket`, and `::DATE` casts on `TIMESTAMPTZ` bucket at UTC
+boundaries — continuous queries with daily or weekly buckets will align to UTC
+midnight from this release onward. Zone-aware predicates remain available via
+offset literals (`'2024-03-15 14:00:00+02:00'`) or `AT TIME ZONE`. Query JSON
+output is unchanged (it was already normalized to UTC), and hosts already
+running in UTC see no change at all.

--- a/internal/compaction/subprocess.go
+++ b/internal/compaction/subprocess.go
@@ -132,6 +132,15 @@ func RunSubprocessJob(config *SubprocessJobConfig) (*SubprocessJobResult, error)
 	}
 	defer db.Close()
 
+	// Pin the session time zone to UTC (#682), mirroring the query engine's
+	// pin: the dedup path TRY_CASTs naive time strings to TIMESTAMPTZ, and
+	// under a host-zone session a non-UTC host would permanently rewrite
+	// those instants shifted by the UTC offset during compaction. Hard-fail:
+	// compacting with a wrong zone corrupts data, not just query results.
+	if _, err := db.Exec("SET TimeZone='UTC'"); err != nil {
+		return nil, fmt.Errorf("failed to pin compaction DuckDB TimeZone to UTC: %w", err)
+	}
+
 	// Set DuckDB memory limit from config. Exceeding it makes DuckDB spill to
 	// its temp_directory (configured below) instead of OOMing the process.
 	if config.MemoryLimit != "" {

--- a/internal/database/duckdb.go
+++ b/internal/database/duckdb.go
@@ -910,6 +910,21 @@ func configureDatabase(db *sql.DB, cfg *Config, logger zerolog.Logger) error {
 		}
 	}
 
+	// Pin the session time zone to UTC for every connection (#682). Arc's
+	// contract is UTC end to end: partitions are UTC hour directories, the
+	// partition pruner parses naive timestamp literals as UTC, arcxrouter
+	// accepts only UTC literals, and the JSON writer renders UTC. DuckDB,
+	// however, defaults the session zone to the HOST's zone, and compares a
+	// naive literal against a TIMESTAMPTZ column in the session zone — so on
+	// a non-UTC host the pruner and the engine disagree about which instant
+	// 'YYYY-MM-DD HH:MM:SS' denotes, and pruning can silently drop matching
+	// rows. Hard-fail like memory_limit: booting without the pin means
+	// silently wrong query results. Users who want zone-aware predicates
+	// keep them via offset literals ('… +02:00') or AT TIME ZONE.
+	if _, err := db.Exec("SET GLOBAL TimeZone='UTC'"); err != nil {
+		return fmt.Errorf("failed to pin DuckDB TimeZone to UTC: %w", err)
+	}
+
 	// Cache Parquet file metadata (schema, row group info) to reduce I/O on repeated access
 	if _, err := db.Exec("SET GLOBAL parquet_metadata_cache=true"); err != nil {
 		logger.Warn().Err(err).Msg("Failed to enable parquet metadata cache (continuing without it)")

--- a/internal/database/duckdb_timezone_test.go
+++ b/internal/database/duckdb_timezone_test.go
@@ -1,0 +1,77 @@
+package database
+
+// Regression tests for #682: DuckDB's session time zone must be pinned to
+// UTC so naive timestamp literals mean the same instant to the engine as
+// they do to the partition pruner (which parses them as UTC).
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// naiveLiteralIsUTC reports whether a naive literal comparison against a
+// TIMESTAMPTZ value behaves with UTC semantics on the given handle: the
+// instant 14:30Z compared against the naive literal '14:00:00' is only >=
+// when the literal is interpreted as 14:00 UTC.
+func naiveLiteralIsUTC(t *testing.T, q interface {
+	QueryRow(query string, args ...interface{}) *sql.Row
+}) bool {
+	t.Helper()
+	var match bool
+	err := q.QueryRow(`SELECT TIMESTAMPTZ '2024-03-15 14:30:00+00' >= '2024-03-15 14:00:00'
+		AND TIMESTAMPTZ '2024-03-15 14:30:00+00' < '2024-03-15 16:00:00'`).Scan(&match)
+	if err != nil {
+		t.Fatalf("literal comparison probe: %v", err)
+	}
+	return match
+}
+
+func TestNew_PinsTimeZoneToUTC(t *testing.T) {
+	tmp := t.TempDir()
+	storageRoot := filepath.Join(tmp, "data")
+	if err := os.MkdirAll(storageRoot, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	db, err := New(&Config{
+		MaxConnections:   2,
+		MemoryLimit:      "256MB",
+		LocalStorageRoot: storageRoot,
+		TempDirectory:    tmp,
+	}, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+
+	var tz string
+	if err := db.db.QueryRow("SELECT current_setting('TimeZone')").Scan(&tz); err != nil {
+		t.Fatalf("read TimeZone: %v", err)
+	}
+	if tz != "UTC" {
+		t.Fatalf("TimeZone = %q, want UTC — the #682 pin was dropped", tz)
+	}
+	if !naiveLiteralIsUTC(t, db.db) {
+		t.Fatal("naive literal not interpreted as UTC on an Arc handle — pruner and engine disagree (#682)")
+	}
+}
+
+// Documents the mechanism the pin closes: on a raw handle with a non-UTC
+// session zone, the same comparison flips, which is exactly the state a
+// non-UTC host was in before the pin.
+func TestNaiveLiteral_MismatchWithoutPin(t *testing.T) {
+	raw, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec("SET TimeZone='America/Costa_Rica'"); err != nil {
+		t.Skipf("cannot set named zone (ICU unavailable?): %v", err)
+	}
+	if naiveLiteralIsUTC(t, raw) {
+		t.Fatal("expected the naive literal to shift under a non-UTC session zone; the #682 hazard no longer reproduces — re-evaluate whether the pin is still needed")
+	}
+}

--- a/internal/database/duckdb_timezone_test.go
+++ b/internal/database/duckdb_timezone_test.go
@@ -31,6 +31,10 @@ func naiveLiteralIsUTC(t *testing.T, q interface {
 }
 
 func TestNew_PinsTimeZoneToUTC(t *testing.T) {
+	// Force a non-UTC host zone so this test guards the pin even on UTC CI
+	// runners: without it, deleting the SET still passes under TZ=UTC.
+	// DuckDB reads TZ at instance open, so Setenv before New is effective.
+	t.Setenv("TZ", "America/Costa_Rica")
 	tmp := t.TempDir()
 	storageRoot := filepath.Join(tmp, "data")
 	if err := os.MkdirAll(storageRoot, 0o700); err != nil {
@@ -68,6 +72,9 @@ func TestNaiveLiteral_MismatchWithoutPin(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	defer raw.Close()
+	// SET TimeZone is session-scoped; force a single pooled connection so
+	// the probe below runs on the session that executed the SET.
+	raw.SetMaxOpenConns(1)
 	if _, err := raw.Exec("SET TimeZone='America/Costa_Rica'"); err != nil {
 		t.Skipf("cannot set named zone (ICU unavailable?): %v", err)
 	}


### PR DESCRIPTION
## Summary

- fixes #682: DuckDB defaulted its session zone to the host's zone while the partition pruner, UTC-hour partition layout, arcxrouter, and JSON output all assume UTC — on a non-UTC host a naive timestamp literal meant different instants to the pruner and the engine, and pruned queries could silently miss matching rows
- pin `TimeZone='UTC'` at query-engine setup AND in the compaction subprocess (whose dedup path TRY_CASTs naive time strings to TIMESTAMPTZ — unpinned, compaction on a non-UTC host would permanently rewrite those instants), both hard-fail like the other correctness-bearing settings
- behavior change documented in the 26.09.2 release notes: naive literals are always UTC; `date_trunc`/`time_bucket`/`::DATE` on TIMESTAMPTZ bucket at UTC boundaries (continuous-query buckets realign on non-UTC hosts); offset literals and AT TIME ZONE remain the zone-aware escape hatch; JSON output was already UTC-normalized and is unchanged

## Process

Same pipeline as #681: adversarial plan review (verified empirically on the vendored engine that the global pin reaches all connections including pre-existing ones, and that ICU is present), independent implementation review (whose blocking finding WAS the unpinned compaction subprocess), and a licensed end-to-end test before merge.

## Verification

- regression tests: fresh engine reports `TimeZone='UTC'` and naive-literal comparisons are UTC-semantic, with the host zone forced non-UTC so the test guards the pin even on UTC CI runners; a mechanism test reproduces the pre-fix mismatch on an unpinned session
- full `database`, `api`, `pruning`, `compaction` suites pass under both `TZ=UTC` and `TZ=America/Costa_Rica`
- licensed e2e with the server under `TZ=America/Costa_Rica`: session zone reports UTC, the #662-e2e query class that returned 0 pre-fix returns its rows with pruning active, the partial-overlap window that pre-fix silently missed returns its row, empty windows stay empty

Closes #682