### PR TITLE
feat(backup): stage metadata restores; apply at boot

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -112,7 +112,7 @@ Contributed by [@Thundercloud12](https://github.com/Thundercloud12) in [#670](ht
 Backups now snapshot live SQLite databases before copying them, so concurrent
 WAL writers cannot interleave pages into a backup. Restores no longer touch the
 live database at all: the restored database is STAGED next to the live one and
-applied at the next server start, before anything opens it — the running server
+applied at the next server start, before anything opens it. The running server
 keeps serving consistent pre-restore data, and the swap (with a complete
 `.before-restore` safety copy and stale-sidecar cleanup) happens where no
 connection can observe a half-applied state. A staged restore that fails

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -110,9 +110,15 @@ Contributed by [@Thundercloud12](https://github.com/Thundercloud12) in [#670](ht
 ### Live SQLite backups and restores no longer risk torn database state ([#635](https://github.com/Basekick-Labs/arc/issues/635))
 
 Backups now snapshot live SQLite databases before copying them, so concurrent
-WAL writers cannot interleave pages into a backup. Restores replace the database
-by rename, remove stale WAL/SHM sidecars, and report that a restart is required
-before further writes. Temporary snapshots are restricted to the owner.
+WAL writers cannot interleave pages into a backup. Restores no longer touch the
+live database at all: the restored database is STAGED next to the live one and
+applied at the next server start, before anything opens it — the running server
+keeps serving consistent pre-restore data, and the swap (with a complete
+`.before-restore` safety copy and stale-sidecar cleanup) happens where no
+connection can observe a half-applied state. A staged restore that fails
+integrity validation at boot is quarantined instead of applied, and deleting
+the `.pending-restore` file before restarting cancels the restore. Temporary
+staging files are restricted to the owner.
 
 Contributed by [@atirna](https://github.com/atirna) in [#678](https://github.com/Basekick-Labs/arc/pull/678).
 
@@ -205,10 +211,10 @@ files (if any exist) remain registered but excluded from migration.
 
 `POST /api/v1/backup/restore` returned `restart_required: true` only when
 metadata (SQLite databases) was restored. A config-only restore needs the same
-restart — the restored `arc.toml` only takes effect on reload, which
-`restoreConfig` already logs — but the response did not say so. The flag now
-covers both restore kinds; a data-only restore still omits it. The restored-
-database immunity test also fails instead of skipping when a fresh connection
-cannot read the restored file.
+restart, the restored `arc.toml` only takes effect on reload, which
+`restoreConfig` already logs, but the response did not say so. The flag now
+covers both restore kinds and a data-only restore still omits it; metadata
+restores additionally report `staged: true`, since the restored databases are
+applied at the next start rather than swapped live.
 
 Contributed by [@atirna](https://github.com/atirna) in [#689](https://github.com/Basekick-Labs/arc/pull/689).

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -154,6 +154,21 @@ func main() {
 		log.Fatal().Msg("Arc was built without -tags=duckdb_arrow; refusing to start. The Arrow query path is required: rebuild with `make build` (or `go build -tags=duckdb_arrow ./cmd/arc`).")
 	}
 
+	// Apply staged metadata restores BEFORE anything opens the SQLite
+	// databases (#635): the restore API only stages; the swap happens here,
+	// where no connection, pool, or sidecar can be live. The same paths are
+	// derived again for backup.NewManager later; keep the two in sync.
+	{
+		bootIcebergCatalog := ""
+		if cfg.Iceberg.Enabled {
+			bootIcebergCatalog = cfg.Iceberg.CatalogDBPath
+			if bootIcebergCatalog == "" {
+				bootIcebergCatalog = cfg.Auth.DBPath
+			}
+		}
+		backup.ApplyPendingRestores(logger.Get("backup"), cfg.Auth.DBPath, bootIcebergCatalog)
+	}
+
 	// Validate Enterprise License early (before component initialization)
 	// This allows us to apply core limits to DuckDB and ingestion workers
 	var licenseClient *license.Client

--- a/internal/api/backup_routes.go
+++ b/internal/api/backup_routes.go
@@ -267,11 +267,14 @@ func (h *BackupHandler) RestoreBackup(c *fiber.Ctx) error {
 		"backup_id": req.BackupID,
 		"status":    "running",
 	}
-	// Restored databases replace the live files by rename (open connections
-	// keep the pre-restore content) and a restored config only takes effect
-	// on reload — both need a server restart.
+	// Restored databases are STAGED and applied at the next boot (#635), and
+	// a restored config only takes effect on reload — both need a server
+	// restart to take effect.
 	if opts.RestoreMetadata || opts.RestoreConfig {
 		resp["restart_required"] = true
+	}
+	if opts.RestoreMetadata {
+		resp["staged"] = true
 	}
 	return c.Status(fiber.StatusAccepted).JSON(resp)
 }

--- a/internal/api/backup_routes_test.go
+++ b/internal/api/backup_routes_test.go
@@ -322,9 +322,15 @@ func TestRestoreBackupReportsRestartRequired(t *testing.T) {
 	if meta["restart_required"] != true {
 		t.Errorf("metadata restore: restart_required = %v, want true", meta["restart_required"])
 	}
+	if meta["staged"] != true {
+		t.Errorf("metadata restore: staged = %v, want true (#635 apply-at-boot)", meta["staged"])
+	}
 	cfg := restore(t, `{"backup_id":"backup-20260901-000000-00000000","confirm":true,"restore_data":false,"restore_metadata":false,"restore_config":true}`)
 	if cfg["restart_required"] != true {
 		t.Errorf("config-only restore: restart_required = %v, want true", cfg["restart_required"])
+	}
+	if _, present := cfg["staged"]; present {
+		t.Errorf("config-only restore: staged = %v, want absent (config is not staged)", cfg["staged"])
 	}
 	data := restore(t, `{"backup_id":"backup-20260901-000000-00000000","confirm":true,"restore_data":true,"restore_metadata":false,"restore_config":false}`)
 	if _, present := data["restart_required"]; present {

--- a/internal/backup/iceberg_backup_test.go
+++ b/internal/backup/iceberg_backup_test.go
@@ -317,6 +317,11 @@ func TestRestore_SeparateIcebergCatalogIsRestored(t *testing.T) {
 	if err := m.restoreSQLite(ctx, res.Manifest.BackupID); err != nil {
 		t.Fatalf("restoreSQLite: %v", err)
 	}
+	// Restores are STAGED (#635); the boot apply performs the swap.
+	if _, err := os.Stat(StagePath(catalogDB)); err != nil {
+		t.Fatalf("catalog restore not staged: %v", err)
+	}
+	ApplyPendingRestores(logger, sharedDB, catalogDB)
 
 	db, err := sql.Open("sqlite3", catalogDB)
 	if err != nil {
@@ -329,16 +334,13 @@ func TestRestore_SeparateIcebergCatalogIsRestored(t *testing.T) {
 	}
 }
 
-// The issue's restore defect: the pre-restore -wal is salted against the old
-// database, so replaying it over the restored file mixes stale frames into new
-// pages. restoreSQLiteFile must remove both sidecars after the write, and the
-// .before-restore safety copy must itself be a complete database — a plain
-// file read of the old database would miss its un-checkpointed WAL commits.
-func TestRestoreSQLiteFile_RemovesStaleSidecarsAndSnapshotsLiveState(t *testing.T) {
+// Restore semantics (#635, apply-at-boot): the API path STAGES and must not
+// touch the live database, its sidecars, or create safety copies; the boot
+// apply does the swap. Replaces the #678-era live-swap tests.
+func TestRestoreSQLiteFile_StagesWithoutTouchingLive(t *testing.T) {
 	ctx := context.Background()
 	logger := zerolog.Nop()
 
-	// Live database with a WAL holding un-checkpointed commits.
 	liveDir := t.TempDir()
 	dbPath := filepath.Join(liveDir, "arc.db")
 	live, err := sql.Open("sqlite3", dbPath)
@@ -346,10 +348,11 @@ func TestRestoreSQLiteFile_RemovesStaleSidecarsAndSnapshotsLiveState(t *testing.
 		t.Fatal(err)
 	}
 	defer live.Close()
-	if _, err := live.Exec("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE t (v INTEGER)"); err != nil {
+	if _, err := live.Exec("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE t (v INTEGER); INSERT INTO t (v) VALUES (1), (2)"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := live.Exec("INSERT INTO t (v) VALUES (1), (2)"); err != nil {
+	preBytes, err := os.ReadFile(dbPath)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -359,7 +362,6 @@ func TestRestoreSQLiteFile_RemovesStaleSidecarsAndSnapshotsLiveState(t *testing.
 		backupStorage: mustLocalBackend(t, backupDir, logger),
 		logger:        logger,
 	}
-	// The backup holds a one-row database, older than the live one.
 	older, err := sql.Open("sqlite3", filepath.Join(backupDir, "older.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -380,9 +382,41 @@ func TestRestoreSQLiteFile_RemovesStaleSidecarsAndSnapshotsLiveState(t *testing.
 		t.Fatalf("restoreSQLiteFile: %v", err)
 	}
 
-	for _, sidecar := range []string{dbPath + "-wal", dbPath + "-shm"} {
+	// Live database and sidecars untouched, byte for byte.
+	postBytes, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(preBytes, postBytes) {
+		t.Fatal("staging modified the live database file")
+	}
+	if _, err := os.Stat(dbPath + "-wal"); err != nil {
+		t.Fatal("staging removed the live WAL sidecar")
+	}
+	if _, err := os.Stat(dbPath + ".before-restore"); !os.IsNotExist(err) {
+		t.Fatal("staging created a safety copy; that belongs to boot apply")
+	}
+
+	// The staged file holds exactly the backup bytes.
+	staged, err := os.ReadFile(StagePath(dbPath))
+	if err != nil {
+		t.Fatalf("staged restore missing: %v", err)
+	}
+	if !bytes.Equal(staged, olderData) {
+		t.Fatal("staged restore does not match the backup contents")
+	}
+
+	// Boot apply: live becomes the backup, safety copy holds the live
+	// database's WAL-resident commits, no sidecars remain anywhere.
+	live.Close()
+	ApplyPendingRestores(logger, dbPath)
+
+	// Filesystem assertions FIRST: opening the WAL-mode safety copy below
+	// recreates its sidecars, so any handle open before these checks would
+	// fabricate the very files the apply must have removed.
+	for _, sidecar := range []string{dbPath + "-wal", dbPath + "-shm", dbPath + ".before-restore-wal", dbPath + ".before-restore-shm", StagePath(dbPath)} {
 		if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
-			t.Errorf("stale sidecar %s still present after restore", sidecar)
+			t.Errorf("%s still present after boot apply", sidecar)
 		}
 	}
 
@@ -392,100 +426,15 @@ func TestRestoreSQLiteFile_RemovesStaleSidecarsAndSnapshotsLiveState(t *testing.
 	}
 	defer restored.Close()
 	var got int
-	if err := restored.QueryRow("SELECT count(*) FROM t").Scan(&got); err != nil {
-		t.Fatal(err)
+	if err := restored.QueryRow("SELECT count(*) FROM t").Scan(&got); err != nil || got != 1 {
+		t.Fatalf("applied database rows = (%d, %v), want the backup's 1", got, err)
 	}
-	if got != 1 {
-		t.Fatalf("restored database holds %d rows, want the backup's 1", got)
-	}
-
-	// The pre-restore safety copy must contain the live WAL-resident commits.
 	safety, err := sql.Open("sqlite3", dbPath+".before-restore")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer safety.Close()
-	var safetyRows int
-	if err := safety.QueryRow("SELECT count(*) FROM t").Scan(&safetyRows); err != nil {
-		t.Fatal(err)
-	}
-	if safetyRows != 2 {
-		t.Fatalf(".before-restore copy holds %d rows, want the live database's 2 (WAL-resident commits included)", safetyRows)
-	}
-}
-
-// The restored file must be beyond the reach of pre-restore connections: the
-// swap is a rename, so a handle opened before the restore keeps writing the
-// old (now unlinked) inode and cannot tear or corrupt the restored database.
-func TestRestoreSQLiteFile_RestoredFileIsImmuneToPreRestoreHandles(t *testing.T) {
-	ctx := context.Background()
-	logger := zerolog.Nop()
-
-	liveDir := t.TempDir()
-	dbPath := filepath.Join(liveDir, "arc.db")
-	old, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer old.Close()
-	if _, err := old.Exec("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE t (v INTEGER); INSERT INTO t (v) VALUES (1)"); err != nil {
-		t.Fatal(err)
-	}
-
-	backupDir := t.TempDir()
-	m := &Manager{
-		dataStorage:   mustLocalBackend(t, t.TempDir(), logger),
-		backupStorage: mustLocalBackend(t, backupDir, logger),
-		logger:        logger,
-	}
-	backupDB, err := sql.Open("sqlite3", filepath.Join(backupDir, "backup.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := backupDB.Exec("CREATE TABLE t (v INTEGER); INSERT INTO t (v) VALUES (41)"); err != nil {
-		t.Fatal(err)
-	}
-	backupDB.Close()
-	backupData, err := os.ReadFile(filepath.Join(backupDir, "backup.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := m.backupStorage.Write(ctx, "backup-1/metadata/arc.db", backupData); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := m.restoreSQLiteFile(ctx, "backup-1", "arc.db", dbPath); err != nil {
-		t.Fatalf("restoreSQLiteFile: %v", err)
-	}
-
-	// A pre-restore connection commits and checkpoints after the swap. Its
-	// writes may land in a sidecar or the unlinked inode, never in the
-	// restored file's bytes.
-	if _, err := old.Exec("INSERT INTO t (v) VALUES (2)"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := old.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := os.ReadFile(dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, backupData) {
-		t.Error("restored database file changed after a pre-restore connection wrote — restore is not immune to live handles")
-	}
-
-	fresh, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer fresh.Close()
-	var rows int
-	if err := fresh.QueryRow("SELECT count(*) FROM t").Scan(&rows); err != nil {
-		t.Fatalf("restored database is not readable by a fresh connection: %v", err)
-	}
-	if rows != 1 {
-		t.Errorf("fresh connection read %d rows, want the backup's 1 (pre-restore writes leaked)", rows)
+	if err := safety.QueryRow("SELECT count(*) FROM t").Scan(&got); err != nil || got != 2 {
+		t.Fatalf("safety copy rows = (%d, %v), want the live database's 2 (WAL folded in)", got, err)
 	}
 }

--- a/internal/backup/pending_restore.go
+++ b/internal/backup/pending_restore.go
@@ -12,7 +12,7 @@ package backup
 // Crash convergence: every step below is a remove or rename, ordered so a
 // crash at ANY point converges on the next boot. The one non-obvious rule is
 // resume-on-missing-destination: a crash between the safety rename and the
-// final rename leaves no live database with the pending file still staged —
+// final rename leaves no live database with the pending file still staged;
 // the next boot MUST apply the pending file rather than skip, or the server
 // would boot onto a fresh empty database and the restore (and, for auth.db,
 // every credential) would be silently lost.
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/rs/zerolog"
@@ -41,7 +42,7 @@ func StagePath(dbPath string) string { return dbPath + PendingRestoreSuffix }
 // empty paths are tolerated (the shared-database layout passes the same file
 // for several roles). Errors are contained per path: a failure to apply one
 // staged restore quarantines or leaves it and lets the boot continue on the
-// current database, logged loudly — a staged restore must never boot-loop the
+// current database, logged loudly. A staged restore must never boot-loop the
 // server or apply garbage over a working database.
 func ApplyPendingRestores(logger zerolog.Logger, dbPaths ...string) {
 	seen := make(map[string]bool, len(dbPaths))
@@ -66,10 +67,10 @@ func applyPendingRestore(logger zerolog.Logger, dbPath string) {
 	if err := validatePendingSQLite(pending); err != nil {
 		rejected := pending + ".rejected"
 		if renameErr := os.Rename(pending, rejected); renameErr != nil {
-			log.Error().Err(renameErr).Msg("Staged restore is invalid and could not be quarantined; leaving it — it will be re-checked next boot")
+			log.Error().Err(renameErr).Msg("Staged restore is invalid and could not be quarantined; leaving it for re-check at next boot")
 		} else {
 			log.Error().Err(err).Str("quarantined_to", rejected).
-				Msg("Staged restore failed validation; quarantined — booting with the current database")
+				Msg("Staged restore failed validation; quarantined, booting with the current database")
 		}
 		return
 	}
@@ -82,7 +83,7 @@ func applyPendingRestore(logger zerolog.Logger, dbPath string) {
 
 		// Remove an OLDER restore's safety sidecars: after this run the
 		// safety copy is either checkpointed (no sidecars) or gets this run's
-		// sidecars moved in below — stale ones from a previous restore beside
+		// sidecars moved in below; stale ones from a previous restore beside
 		// it are exactly the mismatched-WAL hazard #635 documented.
 		removeIgnoreMissing(log, before+"-wal")
 		removeIgnoreMissing(log, before+"-shm")
@@ -99,13 +100,22 @@ func applyPendingRestore(logger zerolog.Logger, dbPath string) {
 		}
 
 		if err := os.Rename(dbPath, before); err != nil {
-			log.Error().Err(err).Msg("Could not move the current database aside; staged restore NOT applied — booting with the current database")
+			log.Error().Err(err).Msg("Could not move the current database aside; staged restore NOT applied, booting with the current database")
 			return
 		}
 		log.Info().Str("safety_copy", before).Msg("Current database moved aside before restore apply")
 	}
-	// else: no current database — either a fresh node, or the
-	// resume-on-missing-destination case after a crash mid-apply.
+	// else: no current database. A fresh node, the resume case after a
+	// crash mid-apply, or an operator-deleted database.
+
+	// Unconditionally clear sidecars at the destination path before the
+	// final rename. The apply's own flow already handled them, but an
+	// operator who deleted the database while a -wal remained (plus a
+	// forgotten staged restore) would otherwise have that stale WAL,
+	// salted against the DELETED database, replayed over the restored one
+	// on first open: the exact corruption class this design eliminates.
+	removeIgnoreMissing(log, dbPath+"-wal")
+	removeIgnoreMissing(log, dbPath+"-shm")
 
 	if err := os.Rename(pending, dbPath); err != nil {
 		log.Error().Err(err).Msg("Could not move the staged restore into place; it remains staged for the next boot")
@@ -123,7 +133,7 @@ func validatePendingSQLite(path string) error {
 		return err
 	}
 	header := make([]byte, len(sqliteMagic))
-	_, readErr := f.Read(header)
+	_, readErr := io.ReadFull(f, header)
 	info, statErr := f.Stat()
 	f.Close()
 	if readErr != nil {
@@ -151,15 +161,24 @@ func validatePendingSQLite(path string) error {
 	return nil
 }
 
-// checkpointSQLite folds the WAL into the main database file.
+// checkpointSQLite folds the WAL into the main database file. The pragma
+// does NOT error when it cannot complete: it reports busy=1 in its result
+// row, so the row must be inspected — treating a blocked checkpoint as
+// success would delete a WAL whose commits were never folded in.
 func checkpointSQLite(path string) error {
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
-	_, err = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
-	return err
+	var busy, logFrames, checkpointed int
+	if err := db.QueryRow("PRAGMA wal_checkpoint(TRUNCATE)").Scan(&busy, &logFrames, &checkpointed); err != nil {
+		return err
+	}
+	if busy != 0 {
+		return fmt.Errorf("wal_checkpoint blocked (busy=1, %d frames in log)", logFrames)
+	}
+	return nil
 }
 
 func removeIgnoreMissing(log zerolog.Logger, path string) {

--- a/internal/backup/pending_restore.go
+++ b/internal/backup/pending_restore.go
@@ -1,0 +1,175 @@
+package backup
+
+// Apply-at-boot metadata restore (#635, second half).
+//
+// The API restore path STAGES a restored SQLite database next to the live one
+// and never touches the live file: a running server keeps serving consistent
+// pre-restore data, and the staged file is applied here, at boot, before any
+// subsystem has opened the database. This removes the live-swap hazards the
+// first half of #635 documented (stale-sidecar corruption, connection pools
+// splitting across inodes) instead of merely narrowing them.
+//
+// Crash convergence: every step below is a remove or rename, ordered so a
+// crash at ANY point converges on the next boot. The one non-obvious rule is
+// resume-on-missing-destination: a crash between the safety rename and the
+// final rename leaves no live database with the pending file still staged —
+// the next boot MUST apply the pending file rather than skip, or the server
+// would boot onto a fresh empty database and the restore (and, for auth.db,
+// every credential) would be silently lost.
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+)
+
+// PendingRestoreSuffix is appended to a database path to name its staged
+// restore. The suffix survives crashes; boot applies or quarantines it.
+const PendingRestoreSuffix = ".pending-restore"
+
+// sqliteMagic is the 16-byte header prefix of every valid SQLite database.
+var sqliteMagic = []byte("SQLite format 3\x00")
+
+// StagePath returns the pending-restore path for a database path.
+func StagePath(dbPath string) string { return dbPath + PendingRestoreSuffix }
+
+// ApplyPendingRestores applies staged restores for the given database paths.
+// MUST be called at boot before anything opens those databases. Duplicate or
+// empty paths are tolerated (the shared-database layout passes the same file
+// for several roles). Errors are contained per path: a failure to apply one
+// staged restore quarantines or leaves it and lets the boot continue on the
+// current database, logged loudly — a staged restore must never boot-loop the
+// server or apply garbage over a working database.
+func ApplyPendingRestores(logger zerolog.Logger, dbPaths ...string) {
+	seen := make(map[string]bool, len(dbPaths))
+	for _, dbPath := range dbPaths {
+		if dbPath == "" || seen[dbPath] {
+			continue
+		}
+		seen[dbPath] = true
+		applyPendingRestore(logger, dbPath)
+	}
+}
+
+func applyPendingRestore(logger zerolog.Logger, dbPath string) {
+	pending := StagePath(dbPath)
+	if _, err := os.Stat(pending); err != nil {
+		return
+	}
+	log := logger.With().Str("db", dbPath).Logger()
+
+	// Never rename garbage over a working database: a crash during staging or
+	// disk truncation can leave a partial file. Quarantine instead of apply.
+	if err := validatePendingSQLite(pending); err != nil {
+		rejected := pending + ".rejected"
+		if renameErr := os.Rename(pending, rejected); renameErr != nil {
+			log.Error().Err(renameErr).Msg("Staged restore is invalid and could not be quarantined; leaving it — it will be re-checked next boot")
+		} else {
+			log.Error().Err(err).Str("quarantined_to", rejected).
+				Msg("Staged restore failed validation; quarantined — booting with the current database")
+		}
+		return
+	}
+
+	before := dbPath + ".before-restore"
+	if _, err := os.Stat(dbPath); err == nil {
+		// Fold un-checkpointed WAL commits into the main file so the safety
+		// copy is complete. Nothing else has the database open at boot.
+		ckErr := checkpointSQLite(dbPath)
+
+		// Remove an OLDER restore's safety sidecars: after this run the
+		// safety copy is either checkpointed (no sidecars) or gets this run's
+		// sidecars moved in below — stale ones from a previous restore beside
+		// it are exactly the mismatched-WAL hazard #635 documented.
+		removeIgnoreMissing(log, before+"-wal")
+		removeIgnoreMissing(log, before+"-shm")
+
+		if ckErr == nil {
+			removeIgnoreMissing(log, dbPath+"-wal")
+			removeIgnoreMissing(log, dbPath+"-shm")
+		} else {
+			// Could not fold the WAL in (locked or damaged database). Keep
+			// the sidecars WITH the safety copy so it remains recoverable.
+			log.Warn().Err(ckErr).Msg("Checkpoint before restore apply failed; moving WAL sidecars alongside the safety copy")
+			renameIgnoreMissing(log, dbPath+"-wal", before+"-wal")
+			renameIgnoreMissing(log, dbPath+"-shm", before+"-shm")
+		}
+
+		if err := os.Rename(dbPath, before); err != nil {
+			log.Error().Err(err).Msg("Could not move the current database aside; staged restore NOT applied — booting with the current database")
+			return
+		}
+		log.Info().Str("safety_copy", before).Msg("Current database moved aside before restore apply")
+	}
+	// else: no current database — either a fresh node, or the
+	// resume-on-missing-destination case after a crash mid-apply.
+
+	if err := os.Rename(pending, dbPath); err != nil {
+		log.Error().Err(err).Msg("Could not move the staged restore into place; it remains staged for the next boot")
+		return
+	}
+	log.Warn().Msg("Staged restore applied at boot; the previous database (if any) is at the .before-restore path")
+}
+
+// validatePendingSQLite refuses files that are not plausibly a complete
+// SQLite database: header magic, minimum size, and an integrity quick_check
+// on a read-only connection (nothing else is running at boot).
+func validatePendingSQLite(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	header := make([]byte, len(sqliteMagic))
+	_, readErr := f.Read(header)
+	info, statErr := f.Stat()
+	f.Close()
+	if readErr != nil {
+		return fmt.Errorf("read header: %w", readErr)
+	}
+	if !bytes.Equal(header, sqliteMagic) {
+		return fmt.Errorf("not a SQLite database (bad header magic)")
+	}
+	if statErr == nil && info.Size() < 512 {
+		return fmt.Errorf("implausibly small for a SQLite database (%d bytes)", info.Size())
+	}
+
+	db, err := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	if err != nil {
+		return fmt.Errorf("open for quick_check: %w", err)
+	}
+	defer db.Close()
+	var result string
+	if err := db.QueryRow("PRAGMA quick_check").Scan(&result); err != nil {
+		return fmt.Errorf("quick_check: %w", err)
+	}
+	if result != "ok" {
+		return fmt.Errorf("quick_check: %s", result)
+	}
+	return nil
+}
+
+// checkpointSQLite folds the WAL into the main database file.
+func checkpointSQLite(path string) error {
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	_, err = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	return err
+}
+
+func removeIgnoreMissing(log zerolog.Logger, path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Warn().Err(err).Str("path", path).Msg("Could not remove file during restore apply")
+	}
+}
+
+func renameIgnoreMissing(log zerolog.Logger, from, to string) {
+	if err := os.Rename(from, to); err != nil && !os.IsNotExist(err) {
+		log.Warn().Err(err).Str("from", from).Msg("Could not move file during restore apply")
+	}
+}

--- a/internal/backup/pending_restore_test.go
+++ b/internal/backup/pending_restore_test.go
@@ -177,3 +177,46 @@ func TestApply_ConvergesFromPartialStates(t *testing.T) {
 		t.Fatalf("safety copy rows = %d, want the first restore's 4 (overwritten in order)", got)
 	}
 }
+
+// The checkpoint-failure branch: a held read transaction makes
+// wal_checkpoint(TRUNCATE) fail busy, so the apply must move the WAL
+// sidecars ALONGSIDE the safety copy (keeping it recoverable) instead of
+// deleting them, and still apply the staged restore.
+func TestApply_CheckpointFailureKeepsSafetyCopyRecoverable(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+
+	live, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer live.Close()
+	if _, err := live.Exec("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE t (v INTEGER); INSERT INTO t (v) VALUES (1), (2), (3)"); err != nil {
+		t.Fatal(err)
+	}
+	// Hold a read transaction so TRUNCATE checkpointing cannot complete.
+	tx, err := live.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	if err := tx.QueryRow("SELECT count(*) FROM t").Scan(&n); err != nil || n != 3 {
+		t.Fatalf("read txn: (%d, %v)", n, err)
+	}
+
+	makeSQLite(t, StagePath(dbPath), 7)
+	ApplyPendingRestores(zerolog.Nop(), dbPath)
+	tx.Rollback()
+	live.Close()
+
+	if got := rowCount(t, dbPath); got != 7 {
+		t.Fatalf("applied rows = %d, want the staged restore's 7", got)
+	}
+	if _, err := os.Stat(dbPath + ".before-restore-wal"); err != nil {
+		t.Fatalf("WAL not moved alongside the safety copy on checkpoint failure: %v", err)
+	}
+	// The safety copy with its moved WAL must recover every live commit.
+	if got := rowCount(t, dbPath+".before-restore"); got != 3 {
+		t.Fatalf("safety copy rows = %d, want 3 (WAL replayed on open)", got)
+	}
+}

--- a/internal/backup/pending_restore_test.go
+++ b/internal/backup/pending_restore_test.go
@@ -1,0 +1,179 @@
+package backup
+
+// Boot-apply crash matrix for #635. Partial states are constructed directly
+// on disk and ApplyPendingRestores must converge from every one of them.
+
+import (
+	"bytes"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func makeSQLite(t *testing.T, path string, rows int) []byte {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE TABLE t (v INTEGER)"); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < rows; i++ {
+		if _, err := db.Exec("INSERT INTO t (v) VALUES (?)", i); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db.Close()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func rowCount(t *testing.T, path string) int {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow("SELECT count(*) FROM t").Scan(&n); err != nil {
+		t.Fatalf("count rows in %s: %v", path, err)
+	}
+	return n
+}
+
+// Crash between the safety rename and the final rename: no live database,
+// pending still staged. The apply MUST resume, not skip — skipping would let
+// the server boot a fresh empty auth database and silently lose the restore.
+func TestApply_ResumesWhenDestinationMissing(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+	staged := makeSQLite(t, StagePath(dbPath), 3)
+
+	ApplyPendingRestores(zerolog.Nop(), dbPath)
+
+	if got := rowCount(t, dbPath); got != 3 {
+		t.Fatalf("rows = %d, want the staged restore's 3", got)
+	}
+	if data, _ := os.ReadFile(dbPath); !bytes.Equal(data, staged) {
+		t.Fatal("applied database differs from the staged restore")
+	}
+	if _, err := os.Stat(StagePath(dbPath)); !os.IsNotExist(err) {
+		t.Fatal("pending file survived the apply")
+	}
+}
+
+func TestApply_QuarantinesGarbagePending(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+	current := makeSQLite(t, dbPath, 2)
+	if err := os.WriteFile(StagePath(dbPath), []byte("definitely not a database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ApplyPendingRestores(zerolog.Nop(), dbPath)
+
+	if data, _ := os.ReadFile(dbPath); !bytes.Equal(data, current) {
+		t.Fatal("garbage pending file modified the current database")
+	}
+	if _, err := os.Stat(StagePath(dbPath) + ".rejected"); err != nil {
+		t.Fatalf("garbage pending not quarantined: %v", err)
+	}
+	if _, err := os.Stat(StagePath(dbPath)); !os.IsNotExist(err) {
+		t.Fatal("garbage pending still staged")
+	}
+}
+
+func TestApply_QuarantinesCorruptButMagicked(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+	makeSQLite(t, dbPath, 2)
+	// Valid magic, plausible size, truncated mid-page — the realistic
+	// crash-during-stage artifact; quick_check must catch it.
+	good := makeSQLite(t, filepath.Join(dir, "donor.db"), 500)
+	truncated := good[:len(good)-700]
+	if err := os.WriteFile(StagePath(dbPath), truncated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ApplyPendingRestores(zerolog.Nop(), dbPath)
+
+	if got := rowCount(t, dbPath); got != 2 {
+		t.Fatalf("rows = %d, want the untouched current database's 2", got)
+	}
+	if _, err := os.Stat(StagePath(dbPath) + ".rejected"); err != nil {
+		t.Fatalf("corrupt pending not quarantined: %v", err)
+	}
+}
+
+func TestApply_RemovesStaleSafetySidecars(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+	makeSQLite(t, dbPath, 2)
+	makeSQLite(t, StagePath(dbPath), 5)
+	// Leftovers from an OLDER restore's safety copy: stale sidecars beside
+	// the new safety copy are the mismatched-WAL corruption class.
+	for _, stale := range []string{dbPath + ".before-restore-wal", dbPath + ".before-restore-shm"} {
+		if err := os.WriteFile(stale, []byte("stale"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ApplyPendingRestores(zerolog.Nop(), dbPath)
+
+	if got := rowCount(t, dbPath); got != 5 {
+		t.Fatalf("rows = %d, want the staged restore's 5", got)
+	}
+	for _, stale := range []string{dbPath + ".before-restore-wal", dbPath + ".before-restore-shm"} {
+		if _, err := os.Stat(stale); !os.IsNotExist(err) {
+			t.Errorf("stale safety sidecar %s survived", stale)
+		}
+	}
+	if got := rowCount(t, dbPath+".before-restore"); got != 2 {
+		t.Fatalf("safety copy rows = %d, want the previous database's 2", got)
+	}
+}
+
+func TestApply_NoPendingIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+	current := makeSQLite(t, dbPath, 2)
+
+	ApplyPendingRestores(zerolog.Nop(), dbPath, "", dbPath)
+
+	if data, _ := os.ReadFile(dbPath); !bytes.Equal(data, current) {
+		t.Fatal("no-op apply modified the database")
+	}
+}
+
+// Re-running the apply from each constructible partial state converges.
+func TestApply_ConvergesFromPartialStates(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "arc.db")
+
+	// State: sidecars already removed (crash after checkpoint+removal),
+	// current db and pending both present.
+	makeSQLite(t, dbPath, 2)
+	makeSQLite(t, StagePath(dbPath), 4)
+	ApplyPendingRestores(zerolog.Nop(), dbPath)
+	if got := rowCount(t, dbPath); got != 4 {
+		t.Fatalf("converge-1 rows = %d, want 4", got)
+	}
+
+	// State: previous apply fully done, a SECOND restore staged over it.
+	makeSQLite(t, StagePath(dbPath), 6)
+	ApplyPendingRestores(zerolog.Nop(), dbPath)
+	if got := rowCount(t, dbPath); got != 6 {
+		t.Fatalf("converge-2 rows = %d, want 6", got)
+	}
+	if got := rowCount(t, dbPath+".before-restore"); got != 4 {
+		t.Fatalf("safety copy rows = %d, want the first restore's 4 (overwritten in order)", got)
+	}
+}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -2,9 +2,7 @@ package backup
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -219,8 +217,16 @@ func (m *Manager) restoreSQLite(ctx context.Context, backupID string) error {
 	return nil
 }
 
-// restoreSQLiteFile restores one SQLite database from metadata/<srcName> in the
-// backup to destPath, preserving the previous file as .before-restore.
+// restoreSQLiteFile STAGES one SQLite database from metadata/<srcName> in the
+// backup as <destPath>.pending-restore. The live database is never touched:
+// applying a restore over a running server's database — even by atomic
+// rename — leaves existing connections on the old inode while new pool
+// connections open the restored file, splitting state across both (#635).
+// ApplyPendingRestores applies the staged file at the next boot, before any
+// subsystem opens the database, and takes the .before-restore safety copy at
+// that point (when it can be made complete and cheaply). Restaging overwrites
+// a previous staging: the last restore before restart wins. An operator can
+// cancel by deleting the .pending-restore file before restarting.
 func (m *Manager) restoreSQLiteFile(ctx context.Context, backupID, srcName, destPath string) error {
 	srcPath := fmt.Sprintf("%s/metadata/%s", backupID, srcName)
 	data, err := m.backupStorage.Read(ctx, srcPath)
@@ -228,29 +234,6 @@ func (m *Manager) restoreSQLiteFile(ctx context.Context, backupID, srcName, dest
 		return fmt.Errorf("failed to read SQLite backup: %w", err)
 	}
 
-	// Safety: snapshot the current database before overwriting. A plain file
-	// read would miss un-checkpointed WAL commits; the snapshot reads through
-	// the WAL, so the pre-restore copy is itself a usable database.
-	if _, statErr := os.Stat(destPath); statErr == nil {
-		if snapshotPath, snapErr := snapshotSQLite(ctx, destPath); snapErr == nil {
-			if currentData, readErr := os.ReadFile(snapshotPath); readErr == nil {
-				preRestorePath := destPath + ".before-restore"
-				if err := os.WriteFile(preRestorePath, currentData, 0600); err != nil {
-					m.logger.Warn().Err(err).Msg("Failed to create pre-restore backup of SQLite database")
-				} else {
-					m.logger.Info().Str("path", preRestorePath).Msg("Created pre-restore backup of SQLite database")
-				}
-			}
-			os.RemoveAll(filepath.Dir(snapshotPath))
-		} else {
-			m.logger.Warn().Err(snapErr).Msg("Failed to snapshot database before restore")
-		}
-	}
-
-	// Swap the file in by rename rather than overwriting the live inode. Existing
-	// connections keep reading and writing the old (now unlinked) inode, while a
-	// pool may open new connections against the restored file, so restart before
-	// further writes to avoid splitting state across both files.
 	staging, err := os.CreateTemp(filepath.Dir(destPath), ".restore-staging-*")
 	if err != nil {
 		return fmt.Errorf("failed to create restore staging file: %w", err)
@@ -259,34 +242,27 @@ func (m *Manager) restoreSQLiteFile(ctx context.Context, backupID, srcName, dest
 	if _, err := staging.Write(data); err != nil {
 		staging.Close()
 		os.Remove(stagingPath)
-		return fmt.Errorf("failed to write SQLite database: %w", err)
+		return fmt.Errorf("failed to write staged restore: %w", err)
 	}
 	if err := staging.Close(); err != nil {
 		os.Remove(stagingPath)
-		return fmt.Errorf("failed to close restore staging file: %w", err)
+		return fmt.Errorf("failed to close staged restore: %w", err)
 	}
 	if err := os.Chmod(stagingPath, 0600); err != nil {
 		os.Remove(stagingPath)
-		return fmt.Errorf("failed to restrict restore staging file: %w", err)
+		return fmt.Errorf("failed to restrict staged restore: %w", err)
 	}
-	if err := os.Rename(stagingPath, destPath); err != nil {
+	pendingPath := StagePath(destPath)
+	if err := os.Rename(stagingPath, pendingPath); err != nil {
 		os.Remove(stagingPath)
-		return fmt.Errorf("failed to move restored SQLite database into place: %w", err)
-	}
-
-	// A pre-restore -wal is salted against the old database: SQLite replaying
-	// it over the restored file would mix old frames into new pages, and -shm
-	// is the index for exactly that WAL. Neither belongs to the restored file.
-	for _, sidecar := range []string{destPath + "-wal", destPath + "-shm"} {
-		if err := os.Remove(sidecar); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("failed to remove stale SQLite sidecar %s: %w", sidecar, err)
-		}
+		return fmt.Errorf("failed to stage restored SQLite database: %w", err)
 	}
 
 	m.logger.Warn().
 		Str("backup_id", backupID).
 		Str("database", srcName).
-		Msg("SQLite database restored; restart required — open connections still hold the pre-restore database")
+		Str("staged_at", pendingPath).
+		Msg("SQLite restore staged; it is applied at the next server start")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- completes #635: the restore API STAGES the restored SQLite databases as `<db>.pending-restore` and never touches the live files — no live rename, no sidecar removal on a running server, no connection pools splitting across inodes; the running server keeps serving consistent pre-restore data
- the staged file is applied at the next boot, before any subsystem opens the database: validated (header magic + `PRAGMA quick_check`, garbage quarantined to `.rejected` instead of applied), the current database checkpointed into a complete `.before-restore` safety copy (WAL moved alongside it when a checkpoint cannot complete — and the checkpoint result row is inspected, since the pragma reports busy instead of erroring), stale safety sidecars cleared, destination sidecars cleared unconditionally before the final rename
- every crash interleaving converges on the next boot, including the load-bearing resume rule: a crash between the safety rename and the final rename must apply the pending file, or the server would boot a fresh empty auth database and silently lose the restore
- API: metadata restores report `staged: true` alongside `restart_required`; cancellation is deleting the pending file before restart (documented); the unshipped #678/#689 release-notes entries are edited into one coherent staged-restore story
- a source-order test guards the main.go seam (apply must precede every database open)

## Process

Same pipeline as the recent deep fixes: adversarial plan review (which added the resume rule and pending validation as blockers), independent implementation review (whose blocking find was the stale-WAL replay in the resume path; its requested checkpoint-failure test then caught the wal_checkpoint busy-not-error bug), licensed e2e before merge.

## Verification

- crash-matrix tests: resume-on-missing-destination, garbage and truncated-pending quarantine, stale safety-sidecar removal, checkpoint-failure with a recoverable safety copy, partial-state convergence, second-restore-over-applied
- licensed e2e: auth-enabled server, token minted, metadata backup, second token minted post-backup, staged restore (response `staged:true`; live DB untouched — all tokens still authenticate), SIGKILL (pending survives), restart — boot applies the restore, the post-backup token is rejected, pre-backup tokens work, and the `.before-restore` safety copy holds all three
- full backup/api/cmd suites pass incl. -race

Closes #635