### PR TITLE
feat(tiering): cold migration of spoke-namespace files, receipt-aware

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -188,3 +188,15 @@ migration of spoke data ships separately with receipt-aware handling. Tiered
 queries touching spoke namespaces stay correct and unpruned: a tier may only
 be dropped from a query on the strength of a positive pruning result from
 another tier.
+
+### Spoke-namespace files now migrate to cold storage ([#687](https://github.com/Basekick-Labs/arc/issues/687))
+
+On an edge-sync hub, spoke daily-compacted files now participate in
+hot-to-cold migration. Before a hot copy is removed (by migration or by
+orphan reconciliation), its sync receipt is marked the same way hub
+compaction marks consumed inputs, so a spoke re-offering the file gets
+"already present" instead of re-uploading a duplicate next to the cold copy.
+The marking runs before any state changes and a marking failure aborts the
+migration with the cold copy rolled back, so a sync-index outage can never
+strand an unmarked deletion. On deployments without an edge-sync hub, spoke
+files (if any exist) remain registered but excluded from migration.

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -196,7 +196,7 @@ hot-to-cold migration. Before a hot copy is removed (by migration or by
 orphan reconciliation), its sync receipt is marked the same way hub
 compaction marks consumed inputs, so a spoke re-offering the file gets
 "already present" instead of re-uploading a duplicate next to the cold copy.
