### PR TITLE
fix(tiering): register spoke-namespace files; harden tier-drop rule

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -174,3 +174,17 @@ registers day-level files (partition time = start of day), and it no longer
 re-registers a file as hot when its metadata row already says cold, so a
 failed post-migration cleanup stays visible to orphan reconciliation instead
 of being re-uploaded every cycle.
+
+### Spoke-namespace files now register with tiering ([#686](https://github.com/Basekick-Labs/arc/pull/686) follow-up)
+
+On an edge-sync hub, spoke data lives one path level deeper than the standard
+layout, and the tiering scanner errored on every spoke file. The scanner now
+parses partition paths by their date tail (the same approach hub compaction
+adopted in #619) and registers spoke files under the query-visible naming
+(database = spoke ID). Spoke files are deliberately excluded from hot-to-cold
+migration for now: legacy spoke-synced daily files carry sync receipts that a
+migration delete would forget, re-introducing upload duplicates; cold
+migration of spoke data ships separately with receipt-aware handling. Tiered
+queries touching spoke namespaces stay correct and unpruned: a tier may only
+be dropped from a query on the strength of a positive pruning result from
+another tier.

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -3147,6 +3147,53 @@ func (h *QueryHandler) extractDBMeasurementFromPath(path string) (database, meas
 	return "", ""
 }
 
+// tierPruneResult pairs one tier's full glob with its pruning outcome.
+type tierPruneResult struct {
+	glob    string
+	paths   []string
+	outcome pruning.TierPruneOutcome
+}
+
+// combineTierPruneResults assembles the final read_parquet path list from
+// per-tier pruning outcomes. Rules:
+//   - Pruned tiers contribute their pruned paths; Fallback tiers contribute
+//     their full glob.
+//   - A verified-Empty tier is DROPPED only when at least one other tier is
+//     Pruned: a positive pruning result is evidence the pruner's view of the
+//     layout matches this query. Without one (an Empty/Fallback mix, e.g. a
+//     spoke-namespace query where generated paths sit one level shallow, plus
+//     a listing error on the other tier), the Empty verdict is not trusted to
+//     hide a tier and its full glob is kept.
+//   - All tiers Empty therefore also yields the full globs, mirroring the
+//     single-tier zero-survivor fallback, counted as unpruned.
+func combineTierPruneResults(results []tierPruneResult) ([]string, int) {
+	anyPruned := false
+	for _, r := range results {
+		if r.outcome == pruning.TierPrunePruned {
+			anyPruned = true
+			break
+		}
+	}
+	var paths []string
+	prunedTiers := 0
+	for _, r := range results {
+		switch r.outcome {
+		case pruning.TierPrunePruned:
+			paths = append(paths, r.paths...)
+			prunedTiers++
+		case pruning.TierPruneEmpty:
+			if anyPruned {
+				prunedTiers++
+			} else {
+				paths = append(paths, r.glob)
+			}
+		default:
+			paths = append(paths, r.glob)
+		}
+	}
+	return paths, prunedTiers
+}
+
 // buildMultiTierReadParquet builds a read_parquet expression that queries tiers with actual data.
 // Queries the tiering metadata to determine which tiers have files for this database/measurement,
 // then only includes paths for tiers that actually have data.
@@ -3204,36 +3251,19 @@ func (h *QueryHandler) buildMultiTierReadParquet(ctx context.Context, database, 
 	// entirely (a recent-range dashboard query never lists or reads cold
 	// object storage beyond the cached parent listings).
 	timeRange := h.pruner.ExtractTimeRange(originalSQL)
-	var paths []string
-	prunedTiers := 0
+	results := make([]tierPruneResult, 0, len(sources))
 	for _, src := range sources {
 		if src.tier == tiering.TierCold && timeRange != nil && timeRange.StartAssumed {
 			// An end-only predicate's assumed start (2020-01-01) must not
 			// exclude cold-archive data that can legitimately be older; scan
 			// the full cold glob instead.
-			paths = append(paths, src.glob)
+			results = append(results, tierPruneResult{glob: src.glob, outcome: pruning.TierPruneFallback})
 			continue
 		}
 		tierPaths, outcome := h.pruner.PruneTierPaths(ctx, src.glob, database, measurement, timeRange, src.backend, src.tier == tiering.TierHot)
-		switch outcome {
-		case pruning.TierPrunePruned:
-			paths = append(paths, tierPaths...)
-			prunedTiers++
-		case pruning.TierPruneEmpty:
-			prunedTiers++
-		default:
-			paths = append(paths, src.glob)
-		}
+		results = append(results, tierPruneResult{glob: src.glob, paths: tierPaths, outcome: outcome})
 	}
-	if len(paths) == 0 && len(sources) > 0 {
-		// Every tier pruned to verified-empty. Mirror the single-tier
-		// zero-survivor behavior and fall back to the full tier globs rather
-		// than fabricating an empty relation.
-		for _, src := range sources {
-			paths = append(paths, src.glob)
-		}
-		prunedTiers = 0
-	}
+	paths, prunedTiers := combineTierPruneResults(results)
 	if prunedTiers > 0 {
 		h.logger.Info().
 			Str("database", database).

--- a/internal/api/tier_combine_test.go
+++ b/internal/api/tier_combine_test.go
@@ -1,0 +1,88 @@
+package api
+
+// combineTierPruneResults rules (#686 follow-up): a verified-Empty tier may
+// only be dropped on the strength of a positive Pruned result from another
+// tier. Without one (spoke-namespace queries generate too-shallow paths that
+// existence-filter to Empty; the other tier may be Fallback after a listing
+// error) the Empty verdict must not hide a tier's data.
+
+import (
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/pruning"
+)
+
+func TestCombineTierPruneResults(t *testing.T) {
+	hot := tierPruneResult{glob: "hot/**", paths: []string{"hot/h1", "hot/h2"}}
+	cold := tierPruneResult{glob: "cold/**", paths: []string{"cold/d1"}}
+
+	cases := []struct {
+		name       string
+		results    []tierPruneResult
+		wantPaths  []string
+		wantPruned int
+	}{
+		{
+			name: "pruned plus empty drops the empty tier",
+			results: []tierPruneResult{
+				{glob: hot.glob, paths: hot.paths, outcome: pruning.TierPrunePruned},
+				{glob: cold.glob, outcome: pruning.TierPruneEmpty},
+			},
+			wantPaths:  []string{"hot/h1", "hot/h2"},
+			wantPruned: 2,
+		},
+		{
+			name: "empty plus fallback keeps BOTH full globs",
+			results: []tierPruneResult{
+				{glob: hot.glob, outcome: pruning.TierPruneEmpty},
+				{glob: cold.glob, outcome: pruning.TierPruneFallback},
+			},
+			wantPaths:  []string{"hot/**", "cold/**"},
+			wantPruned: 0,
+		},
+		{
+			name: "all empty falls back to full globs unpruned",
+			results: []tierPruneResult{
+				{glob: hot.glob, outcome: pruning.TierPruneEmpty},
+				{glob: cold.glob, outcome: pruning.TierPruneEmpty},
+			},
+			wantPaths:  []string{"hot/**", "cold/**"},
+			wantPruned: 0,
+		},
+		{
+			name: "both pruned concatenates",
+			results: []tierPruneResult{
+				{glob: hot.glob, paths: hot.paths, outcome: pruning.TierPrunePruned},
+				{glob: cold.glob, paths: cold.paths, outcome: pruning.TierPrunePruned},
+			},
+			wantPaths:  []string{"hot/h1", "hot/h2", "cold/d1"},
+			wantPruned: 2,
+		},
+		{
+			name: "all fallback keeps full globs",
+			results: []tierPruneResult{
+				{glob: hot.glob, outcome: pruning.TierPruneFallback},
+				{glob: cold.glob, outcome: pruning.TierPruneFallback},
+			},
+			wantPaths:  []string{"hot/**", "cold/**"},
+			wantPruned: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			paths, pruned := combineTierPruneResults(tc.results)
+			if pruned != tc.wantPruned {
+				t.Fatalf("prunedTiers = %d, want %d", pruned, tc.wantPruned)
+			}
+			if len(paths) != len(tc.wantPaths) {
+				t.Fatalf("paths = %v, want %v", paths, tc.wantPaths)
+			}
+			for i := range paths {
+				if paths[i] != tc.wantPaths[i] {
+					t.Fatalf("paths[%d] = %q, want %q", i, paths[i], tc.wantPaths[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/pruning/tier_pruning_test.go
+++ b/internal/pruning/tier_pruning_test.go
@@ -209,3 +209,27 @@ func TestPruneTierPaths_MixedHourAndDayExistence(t *testing.T) {
 		t.Fatalf("paths = %v, want only the day-level glob", paths)
 	}
 }
+
+// A spoke-namespace query reaches the pruner with the query layer's
+// (spoke, spoke-db) split, so generated partition paths sit one level too
+// shallow and existence-filter to verified-empty. Pin that outcome: the
+// query layer's combine rules rely on it (an Empty without any Pruned tier
+// keeps the full glob, so spoke queries stay correct, just unpruned).
+func TestPruneTierPaths_SpokeShapedLayoutIsEmptyNotPruned(t *testing.T) {
+	p := NewPartitionPruner(zerolog.Nop())
+	base := t.TempDir()
+	deep := filepath.Join(base, "rocket-01", "telemetry", "engine_temp", "2024", "03", "15", "14")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deep, "f.parquet"), []byte("p"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	glob := base + "/rocket-01/telemetry/**/*.parquet"
+
+	paths, outcome := p.PruneTierPaths(context.Background(), glob, "rocket-01", "telemetry",
+		tierRange(t, "2024-03-15T14:00:00Z", "2024-03-15T15:00:00Z"), nil, false)
+	if outcome != TierPruneEmpty {
+		t.Fatalf("spoke-shaped outcome = %v (paths=%v), want TierPruneEmpty — pruned paths would miss the extra namespace level", outcome, paths)
+	}
+}

--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -526,6 +526,10 @@ type filePathInfo struct {
 	Database      string
 	Measurement   string
 	PartitionTime time.Time
+	// SpokeNamespaced marks a path with an extra edge-sync namespace level
+	// ({spoke}/{db}/{meas}/...). Such files register for visibility but are
+	// gated out of cold migration until receipt-aware handling exists (#687).
+	SpokeNamespaced bool
 }
 
 // parseFilePath parses a storage path to extract database, measurement, and
@@ -546,7 +550,7 @@ func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
 	//   day-level tail:  {year}/{month}/{day}/{file}.parquet
 	validDate := func(y, mo, d string) (time.Time, bool) {
 		yn, err := strconv.Atoi(y)
-		if err != nil || len(y) != 4 {
+		if err != nil || len(y) != 4 || yn < 1970 {
 			return time.Time{}, false
 		}
 		mn, err := strconv.Atoi(mo)
@@ -590,11 +594,13 @@ func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
 	// rocket-01/telemetry/**), so tier metadata stays query-visible. Deeper
 	// nesting is not a feature (edge-sync forbids relaying); reject it.
 	var database, measurement string
+	spokeNamespaced := false
 	switch len(prefix) {
 	case 2:
 		database, measurement = prefix[0], prefix[1]
 	case 3:
 		database, measurement = prefix[0], prefix[1]
+		spokeNamespaced = true
 	default:
 		return nil, fmt.Errorf("unsupported path depth (%d prefix segments): %s", len(prefix), path)
 	}
@@ -608,8 +614,9 @@ func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
 	}
 
 	return &filePathInfo{
-		Database:      database,
-		Measurement:   measurement,
-		PartitionTime: partitionTime,
+		Database:        database,
+		Measurement:     measurement,
+		PartitionTime:   partitionTime,
+		SpokeNamespaced: spokeNamespaced,
 	}, nil
 }

--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -528,63 +528,84 @@ type filePathInfo struct {
 	PartitionTime time.Time
 }
 
-// parseFilePath parses a storage path to extract database, measurement, and partition time
-// Expected format: {database}/{measurement}/{year}/{month}/{day}/{hour}/{filename}.parquet
+// parseFilePath parses a storage path to extract database, measurement, and
+// partition time. Accepted shapes (hour- and day-level, plain and
+// spoke-namespaced): {db}/{meas}/Y/M/D[/H]/{file}.parquet and
+// {spoke}/{db}/{meas}/Y/M/D[/H]/{file}.parquet.
 func (m *Manager) parseFilePath(path string) (*filePathInfo, error) {
 	// Normalize path separators
 	path = filepath.ToSlash(path)
 	parts := strings.Split(path, "/")
 
-	// Two accepted shapes (#683):
-	//   hour-level:  database/measurement/year/month/day/hour/filename.parquet (7 parts)
-	//   day-level:   database/measurement/year/month/day/filename.parquet      (6 parts)
-	// Day-level is where daily compaction writes its *_daily.parquet output,
-	// the only files the migrator will move to cold, so the scanner must be
-	// able to register them.
-	if len(parts) < 6 {
-		return nil, fmt.Errorf("path too short: %s", path)
-	}
-	dayLevel := len(parts) == 6
-
-	database := parts[0]
-	measurement := parts[1]
-
-	// Validate no path traversal in database or measurement names
-	if strings.Contains(database, "..") || strings.ContainsAny(database, "/\\") {
-		return nil, fmt.Errorf("invalid database name in path: %s", database)
-	}
-	if strings.Contains(measurement, "..") || strings.ContainsAny(measurement, "/\\") {
-		return nil, fmt.Errorf("invalid measurement name in path: %s", measurement)
-	}
-
-	// Parse year, month, day, hour
-	year, err := strconv.Atoi(parts[2])
-	if err != nil {
-		return nil, fmt.Errorf("invalid year in path: %s", parts[2])
+	// Parse by TAIL shape, not absolute segment counts (#619 precedent:
+	// compaction's isHourLevelFile) — a spoke-namespace pseudo-database adds
+	// a path level, so hour-level files have 7 parts plain and 8 under a
+	// spoke, day-level 6 and 7. Validation thresholds mirror
+	// internal/compaction/daily.go isHourLevelFile; keep them in sync.
+	//   hour-level tail: {year}/{month}/{day}/{hour}/{file}.parquet
+	//   day-level tail:  {year}/{month}/{day}/{file}.parquet
+	validDate := func(y, mo, d string) (time.Time, bool) {
+		yn, err := strconv.Atoi(y)
+		if err != nil || len(y) != 4 {
+			return time.Time{}, false
+		}
+		mn, err := strconv.Atoi(mo)
+		if err != nil || mn < 1 || mn > 12 {
+			return time.Time{}, false
+		}
+		dn, err := strconv.Atoi(d)
+		if err != nil || dn < 1 || dn > 31 {
+			return time.Time{}, false
+		}
+		return time.Date(yn, time.Month(mn), dn, 0, 0, 0, 0, time.UTC), true
 	}
 
-	month, err := strconv.Atoi(parts[3])
-	if err != nil {
-		return nil, fmt.Errorf("invalid month in path: %s", parts[3])
-	}
-
-	day, err := strconv.Atoi(parts[4])
-	if err != nil {
-		return nil, fmt.Errorf("invalid day in path: %s", parts[4])
-	}
-
-	// Day-level files carry no hour segment; their partition time is the
-	// start of the day, matching the hour-start convention of hourly rows.
-	hour := 0
-	if !dayLevel {
-		hour, err = strconv.Atoi(parts[5])
-		if err != nil {
-			return nil, fmt.Errorf("invalid hour in path: %s", parts[5])
+	var partitionTime time.Time
+	var prefix []string
+	n := len(parts)
+	if n >= 7 {
+		if day, ok := validDate(parts[n-5], parts[n-4], parts[n-3]); ok {
+			if hn, err := strconv.Atoi(parts[n-2]); err == nil && hn >= 0 && hn <= 23 {
+				partitionTime = day.Add(time.Duration(hn) * time.Hour)
+				prefix = parts[:n-5]
+			}
 		}
 	}
+	if prefix == nil && n >= 6 {
+		if day, ok := validDate(parts[n-4], parts[n-3], parts[n-2]); ok {
+			// Day-level files carry no hour segment; their partition time is
+			// the start of the day, matching hourly rows' hour-start convention.
+			partitionTime = day
+			prefix = parts[:n-4]
+		}
+	}
+	if prefix == nil {
+		return nil, fmt.Errorf("no year/month/day[/hour] partition tail in path: %s", path)
+	}
 
-	// Construct partition time (UTC)
-	partitionTime := time.Date(year, time.Month(month), day, hour, 0, 0, 0, time.UTC)
+	// The prefix is {database}/{measurement} (2 parts) or a spoke namespace
+	// {spoke}/{db}/{measurement} (3 parts). For spoke files, register
+	// (database=spoke, measurement=spoke-db): that is the split the QUERY
+	// layer produces for spoke data (FROM "rocket-01".telemetry globs
+	// rocket-01/telemetry/**), so tier metadata stays query-visible. Deeper
+	// nesting is not a feature (edge-sync forbids relaying); reject it.
+	var database, measurement string
+	switch len(prefix) {
+	case 2:
+		database, measurement = prefix[0], prefix[1]
+	case 3:
+		database, measurement = prefix[0], prefix[1]
+	default:
+		return nil, fmt.Errorf("unsupported path depth (%d prefix segments): %s", len(prefix), path)
+	}
+
+	// Validate no path traversal in database or measurement names
+	if strings.Contains(database, "..") || strings.ContainsAny(database, "\\") {
+		return nil, fmt.Errorf("invalid database name in path: %s", database)
+	}
+	if strings.Contains(measurement, "..") || strings.ContainsAny(measurement, "\\") {
+		return nil, fmt.Errorf("invalid measurement name in path: %s", measurement)
+	}
 
 	return &filePathInfo{
 		Database:      database,

--- a/internal/tiering/migrator.go
+++ b/internal/tiering/migrator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -140,20 +139,16 @@ func (m *Migrator) FindCandidates(ctx context.Context, fromTier, toTier Tier) ([
 		// sync_received receipts, and deleting their hot copy would make
 		// confirmPresent forget the receipt — the spoke then re-offers the
 		// file and the hub re-accepts a duplicate next to the cold copy (the
-		// #611 hazard class). Cold migration of spoke data needs
-		// migrated-receipt marking first (follow-up issue). A spoke path has
-		// an extra namespace level, so the segment after {db}/{meas}/ is the
-		// spoke's measurement rather than a year.
-		if rest, ok := strings.CutPrefix(file.Path, file.Database+"/"+file.Measurement+"/"); ok {
-			if first, _, _ := strings.Cut(rest, "/"); len(first) != 4 {
-				m.manager.logger.Debug().Str("path", file.Path).
-					Msg("Skipping spoke-namespace file for cold migration (receipt handling not implemented)")
-				continue
-			} else if _, err := strconv.Atoi(first); err != nil {
-				m.manager.logger.Debug().Str("path", file.Path).
-					Msg("Skipping spoke-namespace file for cold migration (receipt handling not implemented)")
-				continue
-			}
+		// #611 hazard class, #687). The path shape decides, via the same
+		// parser that registers files: content-based heuristics (numeric
+		// spoke measurement names) and metadata-based reconstruction
+		// (synthetic or legacy PartitionTime values) both misclassify.
+		// An unparseable path is skipped conservatively.
+		info, err := m.manager.parseFilePath(file.Path)
+		if err != nil || info.SpokeNamespaced {
+			m.manager.logger.Debug().Str("path", file.Path).
+				Msg("Skipping spoke-namespace or unrecognized file for cold migration (#687)")
+			continue
 		}
 
 		candidates = append(candidates, MigrationCandidate{

--- a/internal/tiering/migrator.go
+++ b/internal/tiering/migrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -132,6 +133,27 @@ func (m *Migrator) FindCandidates(ctx context.Context, fromTier, toTier Tier) ([
 		// Only migrate daily-compacted files to cold tier
 		if !strings.HasSuffix(file.Path, "_daily.parquet") {
 			continue
+		}
+
+		// Spoke-namespace files register for visibility but do NOT migrate
+		// yet: legacy spoke-side compacted files sync once and carry
+		// sync_received receipts, and deleting their hot copy would make
+		// confirmPresent forget the receipt — the spoke then re-offers the
+		// file and the hub re-accepts a duplicate next to the cold copy (the
+		// #611 hazard class). Cold migration of spoke data needs
+		// migrated-receipt marking first (follow-up issue). A spoke path has
+		// an extra namespace level, so the segment after {db}/{meas}/ is the
+		// spoke's measurement rather than a year.
+		if rest, ok := strings.CutPrefix(file.Path, file.Database+"/"+file.Measurement+"/"); ok {
+			if first, _, _ := strings.Cut(rest, "/"); len(first) != 4 {
+				m.manager.logger.Debug().Str("path", file.Path).
+					Msg("Skipping spoke-namespace file for cold migration (receipt handling not implemented)")
+				continue
+			} else if _, err := strconv.Atoi(first); err != nil {
+				m.manager.logger.Debug().Str("path", file.Path).
+					Msg("Skipping spoke-namespace file for cold migration (receipt handling not implemented)")
+				continue
+			}
 		}
 
 		candidates = append(candidates, MigrationCandidate{

--- a/internal/tiering/spoke_registration_test.go
+++ b/internal/tiering/spoke_registration_test.go
@@ -36,6 +36,18 @@ func TestParseFilePath_SpokeNamespace(t *testing.T) {
 	if _, err := m.parseFilePath("a/b/c/d/2024/03/15/14/f.parquet"); err == nil {
 		t.Fatal("4-segment prefix (double namespacing) unexpectedly accepted")
 	}
+
+	// A NUMERIC spoke measurement name must still classify as spoke: the
+	// migration gate keys on SpokeNamespaced, and a content-based heuristic
+	// here would let such files migrate and trip the #687 receipt hazard.
+	numeric, err := m.parseFilePath("rocket-01/telemetry/2024/2024/03/15/f_daily.parquet")
+	if err != nil || !numeric.SpokeNamespaced {
+		t.Fatalf("numeric spoke measurement = (%+v, %v), want SpokeNamespaced=true", numeric, err)
+	}
+	plain, err := m.parseFilePath("db1/cpu/2024/03/15/14/f.parquet")
+	if err != nil || plain.SpokeNamespaced {
+		t.Fatalf("plain path = (%+v, %v), want SpokeNamespaced=false", plain, err)
+	}
 }
 
 func TestSpokeFilesRegisterButDoNotMigrate(t *testing.T) {

--- a/internal/tiering/spoke_registration_test.go
+++ b/internal/tiering/spoke_registration_test.go
@@ -1,0 +1,74 @@
+package tiering
+
+// Spoke-namespace tiering registration (#686 follow-up): spoke files live one
+// level deeper ({spoke}/{db}/{meas}/...), register with the query-visible
+// split (database=spoke, measurement=spoke-db), and are excluded from cold
+// migration until receipt-aware migration exists.
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestParseFilePath_SpokeNamespace(t *testing.T) {
+	m := &Manager{}
+
+	hour, err := m.parseFilePath("rocket-01/telemetry/engine_temp/2024/03/15/14/f.parquet")
+	if err != nil {
+		t.Fatalf("spoke hour-level rejected: %v", err)
+	}
+	if hour.Database != "rocket-01" || hour.Measurement != "telemetry" {
+		t.Fatalf("spoke hour split = (%q, %q), want the query-visible (rocket-01, telemetry)", hour.Database, hour.Measurement)
+	}
+	if want := time.Date(2024, 3, 15, 14, 0, 0, 0, time.UTC); !hour.PartitionTime.Equal(want) {
+		t.Fatalf("spoke hour partition time = %v, want %v", hour.PartitionTime, want)
+	}
+
+	day, err := m.parseFilePath("rocket-01/telemetry/engine_temp/2024/03/15/f_daily.parquet")
+	if err != nil {
+		t.Fatalf("spoke day-level rejected: %v", err)
+	}
+	if day.Database != "rocket-01" || day.Measurement != "telemetry" {
+		t.Fatalf("spoke day split = (%q, %q), want (rocket-01, telemetry)", day.Database, day.Measurement)
+	}
+
+	if _, err := m.parseFilePath("a/b/c/d/2024/03/15/14/f.parquet"); err == nil {
+		t.Fatal("4-segment prefix (double namespacing) unexpectedly accepted")
+	}
+}
+
+func TestSpokeFilesRegisterButDoNotMigrate(t *testing.T) {
+	m, hot, _, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+	ctx := context.Background()
+
+	spokeDaily := "rocket-01/telemetry/engine_temp/2024/03/15/engine_temp_20240315_231459_1_b1_daily.parquet"
+	plainDaily := "db1/cpu/2024/03/15/cpu_20240315_231459_1_b1_daily.parquet"
+	for _, p := range []string{spokeDaily, plainDaily} {
+		if err := hot.Write(ctx, p, []byte("x")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	res, err := m.ScanAndRegisterFiles(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Errors != 0 || res.FilesRegistered != 2 {
+		t.Fatalf("scan result = %+v, want both files registered with 0 errors (spoke paths previously errored)", res)
+	}
+
+	meta, err := m.metadata.GetFile(ctx, spokeDaily)
+	if err != nil || meta.Database != "rocket-01" || meta.Measurement != "telemetry" {
+		t.Fatalf("spoke row = (%+v, %v), want database rocket-01, measurement telemetry", meta, err)
+	}
+
+	candidates, err := m.migrator.FindCandidates(ctx, TierHot, TierCold)
+	if err != nil {
+		t.Fatalf("FindCandidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Path != plainDaily {
+		t.Fatalf("candidates = %+v, want ONLY the plain daily file (spoke files gated off migration)", candidates)
+	}
+}


### PR DESCRIPTION
## Summary

- the tiering scanner errored on every spoke-namespace file (one path level deeper than the standard layout), leaving hub-side spoke data invisible to tiering; partition paths are now parsed by their validated date tail, the same approach hub compaction adopted for the identical reason in #619
- spoke files register under the query-visible split (database = spoke ID, measurement = spoke database), matching what `FROM \"rocket-01\".telemetry` resolves to, so registered metadata can never diverge from query-time tier assembly
- spoke files are gated OUT of hot-to-cold migration (follow-up #687): legacy spoke-synced daily files carry sync receipts that a migration delete would make confirmPresent forget, re-accepting duplicates (the #611 hazard class); the gate is driven by the same parser that registers files, after review showed both a content-based heuristic (numeric spoke measurement names) and metadata-based reconstruction (legacy rows) misclassify
- multi-tier hardening: a verified-empty tier is dropped from a query only when another tier produced a positive pruning result, so spoke-shaped queries (whose generated paths sit one level shallow and existence-filter to empty) keep their full globs instead of losing a tier to a listing error

## Process

Same pipeline as #681/#684/#686: adversarial plan review (which overturned both original load-bearing assumptions: the registration split and unconditional migration), independent implementation review (which caught the numeric-measurement gate bypass), licensed e2e before merge.

## Verification

- unit + integration tests: spoke/plain/deep parse shapes incl. numeric spoke measurements, spoke register-but-not-migrate, combineTierPruneResults truth table, spoke-shaped pruning outcome
- full tiering/api/pruning/edgesync suites pass, including under TZ=America/Costa_Rica
- licensed e2e with real S3: spoke + plain layout scanned with 0 errors (previously every spoke path errored), migration moved only the plain daily file, spoke files stayed hot, `FROM \"rocket-01\".telemetry` on the tiered hub returns correct rows, and the migrated plain daily file reads back from cold

Refs #686. Spoke cold migration ships separately via #687.