### PR TITLE
fix(tiering): register day-level daily-compacted files for migration

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -139,7 +139,7 @@ every query, including S3/Azure LIST and GET calls on the cold archive. The
 multi-tier path now prunes each tier against its own backend: hour and day
 partitions are generated per tier, existence-filtered with backend-relative
 listings, and a tier verified to hold no data for the query's time range is
-dropped from the query outright — a recent-range dashboard query no longer
+dropped from the query outright, so a recent-range dashboard query no longer
 touches cold object storage at all. File-level time pruning (26.09.2's
 `query.file_time_pruning`) applies to the hot tier inside tiered queries too.
 Listing failures fail open to the tier's full glob, end-only time predicates
@@ -154,11 +154,11 @@ UTC-hour partition layout, arcxrouter, and JSON output all assume UTC. On a
 non-UTC host, a naive timestamp literal (`WHERE time >= '2024-03-15 14:00:00'`)
 meant one instant to the pruner and a different one to the engine, so pruned
 queries could silently miss matching rows. Every Arc session now runs with
-`TimeZone='UTC'` — the query engine and the compaction subprocess alike.
+`TimeZone='UTC'`, in the query engine and the compaction subprocess alike.
 
 What changes on non-UTC hosts: naive timestamp literals are always UTC;
 `date_trunc`, `time_bucket`, and `::DATE` casts on `TIMESTAMPTZ` bucket at UTC
-boundaries — continuous queries with daily or weekly buckets will align to UTC
+boundaries, so continuous queries with daily or weekly buckets will align to UTC
 midnight from this release onward. Zone-aware predicates remain available via
 offset literals (`'2024-03-15 14:00:00+02:00'`) or `AT TIME ZONE`. Query JSON
 output is unchanged (it was already normalized to UTC), and hosts already
@@ -167,7 +167,7 @@ running in UTC see no change at all.
 ### Daily-compacted files now register with tiering and migrate to cold ([#683](https://github.com/Basekick-Labs/arc/issues/683))
 
 The tiering scanner only accepted hour-level paths, while the migrator only
-moves daily-compacted `*_daily.parquet` files — which daily compaction writes
+moves daily-compacted `*_daily.parquet` files, which daily compaction writes
 at day level. On deployments relying on the scan for registration, scheduled
 hot-to-cold migration could therefore never find a candidate. The scanner now
 registers day-level files (partition time = start of day), and it no longer

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -163,3 +163,14 @@ midnight from this release onward. Zone-aware predicates remain available via
 offset literals (`'2024-03-15 14:00:00+02:00'`) or `AT TIME ZONE`. Query JSON
 output is unchanged (it was already normalized to UTC), and hosts already
 running in UTC see no change at all.
+
+### Daily-compacted files now register with tiering and migrate to cold ([#683](https://github.com/Basekick-Labs/arc/issues/683))
+
+The tiering scanner only accepted hour-level paths, while the migrator only
+moves daily-compacted `*_daily.parquet` files — which daily compaction writes
+at day level. On deployments relying on the scan for registration, scheduled
+hot-to-cold migration could therefore never find a candidate. The scanner now
+registers day-level files (partition time = start of day), and it no longer
+re-registers a file as hot when its metadata row already says cold, so a
+failed post-migration cleanup stays visible to orphan reconciliation instead
+of being re-uploaded every cycle.

--- a/internal/tiering/daily_registration_test.go
+++ b/internal/tiering/daily_registration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/basekick-labs/arc/internal/storage"
 )
 