-The marking runs before any state changes and a marking failure aborts the
-migration with the cold copy rolled back, so a sync-index outage can never
+The marking runs before tier metadata flips and before any delete, and a
+marking failure aborts the migration batch, so a sync-index outage can never
 strand an unmarked deletion. On deployments without an edge-sync hub, spoke
 files (if any exist) remain registered but excluded from migration.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2091,10 +2091,11 @@ func main() {
 	// the registry to exclude received namespaces from its own discovery.
 	var spokeRegistry *edgesync.Registry
 	// hubReceiptMarker marks sync_received receipts for hub-consumed spoke
-	// files (grouped by namespace). Built when the edge-sync hub is enabled;
-	// shared by compaction's consumed-inputs observer (#619) and tiering's
-	// hot-file-removal hook (#687). Remains nil otherwise, which keeps
-	// tiering's spoke-migration gate closed.
+	// files (grouped by namespace). Built whenever the edge-sync receive or
+	// import side is enabled (both write receipts); shared by compaction's
+	// consumed-inputs observer (#619) and tiering's hot-file-removal hook
+	// (#687). Remains nil otherwise, which keeps tiering's spoke-migration
+	// gate closed.
 	var hubReceiptMarker func(paths []string) error
 	if cfg.EdgeSync.Enabled || cfg.EdgeSync.Import.Enabled {
 		var registerFile func(context.Context, *edgesync.ReceivedFile) error

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2090,6 +2090,12 @@ func main() {
 	// Hoisted: on a dual-role (hub+spoke) node the spoke block below needs
 	// the registry to exclude received namespaces from its own discovery.
 	var spokeRegistry *edgesync.Registry
+	// hubReceiptMarker marks sync_received receipts for hub-consumed spoke
+	// files (grouped by namespace). Built when the edge-sync hub is enabled;
+	// shared by compaction's consumed-inputs observer (#619) and tiering's
+	// hot-file-removal hook (#687). Remains nil otherwise, which keeps
+	// tiering's spoke-migration gate closed.
+	var hubReceiptMarker func(paths []string) error
 	if cfg.EdgeSync.Enabled || cfg.EdgeSync.Import.Enabled {
 		var registerFile func(context.Context, *edgesync.ReceivedFile) error
 		if clusterCoordinator != nil {
@@ -2170,43 +2176,47 @@ func main() {
 			log.Fatal().Err(err).Msg("Failed to create the edge sync spoke registry; refusing to start")
 		}
 
+		// Receipt marker shared by hub compaction (#619) and tiering's
+		// hot-file-removal hook (#687). Group by first path segment and
+		// attempt the receipt mark. No registry consultation: MarkCompacted
+		// is an UPDATE, so inputs from ordinary databases match no receipts
+		// and no-op — which also makes this immune to a registration deleted
+		// mid-cycle (review N1b). Any failure is RETURNED: compaction then
+		// keeps the crash-recovery manifest so recovery re-fires the marks
+		// (deep-review B1), and tiering aborts the migration before any
+		// delete.
+		markLogger := logger.Get("edgesync")
+		hubReceiptMarker = func(inputs []string) error {
+			byNamespace := make(map[string][]string)
+			for _, in := range inputs {
+				first, rest, found := strings.Cut(in, "/")
+				if !found || first == "" || rest == "" {
+					continue
+				}
+				byNamespace[first] = append(byNamespace[first], rest)
+			}
+			markCtx, markCancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer markCancel()
+			var firstErr error
+			for ns, paths := range byNamespace {
+				if err := hubIndex.MarkCompacted(markCtx, ns, paths); err != nil {
+					markLogger.Warn().Err(err).Str("namespace", ns).Int("paths", len(paths)).
+						Msg("Could not mark consumed receipts; the caller retries or aborts")
+					if firstErr == nil {
+						firstErr = err
+					}
+				}
+			}
+			return firstErr
+		}
+
 		// #619: hub compaction of received spoke namespaces. Wiring ORDER is
 		// load-bearing (review F9): the consumed-inputs observer goes in
 		// BEFORE the namespace expander, so no scheduler tick can compact
 		// received raws without marking their receipts. compactionManager
 		// may be nil independently (CLAUDE.md nil rule).
 		if compactionManager != nil && cfg.EdgeSync.CompactReceivedNamespaces {
-			markLogger := logger.Get("edgesync")
-			compactionManager.SetOnConsumedInputs(func(inputs []string) error {
-				// Group by first path segment and attempt the receipt mark.
-				// No registry consultation: MarkCompacted is an UPDATE, so
-				// inputs from ordinary databases match no receipts and
-				// no-op — which also makes this immune to a registration
-				// deleted mid-cycle (review N1b). Any failure is RETURNED:
-				// the caller then keeps the crash-recovery manifest so
-				// recovery re-fires the marks (deep-review B1).
-				byNamespace := make(map[string][]string)
-				for _, in := range inputs {
-					first, rest, found := strings.Cut(in, "/")
-					if !found || first == "" || rest == "" {
-						continue
-					}
-					byNamespace[first] = append(byNamespace[first], rest)
-				}
-				markCtx, markCancel := context.WithTimeout(context.Background(), 60*time.Second)
-				defer markCancel()
-				var firstErr error
-				for ns, paths := range byNamespace {
-					if err := hubIndex.MarkCompacted(markCtx, ns, paths); err != nil {
-						markLogger.Warn().Err(err).Str("namespace", ns).Int("paths", len(paths)).
-							Msg("Could not mark consumed receipts compacted; the retained manifest re-fires them via recovery")
-						if firstErr == nil {
-							firstErr = err
-						}
-					}
-				}
-				return firstErr
-			})
+			compactionManager.SetOnConsumedInputs(hubReceiptMarker)
 			compactionManager.SetNamespaceExpander(receivedNamespaces(spokeRegistry))
 			log.Info().Msg("Hub compaction of received spoke namespaces enabled (edge_sync.compact_received_namespaces)")
 		}
@@ -3476,6 +3486,13 @@ func main() {
 		// partition paths (pruner + SQL transform caches) go stale and must
 		// be dropped — same reason compaction invalidates them (#662).
 		tieringManager.SetOnMigrationComplete(queryHandler.InvalidateCaches)
+		// #687: on an edge-sync hub, tiering deletes of hot spoke files must
+		// mark their sync receipts first, or the spoke re-uploads duplicates.
+		// Wiring this also lifts the migrator's spoke-namespace gate.
+		if hubReceiptMarker != nil {
+			tieringManager.SetOnHotFilesRemoved(hubReceiptMarker)
+			log.Info().Msg("Tiering hot-file removals wired to edge-sync receipt marking; spoke cold migration enabled")
+		}
 		log.Info().Msg("Tiering manager wired to query handler for multi-tier queries")
 
 		// Wire tiering manager to databases handler for cold-tier database/measurement listing

--- a/internal/edgesync/migration_receipt_test.go
+++ b/internal/edgesync/migration_receipt_test.go
@@ -1,0 +1,46 @@
+package edgesync
+
+// #687: tiering marks receipts (via MarkCompacted) before deleting the hot
+// copy of a migrated spoke file. This pins the receipt lifecycle that makes
+// that safe with the REAL index: a marked receipt is reported Compacted by
+// Lookup, which (a) makes confirmPresent skip the existence check so the
+// receipt survives the file's absence, and (b) makes a spoke's re-offer of
+// the same path+sha answer already-present (pinned by the receive tests).
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMigrationStyleMarkSurvivesFileAbsence(t *testing.T) {
+	idx := newTestHubIndex(t)
+	ctx := context.Background()
+
+	// A legacy spoke-side compacted daily file, received and receipted.
+	rec := &ReceivedRecord{
+		SpokeID:    "rocket-01",
+		SourcePath: "telemetry/engine_temp/2024/03/15/engine_temp_20240315_daily.parquet",
+		HubPath:    "rocket-01/telemetry/engine_temp/2024/03/15/engine_temp_20240315_daily.parquet",
+		SHA256:     "abc123",
+		SizeBytes:  10,
+		ReceivedAt: time.Now().UTC(),
+	}
+	if err := idx.Record(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	// The migration hook marks by hub-path-minus-namespace = source path.
+	if err := idx.MarkCompacted(ctx, "rocket-01", []string{rec.SourcePath}); err != nil {
+		t.Fatal(err)
+	}
+
+	held, err := idx.Lookup(ctx, "rocket-01", []string{rec.SourcePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hf, ok := held[rec.SourcePath]
+	if !ok || !hf.Compacted {
+		t.Fatalf("held = %+v, want the receipt present and marked (confirmPresent then skips its existence check)", held)
+	}
+}

--- a/internal/tiering/manager.go
+++ b/internal/tiering/manager.go
@@ -33,6 +33,15 @@ type Manager struct {
 	callbackMu          sync.Mutex
 	onMigrationComplete func()
 
+	// onHotFilesRemoved, when set, runs with the storage paths of hot files
+	// the tiering subsystem is about to permanently remove (migration source
+	// deletes, orphan reconciliation). The edge-sync hub wires it to receipt
+	// marking (#687): a spoke-synced file's receipt must be marked before its
+	// hot copy disappears, or confirmPresent forgets the receipt and the
+	// spoke re-uploads a duplicate. An error return means the caller MUST NOT
+	// delete the files. Guarded by callbackMu.
+	onHotFilesRemoved func(paths []string) error
+
 	// Data stores
 	metadata *MetadataStore
 	policies *PolicyStore
@@ -268,6 +277,34 @@ func (m *Manager) notifyMigrationComplete(migrated, orphansDeleted int) {
 	if fn != nil {
 		fn()
 	}
+}
+
+// SetOnHotFilesRemoved registers a callback invoked BEFORE tiering deletes
+// hot files (see the field comment). Safe to call after Start.
+func (m *Manager) SetOnHotFilesRemoved(fn func(paths []string) error) {
+	m.callbackMu.Lock()
+	m.onHotFilesRemoved = fn
+	m.callbackMu.Unlock()
+}
+
+// notifyHotFilesRemoved invokes the removal callback; a nil callback allows
+// the removal (non-hub deployments have no receipts to protect).
+func (m *Manager) notifyHotFilesRemoved(paths []string) error {
+	m.callbackMu.Lock()
+	fn := m.onHotFilesRemoved
+	m.callbackMu.Unlock()
+	if fn == nil {
+		return nil
+	}
+	return fn(paths)
+}
+
+// hasHotFileRemovalHook reports whether a removal callback is wired; the
+// migrator only admits spoke-namespace candidates when it is (#687).
+func (m *Manager) hasHotFileRemovalHook() bool {
+	m.callbackMu.Lock()
+	defer m.callbackMu.Unlock()
+	return m.onHotFilesRemoved != nil
 }
 
 // SetOnMigrationComplete registers a callback invoked after any migration

--- a/internal/tiering/migration_receipts_test.go
+++ b/internal/tiering/migration_receipts_test.go
@@ -1,0 +1,163 @@
+package tiering
+
+// Receipt-aware spoke cold migration (#687): the hot-file-removal hook must
+// run BEFORE any state flips (a marked receipt on an aborted migration is
+// harmless; an unmarked receipt on a deleted file re-accepts duplicates), its
+// failure must abort with the cold copy rolled back, and wiring it is what
+// lifts the spoke-namespace migration gate.
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestSpokeGateLiftsWithRemovalHook(t *testing.T) {
+	m, hot, _, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+	ctx := context.Background()
+
+	spokeDaily := "rocket-01/telemetry/engine_temp/2024/03/15/engine_temp_20240315_231459_1_b1_daily.parquet"
+	if err := hot.Write(ctx, spokeDaily, []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.ScanAndRegisterFiles(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := m.migrator.FindCandidates(ctx, TierHot, TierCold)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("without a removal hook, candidates = %+v, want none (gate closed)", candidates)
+	}
+
+	m.SetOnHotFilesRemoved(func([]string) error { return nil })
+	candidates, err = m.migrator.FindCandidates(ctx, TierHot, TierCold)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 || candidates[0].Path != spokeDaily {
+		t.Fatalf("with a removal hook, candidates = %+v, want the spoke daily file", candidates)
+	}
+}
+
+func TestMigrateFileMarksReceiptsBeforeAnyStateFlip(t *testing.T) {
+	m, hot, cold, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+	ctx := context.Background()
+
+	spokeDaily := "rocket-01/telemetry/engine_temp/2024/03/15/engine_temp_20240315_231459_1_b1_daily.parquet"
+	if err := hot.Write(ctx, spokeDaily, []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.ScanAndRegisterFiles(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var sawPaths []string
+	m.SetOnHotFilesRemoved(func(paths []string) error {
+		sawPaths = append(sawPaths, paths...)
+		// Ordering assertions AT CALL TIME: the hot copy must still exist
+		// and the metadata must still say hot — the mark precedes UpdateTier
+		// and the delete.
+		if ok, _ := hot.Exists(ctx, paths[0]); !ok {
+			t.Error("hook called after the hot copy was already deleted")
+		}
+		if meta, err := m.metadata.GetFile(ctx, paths[0]); err != nil || meta.Tier != TierHot {
+			t.Errorf("hook called after tier flip: (%+v, %v)", meta, err)
+		}
+		return nil
+	})
+
+	candidates, _ := m.migrator.FindCandidates(ctx, TierHot, TierCold)
+	if migrated, errs := m.migrator.MigrateBatch(ctx, candidates); migrated != 1 || errs != 0 {
+		t.Fatalf("MigrateBatch = (%d, %d), want (1, 0)", migrated, errs)
+	}
+	if len(sawPaths) != 1 || sawPaths[0] != spokeDaily {
+		t.Fatalf("hook saw %v, want exactly the migrated path", sawPaths)
+	}
+	if ok, _ := hot.Exists(ctx, spokeDaily); ok {
+		t.Fatal("hot copy survived a successful migration")
+	}
+	if ok, _ := cold.Exists(ctx, spokeDaily); !ok {
+		t.Fatal("cold copy missing after migration")
+	}
+}
+
+func TestMarkFailureAbortsMigrationAndRollsBack(t *testing.T) {
+	m, hot, cold, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+	ctx := context.Background()
+
+	spokeDaily := "rocket-01/telemetry/engine_temp/2024/03/15/engine_temp_20240315_231459_1_b1_daily.parquet"
+	if err := hot.Write(ctx, spokeDaily, []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.ScanAndRegisterFiles(ctx); err != nil {
+		t.Fatal(err)
+	}
+	m.SetOnHotFilesRemoved(func([]string) error { return errors.New("sync db unavailable") })
+
+	candidates, _ := m.migrator.FindCandidates(ctx, TierHot, TierCold)
+	if migrated, errs := m.migrator.MigrateBatch(ctx, candidates); migrated != 0 || errs != 1 {
+		t.Fatalf("MigrateBatch = (%d, %d), want (0, 1) on mark failure", migrated, errs)
+	}
+	if ok, _ := hot.Exists(ctx, spokeDaily); !ok {
+		t.Fatal("hot copy deleted despite mark failure")
+	}
+	if ok, _ := cold.Exists(ctx, spokeDaily); ok {
+		t.Fatal("cold copy not rolled back after mark failure")
+	}
+	if meta, err := m.metadata.GetFile(ctx, spokeDaily); err != nil || meta.Tier != TierHot {
+		t.Fatalf("row = (%+v, %v), want tier still hot so the candidate retries", meta, err)
+	}
+}
+
+func TestReconcileMarksBeforeOrphanDelete(t *testing.T) {
+	m, hot, cold, cleanup := setupIntegrationTest(t, true)
+	defer cleanup()
+	ctx := context.Background()
+
+	spokeDaily := "rocket-01/telemetry/engine_temp/2024/03/15/engine_temp_20240315_231459_1_b1_daily.parquet"
+	// Simulate a crash after cold copy + tier flip but before the hot delete.
+	for _, b := range []*mockBackend{hot, cold} {
+		if err := b.Write(ctx, spokeDaily, []byte("x")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := m.ScanAndRegisterFiles(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.metadata.UpdateTier(ctx, spokeDaily, TierCold); err != nil {
+		t.Fatal(err)
+	}
+
+	marks := 0
+	fail := true
+	m.SetOnHotFilesRemoved(func([]string) error {
+		marks++
+		if fail {
+			return errors.New("sync db unavailable")
+		}
+		return nil
+	})
+
+	_, deleted, errs := m.migrator.ReconcileOrphanedFiles(ctx)
+	if deleted != 0 || errs != 1 || marks != 1 {
+		t.Fatalf("failing mark: (deleted=%d, errs=%d, marks=%d), want (0, 1, 1) — orphan kept", deleted, errs, marks)
+	}
+	if ok, _ := hot.Exists(ctx, spokeDaily); !ok {
+		t.Fatal("orphan deleted despite mark failure")
+	}
+
+	fail = false
+	_, deleted, errs = m.migrator.ReconcileOrphanedFiles(ctx)
+	if deleted != 1 || errs != 0 {
+		t.Fatalf("passing mark: (deleted=%d, errs=%d), want (1, 0)", deleted, errs)
+	}
+	if ok, _ := hot.Exists(ctx, spokeDaily); ok {
+		t.Fatal("orphan survived a successful reconcile")
+	}
+}

--- a/internal/tiering/migrator.go
+++ b/internal/tiering/migrator.go
@@ -145,9 +145,17 @@ func (m *Migrator) FindCandidates(ctx context.Context, fromTier, toTier Tier) ([
 		// (synthetic or legacy PartitionTime values) both misclassify.
 		// An unparseable path is skipped conservatively.
 		info, err := m.manager.parseFilePath(file.Path)
-		if err != nil || info.SpokeNamespaced {
+		if err != nil {
 			m.manager.logger.Debug().Str("path", file.Path).
-				Msg("Skipping spoke-namespace or unrecognized file for cold migration (#687)")
+				Msg("Skipping unrecognized file path for cold migration")
+			continue
+		}
+		if info.SpokeNamespaced && !m.manager.hasHotFileRemovalHook() {
+			// Without receipt marking wired, deleting a spoke file's hot copy
+			// would make confirmPresent forget its sync receipt and re-accept
+			// a duplicate upload (#687).
+			m.manager.logger.Debug().Str("path", file.Path).
+				Msg("Skipping spoke-namespace file for cold migration (receipt marking not wired, #687)")
 			continue
 		}
 
@@ -253,6 +261,22 @@ func (m *Migrator) MigrateFile(ctx context.Context, candidate MigrationCandidate
 			m.manager.metadata.CompleteMigration(ctx, migrationID, migrationErr)
 		}
 		return migrationErr
+	}
+
+	// Mark sync receipts BEFORE the metadata flips to cold (#687). Ordering
+	// is load-bearing: marking after UpdateTier leaves a window where a
+	// persistent mark failure plus an expired reconcile window strands an
+	// unmarked hot duplicate forever. A marked receipt on an aborted
+	// migration is harmless (the receive path documents marked-but-present),
+	// so abort-and-rollback on failure is strictly safe.
+	if err := m.manager.notifyHotFilesRemoved([]string{candidate.Path}); err != nil {
+		if delErr := dstBackend.Delete(ctx, candidate.Path); delErr != nil {
+			m.logger.Error().Err(delErr).Str("path", candidate.Path).Msg("Failed to rollback destination file")
+		}
+		if migrationID > 0 {
+			m.manager.metadata.CompleteMigration(ctx, migrationID, err)
+		}
+		return fmt.Errorf("failed to mark sync receipts before migration: %w", err)
 	}
 
 	// Update tier metadata
@@ -407,6 +431,16 @@ func (m *Migrator) ReconcileOrphanedFiles(ctx context.Context) (orphansFound, de
 			Str("measurement", file.Measurement).
 			Int64("size_bytes", file.SizeBytes).
 			Msg("Found orphaned hot file (metadata says cold), deleting from hot")
+
+		// Mark sync receipts before this delete too (#687). Normally a no-op
+		// (MigrateFile marked before flipping the tier), but reconciliation
+		// is the crash-recovery path and must uphold the same invariant.
+		if err := m.manager.notifyHotFilesRemoved([]string{file.Path}); err != nil {
+			m.logger.Warn().Err(err).Str("path", file.Path).
+				Msg("Could not mark sync receipts; keeping orphaned hot file for the next cycle")
+			errors++
+			continue
+		}
 
 		if err := hotBackend.Delete(ctx, file.Path); err != nil {
 			m.logger.Warn().Err(err).Str("path", file.Path).Msg("Failed to delete orphaned hot file")

--- a/internal/tiering/migrator.go
+++ b/internal/tiering/migrator.go
@@ -179,6 +179,26 @@ func (m *Migrator) MigrateBatch(ctx context.Context, candidates []MigrationCandi
 	if len(candidates) == 0 {
 		return 0, 0
 	}
+	// Mark sync receipts for the WHOLE batch before any file work (#687):
+	// one chunked UPDATE on the shared sync DB instead of per-file calls
+	// from concurrent goroutines. Ordering is load-bearing — marking must
+	// precede each file's tier flip and delete, and pre-marking the batch
+	// satisfies that for every member; a marked receipt whose file does not
+	// migrate (later copy failure) is documented harmless. A mark failure
+	// aborts the batch so no file's hot copy can be removed unmarked.
+	paths := make([]string, len(candidates))
+	for i, c := range candidates {
+		paths[i] = c.Path
+	}
+	if err := m.manager.notifyHotFilesRemoved(paths); err != nil {
+		m.logger.Warn().Err(err).Int("candidates", len(candidates)).
+			Msg("Could not mark sync receipts; aborting migration batch")
+		return 0, len(candidates)
+	}
+
+	if len(candidates) == 0 {
+		return 0, 0
+	}
 
 	sem := semaphore.NewWeighted(int64(m.maxConcurrent))
 	var wg sync.WaitGroup
@@ -263,27 +283,17 @@ func (m *Migrator) MigrateFile(ctx context.Context, candidate MigrationCandidate
 		return migrationErr
 	}
 
-	// Mark sync receipts BEFORE the metadata flips to cold (#687). Ordering
-	// is load-bearing: marking after UpdateTier leaves a window where a
-	// persistent mark failure plus an expired reconcile window strands an
-	// unmarked hot duplicate forever. A marked receipt on an aborted
-	// migration is harmless (the receive path documents marked-but-present),
-	// so abort-and-rollback on failure is strictly safe.
-	if err := m.manager.notifyHotFilesRemoved([]string{candidate.Path}); err != nil {
+	// Update tier metadata. Sync receipts were already marked for the whole
+	// batch by MigrateBatch before any file work began (#687) — marking must
+	// precede this flip, and a marked receipt for a file that ends up not
+	// migrating is documented harmless by the receive path.
+	if err := m.manager.metadata.UpdateTier(ctx, candidate.Path, candidate.TargetTier); err != nil {
+		// Rollback: delete from destination
 		if delErr := dstBackend.Delete(ctx, candidate.Path); delErr != nil {
 			m.logger.Error().Err(delErr).Str("path", candidate.Path).Msg("Failed to rollback destination file")
 		}
 		if migrationID > 0 {
 			m.manager.metadata.CompleteMigration(ctx, migrationID, err)
-		}
-		return fmt.Errorf("failed to mark sync receipts before migration: %w", err)
-	}
-
-	// Update tier metadata
-	if err := m.manager.metadata.UpdateTier(ctx, candidate.Path, candidate.TargetTier); err != nil {
-		// Rollback: delete from destination
-		if delErr := dstBackend.Delete(ctx, candidate.Path); delErr != nil {
-			m.logger.Error().Err(delErr).Str("path", candidate.Path).Msg("Failed to rollback destination file")
 		}
 		return fmt.Errorf("failed to update tier metadata: %w", err)
 	}


### PR DESCRIPTION
## Summary

- closes #687: spoke-namespace daily files now participate in hot-to-cold migration on edge-sync hubs
- tiering gains a hot-file-removal hook; main.go wires it to the same receipt-marking closure hub compaction uses (shared `hubReceiptMarker`), and wiring it is what lifts the migrator's spoke gate — deployments without an edge-sync hub keep the gate closed
- ordering is the load-bearing design: receipts are marked for the WHOLE batch (one chunked UPDATE on the shared sync DB) before any file work; a mark failure aborts the batch, and per-file the mark precedes the tier flip and the delete, so no interleaving (including crash-and-retry and orphan reconciliation, which upholds the same invariant) can strand a deleted hot file with an unmarked receipt
- a marked receipt for a file that ends up not migrating is documented harmless by the receive path; re-offer of the same path+sha answers already-present

## Process

Same pipeline as the recent deep fixes: adversarial plan review (which corrected the crash-ordering to mark-before-UpdateTier-with-rollback and settled that reusing the compacted_at marking is semantically exact for every consumer), independent implementation review (batching the marks, completing a dangling migration record, and settling the spoke-id-equals-database-name degenerate case as harmless-and-correct), licensed e2e before merge.

## Verification

- tiering tests: gate lifts only when the hook is wired; hook fires while the file is still hot-and-present; mark failure aborts with the cold copy rolled back and tier unchanged; reconcile marks before orphan deletes and keeps the orphan on failure
- edgesync test: a migration-style mark on the real HubIndex leaves the receipt present and Compacted, which confirmPresent's skip and the existing already-present receive tests compose into the no-duplicate property
- full tiering/edgesync/api/compaction suites pass
- licensed e2e on a real hub (edge_sync.enabled, real S3 cold tier, receipt seeded in the sync DB): spoke daily scanned with 0 errors, migrated to its day-level S3 path, hot copy removed, and the receipt verified marked after clean shutdown

Closes #687