### PR TITLE
fix(backup): report restart_required for config-only restores

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -55,18 +55,6 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 
 ## Bug fixes
 
-### Config-only restores now report `restart_required` (follow-up to [#678](https://github.com/Basekick-Labs/arc/pull/678))
-
-`POST /api/v1/backup/restore` returned `restart_required: true` only when
-metadata (SQLite databases) was restored. A config-only restore needs the same
-restart — the restored `arc.toml` only takes effect on reload, which
-`restoreConfig` already logs — but the response did not say so. The flag now
-covers both restore kinds; a data-only restore still omits it. The restored-
-database immunity test also fails instead of skipping when a fresh connection
-cannot read the restored file.
-
-Contributed by [@atirna](https://github.com/atirna) in [#689](https://github.com/Basekick-Labs/arc/pull/689).
-
 ### Iceberg version hints no longer advance before metadata copies publish ([#636](https://github.com/Basekick-Labs/arc/issues/636))
 
 Directory-based Iceberg readers fetch `version-hint.text` before opening the matching
@@ -200,3 +188,15 @@ migration of spoke data ships separately with receipt-aware handling. Tiered
 queries touching spoke namespaces stay correct and unpruned: a tier may only
 be dropped from a query on the strength of a positive pruning result from
 another tier.
+
+### Config-only restores now report `restart_required` (follow-up to [#678](https://github.com/Basekick-Labs/arc/pull/678))
+
+`POST /api/v1/backup/restore` returned `restart_required: true` only when
+metadata (SQLite databases) was restored. A config-only restore needs the same
+restart — the restored `arc.toml` only takes effect on reload, which
+`restoreConfig` already logs — but the response did not say so. The flag now
+covers both restore kinds; a data-only restore still omits it. The restored-
+database immunity test also fails instead of skipping when a fresh connection
+cannot read the restored file.
+
+Contributed by [@atirna](https://github.com/atirna) in [#689](https://github.com/Basekick-Labs/arc/pull/689).

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -65,7 +65,7 @@ covers both restore kinds; a data-only restore still omits it. The restored-
 database immunity test also fails instead of skipping when a fresh connection
 cannot read the restored file.
 
-Contributed by [@atirna](https://github.com/atirna).
+Contributed by [@atirna](https://github.com/atirna) in [#689](https://github.com/Basekick-Labs/arc/pull/689).
 
 ### Iceberg version hints no longer advance before metadata copies publish ([#636](https://github.com/Basekick-Labs/arc/issues/636))
 

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -55,6 +55,18 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 
 ## Bug fixes
 
+### Config-only restores now report `restart_required` (follow-up to [#678](https://github.com/Basekick-Labs/arc/pull/678))
+
+`POST /api/v1/backup/restore` returned `restart_required: true` only when
+metadata (SQLite databases) was restored. A config-only restore needs the same
+restart — the restored `arc.toml` only takes effect on reload, which
+`restoreConfig` already logs — but the response did not say so. The flag now
+covers both restore kinds; a data-only restore still omits it. The restored-
+database immunity test also fails instead of skipping when a fresh connection
+cannot read the restored file.
+
+Contributed by [@atirna](https://github.com/atirna).
+
 ### Iceberg version hints no longer advance before metadata copies publish ([#636](https://github.com/Basekick-Labs/arc/issues/636))
 
 Directory-based Iceberg readers fetch `version-hint.text` before opening the matching

--- a/internal/api/backup_routes.go
+++ b/internal/api/backup_routes.go
@@ -267,9 +267,10 @@ func (h *BackupHandler) RestoreBackup(c *fiber.Ctx) error {
 		"backup_id": req.BackupID,
 		"status":    "running",
 	}
-	if opts.RestoreMetadata {
-		// Restored databases replace the live files by rename; open
-		// connections keep the pre-restore content until the server restarts.
+	// Restored databases replace the live files by rename (open connections
+	// keep the pre-restore content) and a restored config only takes effect
+	// on reload — both need a server restart.
+	if opts.RestoreMetadata || opts.RestoreConfig {
 		resp["restart_required"] = true
 	}
 	return c.Status(fiber.StatusAccepted).JSON(resp)

--- a/internal/api/backup_routes_test.go
+++ b/internal/api/backup_routes_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -312,8 +311,8 @@ func TestRestoreBackupReportsRestartRequired(t *testing.T) {
 			t.Fatalf("restore status = %d, want 202", resp.StatusCode)
 		}
 		var payload map[string]any
-		if err := json.Unmarshal([]byte(readAll(t, resp.Body)), &payload); err != nil {
-			t.Fatalf("unmarshal restore response: %v", err)
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode restore response: %v", err)
 		}
 		waitForOperationRelease(t, rig.handler)
 		return payload
@@ -331,13 +330,4 @@ func TestRestoreBackupReportsRestartRequired(t *testing.T) {
 	if _, present := data["restart_required"]; present {
 		t.Errorf("data-only restore: restart_required = %v, want absent", data["restart_required"])
 	}
-}
-
-func readAll(t *testing.T, r io.Reader) []byte {
-	t.Helper()
-	b, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read response body: %v", err)
-	}
-	return b
 }

--- a/internal/api/backup_routes_test.go
+++ b/internal/api/backup_routes_test.go
@@ -3,7 +3,9 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -287,4 +289,55 @@ func TestDeleteBackupSharesAdmissionSlot(t *testing.T) {
 	}
 	waitForListCalls(t, rig.storage, 2)
 	waitForOperationRelease(t, rig.handler)
+}
+
+// The restore response must tell operators when a restart is needed: restored
+// databases replace the live files by rename and a restored config only takes
+// effect on reload. A config-only restore is explicitly restart-required too,
+// and a data-only restore is not.
+func TestRestoreBackupReportsRestartRequired(t *testing.T) {
+	rig := newBackupRouteRig(t, nil)
+	close(rig.storage.release)
+
+	restore := func(t *testing.T, body string) map[string]any {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/backup/restore", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := rig.app.Test(req, 5_000)
+		if err != nil {
+			t.Fatalf("POST restore: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusAccepted {
+			t.Fatalf("restore status = %d, want 202", resp.StatusCode)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(readAll(t, resp.Body)), &payload); err != nil {
+			t.Fatalf("unmarshal restore response: %v", err)
+		}
+		waitForOperationRelease(t, rig.handler)
+		return payload
+	}
+
+	meta := restore(t, `{"backup_id":"backup-20260901-000000-00000000","confirm":true,"restore_data":false,"restore_metadata":true}`)
+	if meta["restart_required"] != true {
+		t.Errorf("metadata restore: restart_required = %v, want true", meta["restart_required"])
+	}
+	cfg := restore(t, `{"backup_id":"backup-20260901-000000-00000000","confirm":true,"restore_data":false,"restore_metadata":false,"restore_config":true}`)
+	if cfg["restart_required"] != true {
+		t.Errorf("config-only restore: restart_required = %v, want true", cfg["restart_required"])
+	}
+	data := restore(t, `{"backup_id":"backup-20260901-000000-00000000","confirm":true,"restore_data":true,"restore_metadata":false,"restore_config":false}`)
+	if _, present := data["restart_required"]; present {
+		t.Errorf("data-only restore: restart_required = %v, want absent", data["restart_required"])
+	}
+}
+
+func readAll(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	return b
 }

--- a/internal/backup/iceberg_backup_test.go
+++ b/internal/backup/iceberg_backup_test.go
@@ -483,7 +483,7 @@ func TestRestoreSQLiteFile_RestoredFileIsImmuneToPreRestoreHandles(t *testing.T)
 	defer fresh.Close()
 	var rows int
 	if err := fresh.QueryRow("SELECT count(*) FROM t").Scan(&rows); err != nil {
-		t.Skipf("sidecar from the pre-restore writer shadows the restored file until restart: %v", err)
+		t.Fatalf("restored database is not readable by a fresh connection: %v", err)
 	}
 	if rows != 1 {
 		t.Errorf("fresh connection read %d rows, want the backup's 1 (pre-restore writes leaked)", rows)


### PR DESCRIPTION
## Summary

Two leftovers from the review of #678:

- `POST /api/v1/backup/restore` returned `restart_required: true` only for metadata restores. A config-only restore needs the same restart — `restoreConfig` already logs "(restart required)" because the restored `arc.toml` only takes effect on reload — but the response didn't say so. The flag now covers both, and a data-only restore still omits it.
- `TestRestoreSQLiteFile_RestoredFileIsImmuneToPreRestoreHandles` skipped when the fresh connection's query over the restored database errored. That readability is the behavior under test, so it fails now instead of skipping.

## Test plan

- `TestRestoreBackupReportsRestartRequired` drives the route through the existing rig: metadata restore → flag true; config-only restore → flag true (fails on current `main`, which returns no flag); data-only restore → flag absent.
- `go test -tags=duckdb_arrow -race ./internal/backup/... ./internal/api/...` — ok; `go vet -tags=duckdb_arrow ./...` — clean.