-// ListObjects makes mockBackend an storage.ObjectLister so
+// ListObjects makes mockBackend a storage.ObjectLister so
 // ScanAndRegisterFiles can walk it.
 func (m *mockBackend) ListObjects(_ context.Context, prefix string) ([]storage.ObjectInfo, error) {
 	m.mu.RLock()
@@ -136,5 +136,31 @@ func TestScanDoesNotDowngradeColdRows(t *testing.T) {
 	meta, err := m.metadata.GetFile(ctx, dailyPath)
 	if err != nil || meta.Tier != TierCold {
 		t.Fatalf("row after rescan = (%+v, %v), want tier still cold", meta, err)
+	}
+}
+
+// Current compaction output names embed timestamp, nanos, and batch index
+// (job.go), so a regenerated daily file for a re-compacted day gets a NEW
+// path and registers as a fresh hot row; only the legacy date-only name could
+// ever collide with its migrated predecessor. Pin the modern shape.
+func TestScanRegistersModernDailyFilename(t *testing.T) {
+	m, hot, _, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+	ctx := context.Background()
+
+	modern := "db1/cpu/2024/03/15/cpu_20240315_231459_123456789_b1_daily.parquet"
+	if err := hot.Write(ctx, modern, []byte("daily")); err != nil {
+		t.Fatal(err)
+	}
+	res, err := m.ScanAndRegisterFiles(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Errors != 0 || res.FilesRegistered != 1 {
+		t.Fatalf("scan result = %+v, want the modern-named daily file registered", res)
+	}
+	candidates, err := m.migrator.FindCandidates(ctx, TierHot, TierCold)
+	if err != nil || len(candidates) != 1 || candidates[0].Path != modern {
+		t.Fatalf("candidates = (%+v, %v), want the modern-named daily file", candidates, err)
 	}
 }

--- a/internal/tiering/daily_registration_test.go
+++ b/internal/tiering/daily_registration_test.go
@@ -1,0 +1,140 @@
+package tiering
+
+// Regression tests for #683: daily-compacted files live at DAY level
+// ({db}/{measurement}/{Y}/{M}/{D}/{name}_daily.parquet) — the only files the
+// migrator moves to cold — but the scanner rejected any path without an hour
+// segment, so scan-registered deployments never produced migration candidates.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+)
+
+// ListObjects makes mockBackend an storage.ObjectLister so
+// ScanAndRegisterFiles can walk it.
+func (m *mockBackend) ListObjects(_ context.Context, prefix string) ([]storage.ObjectInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := []storage.ObjectInfo{}
+	for path, data := range m.files {
+		if strings.HasPrefix(path, prefix) {
+			out = append(out, storage.ObjectInfo{Path: path, Size: int64(len(data)), LastModified: time.Now().UTC()})
+		}
+	}
+	return out, nil
+}
+
+func TestParseFilePath_DayAndHourLevels(t *testing.T) {
+	m := &Manager{}
+
+	day, err := m.parseFilePath("db1/cpu/2024/03/15/cpu_20240315_daily.parquet")
+	if err != nil {
+		t.Fatalf("day-level path rejected: %v", err)
+	}
+	if want := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC); !day.PartitionTime.Equal(want) {
+		t.Fatalf("day-level partition time = %v, want %v", day.PartitionTime, want)
+	}
+
+	hour, err := m.parseFilePath("db1/cpu/2024/03/15/14/cpu_x.parquet")
+	if err != nil {
+		t.Fatalf("hour-level path rejected: %v", err)
+	}
+	if want := time.Date(2024, 3, 15, 14, 0, 0, 0, time.UTC); !hour.PartitionTime.Equal(want) {
+		t.Fatalf("hour-level partition time = %v, want %v", hour.PartitionTime, want)
+	}
+
+	for _, bad := range []string{
+		"db1/cpu/2024/03/file.parquet",       // 5 parts: too short
+		"db1/cpu/2024/03/xx/f_daily.parquet", // non-numeric day
+		"db1/cpu/2024/03/15/xx/f.parquet",    // non-numeric hour at hour level
+	} {
+		if _, err := m.parseFilePath(bad); err == nil {
+			t.Fatalf("path %q unexpectedly accepted", bad)
+		}
+	}
+}
+
+func TestScanRegistersAndMigratesDailyFiles(t *testing.T) {
+	m, hot, cold, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+	ctx := context.Background()
+
+	dailyPath := "db1/cpu/2024/03/15/cpu_20240315_daily.parquet"
+	rawPath := "db1/cpu/2024/03/15/14/cpu_20240315_140000_1.parquet"
+	if err := hot.Write(ctx, dailyPath, []byte("daily")); err != nil {
+		t.Fatal(err)
+	}
+	if err := hot.Write(ctx, rawPath, []byte("raw")); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := m.ScanAndRegisterFiles(ctx)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if res.Errors != 0 || res.FilesRegistered != 2 {
+		t.Fatalf("scan result = %+v, want 2 registered, 0 errors (the #683 failure was a path-too-short error here)", res)
+	}
+
+	candidates, err := m.migrator.FindCandidates(ctx, TierHot, TierCold)
+	if err != nil {
+		t.Fatalf("FindCandidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Path != dailyPath {
+		t.Fatalf("candidates = %+v, want exactly the day-level daily file", candidates)
+	}
+
+	migrated, errs := m.migrator.MigrateBatch(ctx, candidates)
+	if migrated != 1 || errs != 0 {
+		t.Fatalf("MigrateBatch = (%d migrated, %d errors), want (1, 0)", migrated, errs)
+	}
+	if ok, _ := cold.Exists(ctx, dailyPath); !ok {
+		t.Fatal("daily file missing from cold backend after migration")
+	}
+	if ok, _ := hot.Exists(ctx, dailyPath); ok {
+		t.Fatal("daily file still present on hot backend after migration")
+	}
+	meta, err := m.metadata.GetFile(ctx, dailyPath)
+	if err != nil || meta.Tier != TierCold {
+		t.Fatalf("metadata after migration = (%+v, %v), want tier cold", meta, err)
+	}
+}
+
+// A hot file whose row already says cold is the orphan ReconcileOrphanedFiles
+// deletes; the scan must not re-register it as hot, which would hide it from
+// reconciliation and re-upload it every cycle.
+func TestScanDoesNotDowngradeColdRows(t *testing.T) {
+	m, hot, cold, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+	ctx := context.Background()
+
+	dailyPath := "db1/cpu/2024/03/15/cpu_20240315_daily.parquet"
+	if err := hot.Write(ctx, dailyPath, []byte("daily")); err != nil {
+		t.Fatal(err)
+	}
+	if err := cold.Write(ctx, dailyPath, []byte("daily")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.ScanAndRegisterFiles(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.metadata.UpdateTier(ctx, dailyPath, TierCold); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := m.ScanAndRegisterFiles(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FilesSkipped != 1 {
+		t.Fatalf("rescan FilesSkipped = %d, want 1 (cold row must not be re-registered)", res.FilesSkipped)
+	}
+	meta, err := m.metadata.GetFile(ctx, dailyPath)
+	if err != nil || meta.Tier != TierCold {
+		t.Fatalf("row after rescan = (%+v, %v), want tier still cold", meta, err)
+	}
+}

--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -455,6 +455,16 @@ func (m *Manager) ScanAndRegisterFiles(ctx context.Context) (*ScanResult, error)
 			continue
 		}
 
+		// Never downgrade a cold row back to hot (#683): the scan lists the
+		// HOT backend, and a hot file whose row already says cold is exactly
+		// the orphan that ReconcileOrphanedFiles deletes after a failed
+		// post-migration cleanup. Re-registering it as hot would hide it from
+		// reconciliation and re-upload it to cold every cycle.
+		if existing, err := m.metadata.GetFile(ctx, obj.Path); err == nil && existing != nil && existing.Tier == TierCold {
+			result.FilesSkipped++
+			continue
+		}
+
 		// Create file metadata
 		file := &FileMetadata{
 			Path:          obj.Path,
@@ -511,10 +521,16 @@ func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
 	path = filepath.ToSlash(path)
 	parts := strings.Split(path, "/")
 
-	// Need at least: database/measurement/year/month/day/hour/filename.parquet
-	if len(parts) < 7 {
+	// Two accepted shapes (#683):
+	//   hour-level:  database/measurement/year/month/day/hour/filename.parquet (7 parts)
+	//   day-level:   database/measurement/year/month/day/filename.parquet      (6 parts)
+	// Day-level is where daily compaction writes its {measurement}_{date}_daily.parquet
+	// output — the only files the migrator will move to cold, so the scanner
+	// must be able to register them.
+	if len(parts) < 6 {
 		return nil, fmt.Errorf("path too short: %s", path)
 	}
+	dayLevel := len(parts) == 6
 
 	database := parts[0]
 	measurement := parts[1]
@@ -543,9 +559,14 @@ func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
 		return nil, fmt.Errorf("invalid day in path: %s", parts[4])
 	}
 
-	hour, err := strconv.Atoi(parts[5])
-	if err != nil {
-		return nil, fmt.Errorf("invalid hour in path: %s", parts[5])
+	// Day-level files carry no hour segment; their partition time is the
+	// start of the day, matching the hour-start convention of hourly rows.
+	hour := 0
+	if !dayLevel {
+		hour, err = strconv.Atoi(parts[5])
+		if err != nil {
+			return nil, fmt.Errorf("invalid hour in path: %s", parts[5])
+		}
 	}
 
 	// Construct partition time (UTC)

--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -435,6 +435,19 @@ func (m *Manager) ScanAndRegisterFiles(ctx context.Context) (*ScanResult, error)
 		return nil, fmt.Errorf("failed to list objects: %w", err)
 	}
 
+	// One query for the cold path set instead of a point lookup per scanned
+	// file: the scan walks every hot file, while the cold set holds only
+	// migrated daily files. Fail the scan on error rather than risk the
+	// downgrade the check exists to prevent.
+	coldFiles, err := m.metadata.GetFilesInTier(ctx, TierCold)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load cold tier paths: %w", err)
+	}
+	coldPaths := make(map[string]bool, len(coldFiles))
+	for _, f := range coldFiles {
+		coldPaths[f.Path] = true
+	}
+
 	for _, obj := range objects {
 		// Only process parquet files
 		if !strings.HasSuffix(obj.Path, ".parquet") {
@@ -458,9 +471,10 @@ func (m *Manager) ScanAndRegisterFiles(ctx context.Context) (*ScanResult, error)
 		// Never downgrade a cold row back to hot (#683): the scan lists the
 		// HOT backend, and a hot file whose row already says cold is exactly
 		// the orphan that ReconcileOrphanedFiles deletes after a failed
-		// post-migration cleanup. Re-registering it as hot would hide it from
-		// reconciliation and re-upload it to cold every cycle.
-		if existing, err := m.metadata.GetFile(ctx, obj.Path); err == nil && existing != nil && existing.Tier == TierCold {
+		// post-migration cleanup. Re-registering it as hot would reset
+		// migrated_at, hide it from reconciliation, and re-upload it to cold
+		// every cycle.
+		if coldPaths[obj.Path] {
 			result.FilesSkipped++
 			continue
 		}
@@ -524,9 +538,9 @@ func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
 	// Two accepted shapes (#683):
 	//   hour-level:  database/measurement/year/month/day/hour/filename.parquet (7 parts)
 	//   day-level:   database/measurement/year/month/day/filename.parquet      (6 parts)
-	// Day-level is where daily compaction writes its {measurement}_{date}_daily.parquet
-	// output — the only files the migrator will move to cold, so the scanner
-	// must be able to register them.
+	// Day-level is where daily compaction writes its *_daily.parquet output,
+	// the only files the migrator will move to cold, so the scanner must be
+	// able to register them.
 	if len(parts) < 6 {
 		return nil, fmt.Errorf("path too short: %s", path)
 	}


### PR DESCRIPTION
## Summary

- fixes #683: the tiering scanner required hour-level paths while the migrator only moves `*_daily.parquet` files, which daily compaction writes at DAY level, so scan-registered deployments never produced a hot-to-cold migration candidate
- the scanner now accepts 6-part day-level paths (partition time = start of day, matching the hour-start convention); 7-part hour parsing is byte-for-byte unchanged
- the scan no longer re-registers a file as hot when its metadata row already says cold: that upsert reset migrated_at and hid post-migration orphans from ReconcileOrphanedFiles while re-uploading them every cycle; the check is one cold-tier path-set query per scan, and a failure of that query fails the scan rather than risking a downgrade

## Review notes

- the same-path regeneration concern (day re-compacted after backfill) was settled during review: current compaction output names embed timestamp, nanos, and batch index, so regenerated daily files get new paths; a test pins the modern name shape
- known limitation, pre-existing: spoke-namespace pseudo-databases (#619, extra path level) still fail path parsing at any depth; this PR does not change that
- every writer into the data root was traced during review: no legitimate 6-part non-daily `.parquet` shape exists, so the widened acceptance registers only daily-compaction output

## Verification

- unit + integration tests: day/hour parse shapes, scan -> candidates -> migrate over a day-level daily file (asserting cold placement and hot removal), cold-row no-downgrade, modern filename shape
- licensed e2e with a real S3 cold tier: day-level daily file scanned with 0 errors (pre-fix: path-too-short errors), migrated to its day-level path under a prefixed bucket, and queried back through the API via the #662 day-path cold pruning
- full tiering/api/pruning suites pass

Closes #683