### PR TITLE
feat(iceberg): clear catalog artifacts on database drop

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -230,3 +230,13 @@ unaddressable" mode. Local warehouse metadata written by the embedded Iceberg
 library is tightened to owner-only permissions after each commit (tighten
 only; deliberately restrictive modes are never loosened). Restore staging
 streams from backup storage instead of buffering entire databases in memory.
+
+### Dropping a database now clears its Iceberg catalog artifacts ([#639](https://github.com/Basekick-Labs/arc/issues/639) item 3)
+
+`DELETE /api/v1/databases/{name}` previously deleted the data files but left
+the database's Iceberg namespace, table rows, and warehouse metadata behind
+forever. The delete now also drops each catalog table, the namespace, and the
+warehouse metadata directory, after the files are removed, so a racing
+reconcile pass can only empty tables rather than recreate them. Cleanup
+failures are logged and re-running the DELETE retries them, including when the
+files are already gone.

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -3162,6 +3162,8 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to initialize Iceberg exporter")
 		}
+		// #639 item 3: database deletion clears the Iceberg catalog too.
+		databasesHandler.SetIcebergDropper(exporter)
 		icebergSource := iceberg.NewStorageWalkSource(storageBackend, cfg.Iceberg.NamespacePrefix, logger.Get("iceberg"))
 		// Writer gate: in cluster mode reuse the compaction gate; nil in OSS (single node, always
 		// runs). SINGLE-WRITER REQUIREMENT: the reconciler writes version-hint.text / v<N>.json

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -21,6 +21,7 @@ type DatabasesHandler struct {
 	tieringManager *tiering.Manager
 	authManager    *auth.AuthManager
 	logger         zerolog.Logger
+	icebergDropper IcebergCatalogDropper
 }
 
 // CreateDatabaseRequest represents a request to create a new database
@@ -62,6 +63,18 @@ var reservedDatabaseNames = map[string]bool{
 }
 
 // NewDatabasesHandler creates a new databases handler
+// IcebergCatalogDropper removes a dropped database's Iceberg catalog
+// artifacts (#639 item 3). Implemented by iceberg.Exporter; nil when Iceberg
+// export is disabled.
+type IcebergCatalogDropper interface {
+	DropDatabase(ctx context.Context, database string) error
+}
+
+// SetIcebergDropper wires catalog cleanup into database deletion.
+func (h *DatabasesHandler) SetIcebergDropper(d IcebergCatalogDropper) {
+	h.icebergDropper = d
+}
+
 func NewDatabasesHandler(storage storage.Backend, deleteConfig *config.DeleteConfig, authManager *auth.AuthManager, logger zerolog.Logger) *DatabasesHandler {
 	return &DatabasesHandler{
 		storage:      storage,
@@ -330,6 +343,10 @@ func (h *DatabasesHandler) handleDelete(c *fiber.Ctx) error {
 	}
 
 	if !exists {
+		// Converge re-runs (#639 item 3): a previous DELETE may have removed
+		// the files then crashed before catalog cleanup. Best-effort here so
+		// repeating the DELETE clears the residue; the 404 contract stands.
+		h.dropIcebergCatalog(ctx, name)
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
 			"error": "Database '" + name + "' not found",
 		})
@@ -384,6 +401,13 @@ func (h *DatabasesHandler) handleDelete(c *fiber.Ctx) error {
 			h.logger.Debug().Err(err).Str("database", name).Msg("Could not remove database directory (may not be empty)")
 		}
 	}
+
+	// Iceberg catalog cleanup AFTER file deletion (#639 item 3): with the
+	// files gone, a racing reconcile pass can only empty tables, never
+	// recreate them. Failures are logged, not returned: the files are
+	// already deleted, catalog residue equals the pre-fix status quo, and
+	// re-running the DELETE retries the cleanup.
+	h.dropIcebergCatalog(ctx, name)
 
 	if len(deleteErrors) > 0 {
 		h.logger.Error().
@@ -678,4 +702,18 @@ func extractSubdirectories(files []string, prefix string) []string {
 		dirs = append(dirs, dir)
 	}
 	return dirs
+}
+
+// dropIcebergCatalog is the nil-safe, logged wrapper around the wired
+// catalog dropper.
+func (h *DatabasesHandler) dropIcebergCatalog(ctx context.Context, name string) {
+	if h.icebergDropper == nil {
+		return
+	}
+	if err := h.icebergDropper.DropDatabase(ctx, name); err != nil {
+		h.logger.Warn().Err(err).Str("database", name).
+			Msg("Iceberg catalog cleanup after database drop failed; re-running the DELETE retries it")
+	} else {
+		h.logger.Info().Str("database", name).Msg("Iceberg catalog artifacts removed for dropped database")
+	}
 }

