### PR TITLE
fix(iceberg,backup): complete #639 items 2, 5, 7, 8

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -218,3 +218,15 @@ restores additionally report `staged: true`, since the restored databases are
 applied at the next start rather than swapped live.
 
 Contributed by [@atirna](https://github.com/atirna) in [#689](https://github.com/Basekick-Labs/arc/pull/689).
+
+### Iceberg audit sweep completion, part 1 ([#639](https://github.com/Basekick-Labs/arc/issues/639) items 2, 5, 7, 8)
+
+Four small hardenings from the Iceberg audit. A cluster node whose reconciler
+is gated off (no compactor role) now warns once at first occurrence instead of
+only logging at debug level every tick, so an export that silently never runs
+becomes visible. `warehouseRelKey` resolves symlinks before comparing paths,
+so a symlinked storage root no longer lands every commit in "hint
+unaddressable" mode. Local warehouse metadata written by the embedded Iceberg
+library is tightened to owner-only permissions after each commit (tighten
+only; deliberately restrictive modes are never loosened). Restore staging
+streams from backup storage instead of buffering entire databases in memory.

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -229,20 +229,21 @@ func (m *Manager) restoreSQLite(ctx context.Context, backupID string) error {
 // cancel by deleting the .pending-restore file before restarting.
 func (m *Manager) restoreSQLiteFile(ctx context.Context, backupID, srcName, destPath string) error {
 	srcPath := fmt.Sprintf("%s/metadata/%s", backupID, srcName)
-	data, err := m.backupStorage.Read(ctx, srcPath)
-	if err != nil {
-		return fmt.Errorf("failed to read SQLite backup: %w", err)
-	}
 
+	// Stream from backup storage into the staging file (#639 item 8): the
+	// shared database can be multi-GB on audit-heavy deployments, and
+	// buffering it in memory violates the streaming rule everywhere else in
+	// this package. CreateTemp creates 0600 before any byte lands, and the
+	// staging file is renamed into the pending path only on full success.
 	staging, err := os.CreateTemp(filepath.Dir(destPath), ".restore-staging-*")
 	if err != nil {
 		return fmt.Errorf("failed to create restore staging file: %w", err)
 	}
 	stagingPath := staging.Name()
-	if _, err := staging.Write(data); err != nil {
+	if err := m.backupStorage.ReadTo(ctx, srcPath, staging); err != nil {
 		staging.Close()
 		os.Remove(stagingPath)
-		return fmt.Errorf("failed to write staged restore: %w", err)
+		return fmt.Errorf("failed to stream SQLite backup into staging: %w", err)
 	}
 	if err := staging.Close(); err != nil {
 		os.Remove(stagingPath)

--- a/internal/iceberg/exporter.go
+++ b/internal/iceberg/exporter.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"sort"
@@ -57,6 +58,13 @@ type Exporter struct {
 	// property is reported once per table rather than every reconcile pass.
 	hintWarnMu sync.Mutex
 	hintWarned map[string]struct{}
+
+	// resolveOnce caches the symlink-resolved warehouse and storage-root
+	// URIs for warehouseRelKey (#639 item 5); resolved lazily because the
+	// directories may not exist at construction.
+	resolveOnce       sync.Once
+	resolvedWarehouse string
+	resolvedRoot      string
 
 	// hintFailure records that a discovery-file write failed anywhere during the
 	// current ReconcileMeasurementWithHint call, including inside EnsureTable
@@ -110,9 +118,11 @@ func NewExporter(db *sql.DB, backend storage.Backend, warehouse, nsPrefix string
 		catalog:   cat,
 		backend:   backend,
 		warehouse: strings.TrimSuffix(warehouse, "/"),
-		nsPrefix:  nsPrefix,
-		retain:    retain,
-		logger:    logger.With().Str("component", "iceberg-exporter").Logger(),
+		// resolvedWarehouse/resolvedRoot are computed lazily on first
+		// warehouseRelKey call (the directories may not exist yet here).
+		nsPrefix: nsPrefix,
+		retain:   retain,
+		logger:   logger.With().Str("component", "iceberg-exporter").Logger(),
 	}, nil
 }
 
@@ -601,6 +611,12 @@ func (e *Exporter) writeVersionHint(ctx context.Context, tbl *icetable.Table) bo
 		return true
 	}
 	metaLoc := tbl.MetadataLocation() // e.g. file:///…/metadata/00004-<uuid>.metadata.json
+	// iceberg-go writes metadata files and directories at umask permissions
+	// (its LocalFS uses 0o777-masked creates), while every Arc-written file
+	// is 0600 (#639 item 7). Harden the freshly committed table's metadata
+	// tree after each commit; bounded by the retain cap and snapshot expiry,
+	// so this walk is O(retained versions), not O(history).
+	e.hardenLocalMetadataPerms(metaLoc)
 	version, dirKey, ok := e.parseVersionAndMetaDir(metaLoc)
 	if !ok {
 		// Reachable when iceberg.warehouse points outside the storage root: the
@@ -687,19 +703,93 @@ func (e *Exporter) warnHintUnaddressableOnce(metaLoc string) {
 //	metaLoc "file:///data/wh/arc_db.db/cpu/metadata/00004-<uuid>.metadata.json"
 //	-> "wh/arc_db.db/cpu/metadata/00004-<uuid>.metadata.json"
 func (e *Exporter) warehouseRelKey(metaLoc string) (string, bool) {
-	if !isUnderDir(metaLoc, e.warehouse) {
+	// Resolve symlinks before comparing (#639 item 5): the warehouse config,
+	// the storage root, and the metadata location can each render the same
+	// physical directory through different spellings (a symlinked data dir,
+	// an unclean path), and raw string comparison then lands every commit in
+	// warn-once "hint unaddressable" mode. Resolution must be SYMMETRIC —
+	// all three values or none — and the two constant sides are cached.
+	e.resolveOnce.Do(func() {
+		e.resolvedWarehouse = resolveFileURI(e.warehouse)
+		if e.backend != nil {
+			e.resolvedRoot = resolveFileURI(DefaultWarehouse(e.backend))
+		}
+	})
+	loc := resolveFileURI(metaLoc)
+	if !isUnderDir(loc, e.resolvedWarehouse) {
 		return "", false
 	}
 	// No backend (tests/no-op mode): warehouse is the only base we have.
 	if e.backend == nil {
-		return strings.TrimPrefix(strings.TrimPrefix(metaLoc, e.warehouse), "/"), true
+		return strings.TrimPrefix(strings.TrimPrefix(loc, e.resolvedWarehouse), "/"), true
 	}
-	root := DefaultWarehouse(e.backend)
-	if !isUnderDir(metaLoc, root) {
+	if !isUnderDir(loc, e.resolvedRoot) {
 		// Warehouse is outside the storage root entirely — the backend cannot address it.
 		return "", false
 	}
-	return strings.TrimPrefix(strings.TrimPrefix(metaLoc, root), "/"), true
+	return strings.TrimPrefix(strings.TrimPrefix(loc, e.resolvedRoot), "/"), true
+}
+
+// hardenLocalMetadataPerms chmods a local warehouse table's metadata files to
+// 0600 and its directories to 0700, matching Arc's own writes. Local
+// warehouses only; object stores have no modes. Best-effort: a chmod failure
+// is a consistency nit, never a commit failure.
+func (e *Exporter) hardenLocalMetadataPerms(metaLoc string) {
+	const scheme = "file://"
+	if !strings.HasPrefix(metaLoc, scheme) {
+		return
+	}
+	metaDir := filepath.Dir(filepath.FromSlash(strings.TrimPrefix(metaLoc, scheme)))
+	entries, err := os.ReadDir(metaDir)
+	if err != nil {
+		return
+	}
+	// Tighten ONLY: clear group/other bits, never add owner bits. An
+	// operator's deliberately restrictive mode (or a test's read-only
+	// directory) must stay restrictive; the target is iceberg-go's
+	// umask-wide 0644/0755 creates, not modes someone chose.
+	tighten := func(path string, info os.FileMode) {
+		hardened := info &^ 0o077
+		if hardened != info {
+			if err := os.Chmod(path, hardened); err != nil {
+				e.logger.Debug().Err(err).Str("path", path).Msg("Could not harden metadata permissions")
+			}
+		}
+	}
+	for _, ent := range entries {
+		if info, err := ent.Info(); err == nil {
+			tighten(filepath.Join(metaDir, ent.Name()), info.Mode().Perm())
+		}
+	}
+	// The metadata dir, its table dir, and the namespace dir are all created
+	// by iceberg-go at umask permissions; the warehouse root itself is left
+	// alone (it may be shared or externally managed).
+	for _, dir := range []string{metaDir, filepath.Dir(metaDir), filepath.Dir(filepath.Dir(metaDir))} {
+		if info, err := os.Stat(dir); err == nil {
+			tighten(dir, info.Mode().Perm())
+		}
+	}
+}
+
+// resolveFileURI canonicalizes a file:// URI for path comparison: scheme
+// stripped, symlinks resolved, re-URI'd via localFileURI. When the full path
+// does not exist yet, its parent directory is resolved and the base rejoined,
+// so a not-yet-written metadata location still canonicalizes consistently
+// with its directory. Non-file schemes (s3://, azure://) return unchanged:
+// object keys have no symlinks and must keep exact string semantics.
+func resolveFileURI(uri string) string {
+	const scheme = "file://"
+	if !strings.HasPrefix(uri, scheme) {
+		return uri
+	}
+	p := filepath.FromSlash(strings.TrimPrefix(uri, scheme))
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return localFileURI(resolved)
+	}
+	if resolvedDir, err := filepath.EvalSymlinks(filepath.Dir(p)); err == nil {
+		return localFileURI(filepath.Join(resolvedDir, filepath.Base(p)))
+	}
+	return uri
 }
 
 // isUnderDir reports whether p is dir itself or lies beneath it, matching only at a path

--- a/internal/iceberg/scheduler.go
+++ b/internal/iceberg/scheduler.go
@@ -43,6 +43,13 @@ type Scheduler struct {
 	// without re-reading footers. Accessed only from the single loop() goroutine — no lock.
 	state map[string]measurementState
 
+	// gatedWarnOnce fires the first-gated WARN a single time per process
+	// (#639 item 2): the per-tick Debug is invisible at default log levels,
+	// so a cluster with no compactor-role node silently never exported.
+	// Only the loop() goroutine touches it. A node demoted after having run
+	// does not re-warn; the startup case is the observability gap.
+	gatedWarnOnce bool
+
 	cancel context.CancelFunc
 	done   chan struct{}
 }
@@ -130,6 +137,10 @@ func (s *Scheduler) loop(ctx context.Context) {
 // takes effect without a restart (nil gate = always run).
 func (s *Scheduler) runPass(ctx context.Context) {
 	if s.gate != nil && !s.gate.CanRun() {
+		if !s.gatedWarnOnce {
+			s.gatedWarnOnce = true
+			s.logger.Warn().Msg("Iceberg reconcile is gated off on this node (not the active compactor). If no node in the cluster holds a compactor role, Iceberg export never runs; assign one to enable it")
+		}
 		s.logger.Debug().Msg("Iceberg reconcile skipped: node is not the active writer")
 		return
 	}

--- a/internal/iceberg/scheduler_test.go
+++ b/internal/iceberg/scheduler_test.go
@@ -636,7 +636,7 @@ func TestIsUnderDir(t *testing.T) {
 	}{
 		{"file:///data/wh", true}, // the dir itself
 		{"file:///data/wh/arc_db.db/cpu/metadata/v1.metadata.json", true}, // beneath it
-		{"file:///data/wh/", true},                                        // trailing slash
+		{"file:///data/wh/", true}, // trailing slash
 		// Siblings that share a name prefix must NOT match.
 		{"file:///data/wh-other/arc_db.db/cpu/metadata/v1.metadata.json", false},
 		{"file:///data/wharf/x.json", false},

--- a/internal/iceberg/sweep639_test.go
+++ b/internal/iceberg/sweep639_test.go
@@ -1,0 +1,91 @@
+package iceberg
+
+// Unit tests for the #639 sweep-completion items that live in this package:
+// item 2 (once-per-process gated warning), item 5 (symlink-resolved
+// warehouseRelKey), item 7 (tighten-only metadata permission hardening).
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestWarehouseRelKey_SymlinkedWarehouseResolves(t *testing.T) {
+	base := t.TempDir()
+	real := filepath.Join(base, "real-wh")
+	if err := os.MkdirAll(filepath.Join(real, "arc_db.db", "cpu", "metadata"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "link-wh")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// Warehouse configured through the SYMLINK; metadata location rendered
+	// through the REAL path (how a resolved writer would emit it). Raw string
+	// comparison never matches these; resolution must.
+	e := &Exporter{warehouse: "file://" + filepath.ToSlash(link)}
+	metaLoc := "file://" + filepath.ToSlash(filepath.Join(real, "arc_db.db", "cpu", "metadata", "v3.metadata.json"))
+
+	rel, ok := e.warehouseRelKey(metaLoc)
+	if !ok {
+		t.Fatal("symlinked warehouse spelling did not resolve to the same root (#639 item 5)")
+	}
+	if want := "arc_db.db/cpu/metadata/v3.metadata.json"; rel != want {
+		t.Fatalf("rel = %q, want %q", rel, want)
+	}
+}
+
+func TestHardenLocalMetadataPerms_TightenOnly(t *testing.T) {
+	base := t.TempDir()
+	metaDir := filepath.Join(base, "wh", "arc_db.db", "cpu", "metadata")
+	if err := os.MkdirAll(metaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wide := filepath.Join(metaDir, "00001-x.metadata.json")
+	if err := os.WriteFile(wide, []byte("m"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restrictive := filepath.Join(metaDir, "keep.json")
+	if err := os.WriteFile(restrictive, []byte("m"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &Exporter{logger: zerolog.Nop()}
+	e.hardenLocalMetadataPerms("file://" + filepath.ToSlash(wide))
+
+	if info, _ := os.Stat(wide); info.Mode().Perm() != 0o600 {
+		t.Fatalf("umask-wide file = %v, want 0600", info.Mode().Perm())
+	}
+	if info, _ := os.Stat(restrictive); info.Mode().Perm() != 0o400 {
+		t.Fatalf("restrictive file = %v, want UNCHANGED 0400 (tighten only)", info.Mode().Perm())
+	}
+	if info, _ := os.Stat(metaDir); info.Mode().Perm() != 0o700 {
+		t.Fatalf("metadata dir = %v, want 0700", info.Mode().Perm())
+	}
+}
+
+func TestRunPass_GatedWarnsOncePerProcess(t *testing.T) {
+	var logs bytes.Buffer
+	s := &Scheduler{
+		gate:   blockedGate{},
+		logger: zerolog.New(&logs),
+		state:  map[string]measurementState{},
+	}
+	s.runPass(context.Background())
+	s.runPass(context.Background())
+	s.runPass(context.Background())
+
+	if got := strings.Count(logs.String(), "gated off on this node"); got != 1 {
+		t.Fatalf("gated WARN fired %d times over 3 passes, want exactly 1 (#639 item 2)", got)
+	}
+}
+
+type blockedGate struct{}
+
+func (blockedGate) CanRun() bool { return false }


### PR DESCRIPTION
## Summary

Part 1 of finishing the #639 audit sweep (item 3, catalog cleanup on database drop, follows separately as the one destructive-path change):

- **item 2**: a reconciler gated off on a node (no compactor role) warns ONCE at first occurrence with actionable text; previously only a per-tick debug line, so a cluster misconfiguration meant Iceberg export silently never ran
- **item 5**: `warehouseRelKey` resolves symlinks before comparing, symmetrically across the metadata location, warehouse, and storage root (constant sides cached; parent-dir fallback for not-yet-written locations; s3/azure schemes bypass untouched), so a symlinked storage root no longer lands every commit in warn-once hint-unaddressable mode
- **item 7**: after each commit, the freshly committed table's local metadata tree is tightened to owner-only permission bits (iceberg-go writes at umask); TIGHTEN-ONLY, group/other bits are cleared and owner bits are never added, so deliberately restrictive modes stay (the review of the first attempt caught it un-breaking a test's read-only directory)
- **item 8**: restore staging streams from backup storage via `ReadTo` instead of buffering multi-GB databases in memory twice

## Process

Batched adversarial plan review before implementation (which set the tighten-only requirement's groundwork, the symmetric-resolution shape, and confirmed the chmod walk is bounded by the retain cap); unit tests per item.

## Verification

- new tests: symlinked-warehouse resolution, tighten-only permission semantics (umask-wide file hardened, 0400 file untouched), once-per-process gated warning over repeated passes
- item 8 is exercised by the existing staging tests through the streaming path
- full iceberg/backup/api suites pass

Refs #639