### PR TITLE
fix(wal): chunk oversized payloads so wide-row ingest stays durable (#677)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -55,6 +55,21 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 
 ## Bug fixes
 
+### Wide-row ingest requests no longer silently bypass the WAL ([#677](https://github.com/Basekick-Labs/arc/issues/677))
+
+A single ingest request larger than the WAL's 100MB per-entry payload cap
+(wide rows make this easy to hit well under the 1GB request limit) was
+rejected wholesale by the WAL, so ingest kept reporting healthy while the
+WAL directory held only a 7-byte header file: writes were durable in
+Parquet flushes alone and nothing on the metrics endpoint said so. The WAL
+now splits an oversized payload into multiple entries at msgpack element
+boundaries (row-format requests between records, columnar requests by row
+range), each under the cap and independently replayable with no format
+change. A payload that still cannot be split, a single record or row above
+the cap, keeps the loud rejection, now also counted in the new
+`arc_wal_oversized_payloads_total` metric so a WAL that records nothing
+never looks healthy again.
+
 ### S3 query paths now follow calendar days across DST ([#321](https://github.com/Basekick-Labs/arc/issues/321))
 
 S3 time-range path generation now builds one inclusive partition path per UTC

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -264,3 +264,5 @@ warehouse metadata directory, after the files are removed, so a racing
 reconcile pass can only empty tables rather than recreate them. Cleanup
 failures are logged and re-running the DELETE retries them, including when the
 files are already gone.
+
+Contributed by [@atirna](https://github.com/atirna) in [#696](https://github.com/Basekick-Labs/arc/pull/696).

--- a/internal/ingest/wal_wide_payload_test.go
+++ b/internal/ingest/wal_wide_payload_test.go
@@ -1,0 +1,98 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/basekick-labs/arc/internal/wal"
+	"github.com/rs/zerolog"
+)
+
+// TestWideRequestReachesWALAndReplays is the #677 repro end to end: a wide
+// columnar msgpack request above the WAL single-entry cap goes through the
+// real decode -> ArrowBuffer.Write path with a real WAL writer attached, the
+// WAL holds the request's rows as chunked entries instead of a header-only
+// file, and those entries replay through the recovery callback the same way
+// boot recovery would apply them.
+func TestWideRequestReachesWALAndReplays(t *testing.T) {
+	tmp := t.TempDir()
+	writer, err := wal.NewWriter(&wal.WriterConfig{
+		WALDir: filepath.Join(tmp, "wal"), SyncMode: wal.SyncModeAsync,
+		MaxSizeBytes: 1024 * 1024 * 1024, BufferSize: 100000, Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("wal.NewWriter: %v", err)
+	}
+	buf := newReplayTestBuffer(t, filepath.Join(tmp, "data")) // package-standard buffer+storage wiring
+	t.Cleanup(func() { buf.Close() })
+	buf.SetWAL(writer)
+
+	// The reporter's payload: time + 10 fields of ~10 KB per row, above the
+	// WAL single-entry cap.
+	const rows = 1200
+	wide := strings.Repeat("w", 10*1024)
+	timeCol := make([]interface{}, rows)
+	for i := range timeCol {
+		timeCol[i] = int64(1_700_000_000_000_000 + i)
+	}
+	wideRow := make([]interface{}, rows)
+	for i := range wideRow {
+		wideRow[i] = wide
+	}
+	columns := map[string]interface{}{"time": timeCol}
+	for f := 0; f < 10; f++ {
+		columns[fmt.Sprintf("field_%d", f)] = wideRow
+	}
+	payload, err := msgpack.Marshal(map[string]interface{}{"m": "cpu", "columns": columns})
+	if err != nil || len(payload) <= wal.MaxWALPayloadSize {
+		t.Fatalf("marshal (%v) or payload %d not above cap", err, len(payload))
+	}
+
+	// The live path: decode the request, write the decoded records.
+	decoded, err := NewMessagePackDecoder(zerolog.Nop()).Decode(payload)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if err := buf.Write(context.Background(), "default", decoded); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	walPath := writer.CurrentFile()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("wal close: %v", err)
+	}
+	// The WAL must not be header-only, and its entries must cover every row.
+	if info, err := os.Stat(walPath); err != nil {
+		t.Fatalf("stat: %v", err)
+	} else if info.Size() <= 7 {
+		t.Fatalf("WAL is header-only (%d bytes): the wide request never reached the WAL", info.Size())
+	}
+	entries, err := wal.NewReader(walPath, zerolog.Nop()).ReadAll()
+	if err != nil || len(entries) < 2 {
+		t.Fatalf("expected chunked entries, got %d (%v)", len(entries), err)
+	}
+
+	// Replay: a fresh buffer applies each entry the way boot recovery would.
+	replayBuf := newReplayTestBuffer(t, filepath.Join(tmp, "replay-data"))
+	t.Cleanup(func() { replayBuf.Close() })
+	totalRows := 0
+	for i, e := range entries {
+		if e.ColumnarData == nil {
+			t.Fatalf("entry %d not columnar", i)
+		}
+		if err := replayBuf.WriteColumnarDirectNoWAL(context.Background(), e.ColumnarData.Database, e.ColumnarData.Measurement, e.ColumnarData.Columns); err != nil {
+			t.Fatalf("replay entry %d: %v", i, err)
+		}
+		for _, col := range e.ColumnarData.Columns {
+			totalRows += len(col)
+			break
+		}
+	}
+	if totalRows != rows {
+		t.Fatalf("replayed rows = %d, want %d", totalRows, rows)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -112,11 +112,12 @@ type Metrics struct {
 	auditWriteErrors atomic.Int64
 
 	// WAL metrics
-	walRecordsPreserved atomic.Int64 // Records preserved in WAL for recovery (flush failures)
-	walRecoveryTotal    atomic.Int64 // Successful WAL recovery operations
-	walRecoveryRecords  atomic.Int64 // Total records recovered from WAL
-	walDroppedEntries   atomic.Int64 // Entries dropped due to full WAL buffer
-	walFailedWrites     atomic.Int64 // Write failures to WAL file
+	walRecordsPreserved  atomic.Int64 // Records preserved in WAL for recovery (flush failures)
+	walRecoveryTotal     atomic.Int64 // Successful WAL recovery operations
+	walRecoveryRecords   atomic.Int64 // Total records recovered from WAL
+	walDroppedEntries    atomic.Int64 // Entries dropped due to full WAL buffer
+	walFailedWrites      atomic.Int64 // Write failures to WAL file
+	walOversizedPayloads atomic.Int64 // Payloads rejected for exceeding the single-entry cap even after chunking (#677)
 
 	// Decompression pool metrics
 	decompBufferDiscards atomic.Int64 // Oversized buffers not returned to pool
@@ -372,6 +373,7 @@ func (m *Metrics) IncWALRecoveryTotal()               { m.walRecoveryTotal.Add(1
 func (m *Metrics) IncWALRecoveryRecords(count int64)  { m.walRecoveryRecords.Add(count) }
 func (m *Metrics) IncWALDroppedEntries()              { m.walDroppedEntries.Add(1) }
 func (m *Metrics) IncWALFailedWrites()                { m.walFailedWrites.Add(1) }
+func (m *Metrics) IncWALOversizedPayloads()           { m.walOversizedPayloads.Add(1) }
 
 // Decompression Pool Metrics
 func (m *Metrics) IncDecompBufferDiscards() { m.decompBufferDiscards.Add(1) }
@@ -555,11 +557,12 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 		"mqtt_reconnects":        m.mqttReconnects.Load(),
 
 		// WAL
-		"wal_records_preserved": m.walRecordsPreserved.Load(),
-		"wal_recovery_total":    m.walRecoveryTotal.Load(),
-		"wal_recovery_records":  m.walRecoveryRecords.Load(),
-		"wal_dropped_entries":   m.walDroppedEntries.Load(),
-		"wal_failed_writes":     m.walFailedWrites.Load(),
+		"wal_records_preserved":  m.walRecordsPreserved.Load(),
+		"wal_recovery_total":     m.walRecoveryTotal.Load(),
+		"wal_recovery_records":   m.walRecoveryRecords.Load(),
+		"wal_dropped_entries":    m.walDroppedEntries.Load(),
+		"wal_failed_writes":      m.walFailedWrites.Load(),
+		"wal_oversized_payloads": m.walOversizedPayloads.Load(),
 
 		// Decompression Pool
 		"decomp_buffer_discards": m.decompBufferDiscards.Load(),
@@ -882,6 +885,10 @@ func (m *Metrics) PrometheusFormat() string {
 	b = append(b, "# HELP arc_wal_failed_writes_total WAL write failures\n"...)
 	b = append(b, "# TYPE arc_wal_failed_writes_total counter\n"...)
 	b = appendMetric(b, "arc_wal_failed_writes_total", float64(m.walFailedWrites.Load()))
+
+	b = append(b, "# HELP arc_wal_oversized_payloads_total Payloads rejected for exceeding the single-entry cap even after chunking\n"...)
+	b = append(b, "# TYPE arc_wal_oversized_payloads_total counter\n"...)
+	b = appendMetric(b, "arc_wal_oversized_payloads_total", float64(m.walOversizedPayloads.Load()))
 
 	// Decompression pool metrics
 	b = append(b, "# HELP arc_decomp_buffer_discards_total Oversized decompression buffers not returned to pool\n"...)

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -84,7 +84,8 @@ func ParseEnvelope(payload []byte, defaultDB string) (database string, msgpackDa
 // reject. A crash between chunk writes replays the completed prefix, which is
 // safe because rows are independent.
 func splitOversizedPayload(payload []byte) ([][]byte, error) {
-	dec := msgpack.NewDecoder(bytes.NewReader(payload))
+	reader := bytes.NewReader(payload)
+	dec := msgpack.NewDecoder(reader)
 	code, err := dec.PeekCode()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read msgpack header: %w", err)
@@ -141,46 +142,35 @@ func splitOversizedPayload(payload []byte) ([][]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read map header: %w", err)
 		}
-		keys := make([]msgpack.RawMessage, 0, n)
-		vals := make([]msgpack.RawMessage, 0, n)
+		fields := make([]rawField, 0, n)
+		colIdx := -1
 		for i := 0; i < n; i++ {
-			k, err := dec.DecodeRaw()
-			if err != nil {
+			key := rawSpan{start: len(payload) - reader.Len()}
+			if err := dec.Skip(); err != nil {
 				return nil, fmt.Errorf("failed to read map key: %w", err)
 			}
-			v, err := dec.DecodeRaw()
-			if err != nil {
+			key.end = len(payload) - reader.Len()
+			value := rawSpan{start: len(payload) - reader.Len()}
+			if err := dec.Skip(); err != nil {
 				return nil, fmt.Errorf("failed to read map value: %w", err)
 			}
-			keys = append(keys, k)
-			vals = append(vals, v)
-		}
-
-		colIdx := -1
-		for i, k := range keys {
+			value.end = len(payload) - reader.Len()
+			fields = append(fields, rawField{key: key, value: value})
 			var name string
-			if err := msgpack.Unmarshal(k, &name); err == nil && name == "columns" {
+			if err := msgpack.Unmarshal(payload[key.start:key.end], &name); err == nil && name == "columns" {
 				colIdx = i
-				break
 			}
 		}
 		if colIdx < 0 {
 			return [][]byte{payload}, nil
 		}
 
-		columns, err := decodeColumnarColumns(vals[colIdx])
+		columns, rows, err := decodeColumnarColumns(payload, fields[colIdx].value)
 		if err != nil {
 			return nil, err
 		}
 		if len(columns) == 0 {
 			return [][]byte{payload}, nil
-		}
-
-		rows := len(columns[0].values)
-		for _, column := range columns[1:] {
-			if len(column.values) != rows {
-				return nil, fmt.Errorf("column %q has %d values, want %d", column.name, len(column.values), rows)
-			}
 		}
 		if rows == 0 {
 			return [][]byte{payload}, nil
@@ -190,13 +180,17 @@ func splitOversizedPayload(payload []byte) ([][]byte, error) {
 		// walChunkTarget. Sizes vary per column; the target only picks the
 		// range length, and the hard cap check on the final entry rejects a
 		// range that still does not fit.
-		bytesPerRow := len(vals[colIdx]) / rows
+		bytesPerRow := fields[colIdx].value.end - fields[colIdx].value.start
+		bytesPerRow /= rows
 		if bytesPerRow < 1 {
 			bytesPerRow = 1
 		}
 		rowsPerChunk := walChunkTarget / bytesPerRow
 		if rowsPerChunk < 1 {
 			rowsPerChunk = 1
+		}
+		if err := recordColumnOffsets(payload, columns, rows, rowsPerChunk); err != nil {
+			return nil, err
 		}
 
 		var chunks [][]byte
@@ -205,7 +199,7 @@ func splitOversizedPayload(payload []byte) ([][]byte, error) {
 			if hi > rows {
 				hi = rows
 			}
-			out, err := encodeColumnarRange(keys, vals, colIdx, columns, lo, hi)
+			out, err := encodeColumnarRange(payload, fields, colIdx, columns, lo/rowsPerChunk, hi-lo)
 			if err != nil {
 				return nil, err
 			}
@@ -217,95 +211,125 @@ func splitOversizedPayload(payload []byte) ([][]byte, error) {
 	return [][]byte{payload}, nil
 }
 
-type rawColumn struct {
-	name   string
-	key    msgpack.RawMessage
-	values []msgpack.RawMessage
+type rawSpan struct {
+	start int
+	end   int
 }
 
-func decodeColumnarColumns(raw msgpack.RawMessage) ([]rawColumn, error) {
-	dec := msgpack.NewDecoder(bytes.NewReader(raw))
+type rawField struct {
+	key   rawSpan
+	value rawSpan
+}
+
+type rawColumn struct {
+	name    string
+	key     rawSpan
+	values  rawSpan
+	offsets []int
+}
+
+func decodeColumnarColumns(payload []byte, raw rawSpan) ([]rawColumn, int, error) {
+	reader := bytes.NewReader(payload[raw.start:raw.end])
+	dec := msgpack.NewDecoder(reader)
+	rawLen := raw.end - raw.start
 	n, err := dec.DecodeMapLen()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read columns map: %w", err)
+		return nil, 0, fmt.Errorf("failed to read columns map: %w", err)
 	}
 	columns := make([]rawColumn, 0, n)
+	rows := -1
 	for i := 0; i < n; i++ {
-		key, err := dec.DecodeRaw()
-		if err != nil {
-			return nil, fmt.Errorf("failed to read column key: %w", err)
+		key := rawSpan{start: raw.start + rawLen - reader.Len()}
+		if err := dec.Skip(); err != nil {
+			return nil, 0, fmt.Errorf("failed to read column key: %w", err)
 		}
+		key.end = raw.start + rawLen - reader.Len()
 		var name string
-		if err := msgpack.Unmarshal(key, &name); err != nil {
-			return nil, fmt.Errorf("failed to decode column name: %w", err)
+		if err := msgpack.Unmarshal(payload[key.start:key.end], &name); err != nil {
+			return nil, 0, fmt.Errorf("failed to decode column name: %w", err)
 		}
-		value, err := dec.DecodeRaw()
+		values := rawSpan{start: raw.start + rawLen - reader.Len()}
+		valueLen, err := dec.DecodeArrayLen()
 		if err != nil {
-			return nil, fmt.Errorf("failed to read column %q: %w", name, err)
+			return nil, 0, fmt.Errorf("failed to read column %q array: %w", name, err)
 		}
-		values, err := decodeArrayElements(value)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode column %q: %w", name, err)
+		if valueLen < 0 {
+			return nil, 0, fmt.Errorf("column %q is nil, want an array", name)
+		}
+		for j := 0; j < valueLen; j++ {
+			if err := dec.Skip(); err != nil {
+				return nil, 0, fmt.Errorf("failed to read column %q value %d: %w", name, j, err)
+			}
+		}
+		values.end = raw.start + rawLen - reader.Len()
+		if rows == -1 {
+			rows = valueLen
+		} else if valueLen != rows {
+			return nil, 0, fmt.Errorf("column %q has %d values, want %d", name, valueLen, rows)
 		}
 		columns = append(columns, rawColumn{name: name, key: key, values: values})
 	}
-	return columns, nil
+	return columns, rows, nil
 }
 
-func decodeArrayElements(raw msgpack.RawMessage) ([]msgpack.RawMessage, error) {
-	dec := msgpack.NewDecoder(bytes.NewReader(raw))
-	n, err := dec.DecodeArrayLen()
-	if err != nil {
-		return nil, err
-	}
-	values := make([]msgpack.RawMessage, n)
-	for i := range values {
-		values[i], err = dec.DecodeRaw()
+func recordColumnOffsets(payload []byte, columns []rawColumn, rows, rowsPerChunk int) error {
+	for i := range columns {
+		column := &columns[i]
+		reader := bytes.NewReader(payload[column.values.start:column.values.end])
+		dec := msgpack.NewDecoder(reader)
+		valueLen, err := dec.DecodeArrayLen()
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("failed to reread column %q array: %w", column.name, err)
+		}
+		if valueLen != rows {
+			return fmt.Errorf("column %q has %d values, want %d", column.name, valueLen, rows)
+		}
+		column.offsets = make([]int, 0, (rows+rowsPerChunk-1)/rowsPerChunk+1)
+		column.offsets = append(column.offsets, column.values.start+len(payload[column.values.start:column.values.end])-reader.Len())
+		for lo := 0; lo < rows; lo += rowsPerChunk {
+			hi := lo + rowsPerChunk
+			if hi > rows {
+				hi = rows
+			}
+			for row := lo; row < hi; row++ {
+				if err := dec.Skip(); err != nil {
+					return fmt.Errorf("failed to read column %q value %d: %w", column.name, row, err)
+				}
+			}
+			column.offsets = append(column.offsets, column.values.start+len(payload[column.values.start:column.values.end])-reader.Len())
 		}
 	}
-	return values, nil
+	return nil
 }
 
 // encodeColumnarRange re-emits the columnar record with every column sliced
 // to rows [lo, hi). Keys other than "columns" (e.g. "m") carry over unchanged
 // through their raw bytes.
-func encodeColumnarRange(keys, vals []msgpack.RawMessage, colIdx int, columns []rawColumn, lo, hi int) ([]byte, error) {
+func encodeColumnarRange(payload []byte, fields []rawField, colIdx int, columns []rawColumn, chunk, rowCount int) ([]byte, error) {
 	var cols bytes.Buffer
 	cenc := msgpack.NewEncoder(&cols)
 	if err := cenc.EncodeMapLen(len(columns)); err != nil {
 		return nil, err
 	}
 	for _, column := range columns {
-		if err := cenc.Encode(msgpack.RawMessage(column.key)); err != nil {
+		cols.Write(payload[column.key.start:column.key.end])
+		if err := cenc.EncodeArrayLen(rowCount); err != nil {
 			return nil, err
 		}
-		if err := cenc.EncodeArrayLen(hi - lo); err != nil {
-			return nil, err
-		}
-		for _, value := range column.values[lo:hi] {
-			if err := cenc.Encode(msgpack.RawMessage(value)); err != nil {
-				return nil, err
-			}
-		}
+		cols.Write(payload[column.offsets[chunk]:column.offsets[chunk+1]])
 	}
 
 	var out bytes.Buffer
 	enc := msgpack.NewEncoder(&out)
-	if err := enc.EncodeMapLen(len(keys)); err != nil {
+	if err := enc.EncodeMapLen(len(fields)); err != nil {
 		return nil, err
 	}
-	for i := range keys {
-		if err := enc.Encode(msgpack.RawMessage(keys[i])); err != nil {
-			return nil, err
-		}
+	for i := range fields {
+		out.Write(payload[fields[i].key.start:fields[i].key.end])
 		if i == colIdx {
-			if _, err := out.Write(cols.Bytes()); err != nil {
-				return nil, err
-			}
-		} else if err := enc.Encode(msgpack.RawMessage(vals[i])); err != nil {
-			return nil, err
+			out.Write(cols.Bytes())
+		} else {
+			out.Write(payload[fields[i].value.start:fields[i].value.end])
 		}
 	}
 	return out.Bytes(), nil

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/Basekick-Labs/msgpack/v6/msgpcode"
 	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/rs/zerolog"
 )
@@ -34,6 +36,13 @@ const (
 	// aligns with the replication protocol limit (100MB).
 	MaxWALPayloadSize = 100 * 1024 * 1024 // 100MB
 
+	// walChunkTarget is the payload size an oversized payload is chunked down
+	// to (#677). It sits well below MaxWALPayloadSize so a chunk still clears
+	// the single-entry cap after its msgpack container headers, and stays under
+	// the replication protocol's own 100MB message limit once the JSON + base64
+	// envelope (bytes expand 4/3) is accounted for.
+	walChunkTarget = 32 * 1024 * 1024 // 32MB
+
 	// WALEnvelopeMarker is the first byte of an enveloped WAL payload.
 	// Enveloped format: [0x01][2-byte db name length][db name][original msgpack]
 	// Since msgpack maps/arrays always start with bytes >= 0x80, 0x01 is unambiguous.
@@ -52,6 +61,205 @@ func ParseEnvelope(payload []byte, defaultDB string) (database string, msgpackDa
 		}
 	}
 	return defaultDB, payload
+}
+
+// splitOversizedPayload divides a payload larger than MaxWALPayloadSize into
+// chunks that each fit the cap (#677). It never operates on arbitrary byte
+// ranges: WAL payloads are replayed as whole msgpack values, and a bare byte
+// tail of an array is not one — it decodes as the first value only and
+// silently drops the rest. Chunks are re-emitted as self-contained msgpack
+// values instead:
+//
+//   - a top-level array (the row format Append marshals) is split between
+//     elements; each chunk is a shorter array holding a contiguous run of
+//     the same records
+//   - a top-level map whose "columns" value is a map of arrays (the columnar
+//     format the zero-copy path stores) is split by row range: every other
+//     key carries over unchanged and each column array is sliced to the same
+//     [lo, hi) rows
+//
+// A payload whose top-level shape cannot be split without inventing a new
+// record format (including a map without "columns", or a single element
+// larger than the cap) is returned as the sole chunk for the caller to
+// reject.
+func splitOversizedPayload(payload []byte) ([][]byte, error) {
+	dec := msgpack.NewDecoder(bytes.NewReader(payload))
+	code, err := dec.PeekCode()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read msgpack header: %w", err)
+	}
+
+	if msgpcode.IsFixedArray(code) || code == msgpcode.Array16 || code == msgpcode.Array32 {
+		n, err := dec.DecodeArrayLen()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read array header: %w", err)
+		}
+		var chunks [][]byte
+		var elem bytes.Buffer
+		count := 0
+		flush := func() error {
+			if count == 0 {
+				return nil
+			}
+			var out bytes.Buffer
+			enc := msgpack.NewEncoder(&out)
+			if err := enc.EncodeArrayLen(count); err != nil {
+				return err
+			}
+			out.Write(elem.Bytes())
+			chunks = append(chunks, out.Bytes())
+			elem.Reset()
+			count = 0
+			return nil
+		}
+		for i := 0; i < n; i++ {
+			raw, err := dec.DecodeRaw()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read element %d: %w", i, err)
+			}
+			elem.Write(raw)
+			count++
+			if elem.Len() >= walChunkTarget {
+				if err := flush(); err != nil {
+					return nil, err
+				}
+			}
+		}
+		if err := flush(); err != nil {
+			return nil, err
+		}
+		if len(chunks) == 0 {
+			// An empty array cannot be oversized; return it unchanged.
+			chunks = append(chunks, payload)
+		}
+		return chunks, nil
+	}
+
+	if msgpcode.IsFixedMap(code) || code == msgpcode.Map16 || code == msgpcode.Map32 {
+		n, err := dec.DecodeMapLen()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read map header: %w", err)
+		}
+		keys := make([]msgpack.RawMessage, 0, n)
+		vals := make([]msgpack.RawMessage, 0, n)
+		for i := 0; i < n; i++ {
+			k, err := dec.DecodeRaw()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read map key: %w", err)
+			}
+			v, err := dec.DecodeRaw()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read map value: %w", err)
+			}
+			keys = append(keys, k)
+			vals = append(vals, v)
+		}
+
+		colIdx := -1
+		for i, k := range keys {
+			var name string
+			if err := msgpack.Unmarshal(k, &name); err == nil && name == "columns" {
+				colIdx = i
+				break
+			}
+		}
+		if colIdx < 0 {
+			return [][]byte{payload}, nil
+		}
+
+		var columnsMap map[string]msgpack.RawMessage
+		if err := msgpack.Unmarshal(vals[colIdx], &columnsMap); err != nil {
+			return nil, fmt.Errorf("failed to read columns map: %w", err)
+		}
+		if len(columnsMap) == 0 {
+			return [][]byte{payload}, nil
+		}
+
+		decoded := make(map[string][]interface{}, len(columnsMap))
+		for name, v := range columnsMap {
+			var arr []interface{}
+			if err := msgpack.Unmarshal(v, &arr); err != nil {
+				return nil, fmt.Errorf("failed to decode column %q: %w", name, err)
+			}
+			decoded[name] = arr
+		}
+
+		rows := 0
+		for _, arr := range decoded {
+			rows = len(arr)
+			break
+		}
+		if rows == 0 {
+			return [][]byte{payload}, nil
+		}
+
+		// Slice columns by row range, sized so a chunk's columns stay near
+		// walChunkTarget. Sizes vary per column; the target only picks the
+		// range length, and the hard cap check on the final entry rejects a
+		// range that still does not fit.
+		bytesPerRow := len(vals[colIdx]) / rows
+		if bytesPerRow < 1 {
+			bytesPerRow = 1
+		}
+		rowsPerChunk := walChunkTarget / bytesPerRow
+		if rowsPerChunk < 1 {
+			rowsPerChunk = 1
+		}
+
+		var chunks [][]byte
+		for lo := 0; lo < rows; lo += rowsPerChunk {
+			hi := lo + rowsPerChunk
+			if hi > rows {
+				hi = rows
+			}
+			out, err := encodeColumnarRange(keys, vals, colIdx, decoded, lo, hi)
+			if err != nil {
+				return nil, err
+			}
+			chunks = append(chunks, out)
+		}
+		return chunks, nil
+	}
+
+	return [][]byte{payload}, nil
+}
+
+// encodeColumnarRange re-emits the columnar record with every column sliced
+// to rows [lo, hi). Keys other than "columns" (e.g. "m") carry over unchanged
+// through their raw bytes.
+func encodeColumnarRange(keys, vals []msgpack.RawMessage, colIdx int, decoded map[string][]interface{}, lo, hi int) ([]byte, error) {
+	var cols bytes.Buffer
+	cenc := msgpack.NewEncoder(&cols)
+	if err := cenc.EncodeMapLen(len(decoded)); err != nil {
+		return nil, err
+	}
+	for name, arr := range decoded {
+		if err := cenc.Encode(name); err != nil {
+			return nil, err
+		}
+		if err := cenc.Encode(arr[lo:hi]); err != nil {
+			return nil, err
+		}
+	}
+
+	var out bytes.Buffer
+	enc := msgpack.NewEncoder(&out)
+	if err := enc.EncodeMapLen(len(keys)); err != nil {
+		return nil, err
+	}
+	for i := range keys {
+		if err := enc.Encode(msgpack.RawMessage(keys[i])); err != nil {
+			return nil, err
+		}
+		if i == colIdx {
+			if _, err := out.Write(cols.Bytes()); err != nil {
+				return nil, err
+			}
+		} else if err := enc.Encode(msgpack.RawMessage(vals[i])); err != nil {
+			return nil, err
+		}
+	}
+	return out.Bytes(), nil
 }
 
 // SyncMode defines how WAL syncs to disk
@@ -384,15 +592,45 @@ func (w *Writer) Append(records []map[string]interface{}) error {
 //
 // Unlike calling AppendRaw with a pre-built envelope, this method builds the
 // WAL entry in a single allocation to avoid copying the payload twice.
+//
+// A payload whose logical entry exceeds MaxWALPayloadSize is split into
+// multiple entries, each carrying the same database envelope (#677) — a wide
+// ingest request previously landed here as a wholesale ErrPayloadTooLarge
+// rejection, so the WAL silently recorded nothing while ingest reported
+// healthy.
 func (w *Writer) AppendRawWithMeta(database string, payload []byte) error {
 	dbBytes := []byte(database)
 	envelopeHeaderLen := 1 + 2 + len(dbBytes) // marker + dbLen + dbName
 	totalPayloadLen := envelopeHeaderLen + len(payload)
 
-	if totalPayloadLen > MaxWALPayloadSize {
-		return fmt.Errorf("%w: size %d exceeds limit %d", ErrPayloadTooLarge, totalPayloadLen, MaxWALPayloadSize)
+	if totalPayloadLen <= MaxWALPayloadSize {
+		return w.appendEnvelopedEntry(dbBytes, envelopeHeaderLen, payload, totalPayloadLen)
 	}
 
+	// Oversized: split the msgpack payload into size-valid chunks and write
+	// each as its own enveloped entry. A chunk that still exceeds the cap (a
+	// single record or row larger than the limit) keeps the loud rejection.
+	chunks, err := splitOversizedPayload(payload)
+	if err != nil {
+		return err
+	}
+	for _, chunk := range chunks {
+		if chunkLen := envelopeHeaderLen + len(chunk); chunkLen > MaxWALPayloadSize {
+			metrics.Get().IncWALOversizedPayloads()
+			return fmt.Errorf("%w: size %d exceeds limit %d", ErrPayloadTooLarge, chunkLen, MaxWALPayloadSize)
+		}
+	}
+	for _, chunk := range chunks {
+		if err := w.appendEnvelopedEntry(dbBytes, envelopeHeaderLen, chunk, envelopeHeaderLen+len(chunk)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// appendEnvelopedEntry is AppendRawWithMeta's single-entry fast path: CRC,
+// replication hook, and entry assembly for one size-validated payload.
+func (w *Writer) appendEnvelopedEntry(dbBytes []byte, envelopeHeaderLen int, payload []byte, totalPayloadLen int) error {
 	// Compute CRC32 over the logical payload (envelope header + msgpack) without copying
 	crc := crc32.NewIEEE()
 	var envHeader [1 + 2 + 255]byte // envelope header (db name max 255 bytes)
@@ -455,11 +693,35 @@ func (w *Writer) tryEnqueue(entryData []byte) error {
 // AppendRaw writes raw (already serialized) msgpack bytes to the WAL asynchronously
 // This is a zero-copy optimization - use this when you already have msgpack bytes
 func (w *Writer) AppendRaw(payload []byte) error {
-	// Validate payload size to prevent integer overflow during allocation (CWE-190)
+	// Validate payload size to prevent integer overflow during allocation (CWE-190).
+	// An oversized payload is split into size-valid entries (#677) instead of
+	// being rejected wholesale; a payload that cannot be split (a single
+	// element larger than the limit) keeps the loud rejection.
 	if len(payload) > MaxWALPayloadSize {
-		return fmt.Errorf("%w: size %d exceeds limit %d", ErrPayloadTooLarge, len(payload), MaxWALPayloadSize)
+		chunks, err := splitOversizedPayload(payload)
+		if err != nil {
+			return err
+		}
+		for _, chunk := range chunks {
+			if len(chunk) > MaxWALPayloadSize {
+				metrics.Get().IncWALOversizedPayloads()
+				return fmt.Errorf("%w: size %d exceeds limit %d", ErrPayloadTooLarge, len(chunk), MaxWALPayloadSize)
+			}
+		}
+		for _, chunk := range chunks {
+			if err := w.appendRawEntry(chunk); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
+	return w.appendRawEntry(payload)
+}
+
+// appendRawEntry is AppendRaw's single-entry path: checksum, replication
+// hook, and entry assembly for one size-validated payload.
+func (w *Writer) appendRawEntry(payload []byte) error {
 	// Calculate checksum (CRC32)
 	checksum := crc32.ChecksumIEEE(payload)
 

--- a/internal/wal/wal_chunking_test.go
+++ b/internal/wal/wal_chunking_test.go
@@ -1,0 +1,94 @@
+package wal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Basekick-Labs/msgpack/v6"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/rs/zerolog"
+)
+
+// Writer-level boundaries of #677 payload chunking; the columnar half is
+// covered end to end by internal/ingest's TestWideRequestReachesWALAndReplays,
+// and the at-cap fast path stays pinned by TestWriter_AppendRaw_PayloadAtLimit.
+
+func newChunkTestWriter(t *testing.T) *Writer {
+	t.Helper()
+	writer, err := NewWriter(&WriterConfig{
+		WALDir:       t.TempDir(),
+		SyncMode:     SyncModeAsync,
+		MaxSizeBytes: 1024 * 1024 * 1024, // no rotation mid-test
+		BufferSize:   100000,
+		Logger:       zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	return writer
+}
+
+// TestWriter_AppendRaw_ChunksOversizedRowPayload: a top-level msgpack array
+// of records above the cap is written as multiple entries, each a decodable
+// array whose record union equals the original payload.
+func TestWriter_AppendRaw_ChunksOversizedRowPayload(t *testing.T) {
+	writer := newChunkTestWriter(t)
+
+	// 2000 records of ~64 KB each: ~128 MB, above the 100MB cap.
+	record := map[string]interface{}{"_measurement": "cpu", "time": int64(1), "field": strings.Repeat("r", 64*1024)}
+	records := make([]interface{}, 2000)
+	for i := range records {
+		records[i] = record
+	}
+	payload, err := msgpack.Marshal(records)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(payload) <= MaxWALPayloadSize {
+		t.Fatalf("test bug: payload %d not above cap", len(payload))
+	}
+	if err := writer.AppendRaw(payload); err != nil {
+		t.Fatalf("AppendRaw: %v", err)
+	}
+	path := writer.CurrentFile()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	entries, err := NewReader(path, zerolog.Nop()).ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Fatalf("expected multiple chunk entries, got %d", len(entries))
+	}
+	total := 0
+	for i, e := range entries {
+		if e.Records == nil {
+			t.Fatalf("entry %d not row format", i)
+		}
+		total += len(e.Records)
+	}
+	if total != 2000 {
+		t.Fatalf("record union mismatch: got %d, want 2000", total)
+	}
+}
+
+// TestWriter_AppendRaw_SingleOversizedElementStillRejected: a payload with no
+// element boundary to split at keeps the loud error and bumps the metric.
+func TestWriter_AppendRaw_SingleOversizedElementStillRejected(t *testing.T) {
+	writer := newChunkTestWriter(t)
+	defer writer.Close()
+
+	payload, err := msgpack.Marshal(strings.Repeat("x", MaxWALPayloadSize+1000))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	before := metrics.Get().Snapshot()["wal_oversized_payloads"].(int64)
+	err = writer.AppendRaw(payload)
+	if err == nil || !strings.Contains(err.Error(), "104857600") {
+		t.Fatalf("want ErrPayloadTooLarge naming the limit, got: %v", err)
+	}
+	if after := metrics.Get().Snapshot()["wal_oversized_payloads"].(int64); after != before+1 {
+		t.Fatalf("oversized metric should bump by 1, got %d -> %d", before, after)
+	}
+}


### PR DESCRIPTION
## Description

Wide ingest requests (a single client body with tens of KB per row) can exceed
the WAL's 100MB single-entry payload cap while staying well under the server's
1GB request limit. Before this change every such write was rejected wholesale
by the WAL: ingest kept reporting healthy while each writer's WAL directory
held a 7-byte header-only file for hours, and the only trace of the rejection
was a log line. There was no cap value that fixed it, any byte cap large
enough for a full row-bounded buffer is absurd, and any row bound small enough
to fit the cap throttles narrow-row ingest.

The WAL now splits an oversized payload into multiple entries at msgpack
element boundaries, so the same request's data reaches the WAL as N
size-valid entries:

- row-format payloads (a top-level msgpack array of records) split between
  records, each chunk a shorter array of the same records
- columnar payloads (the zero-copy path's top-level map with a `columns`
  sub-map) split by row range; `m` carries over and each column array is
  sliced to the same `[lo, hi)` rows

Chunks are self-contained msgpack values, so the reader replays them with no
format change: concatenating the chunks' decoded rows reproduces the original
request. A payload that still cannot be split (a single record or single row
larger than the cap) keeps the loud `ErrPayloadTooLarge` rejection, and that
rejection is now counted in the `arc_wal_oversized_payloads_total` metric
instead of living only in a log line.

Fixes #677

## Why

The WAL is the durability window between ingest accepting a write and the
Parquet flush landing. An operator watching a bulk load of wide rows believed
that window was protected; it was not, and nothing on the metrics endpoint
said so. Chunking removes the mismatch at the boundary that owns it (the WAL
entry size), which resolves the issue for both proposed fix shapes without a
config change and without throttling narrow-row ingest.

## Verification

- before, on current `main`: a 117.2 MiB columnar msgpack request fed through
  the real decode and buffer write path with a real WAL writer attached is
  accepted by ingest while the WAL directory holds a single 7-byte
  header-only file, and the rejection appears only as a `WAL write failed -
  data may be lost on crash` log line
- after: the same request produces multiple WAL entries each under the cap;
  reading the file back with the WAL reader returns entries whose decoded row
  union equals the request, and replaying them through the recovery path
  (`WriteColumnarDirectNoWAL`) applies every row
- new regression tests fail on the pre-fix tree and pass after:
  `go test ./internal/wal/ -run 'ChunksOversized|SingleOversized|PayloadAtLimitSingleEntry'`
  and `go test ./internal/ingest/ -run 'TestWideRequest'`
- full focused suites green: `go test ./internal/wal/ ./internal/metrics/
  ./internal/ingest/ ./internal/cluster/... -count=1`, plus the new tests
  under `-race`; `gofmt -l` empty and `go vet` clean on the touched packages

## Notes

- chunk target is 32MB, sized so every chunk clears the 100MB single-entry
  cap after container headers, the WAL envelope, and the JSON + base64
  envelope replication wraps around a payload
- replication streams each chunk as its own `ReplicateEntry` under the
  protocol's own 100MB message cap
