### PR TITLE
test(cluster): wait for config replication before stopping the leader

### DIFF
--- a/internal/cluster/multi_writer_integration_test.go
+++ b/internal/cluster/multi_writer_integration_test.go
@@ -198,6 +198,28 @@ func TestMultiWriter_SharedStorageMode_LeaderElection_And_RoleGate(t *testing.T)
 		return raftC.LeaderID() == "writer-A"
 	}, "writer-C to recognise writer-A as leader")
 
+	// Both followers must have RECEIVED the full 3-server configuration
+	// before property 3 stops the leader. AddVoter's future resolving only
+	// proves the membership entry committed on a quorum — which can be A+C,
+	// leaving writer-B's local configuration at {A, B}. Stop A in that state
+	// and the cluster deadlocks unelectable: B needs dead A's vote, and B
+	// rejects C's vote requests as "not in configuration" (#671 — this exact
+	// race produced the CI failures with both followers seeing no leader).
+	serverCount := func(n *raft.Node) int {
+		ids, err := n.ConfigurationServerIDs()
+		if err != nil {
+			return 0
+		}
+		return len(ids)
+	}
+	waitFor(t, 10*time.Second, func() bool {
+		return serverCount(raftB) == 3 && serverCount(raftC) == 3
+	}, "writer-B and writer-C to receive the 3-server configuration", func() string {
+		bIDs, _ := raftB.ConfigurationServerIDs()
+		cIDs, _ := raftC.ConfigurationServerIDs()
+		return fmt.Sprintf("writer-B knows %v, writer-C knows %v", bIDs, cIDs)
+	})
+
 	if raftB.IsLeader() || raftC.IsLeader() {
 		t.Fatal("only writer-A should be leader at this point")
 	}

--- a/internal/cluster/raft/node.go
+++ b/internal/cluster/raft/node.go
@@ -664,3 +664,22 @@ func (n *Node) LeaderCh() <-chan bool {
 	}
 	return n.raft.LeaderCh()
 }
+
+// ConfigurationServerIDs returns the server IDs in this node's current,
+// locally-known Raft configuration. A joiner has not necessarily received
+// the latest membership entry the leader committed (a config change commits
+// on a quorum that may exclude this node), so callers coordinating
+// membership-dependent actions — a test stopping the leader, an operator
+// draining a node — must check every node's own view, not the leader's.
+func (n *Node) ConfigurationServerIDs() ([]string, error) {
+	future := n.raft.GetConfiguration()
+	if err := future.Error(); err != nil {
+		return nil, err
+	}
+	servers := future.Configuration().Servers
+	ids := make([]string, 0, len(servers))
+	for _, s := range servers {
+		ids = append(ids, string(s.ID))
+	}
+	return ids, nil
+}


### PR DESCRIPTION
## Summary

- root cause of the residual #671 flake (the mode that survived #680): `AddVoter`'s future resolving proves the membership entry committed on a quorum — which can be leader+C, leaving follower B's local configuration at {A, B}. Property 3 then stops the leader, and the cluster deadlocks unelectable: B needs dead A's vote, and B rejects C's vote requests as "not in configuration". That is precisely the both-followers-see-no-leader signature the #680 diagnostics captured on CI.
- fix: wait until BOTH followers report the full 3-server configuration before stopping the leader, via a new `Node.ConfigurationServerIDs()` accessor; the wait's timeout diagnostics print each follower's membership view
- the #680 timing change stands (it fixed the handshake-compounding mode); this closes the second, distinct mode

## Verification

- root-caused from a failing run's per-node raft traces (instrumented stress reproduction at GOMAXPROCS=2 with -race failed on iteration 30; follower B's log shows the vote rejection and a config containing only {A, B})
- post-fix: 40x stress loop under the same conditions, clean; 3x plain -race run, clean

Closes #671