### PR TITLE
fix(storage): use calendar days for S3 ranges

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -55,6 +55,14 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 
 ## Bug fixes
 
+### S3 query paths now follow calendar days across DST ([#321](https://github.com/Basekick-Labs/arc/issues/321))
+
+S3 time-range pruning now builds one inclusive partition path per calendar day in
+the range's starting time zone. Non-UTC offsets and daylight-saving transitions
+no longer shift the first or last date or skip a local day.
+
+Contributed by [@copacabanaservice01](https://github.com/copacabanaservice01) in [#690](https://github.com/Basekick-Labs/arc/pull/690).
+
 ### Iceberg version hints no longer advance before metadata copies publish ([#636](https://github.com/Basekick-Labs/arc/issues/636))
 
 Directory-based Iceberg readers fetch `version-hint.text` before opening the matching

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -685,16 +685,21 @@ func (b *S3Backend) GetQueryPath(database, measurement string, year, month, day,
 func (b *S3Backend) GetQueryPathRange(database, measurement string, startTime, endTime time.Time) []string {
 	var paths []string
 
-	// Generate paths for each day in the range
-	current := startTime.Truncate(24 * time.Hour)
-	end := endTime.Truncate(24 * time.Hour).Add(24 * time.Hour)
+	// Generate paths for each calendar day in the range. Truncate(24h) and
+	// Add(24h) operate on elapsed time, so they shift local dates across UTC
+	// offsets and daylight-saving transitions.
+	location := startTime.Location()
+	startYear, startMonth, startDay := startTime.Date()
+	current := time.Date(startYear, startMonth, startDay, 0, 0, 0, 0, location)
+	endYear, endMonth, endDay := endTime.In(location).Date()
+	end := time.Date(endYear, endMonth, endDay, 0, 0, 0, 0, location).AddDate(0, 0, 1)
 
 	for current.Before(end) {
 		path := fmt.Sprintf("s3://%s/%s%s/%s/%04d/%02d/%02d/*/*.parquet",
 			b.bucket, b.prefix, database, measurement,
 			current.Year(), int(current.Month()), current.Day())
 		paths = append(paths, path)
-		current = current.Add(24 * time.Hour)
+		current = current.AddDate(0, 0, 1)
 	}
 
 	return paths

--- a/internal/storage/s3_query_path_test.go
+++ b/internal/storage/s3_query_path_test.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGetQueryPathRangeUsesCalendarDaysAcrossDST(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load timezone: %v", err)
+	}
+
+	backend := &S3Backend{bucket: "test-bucket", prefix: "tenant/"}
+	start := time.Date(2026, time.October, 31, 12, 0, 0, 0, loc)
+	end := time.Date(2026, time.November, 2, 12, 0, 0, 0, loc)
+
+	got := backend.GetQueryPathRange("metrics", "cpu", start, end)
+	want := expectedDSTPaths()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected paths across DST boundary:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestGetQueryPathRangeUsesStartLocationForRange(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load start timezone: %v", err)
+	}
+	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("load end timezone: %v", err)
+	}
+
+	backend := &S3Backend{bucket: "test-bucket", prefix: "tenant/"}
+	start := time.Date(2026, time.October, 31, 12, 0, 0, 0, newYork)
+	end := time.Date(2026, time.November, 2, 12, 0, 0, 0, losAngeles)
+
+	got := backend.GetQueryPathRange("metrics", "cpu", start, end)
+	want := expectedDSTPaths()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected paths with mixed locations:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func expectedDSTPaths() []string {
+	return []string{
+		"s3://test-bucket/tenant/metrics/cpu/2026/10/31/*/*.parquet",
+		"s3://test-bucket/tenant/metrics/cpu/2026/11/01/*/*.parquet",
+		"s3://test-bucket/tenant/metrics/cpu/2026/11/02/*/*.parquet",
+	}
+}


### PR DESCRIPTION
## Summary

- generate S3 query paths by local calendar day instead of elapsed 24-hour intervals
- interpret both range boundaries in the start time's location, including mixed-location inputs
- add regression coverage for a DST fall-back boundary and mixed locations

## Problem

`time.Time.Truncate(24*time.Hour)` truncates elapsed time from the zero instant rather than finding local midnight, and `Add(24*time.Hour)` can cross a daylight-saving transition without advancing to the next local date. On current `main`, an Oct 31–Nov 2 New York range produced Oct 30, Oct 31, and Nov 1 paths.

## Approach

Construct midnight boundaries in `startTime.Location()`, convert `endTime` into that same location, and advance with `AddDate(0, 0, 1)`. This preserves the existing inclusive-day contract while making the calendar semantics explicit.

## Verification

- `gofmt` clean for the changed Go files
- `go vet ./internal/storage`
- `go test ./internal/storage -count=1`
- `TZ=America/New_York go test ./internal/storage -count=1`
- regression test proved red against the pre-fix implementation and green with the fix

The repository-wide `go test ./...` was attempted but is not runnable in this Windows environment: `CGO_ENABLED=0`, no C compiler is installed, DuckDB's Windows binding files are excluded, and SQLite tests report that `go-sqlite3` requires cgo. The focused storage package is cgo-independent and passes; Linux CI remains authoritative per `CONTRIBUTING.md`.

## Risk and exclusions

Low risk: one date-iteration function and focused tests. No storage I/O, API shape, dependencies, or partition format changed. Out of scope: validation policy for an end instant earlier than the start instant.

AI assistance disclosure: this change was produced through an autonomous coding agent, independently reviewed, and verified with the commands above.

Closes #321
