### PR TITLE
fix(storage): anchor S3 range paths to UTC calendar days

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -57,9 +57,10 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 
 ### S3 query paths now follow calendar days across DST ([#321](https://github.com/Basekick-Labs/arc/issues/321))
 
-S3 time-range pruning now builds one inclusive partition path per calendar day in
-the range's starting time zone. Non-UTC offsets and daylight-saving transitions
-no longer shift the first or last date or skip a local day.
+S3 time-range path generation now builds one inclusive partition path per UTC
+calendar day covering the range, matching Arc's UTC partition layout. Non-UTC
+inputs are normalized to UTC, and daylight-saving transitions can no longer
+shift, skip, or duplicate a date.
 
 Contributed by [@copacabanaservice01](https://github.com/copacabanaservice01) in [#690](https://github.com/Basekick-Labs/arc/pull/690).
 

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -585,4 +585,3 @@ func isAzureNotFoundError(err error) bool {
 		strings.Contains(errStr, "404") ||
 		strings.Contains(errStr, "NotFound")
 }
-

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -685,14 +685,17 @@ func (b *S3Backend) GetQueryPath(database, measurement string, year, month, day,
 func (b *S3Backend) GetQueryPathRange(database, measurement string, startTime, endTime time.Time) []string {
 	var paths []string
 
-	// Generate paths for each calendar day in the range. Truncate(24h) and
-	// Add(24h) operate on elapsed time, so they shift local dates across UTC
-	// offsets and daylight-saving transitions.
-	location := startTime.Location()
-	startYear, startMonth, startDay := startTime.Date()
-	current := time.Date(startYear, startMonth, startDay, 0, 0, 0, 0, location)
-	endYear, endMonth, endDay := endTime.In(location).Date()
-	end := time.Date(endYear, endMonth, endDay, 0, 0, 0, 0, location).AddDate(0, 0, 1)
+	// Generate one path per UTC calendar day covering the range. Arc's
+	// partition directories are UTC dates (ingestion, pruning, and the query
+	// engine's pinned session zone all agree), so the inputs are normalized
+	// to UTC first: anchoring to a caller's local zone would skip the
+	// trailing UTC partition for west-of-UTC ranges and add a spurious
+	// leading one (#690 follow-up). AddDate keeps day-stepping calendar-
+	// correct, which in UTC is also DST-proof (#321).
+	startYear, startMonth, startDay := startTime.UTC().Date()
+	current := time.Date(startYear, startMonth, startDay, 0, 0, 0, 0, time.UTC)
+	endYear, endMonth, endDay := endTime.UTC().Date()
+	end := time.Date(endYear, endMonth, endDay, 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1)
 
 	for current.Before(end) {
 		path := fmt.Sprintf("s3://%s/%s%s/%s/%04d/%02d/%02d/*/*.parquet",

--- a/internal/storage/s3_query_path_test.go
+++ b/internal/storage/s3_query_path_test.go
@@ -6,50 +6,73 @@ import (
 	"time"
 )
 
-func TestGetQueryPathRangeUsesCalendarDaysAcrossDST(t *testing.T) {
+// GetQueryPathRange generates UTC calendar-day paths: Arc partitions are UTC
+// dates, so non-UTC inputs normalize to UTC rather than anchoring the walk to
+// their own zone. The Nov 2 20:00 New York instant is Nov 3 01:00 UTC, so the
+// 11/03 partition MUST be listed; a local-day walk stops at 11/02 and drops it.
+func TestGetQueryPathRangeUsesUTCCalendarDays(t *testing.T) {
 	loc, err := time.LoadLocation("America/New_York")
 	if err != nil {
 		t.Fatalf("load timezone: %v", err)
 	}
 
 	backend := &S3Backend{bucket: "test-bucket", prefix: "tenant/"}
-	start := time.Date(2026, time.October, 31, 12, 0, 0, 0, loc)
-	end := time.Date(2026, time.November, 2, 12, 0, 0, 0, loc)
+	start := time.Date(2026, time.October, 31, 12, 0, 0, 0, loc) // Oct 31 16:00 UTC
+	end := time.Date(2026, time.November, 2, 20, 0, 0, 0, loc)   // Nov 3 01:00 UTC
 
 	got := backend.GetQueryPathRange("metrics", "cpu", start, end)
-	want := expectedDSTPaths()
-
+	want := []string{
+		"s3://test-bucket/tenant/metrics/cpu/2026/10/31/*/*.parquet",
+		"s3://test-bucket/tenant/metrics/cpu/2026/11/01/*/*.parquet",
+		"s3://test-bucket/tenant/metrics/cpu/2026/11/02/*/*.parquet",
+		"s3://test-bucket/tenant/metrics/cpu/2026/11/03/*/*.parquet",
+	}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("unexpected paths across DST boundary:\ngot:  %v\nwant: %v", got, want)
+		t.Fatalf("non-UTC inputs must yield UTC-day paths:\ngot:  %v\nwant: %v", got, want)
 	}
 }
 
-func TestGetQueryPathRangeUsesStartLocationForRange(t *testing.T) {
+// The DST fall-back weekend must not skip or duplicate a day (#321): AddDate
+// in UTC steps calendar days regardless of any zone's transitions.
+func TestGetQueryPathRangeCalendarDaysAcrossDST(t *testing.T) {
+	backend := &S3Backend{bucket: "test-bucket", prefix: "tenant/"}
+	start := time.Date(2026, time.October, 31, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, time.November, 2, 12, 0, 0, 0, time.UTC)
+
+	got := backend.GetQueryPathRange("metrics", "cpu", start, end)
+	want := []string{
+		"s3://test-bucket/tenant/metrics/cpu/2026/10/31/*/*.parquet",
+		"s3://test-bucket/tenant/metrics/cpu/2026/11/01/*/*.parquet",
+		"s3://test-bucket/tenant/metrics/cpu/2026/11/02/*/*.parquet",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected paths across the DST weekend:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+// Mixed-zone inputs normalize to one UTC day set; neither input's zone may
+// influence the walk.
+func TestGetQueryPathRangeMixedLocationsNormalize(t *testing.T) {
 	newYork, err := time.LoadLocation("America/New_York")
 	if err != nil {
 		t.Fatalf("load start timezone: %v", err)
 	}
-	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
 	if err != nil {
 		t.Fatalf("load end timezone: %v", err)
 	}
 
 	backend := &S3Backend{bucket: "test-bucket", prefix: "tenant/"}
-	start := time.Date(2026, time.October, 31, 12, 0, 0, 0, newYork)
-	end := time.Date(2026, time.November, 2, 12, 0, 0, 0, losAngeles)
+	start := time.Date(2026, time.October, 31, 12, 0, 0, 0, newYork) // Oct 31 16:00 UTC
+	end := time.Date(2026, time.November, 3, 8, 0, 0, 0, tokyo)      // Nov 2 23:00 UTC
 
 	got := backend.GetQueryPathRange("metrics", "cpu", start, end)
-	want := expectedDSTPaths()
-
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("unexpected paths with mixed locations:\ngot:  %v\nwant: %v", got, want)
-	}
-}
-
-func expectedDSTPaths() []string {
-	return []string{
+	want := []string{
 		"s3://test-bucket/tenant/metrics/cpu/2026/10/31/*/*.parquet",
 		"s3://test-bucket/tenant/metrics/cpu/2026/11/01/*/*.parquet",
 		"s3://test-bucket/tenant/metrics/cpu/2026/11/02/*/*.parquet",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mixed-zone inputs must normalize to UTC days:\ngot:  %v\nwant: %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Maintainer follow-up to #690, implementing the zone correction from its review: `GetQueryPathRange` now normalizes both boundaries to UTC and walks UTC calendar days, matching Arc's UTC partition layout (ingestion, the pruner, and the #684 engine pin all agree). Anchoring to the start time's location dropped the trailing UTC partition for west-of-UTC ranges and added a spurious leading one.

The contributor's DST mechanics (`AddDate` day-stepping) and test scaffolding are retained; the tests now assert UTC-day output for non-UTC and mixed-zone inputs, including the boundary case where a New York evening instant belongs to the next UTC day. Release-note wording updated to match; contributor credit unchanged.

Note: this function has no production callers today, so this is contract-correctness for whoever wires it, pinned by tests before that happens.

## Verification

- `go test ./internal/storage` under host TZ and `TZ=America/New_York`
- full build clean

Refs #321, #690