--- a/internal/iceberg/drop_database_test.go
+++ b/internal/iceberg/drop_database_test.go
@@ -1,0 +1,77 @@
+package iceberg
+
+// #639 item 3: DropDatabase removes catalog tables, the namespace, and the
+// warehouse metadata directory for a dropped Arc database, idempotently.
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+func TestDropDatabase_RemovesCatalogAndWarehouse(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	backend, err := storage.NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := int64(1_700_000_000_000_000)
+	writeArcStyleParquet(t, filepath.Join(root, "mydb/cpu/2023/11/14/22/cpu_a.parquet"), base, 50)
+	db, err := sql.Open("sqlite3", filepath.Join(root, "arc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	exp, err := NewExporter(db, backend, "file://"+root, "arc", 2, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := NewStorageWalkSource(backend, "arc", zerolog.Nop())
+	sched := NewScheduler(SchedulerConfig{Exporter: exp, Source: src, Logger: zerolog.Nop()})
+	sched.runPass(ctx)
+
+	nsDir := filepath.Join(root, "arc_mydb.db")
+	if _, err := os.Stat(nsDir); err != nil {
+		t.Fatalf("reconcile did not create the warehouse namespace dir: %v", err)
+	}
+	var tables int
+	if err := db.QueryRow("SELECT count(*) FROM iceberg_tables").Scan(&tables); err != nil || tables != 1 {
+		t.Fatalf("catalog tables = (%d, %v), want 1 after reconcile", tables, err)
+	}
+
+	if err := exp.DropDatabase(ctx, "mydb"); err != nil {
+		t.Fatalf("DropDatabase: %v", err)
+	}
+	if err := db.QueryRow("SELECT count(*) FROM iceberg_tables").Scan(&tables); err != nil || tables != 0 {
+		t.Fatalf("catalog tables = (%d, %v), want 0 after drop", tables, err)
+	}
+	var namespaces int
+	if err := db.QueryRow("SELECT count(*) FROM iceberg_namespace_properties").Scan(&namespaces); err == nil && namespaces != 0 {
+		t.Fatalf("namespace properties = %d, want 0 after drop", namespaces)
+	}
+	entries, _ := os.ReadDir(nsDir)
+	if len(entries) != 0 {
+		if _, statErr := os.Stat(nsDir); statErr == nil {
+			t.Fatalf("warehouse namespace dir still holds %d entries after drop", len(entries))
+		}
+	}
+
+	// Idempotence: dropping again, and dropping a never-exported database.
+	if err := exp.DropDatabase(ctx, "mydb"); err != nil {
+		t.Fatalf("second DropDatabase: %v", err)
+	}
+	if err := exp.DropDatabase(ctx, "neverdb"); err != nil {
+		t.Fatalf("never-exported DropDatabase: %v", err)
+	}
+
+	// Spoke pseudo-databases are refused.
+	if err := exp.DropDatabase(ctx, "rocket-01/telemetry"); err == nil {
+		t.Fatal("namespaced database name unexpectedly accepted")
+	}
+}

--- a/internal/iceberg/exporter.go
+++ b/internal/iceberg/exporter.go
@@ -853,3 +853,77 @@ func isAlreadyExists(err error) bool {
 	return errors.Is(err, icecatalog.ErrNamespaceAlreadyExists) ||
 		errors.Is(err, icecatalog.ErrTableAlreadyExists)
 }
+
+// DropDatabase removes every Iceberg catalog artifact for an Arc database
+// (#639 item 3): each table in its namespace, the namespace itself, and the
+// warehouse metadata files under the namespace directory. Called from the
+// database-delete API after the data files are gone; that ordering is
+// load-bearing — with no files left, a racing reconcile pass can only empty
+// tables, never recreate them, whereas catalog-first would let EnsureTable
+// resurrect residue mid-cleanup. Idempotent: a database that was never
+// exported (or already cleaned) returns nil, so a re-run of the delete
+// converges.
+//
+// Spoke-namespace pseudo-databases contain a path separator and are refused:
+// their namespace naming does not follow this mapping, and their lifecycle is
+// owned by edge-sync.
+func (e *Exporter) DropDatabase(ctx context.Context, database string) error {
+	if strings.ContainsAny(database, "/\\") {
+		return fmt.Errorf("refusing to drop namespaced database %q from the Iceberg catalog", database)
+	}
+	ns := icetable.Identifier{e.nsPrefix + "_" + database}
+
+	// The SQL catalog's DropNamespace refuses non-empty namespaces, so drop
+	// every table first. Collect the first error but keep going: partial
+	// cleanup converges on the next delete attempt.
+	var firstErr error
+	for ident, err := range e.catalog.ListTables(ctx, ns) {
+		if err != nil {
+			if errors.Is(err, icecatalog.ErrNoSuchNamespace) {
+				return nil // never exported; nothing to clean
+			}
+			return fmt.Errorf("list tables for drop: %w", err)
+		}
+		if err := e.catalog.DropTable(ctx, ident); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("drop table %v: %w", ident, err)
+		}
+	}
+	if err := e.catalog.DropNamespace(ctx, ns); err != nil && !errors.Is(err, icecatalog.ErrNoSuchNamespace) && firstErr == nil {
+		firstErr = fmt.Errorf("drop namespace: %w", err)
+	}
+
+	// Warehouse holds ONLY metadata (data files are Arc's own tree, already
+	// deleted by the caller); remove the namespace directory's objects via
+	// the backend so local and object-store warehouses behave alike.
+	if e.backend != nil {
+		nsDirURI := e.warehouse + "/" + e.nsPrefix + "_" + database + ".db"
+		if relDir, ok := e.warehouseRelKey(nsDirURI); ok {
+			keys, err := e.backend.List(ctx, relDir+"/")
+			if err != nil && firstErr == nil {
+				firstErr = fmt.Errorf("list warehouse metadata: %w", err)
+			}
+			dirs := map[string]bool{relDir: true}
+			for _, key := range keys {
+				if err := e.backend.Delete(ctx, key); err != nil && firstErr == nil {
+					firstErr = fmt.Errorf("delete warehouse object %s: %w", key, err)
+				}
+				for d := path.Dir(key); len(d) > len(relDir); d = path.Dir(d) {
+					dirs[d] = true
+				}
+			}
+			// RemoveDirectory is non-recursive, so sweep the now-empty
+			// directory tree deepest-first (object stores no-op here).
+			if remover, ok := e.backend.(storage.DirectoryRemover); ok {
+				ordered := make([]string, 0, len(dirs))
+				for d := range dirs {
+					ordered = append(ordered, d)
+				}
+				sort.Slice(ordered, func(i, j int) bool { return len(ordered[i]) > len(ordered[j]) })
+				for _, d := range ordered {
+					_ = remover.RemoveDirectory(ctx, d)
+				}
+			}
+		}
+	}
+	return firstErr
+}


### PR DESCRIPTION
## Summary

- completes #639 (item 3, the final open item): `DELETE /api/v1/databases/{name}` now also removes the database's Iceberg catalog tables, its namespace, and its warehouse metadata directory, previously all of it persisted forever
- ordering is files-first (the existing delete flow) so a racing reconcile pass can only empty tables, never resurrect them via `EnsureTable`; catalog-first was explicitly rejected in plan review for that reason
- the SQL catalog's `DropNamespace` refuses non-empty namespaces, so tables are dropped individually first; `ErrNoSuchNamespace` reads as success (database never exported), making the operation idempotent
- cleanup also runs best-effort on the 404 path, so re-running the DELETE after a crash between file deletion and catalog cleanup converges, without changing the API's not-found contract
- warehouse directory sweep is deepest-first (`RemoveDirectory` is non-recursive, which is the very behavior the issue documents); spoke pseudo-databases are refused (their lifecycle belongs to edge-sync, and the review confirmed a bare spoke-ID delete hits a nonexistent namespace harmlessly)
- nil-safe wiring: deployments without Iceberg export are untouched

## Verification

- exporter test with a real SQL catalog: reconcile creates the table, drop empties `iceberg_tables` and namespace properties and removes the warehouse namespace tree, second drop and never-exported drop are no-ops, namespaced names refused
- full iceberg/api suites pass

Refs #693 (items 2/5/7/8). Closes #639.