### PR TITLE
fix(cluster): add periodic file replication reconciliation (#393)

### DIFF
--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -2,21 +2,6 @@
 
 > **Status:** Released 2026-08-31.
 
-## New: periodic peer file replication reconciliation
-
-Cluster nodes now re-walk the Raft file manifest every five minutes by default
-after the startup catch-up attempt. The interval is configurable with
-`cluster.replication_reconciliation_interval_seconds`. The pass uses the
-existing paginated manifest walk, pull queue, deduplication, retries, checksum
-verification, and local-file checks, so a missed reactive callback can be
-repaired without restarting the node. Healthy writer, reader, and compactor
-nodes may run the pass; joining, leaving, unhealthy, and standalone nodes are
-gated. Startup catch-up remains a one-shot operation and keeps its existing
-`catchup_*` readiness and query-gate semantics. The existing
-`cluster.replication_catchup_enabled` switch disables both startup and
-periodic reconciliation. Recheck outcomes are exposed under
-`replication_catchup_status` as `replication_recheck_*` counters.
-
 ## New: Apache Iceberg export (opt-in)
 
 Arc can now publish its data as **Apache Iceberg tables** so any Iceberg-aware engine — Spark, Trino, DuckDB, Snowflake, PyIceberg — can query Arc's data directly, without going through Arc's API. This is the strongest form of the "your data, no lock-in" promise: Arc already writes open Parquet files you own; now those same files are also a standard Iceberg lakehouse table.

--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -2,6 +2,17 @@
 
 > **Status:** Released 2026-08-31.
 
+## New: periodic peer file replication reconciliation
+
+Cluster nodes now re-walk the Raft file manifest every five minutes after the
+startup catch-up attempt. The pass uses the existing paginated manifest walk,
+pull queue, deduplication, retries, checksum verification, and local-file
+checks, so a missed reactive callback can be repaired without restarting the
+node. Startup catch-up remains a one-shot operation and keeps its existing
+`catchup_*` readiness and query-gate semantics. The existing
+`cluster.replication_catchup_enabled` switch disables both startup and
+periodic reconciliation.
+
 ## New: Apache Iceberg export (opt-in)
 
 Arc can now publish its data as **Apache Iceberg tables** so any Iceberg-aware engine — Spark, Trino, DuckDB, Snowflake, PyIceberg — can query Arc's data directly, without going through Arc's API. This is the strongest form of the "your data, no lock-in" promise: Arc already writes open Parquet files you own; now those same files are also a standard Iceberg lakehouse table.

--- a/RELEASE_NOTES_2026.09.1.md
+++ b/RELEASE_NOTES_2026.09.1.md
@@ -4,14 +4,18 @@
 
 ## New: periodic peer file replication reconciliation
 
-Cluster nodes now re-walk the Raft file manifest every five minutes after the
-startup catch-up attempt. The pass uses the existing paginated manifest walk,
-pull queue, deduplication, retries, checksum verification, and local-file
-checks, so a missed reactive callback can be repaired without restarting the
-node. Startup catch-up remains a one-shot operation and keeps its existing
+Cluster nodes now re-walk the Raft file manifest every five minutes by default
+after the startup catch-up attempt. The interval is configurable with
+`cluster.replication_reconciliation_interval_seconds`. The pass uses the
+existing paginated manifest walk, pull queue, deduplication, retries, checksum
+verification, and local-file checks, so a missed reactive callback can be
+repaired without restarting the node. Healthy writer, reader, and compactor
+nodes may run the pass; joining, leaving, unhealthy, and standalone nodes are
+gated. Startup catch-up remains a one-shot operation and keeps its existing
 `catchup_*` readiness and query-gate semantics. The existing
 `cluster.replication_catchup_enabled` switch disables both startup and
-periodic reconciliation.
+periodic reconciliation. Recheck outcomes are exposed under
+`replication_catchup_status` as `replication_recheck_*` counters.
 
 ## New: Apache Iceberg export (opt-in)
 

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -55,6 +55,24 @@ literals (e.g. a log-search `LIKE '%INTERVAL 5 MINUTE%'`) and identifiers such a
 
 ## Bug fixes
 
+### Periodic peer file replication reconciliation repairs missed FSM callbacks ([#393](https://github.com/Basekick-Labs/arc/issues/393))
+
+Cluster nodes now re-walk the Raft file manifest every five minutes by default
+after the startup catch-up attempt. The interval is configurable with
+`cluster.replication_reconciliation_interval_seconds`. The pass uses the
+existing paginated manifest walk, pull queue, deduplication, retries, checksum
+verification, and local-file checks, so a missed reactive callback can be
+repaired without restarting the node. Healthy writer, reader, and compactor
+nodes may run the pass; joining, leaving, unhealthy, and standalone nodes are
+gated. Startup catch-up remains a one-shot operation: periodic failures never
+reopen readiness, while a successful reconciliation pull may heal previously
+recorded startup failure or drop state for that path. The existing
+`cluster.replication_catchup_enabled` switch disables both startup and
+periodic reconciliation. Recheck outcomes are exposed under
+`replication_catchup_status` as `replication_recheck_*` counters.
+
+Contributed by [@bferanmi806-sketch](https://github.com/bferanmi806-sketch) in [#697](https://github.com/Basekick-Labs/arc/pull/697).
+
 ### S3 query paths now follow calendar days across DST ([#321](https://github.com/Basekick-Labs/arc/issues/321))
 
 S3 time-range path generation now builds one inclusive partition path per UTC

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -2356,14 +2356,19 @@ func (c *Coordinator) startFilePullerLocked() error {
 		Int("delete_queue_size", deleteQueueSize).
 		Msg("Peer file replication puller started")
 
-	// Phase 3: kick off the catch-up walker in a background goroutine so
-	// Start() doesn't block on a potentially slow manifest walk. Queries can
+	// Phase 3: kick off the one-shot catch-up walker in a background goroutine
+	// so Start() doesn't block on a potentially slow manifest walk. Queries can
 	// hit the node during catch-up — they see eventually-consistent results
-	// and operators read /api/v1/cluster/status for progress. The walker is
-	// gated on cluster.replication_catchup_enabled so operators can disable
-	// it as an emergency kill-switch on pathologically large manifests.
+	// and operators read /api/v1/cluster/status for progress. The startup walk
+	// and the periodic walk share the same paginated feeder, but only the
+	// startup walk participates in the #392 readiness bookkeeping.
+	// Both are gated on cluster.replication_catchup_enabled so operators can
+	// disable the replication safety net as an emergency kill-switch.
 	if c.cfg.ReplicationCatchUpEnabled {
 		go c.runCatchUpOnce()
+		puller.StartPeriodicReconciliation(func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+			return fsm.GetFilesPaginated(cursor, limit)
+		})
 	} else {
 		c.logger.Warn().Msg("Peer file replication catch-up disabled via config (replication_catchup_enabled=false)")
 	}
@@ -2389,7 +2394,8 @@ func (c *Coordinator) startFilePullerLocked() error {
 // any entries the walker missed as they apply.
 func (c *Coordinator) runCatchUpOnce() {
 	c.catchupOnce.Do(func() {
-		if c.puller == nil || c.raftNode == nil {
+		puller := c.puller
+		if puller == nil || c.raftNode == nil {
 			return
 		}
 
@@ -2436,7 +2442,7 @@ func (c *Coordinator) runCatchUpOnce() {
 		// stable for the lifetime of the node — hashicorp/raft never
 		// replaces the FSM instance once set. The nil guard above ensures
 		// the capture is safe even if the puller outlives the coordinator.
-		c.puller.RunCatchUp(ctx, func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		puller.RunCatchUp(ctx, func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
 			return fsm.GetFilesPaginated(cursor, limit)
 		})
 	})

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1735,6 +1735,36 @@ func (c *Coordinator) IsRunning() bool {
 	return c.running
 }
 
+// canRunFileReconciliation reports whether this coordinator is currently
+// eligible to perform a periodic manifest recheck. File replication is a
+// per-node concern, so every clustered role may run it; only lifecycle and
+// health state gate the work.
+func (c *Coordinator) canRunFileReconciliation() bool {
+	// Stop holds c.mu while it waits for the puller scheduler to exit. Do not
+	// block on that lock from the scheduler's gate check, or shutdown can
+	// deadlock waiting for this goroutine.
+	if !c.mu.TryRLock() {
+		return false
+	}
+	running := c.running
+	localNode := c.localNode
+	c.mu.RUnlock()
+	if !running || localNode == nil {
+		return false
+	}
+
+	node := localNode.Clone()
+	if node.State != StateHealthy {
+		return false
+	}
+	switch node.Role {
+	case RoleWriter, RoleReader, RoleCompactor:
+		return true
+	default:
+		return false
+	}
+}
+
 // GetRole returns the role of the local node.
 func (c *Coordinator) GetRole() NodeRole {
 	return c.localNode.Role
@@ -1824,6 +1854,7 @@ func (c *Coordinator) GetCapabilities() RoleCapabilities {
 func (c *Coordinator) Status() map[string]interface{} {
 	c.mu.RLock()
 	running := c.running
+	puller := c.puller
 	c.mu.RUnlock()
 
 	nodes := c.registry.GetAll()
@@ -1855,6 +1886,9 @@ func (c *Coordinator) Status() map[string]interface{} {
 		"writers":       summary["writers"],
 		"readers":       summary["readers"],
 		"compactors":    summary["compactors"],
+	}
+	if puller != nil {
+		status["replication_catchup_status"] = puller.CatchUpStatus()
 	}
 
 	// Add Raft status if configured (Phase 3)
@@ -2254,17 +2288,19 @@ func (c *Coordinator) startFilePullerLocked() error {
 	})
 
 	pullerCfg := filereplication.Config{
-		SelfNodeID:            c.localNode.ID,
-		Backend:               c.storage,
-		Fetcher:               fetchClient,
-		PeerResolver:          resolver,
-		Workers:               c.cfg.ReplicationPullWorkers,
-		QueueSize:             c.cfg.ReplicationQueueSize,
-		RetryMaxAttempts:      c.cfg.ReplicationRetryMaxAttempts,
-		FetchTimeout:          time.Duration(c.cfg.ReplicationFetchTimeoutMs) * time.Millisecond,
-		RetryInitialBackoff:   500 * time.Millisecond,
-		CatchUpQueueHighWater: c.cfg.ReplicationCatchUpQueueHighWater,
-		Logger:                c.logger,
+		SelfNodeID:             c.localNode.ID,
+		Backend:                c.storage,
+		Fetcher:                fetchClient,
+		PeerResolver:           resolver,
+		Workers:                c.cfg.ReplicationPullWorkers,
+		QueueSize:              c.cfg.ReplicationQueueSize,
+		RetryMaxAttempts:       c.cfg.ReplicationRetryMaxAttempts,
+		FetchTimeout:           time.Duration(c.cfg.ReplicationFetchTimeoutMs) * time.Millisecond,
+		RetryInitialBackoff:    500 * time.Millisecond,
+		CatchUpQueueHighWater:  c.cfg.ReplicationCatchUpQueueHighWater,
+		ReconciliationInterval: time.Duration(c.cfg.ReplicationReconciliationIntervalSeconds) * time.Second,
+		ReconciliationGate:     c.canRunFileReconciliation,
+		Logger:                 c.logger,
 	}
 
 	puller, err := filereplication.New(pullerCfg)
@@ -2394,15 +2430,19 @@ func (c *Coordinator) startFilePullerLocked() error {
 // any entries the walker missed as they apply.
 func (c *Coordinator) runCatchUpOnce() {
 	c.catchupOnce.Do(func() {
+		c.mu.RLock()
 		puller := c.puller
-		if puller == nil || c.raftNode == nil {
+		raftNode := c.raftNode
+		ctx := c.ctx
+		c.mu.RUnlock()
+		if puller == nil || raftNode == nil {
 			return
 		}
 
 		// Wait for a leader. On failure we still proceed — a follower with a
 		// non-empty FSM is a valid catch-up candidate against cluster state
 		// it already has locally, even if no leader is currently elected.
-		if err := c.raftNode.WaitForLeader(30 * time.Second); err != nil {
+		if err := raftNode.WaitForLeader(30 * time.Second); err != nil {
 			c.logger.Warn().
 				Err(err).
 				Msg("Catch-up: no leader after 30s, proceeding against possibly-stale manifest")
@@ -2417,14 +2457,14 @@ func (c *Coordinator) runCatchUpOnce() {
 		if barrierTimeout <= 0 {
 			barrierTimeout = 10 * time.Second
 		}
-		if err := c.raftNode.Barrier(barrierTimeout); err != nil {
+		if err := raftNode.Barrier(barrierTimeout); err != nil {
 			c.logger.Warn().
 				Err(err).
 				Dur("timeout", barrierTimeout).
 				Msg("Catch-up: Raft barrier timed out, proceeding against possibly-stale manifest")
 		}
 
-		fsm := c.raftNode.FSM()
+		fsm := raftNode.FSM()
 		if fsm == nil {
 			c.logger.Error().Msg("Catch-up: Raft FSM not available, skipping")
 			return
@@ -2434,7 +2474,6 @@ func (c *Coordinator) runCatchUpOnce() {
 		// Derive a context from c.ctx (or Background if c.ctx is nil, which
 		// happens in tests that bypass Start). The walker honors cancellation
 		// so shutdown doesn't block on a large catch-up.
-		ctx := c.ctx
 		if ctx == nil {
 			ctx = context.Background()
 		}
@@ -2448,14 +2487,16 @@ func (c *Coordinator) runCatchUpOnce() {
 	})
 }
 
-// ReplicationCatchUpStatus returns the puller's catch-up-specific stats as a
+// ReplicationCatchUpStatus returns the puller's replication and catch-up stats as a
 // JSON-serializable map, or nil when the puller is not running. Consumed by
 // /api/v1/cluster/status (operator visibility) and the query gate's 503 body
 // (so clients can implement bounded retry without a separate probe). The
-// queue_depth, inflight_count, failed, and dropped keys are the live signals
-// — non-zero on any means the gate will keep firing.
+// catchup_inflight, catchup_failed, and catchup_dropped keys are the startup
+// readiness signals; replication_recheck_* keys describe periodic passes.
 func (c *Coordinator) ReplicationCatchUpStatus() map[string]int64 {
+	c.mu.RLock()
 	puller := c.puller
+	c.mu.RUnlock()
 	if puller == nil {
 		return nil
 	}
@@ -2486,7 +2527,9 @@ func (c *Coordinator) ReplicationCatchUpStatus() map[string]int64 {
 // Snapshot puller into a local before nil-checking to close the
 // shutdown-time TOCTOU window where Stop() nils c.puller.
 func (c *Coordinator) ReplicationReady() bool {
+	c.mu.RLock()
 	puller := c.puller
+	c.mu.RUnlock()
 	if puller == nil {
 		// No puller means peer replication is off — treat as always ready
 		// so the gate is a no-op for OSS / standalone paths.

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1737,8 +1737,8 @@ func (c *Coordinator) IsRunning() bool {
 
 // canRunFileReconciliation reports whether this coordinator is currently
 // eligible to perform a periodic manifest recheck. File replication is a
-// per-node concern, so every clustered role may run it; only lifecycle and
-// health state gate the work.
+// per-node concern, so every clustered role may run it; current membership,
+// lifecycle, and health state gate the work.
 func (c *Coordinator) canRunFileReconciliation() bool {
 	// Stop holds c.mu while it waits for the puller scheduler to exit. Do not
 	// block on that lock from the scheduler's gate check, or shutdown can
@@ -1747,13 +1747,24 @@ func (c *Coordinator) canRunFileReconciliation() bool {
 		return false
 	}
 	running := c.running
+	registry := c.registry
 	localNode := c.localNode
+	localNodeID := ""
+	if localNode != nil {
+		localNodeID = localNode.ID
+	}
 	c.mu.RUnlock()
-	if !running || localNode == nil {
+	if !running || registry == nil || localNodeID == "" {
 		return false
 	}
 
-	node := localNode.Clone()
+	// c.localNode is an identity/lifecycle pointer and can outlive registry
+	// membership. Registry.Get is the canonical current-membership snapshot;
+	// it returns false after a Raft leave/removal callback unregisters the ID.
+	node, exists := registry.Get(localNodeID)
+	if !exists {
+		return false
+	}
 	if node.State != StateHealthy {
 		return false
 	}

--- a/internal/cluster/coordinator_test.go
+++ b/internal/cluster/coordinator_test.go
@@ -268,14 +268,94 @@ func TestCanRunFileReconciliation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			localNode := NewNode("test-node", "test-node", tt.role, "test-cluster")
+			localNode.UpdateState(tt.state)
+			registry := NewRegistry(&RegistryConfig{LocalNode: localNode})
 			c := &Coordinator{
-				localNode: NewNode("test-node", "test-node", tt.role, "test-cluster"),
+				localNode: localNode,
+				registry:  registry,
 				running:   tt.running,
 				logger:    zerolog.Nop(),
 			}
-			c.localNode.UpdateState(tt.state)
 			if got := c.canRunFileReconciliation(); got != tt.want {
 				t.Errorf("canRunFileReconciliation() = %v, want %v (role=%s state=%s running=%v)", got, tt.want, tt.role, tt.state, tt.running)
+			}
+		})
+	}
+}
+
+func TestCanRunFileReconciliationRejectsUnregisteredLocalNode(t *testing.T) {
+	localNode := NewNode("test-node", "test-node", RoleReader, "test-cluster")
+	localNode.UpdateState(StateHealthy)
+	registry := NewRegistry(&RegistryConfig{LocalNode: localNode})
+	c := &Coordinator{
+		localNode: localNode,
+		registry:  registry,
+		running:   true,
+		logger:    zerolog.Nop(),
+	}
+
+	registry.Unregister(localNode.ID)
+	if got := c.canRunFileReconciliation(); got {
+		t.Error("canRunFileReconciliation() = true after local node was unregistered, want false")
+	}
+}
+
+func TestCanRunFileReconciliationUsesCurrentRegistryNode(t *testing.T) {
+	tests := []struct {
+		name         string
+		staleRole    NodeRole
+		staleState   NodeState
+		currentRole  NodeRole
+		currentState NodeState
+		wantEligible bool
+	}{
+		{
+			name:         "current state overrides stale healthy state",
+			staleRole:    RoleReader,
+			staleState:   StateHealthy,
+			currentRole:  RoleReader,
+			currentState: StateJoining,
+			wantEligible: false,
+		},
+		{
+			name:         "current role overrides stale clustered role",
+			staleRole:    RoleReader,
+			staleState:   StateHealthy,
+			currentRole:  RoleStandalone,
+			currentState: StateHealthy,
+			wantEligible: false,
+		},
+		{
+			name:         "current healthy role overrides stale unhealthy state",
+			staleRole:    RoleReader,
+			staleState:   StateUnhealthy,
+			currentRole:  RoleCompactor,
+			currentState: StateHealthy,
+			wantEligible: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			staleNode := NewNode("test-node", "test-node", tt.staleRole, "test-cluster")
+			staleNode.UpdateState(tt.staleState)
+			registry := NewRegistry(&RegistryConfig{LocalNode: staleNode})
+
+			currentNode := NewNode("test-node", "test-node", tt.currentRole, "test-cluster")
+			currentNode.UpdateState(tt.currentState)
+			if err := registry.Register(currentNode); err != nil {
+				t.Fatalf("registry.Register: %v", err)
+			}
+
+			c := &Coordinator{
+				localNode: staleNode,
+				registry:  registry,
+				running:   true,
+				logger:    zerolog.Nop(),
+			}
+			if got := c.canRunFileReconciliation(); got != tt.wantEligible {
+				t.Errorf("canRunFileReconciliation() = %v, want %v (stale role/state=%s/%s current=%s/%s)", got, tt.wantEligible, tt.staleRole, tt.staleState, tt.currentRole, tt.currentState)
 			}
 		})
 	}

--- a/internal/cluster/coordinator_test.go
+++ b/internal/cluster/coordinator_test.go
@@ -247,3 +247,51 @@ func TestIsPrimaryWriter_SharedStorageMode_NonWriterLeaderRejected(t *testing.T)
 		})
 	}
 }
+
+func TestCanRunFileReconciliation(t *testing.T) {
+	tests := []struct {
+		name    string
+		role    NodeRole
+		state   NodeState
+		running bool
+		want    bool
+	}{
+		{name: "healthy writer", role: RoleWriter, state: StateHealthy, running: true, want: true},
+		{name: "healthy reader", role: RoleReader, state: StateHealthy, running: true, want: true},
+		{name: "healthy compactor", role: RoleCompactor, state: StateHealthy, running: true, want: true},
+		{name: "standalone", role: RoleStandalone, state: StateHealthy, running: true, want: false},
+		{name: "joining", role: RoleReader, state: StateJoining, running: true, want: false},
+		{name: "leaving", role: RoleReader, state: StateLeaving, running: true, want: false},
+		{name: "unhealthy", role: RoleWriter, state: StateUnhealthy, running: true, want: false},
+		{name: "stopped", role: RoleReader, state: StateHealthy, running: false, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Coordinator{
+				localNode: NewNode("test-node", "test-node", tt.role, "test-cluster"),
+				running:   tt.running,
+				logger:    zerolog.Nop(),
+			}
+			c.localNode.UpdateState(tt.state)
+			if got := c.canRunFileReconciliation(); got != tt.want {
+				t.Errorf("canRunFileReconciliation() = %v, want %v (role=%s state=%s running=%v)", got, tt.want, tt.role, tt.state, tt.running)
+			}
+		})
+	}
+}
+
+func TestCanRunFileReconciliationDoesNotBlockOnCoordinatorLock(t *testing.T) {
+	c := &Coordinator{
+		localNode: NewNode("test-node", "test-node", RoleReader, "test-cluster"),
+		running:   true,
+		logger:    zerolog.Nop(),
+	}
+	c.localNode.UpdateState(StateHealthy)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if got := c.canRunFileReconciliation(); got {
+		t.Error("canRunFileReconciliation() = true while coordinator lock is held, want false")
+	}
+}

--- a/internal/cluster/filereplication/catchup.go
+++ b/internal/cluster/filereplication/catchup.go
@@ -10,47 +10,78 @@ import (
 // RunCatchUp walks the cluster file manifest in pages and enqueues every
 // entry the local node should hold but doesn't. It is the Phase 3 mechanism
 // that brings a node with a stale or empty local backend back into sync with
-// the manifest: on startup (and only on startup — periodic reconciliation is
-// not in scope for Phase 3), the coordinator hands us a paginated fetch
-// function (backed by fsm.GetFilesPaginated) and we feed each page through
-// Enqueue so the regular worker pool pulls the missing bytes from a peer.
+// the manifest: on startup (and only on startup), the coordinator hands us a
+// paginated fetch function (backed by fsm.GetFilesPaginated) and we feed each
+// page through Enqueue so the regular worker pool pulls the missing bytes from
+// a peer.
 //
 // The fetch function follows cursor-based pagination: cursor="" for the first
 // page, and each call returns (page, nextCursor, error). An empty nextCursor
 // means no more pages. This avoids allocating a full O(N) snapshot of the
-// manifest — for 1M+ files the old GetAllFiles() path caused ~50ms apply-path
-// spikes and ~50MB transient memory.
+// manifest.
 //
-// RunCatchUp does NOT itself talk to peers or verify files — it relies on
-// Enqueue's existing origin-is-self check, the inflight dedup set (so
-// reactive FSM callbacks can race without double-pulling), and the workers'
-// backend.Exists pre-check. All the actual fetch work flows through the
-// same code path that Phase 2 reactive pulls use, which means the same
-// retry/backoff/checksum/metrics apply automatically.
+// RunCatchUp does NOT itself talk to peers or verify files. It relies on
+// Enqueue's existing origin-is-self check, the inflight dedup set (so reactive
+// FSM callbacks can race without double-pulling), and the workers' backend
+// checks. All actual fetch work flows through the same code path that Phase 2
+// reactive pulls use, which means the same retry, backoff, checksum, and
+// metrics behavior applies automatically.
 //
 // To avoid a thundering-herd drop storm on large manifests, the feeder sleeps
 // briefly whenever the queue is above CatchUpQueueHighWater (default 80%).
-// This gives the workers time to drain and keeps reactive drops rare. The
-// walker is NOT a hard gate on queries — the release notes document the
+// The walker is not a hard gate on queries — the release notes document the
 // eventual-consistency window between startup and full drain.
 //
 // RunCatchUp is safe to call at most once per puller lifecycle: the
-// catchupStartedAt atomic is CAS-guarded so a second call short-circuits.
-// The method returns when all entries have been processed (enqueued or
-// skipped) or ctx is cancelled; it does not wait for the actual pulls to
-// complete.
+// catchupStartedAt atomic is CAS-guarded so a second call short-circuits. The
+// method returns when all entries have been processed (enqueued or skipped) or
+// ctx is cancelled; it does not wait for actual pulls to complete.
 func (p *Puller) RunCatchUp(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error)) {
 	// Single-shot guard: only one catch-up per puller lifetime.
 	if !p.catchupStartedAt.CompareAndSwap(0, time.Now().Unix()) {
 		p.logger.Debug().Msg("File puller catch-up already ran, skipping")
 		return
 	}
+	defer close(p.catchupFinished)
 
-	p.logger.Info().Msg("File puller catch-up started (paginated)")
+	p.reconciliationMu.Lock()
+	defer p.reconciliationMu.Unlock()
+	p.walkManifest(ctx, fetch, true)
+}
 
-	// Pre-capture stats counters so we can log the delta at the end. Using
-	// the Stats() map would pull in catch-up counters and confuse the
-	// summary — we want "what did catch-up cause".
+// RunReconciliation walks the current manifest and enqueues entries through
+// the normal pull path. Unlike RunCatchUp, it is repeatable and deliberately
+// does not participate in startup catch-up bookkeeping or query readiness.
+// It returns false when another manifest walk is already in progress.
+func (p *Puller) RunReconciliation(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error)) bool {
+	if !p.reconciliationMu.TryLock() {
+		return false
+	}
+	defer p.reconciliationMu.Unlock()
+	p.walkManifest(ctx, fetch, false)
+	return true
+}
+
+func lifecycleDone(ctx context.Context) <-chan struct{} {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Done()
+}
+
+// walkManifest is the shared paginated manifest feeder. Startup walks retain
+// the #392 metrics and path bookkeeping; periodic walks only reuse the
+// backpressure and Enqueue behavior so they cannot re-open the startup gate.
+func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error), startup bool) {
+	if startup {
+		p.logger.Info().Msg("File puller catch-up started (paginated)")
+	}
+	p.mu.Lock()
+	lifecycleCtx := p.ctx
+	p.mu.Unlock()
+
+	// Pre-capture stats counters so startup logging reports what the walk
+	// caused. Periodic walks use the same deltas for operational logging.
 	startEnqueued := p.totalEnqueued.Load()
 	startPulled := p.totalPulled.Load()
 	startSkippedLocal := p.totalSkippedLocal.Load()
@@ -68,27 +99,35 @@ func (p *Puller) RunCatchUp(ctx context.Context, fetch func(cursor string, limit
 	const pageSize = 1000
 	cursor := ""
 	for {
-		if ctx.Err() != nil {
-			p.logger.Warn().
-				Int64("walked", p.catchupEntriesWalked.Load()).
-				Msg("File puller catch-up cancelled")
+		if ctx.Err() != nil || (lifecycleCtx != nil && lifecycleCtx.Err() != nil) {
+			if startup {
+				p.logger.Warn().
+					Int64("walked", p.catchupEntriesWalked.Load()).
+					Msg("File puller catch-up cancelled")
+			}
 			return
 		}
 
 		page, nextCursor, err := fetch(cursor, pageSize)
 		if err != nil {
-			p.logger.Error().Err(err).Str("cursor", cursor).Msg("Catch-up: page fetch failed, aborting")
+			if startup {
+				p.logger.Error().Err(err).Str("cursor", cursor).Msg("Catch-up: page fetch failed, aborting")
+			} else {
+				p.logger.Error().Err(err).Str("cursor", cursor).Msg("Periodic file reconciliation page fetch failed, aborting")
+			}
 			return
 		}
 		if len(page) == 0 {
-			break // no more entries
+			break
 		}
 
 		for _, entry := range page {
-			if ctx.Err() != nil {
+			if ctx.Err() != nil || (lifecycleCtx != nil && lifecycleCtx.Err() != nil) {
 				return
 			}
-			p.catchupEntriesWalked.Add(1)
+			if startup {
+				p.catchupEntriesWalked.Add(1)
+			}
 			if entry == nil {
 				continue
 			}
@@ -99,21 +138,23 @@ func (p *Puller) RunCatchUp(ctx context.Context, fetch func(cursor string, limit
 				select {
 				case <-ctx.Done():
 					return
-				case <-p.ctx.Done():
+				case <-lifecycleDone(lifecycleCtx):
 					return
 				case <-time.After(50 * time.Millisecond):
 				}
 			}
 
-			// Fast-path: if origin is self, Enqueue would skip and we don't
-			// want to leak a catch-up tag.
-			if entry.OriginNodeID == p.cfg.SelfNodeID {
-				p.totalSkippedSelf.Add(1)
-				p.catchupSkippedLocal.Add(1)
-				continue
+			marked := false
+			if startup {
+				// Fast-path self-origin entries so Enqueue does not create a
+				// catch-up tag for a file this node already owns.
+				if entry.OriginNodeID == p.cfg.SelfNodeID {
+					p.totalSkippedSelf.Add(1)
+					p.catchupSkippedLocal.Add(1)
+					continue
+				}
+				marked = p.markCatchUp(entry.Path)
 			}
-
-			marked := p.markCatchUp(entry.Path)
 
 			beforeEnqueued := p.totalEnqueued.Load()
 			beforeSkippedDup := p.totalSkippedDup.Load()
@@ -121,16 +162,18 @@ func (p *Puller) RunCatchUp(ctx context.Context, fetch func(cursor string, limit
 
 			p.Enqueue(entry)
 
-			switch {
-			case p.totalEnqueued.Load() > beforeEnqueued:
-				p.catchupEnqueued.Add(1)
-			case p.totalSkippedDup.Load() > beforeSkippedDup:
-				p.catchupSkippedLocal.Add(1)
-			case p.totalDropped.Load() > beforeDropped:
-				if marked {
-					p.unmarkCatchUp(entry.Path)
+			if startup {
+				switch {
+				case p.totalEnqueued.Load() > beforeEnqueued:
+					p.catchupEnqueued.Add(1)
+				case p.totalSkippedDup.Load() > beforeSkippedDup:
+					p.catchupSkippedLocal.Add(1)
+				case p.totalDropped.Load() > beforeDropped:
+					if marked {
+						p.unmarkCatchUp(entry.Path)
+					}
+					p.recordCatchUpDrop(entry.Path)
 				}
-				p.recordCatchUpDrop(entry.Path)
 			}
 		}
 
@@ -140,16 +183,26 @@ func (p *Puller) RunCatchUp(ctx context.Context, fetch func(cursor string, limit
 		}
 	}
 
-	p.catchupCompletedAt.Store(time.Now().Unix())
+	if startup {
+		p.catchupCompletedAt.Store(time.Now().Unix())
 
-	p.logger.Info().
-		Int64("catchup_walked", p.catchupEntriesWalked.Load()).
-		Int64("catchup_enqueued", p.catchupEnqueued.Load()).
-		Int64("catchup_skipped_local", p.catchupSkippedLocal.Load()).
-		Int64("enqueued_delta", p.totalEnqueued.Load()-startEnqueued).
-		Int64("pulled_so_far_delta", p.totalPulled.Load()-startPulled).
-		Int64("skipped_local_delta", p.totalSkippedLocal.Load()-startSkippedLocal).
-		Int64("skipped_dup_delta", p.totalSkippedDup.Load()-startSkippedDup).
-		Int64("dropped_delta", p.totalDropped.Load()-startDropped).
-		Msg("File puller catch-up completed")
+		p.logger.Info().
+			Int64("catchup_walked", p.catchupEntriesWalked.Load()).
+			Int64("catchup_enqueued", p.catchupEnqueued.Load()).
+			Int64("catchup_skipped_local", p.catchupSkippedLocal.Load()).
+			Int64("enqueued_delta", p.totalEnqueued.Load()-startEnqueued).
+			Int64("pulled_so_far_delta", p.totalPulled.Load()-startPulled).
+			Int64("skipped_local_delta", p.totalSkippedLocal.Load()-startSkippedLocal).
+			Int64("skipped_dup_delta", p.totalSkippedDup.Load()-startSkippedDup).
+			Int64("dropped_delta", p.totalDropped.Load()-startDropped).
+			Msg("File puller catch-up completed")
+	} else {
+		p.logger.Debug().
+			Int64("enqueued_delta", p.totalEnqueued.Load()-startEnqueued).
+			Int64("pulled_so_far_delta", p.totalPulled.Load()-startPulled).
+			Int64("skipped_local_delta", p.totalSkippedLocal.Load()-startSkippedLocal).
+			Int64("skipped_dup_delta", p.totalSkippedDup.Load()-startSkippedDup).
+			Int64("dropped_delta", p.totalDropped.Load()-startDropped).
+			Msg("Periodic file reconciliation completed")
+	}
 }

--- a/internal/cluster/filereplication/catchup.go
+++ b/internal/cluster/filereplication/catchup.go
@@ -7,6 +7,23 @@ import (
 	"github.com/basekick-labs/arc/internal/cluster/raft"
 )
 
+type manifestWalkStatus uint8
+
+const (
+	manifestWalkCompleted manifestWalkStatus = iota
+	manifestWalkAborted
+	manifestWalkGated
+)
+
+type manifestWalkResult struct {
+	status        manifestWalkStatus
+	gated         bool
+	entriesWalked int64
+	enqueued      int64
+	skipped       int64
+	dropped       int64
+}
+
 // RunCatchUp walks the cluster file manifest in pages and enqueues every
 // entry the local node should hold but doesn't. It is the Phase 3 mechanism
 // that brings a node with a stale or empty local backend back into sync with
@@ -55,10 +72,28 @@ func (p *Puller) RunCatchUp(ctx context.Context, fetch func(cursor string, limit
 // It returns false when another manifest walk is already in progress.
 func (p *Puller) RunReconciliation(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error)) bool {
 	if !p.reconciliationMu.TryLock() {
+		p.recheckBusy.Add(1)
 		return false
 	}
 	defer p.reconciliationMu.Unlock()
-	p.walkManifest(ctx, fetch, false)
+
+	p.recheckStarted.Add(1)
+	result := p.walkManifest(ctx, fetch, false)
+	p.recheckEntriesWalked.Add(result.entriesWalked)
+	p.recheckEnqueued.Add(result.enqueued)
+	p.recheckSkipped.Add(result.skipped)
+	p.recheckDropped.Add(result.dropped)
+	if result.gated {
+		p.recheckGated.Add(1)
+	}
+	switch result.status {
+	case manifestWalkCompleted:
+		p.recheckCompleted.Add(1)
+	case manifestWalkGated:
+		// A gate rejection is reported separately from an aborted pass.
+	default:
+		p.recheckAborted.Add(1)
+	}
 	return true
 }
 
@@ -72,7 +107,8 @@ func lifecycleDone(ctx context.Context) <-chan struct{} {
 // walkManifest is the shared paginated manifest feeder. Startup walks retain
 // the #392 metrics and path bookkeeping; periodic walks only reuse the
 // backpressure and Enqueue behavior so they cannot re-open the startup gate.
-func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error), startup bool) {
+func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error), startup bool) manifestWalkResult {
+	result := manifestWalkResult{status: manifestWalkCompleted}
 	if startup {
 		p.logger.Info().Msg("File puller catch-up started (paginated)")
 	}
@@ -81,7 +117,7 @@ func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, lim
 	p.mu.Unlock()
 
 	// Pre-capture stats counters so startup logging reports what the walk
-	// caused. Periodic walks use the same deltas for operational logging.
+	// caused. Periodic passes use their local result counters instead.
 	startEnqueued := p.totalEnqueued.Load()
 	startPulled := p.totalPulled.Load()
 	startSkippedLocal := p.totalSkippedLocal.Load()
@@ -95,17 +131,46 @@ func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, lim
 	if highWater < 1 {
 		highWater = 1
 	}
+	reconciliationGateRejected := func(midPass bool) bool {
+		if startup || p.reconciliationAllowed() {
+			return false
+		}
+		result.gated = true
+		if midPass {
+			result.status = manifestWalkAborted
+			p.logger.Warn().
+				Str("replication_recheck_status", "aborted").
+				Str("reason", "eligibility changed").
+				Msg("Periodic file reconciliation aborted")
+		} else {
+			result.status = manifestWalkGated
+			p.logger.Info().
+				Str("replication_recheck_status", "gated").
+				Msg("Periodic file reconciliation gated")
+		}
+		return true
+	}
 
 	const pageSize = 1000
 	cursor := ""
+	manifestFetchStarted := false
 	for {
 		if ctx.Err() != nil || (lifecycleCtx != nil && lifecycleCtx.Err() != nil) {
 			if startup {
 				p.logger.Warn().
 					Int64("walked", p.catchupEntriesWalked.Load()).
 					Msg("File puller catch-up cancelled")
+			} else {
+				p.logger.Warn().
+					Str("replication_recheck_status", "aborted").
+					Str("reason", "context cancelled").
+					Msg("Periodic file reconciliation aborted")
 			}
-			return
+			result.status = manifestWalkAborted
+			return result
+		}
+		if reconciliationGateRejected(manifestFetchStarted) {
+			return result
 		}
 
 		page, nextCursor, err := fetch(cursor, pageSize)
@@ -113,20 +178,56 @@ func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, lim
 			if startup {
 				p.logger.Error().Err(err).Str("cursor", cursor).Msg("Catch-up: page fetch failed, aborting")
 			} else {
-				p.logger.Error().Err(err).Str("cursor", cursor).Msg("Periodic file reconciliation page fetch failed, aborting")
+				p.logger.Error().
+					Err(err).
+					Str("cursor", cursor).
+					Str("replication_recheck_status", "aborted").
+					Msg("Periodic file reconciliation page fetch failed")
 			}
-			return
+			result.status = manifestWalkAborted
+			return result
+		}
+		manifestFetchStarted = true
+		if ctx.Err() != nil || (lifecycleCtx != nil && lifecycleCtx.Err() != nil) {
+			result.status = manifestWalkAborted
+			return result
+		}
+		if reconciliationGateRejected(true) {
+			return result
 		}
 		if len(page) == 0 {
-			break
+			if nextCursor == "" {
+				break
+			}
+			if nextCursor == cursor {
+				if startup {
+					p.logger.Error().Str("cursor", cursor).Msg("Catch-up: page cursor did not advance, aborting")
+				} else {
+					p.logger.Error().
+						Str("cursor", cursor).
+						Str("replication_recheck_status", "aborted").
+						Msg("Periodic file reconciliation cursor did not advance")
+				}
+				result.status = manifestWalkAborted
+				return result
+			}
+			cursor = nextCursor
+			continue
 		}
 
 		for _, entry := range page {
 			if ctx.Err() != nil || (lifecycleCtx != nil && lifecycleCtx.Err() != nil) {
-				return
+				result.status = manifestWalkAborted
+				return result
+			}
+			if reconciliationGateRejected(true) {
+				return result
 			}
 			if startup {
 				p.catchupEntriesWalked.Add(1)
+			}
+			if !startup {
+				result.entriesWalked++
 			}
 			if entry == nil {
 				continue
@@ -135,13 +236,21 @@ func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, lim
 			// Backpressure: if the queue is above the high-water mark, sleep
 			// briefly to let workers drain.
 			for len(p.queue) >= highWater {
+				if reconciliationGateRejected(true) {
+					return result
+				}
 				select {
 				case <-ctx.Done():
-					return
+					result.status = manifestWalkAborted
+					return result
 				case <-lifecycleDone(lifecycleCtx):
-					return
+					result.status = manifestWalkAborted
+					return result
 				case <-time.After(50 * time.Millisecond):
 				}
+			}
+			if reconciliationGateRejected(true) {
+				return result
 			}
 
 			marked := false
@@ -156,31 +265,61 @@ func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, lim
 				marked = p.markCatchUp(entry.Path)
 			}
 
-			beforeEnqueued := p.totalEnqueued.Load()
-			beforeSkippedDup := p.totalSkippedDup.Load()
-			beforeDropped := p.totalDropped.Load()
-
-			p.Enqueue(entry)
+			source := enqueueSourceReconciliation
+			if startup {
+				source = enqueueSourceCatchUp
+			}
+			enqueueStatus := p.enqueue(entry, source)
 
 			if startup {
-				switch {
-				case p.totalEnqueued.Load() > beforeEnqueued:
+				switch enqueueStatus {
+				case enqueueResultEnqueued:
 					p.catchupEnqueued.Add(1)
-				case p.totalSkippedDup.Load() > beforeSkippedDup:
+				case enqueueResultSkippedSelf, enqueueResultSkippedDuplicate:
 					p.catchupSkippedLocal.Add(1)
-				case p.totalDropped.Load() > beforeDropped:
+				case enqueueResultDropped:
 					if marked {
+						// No worker will remove a tag when the queue rejects the
+						// entry, so compensate for the pre-enqueue mark.
 						p.unmarkCatchUp(entry.Path)
 					}
 					p.recordCatchUpDrop(entry.Path)
 				}
+			} else {
+				switch enqueueStatus {
+				case enqueueResultEnqueued:
+					result.enqueued++
+				case enqueueResultSkippedSelf, enqueueResultSkippedDuplicate:
+					result.skipped++
+				case enqueueResultDropped:
+					result.dropped++
+				}
 			}
 		}
+		if ctx.Err() != nil || (lifecycleCtx != nil && lifecycleCtx.Err() != nil) {
+			result.status = manifestWalkAborted
+			return result
+		}
+		if reconciliationGateRejected(true) {
+			return result
+		}
 
-		cursor = nextCursor
-		if cursor == "" {
+		if nextCursor == "" {
 			break
 		}
+		if nextCursor == cursor {
+			if startup {
+				p.logger.Error().Str("cursor", cursor).Msg("Catch-up: page cursor did not advance, aborting")
+			} else {
+				p.logger.Error().
+					Str("cursor", cursor).
+					Str("replication_recheck_status", "aborted").
+					Msg("Periodic file reconciliation cursor did not advance")
+			}
+			result.status = manifestWalkAborted
+			return result
+		}
+		cursor = nextCursor
 	}
 
 	if startup {
@@ -197,12 +336,13 @@ func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, lim
 			Int64("dropped_delta", p.totalDropped.Load()-startDropped).
 			Msg("File puller catch-up completed")
 	} else {
-		p.logger.Debug().
-			Int64("enqueued_delta", p.totalEnqueued.Load()-startEnqueued).
-			Int64("pulled_so_far_delta", p.totalPulled.Load()-startPulled).
-			Int64("skipped_local_delta", p.totalSkippedLocal.Load()-startSkippedLocal).
-			Int64("skipped_dup_delta", p.totalSkippedDup.Load()-startSkippedDup).
-			Int64("dropped_delta", p.totalDropped.Load()-startDropped).
+		p.logger.Info().
+			Str("replication_recheck_status", "completed").
+			Int64("replication_recheck_entries_walked", result.entriesWalked).
+			Int64("replication_recheck_enqueued", result.enqueued).
+			Int64("replication_recheck_skipped", result.skipped).
+			Int64("replication_recheck_dropped", result.dropped).
 			Msg("Periodic file reconciliation completed")
 	}
+	return result
 }

--- a/internal/cluster/filereplication/catchup.go
+++ b/internal/cluster/filereplication/catchup.go
@@ -67,9 +67,11 @@ func (p *Puller) RunCatchUp(ctx context.Context, fetch func(cursor string, limit
 }
 
 // RunReconciliation walks the current manifest and enqueues entries through
-// the normal pull path. Unlike RunCatchUp, it is repeatable and deliberately
-// does not participate in startup catch-up bookkeeping or query readiness.
-// It returns false when another manifest walk is already in progress.
+// the normal pull path. Unlike RunCatchUp, it is repeatable and does not
+// create startup catch-up state or remove startup tags. Its failures do not
+// reopen readiness, while successful pulls may heal existing path-scoped
+// catch-up failure/drop state. It returns false when another manifest walk is
+// already in progress.
 func (p *Puller) RunReconciliation(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error)) bool {
 	if !p.reconciliationMu.TryLock() {
 		p.recheckBusy.Add(1)
@@ -105,8 +107,9 @@ func lifecycleDone(ctx context.Context) <-chan struct{} {
 }
 
 // walkManifest is the shared paginated manifest feeder. Startup walks retain
-// the #392 metrics and path bookkeeping; periodic walks only reuse the
-// backpressure and Enqueue behavior so they cannot re-open the startup gate.
+// the #392 metrics and path bookkeeping; periodic walks use separate metrics,
+// never create or remove startup tags, and can heal existing path-scoped
+// failure/drop state only when their pull succeeds.
 func (p *Puller) walkManifest(ctx context.Context, fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error), startup bool) manifestWalkResult {
 	result := manifestWalkResult{status: manifestWalkCompleted}
 	if startup {

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -467,16 +467,20 @@ func (p *Puller) startPeriodicReconciliation(fetch func(cursor string, limit int
 		if interval <= 0 {
 			interval = 5 * time.Minute
 		}
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
+		timer := time.NewTimer(interval)
+		defer timer.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
+			case <-timer.C:
 				if !p.RunReconciliation(ctx, fetch) {
 					p.logger.Debug().Msg("File puller reconciliation already running, skipping periodic pass")
 				}
+				if ctx.Err() != nil {
+					return
+				}
+				timer.Reset(interval)
 			}
 		}
 	}()

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -25,6 +25,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const defaultReconciliationInterval = 5 * time.Minute
+
 // Fetcher is the contract the puller uses to download a single file from a
 // peer. It's an interface rather than a concrete type so the puller can be
 // unit-tested with a fake that returns deterministic bytes/errors without
@@ -62,6 +64,29 @@ type Fetcher interface {
 // known peers" and is treated as a transient failure the puller can retry.
 type PeerResolver interface {
 	ResolvePeers(originNodeID, path string) []string
+}
+
+type enqueueSource uint8
+
+const (
+	enqueueSourceReactive enqueueSource = iota
+	enqueueSourceCatchUp
+	enqueueSourceReconciliation
+)
+
+type enqueueResult uint8
+
+const (
+	enqueueResultInvalid enqueueResult = iota
+	enqueueResultEnqueued
+	enqueueResultSkippedSelf
+	enqueueResultSkippedDuplicate
+	enqueueResultDropped
+)
+
+type pullRequest struct {
+	entry  *raft.FileEntry
+	source enqueueSource
 }
 
 // Config bundles the puller's dependencies and tunables.
@@ -106,6 +131,14 @@ type Config struct {
 	// Default: 0.8 (sleep when > 80% full).
 	CatchUpQueueHighWater float64
 
+	// ReconciliationInterval controls the delay between periodic manifest
+	// rechecks. Default: 5 minutes.
+	ReconciliationInterval time.Duration
+
+	// ReconciliationGate is evaluated before and during each periodic manifest
+	// walk. A nil gate allows reconciliation unconditionally.
+	ReconciliationGate func() bool
+
 	// Logger receives structured log output.
 	Logger zerolog.Logger
 }
@@ -114,12 +147,13 @@ type Config struct {
 // the dependencies (Backend, Fetcher, PeerResolver, SelfNodeID, Logger).
 func DefaultConfig() Config {
 	return Config{
-		Workers:               4,
-		QueueSize:             1024,
-		RetryMaxAttempts:      3,
-		RetryInitialBackoff:   500 * time.Millisecond,
-		FetchTimeout:          60 * time.Second,
-		CatchUpQueueHighWater: 0.8,
+		Workers:                4,
+		QueueSize:              1024,
+		RetryMaxAttempts:       3,
+		RetryInitialBackoff:    500 * time.Millisecond,
+		FetchTimeout:           60 * time.Second,
+		CatchUpQueueHighWater:  0.8,
+		ReconciliationInterval: defaultReconciliationInterval,
 	}
 }
 
@@ -127,7 +161,7 @@ func DefaultConfig() Config {
 // callbacks and pulls missing files from their origin peers.
 type Puller struct {
 	cfg    Config
-	queue  chan *raft.FileEntry
+	queue  chan *pullRequest
 	logger zerolog.Logger
 
 	// Lifecycle
@@ -155,7 +189,9 @@ type Puller struct {
 	// (FullyCaughtUp, Stats during a 503 storm) don't take inflightMu and
 	// contend with the workers. The map is the source of truth for dedup;
 	// the counter is updated under inflightMu in the same critical section
-	// so they cannot diverge.
+	// so they cannot diverge. The same lock protects catch-up path tags so a
+	// worker finishing while the startup walker marks a path cannot lose the
+	// catch-up failure signal.
 	inflightMu    sync.Mutex
 	inflight      map[string]struct{}
 	inflightCount atomic.Int64
@@ -198,13 +234,11 @@ type Puller struct {
 	// catchupFailedPaths holds catch-up paths whose pull permanently gave up
 	// after retries. catchupDroppedPaths holds catch-up paths the walker
 	// could not enqueue because the queue was full. Both are tracked so a
-	// later successful pull (reactive FSM callback after the underlying
-	// issue clears, or a subsequent catch-up scan) can decrement the
+	// later successful startup or reactive pull after the underlying issue
+	// clears can decrement the
 	// corresponding scoped counter and let the gate self-heal without a
-	// process restart. All three sets share catchupPathsMu — they're all
-	// catch-up bookkeeping and the lock is only ever held for tiny critical
-	// sections.
-	catchupPathsMu      sync.Mutex
+	// process restart. All three sets share inflightMu with the in-flight map,
+	// which keeps finish/tag bookkeeping atomic.
 	catchupPaths        map[string]struct{}
 	catchupFailedPaths  map[string]struct{}
 	catchupDroppedPaths map[string]struct{}
@@ -213,10 +247,24 @@ type Puller struct {
 	// catchupFailed / catchupDropped count failures and drops scoped to the
 	// catch-up batch only. FullyCaughtUp uses these (not the cumulative
 	// totalFailed / totalDropped) so transient steady-state failures don't
-	// keep the gate red forever. Both self-heal when a later pull succeeds
-	// for the affected path — see clearCatchUpFailure / clearCatchUpDrop.
+	// keep the gate red forever. Both self-heal when a later startup or
+	// reactive pull succeeds for the affected path — see clearCatchUpFailure /
+	// clearCatchUpDrop.
 	catchupFailed  atomic.Int64
 	catchupDropped atomic.Int64
+
+	// Periodic reconciliation metrics. These are intentionally separate from
+	// the startup catch-up counters because a recheck must never reopen or
+	// otherwise change the #392 readiness scope.
+	recheckStarted       atomic.Int64
+	recheckCompleted     atomic.Int64
+	recheckAborted       atomic.Int64
+	recheckGated         atomic.Int64
+	recheckBusy          atomic.Int64
+	recheckEntriesWalked atomic.Int64
+	recheckEnqueued      atomic.Int64
+	recheckSkipped       atomic.Int64
+	recheckDropped       atomic.Int64
 }
 
 // New constructs a Puller. Does not start background workers — call Start.
@@ -256,10 +304,13 @@ func New(cfg Config) (*Puller, error) {
 	if cfg.CatchUpQueueHighWater <= 0 || cfg.CatchUpQueueHighWater >= 1 {
 		cfg.CatchUpQueueHighWater = defaults.CatchUpQueueHighWater
 	}
+	if cfg.ReconciliationInterval <= 0 {
+		cfg.ReconciliationInterval = defaults.ReconciliationInterval
+	}
 
 	return &Puller{
 		cfg:                 cfg,
-		queue:               make(chan *raft.FileEntry, cfg.QueueSize),
+		queue:               make(chan *pullRequest, cfg.QueueSize),
 		inflight:            make(map[string]struct{}),
 		catchupPaths:        make(map[string]struct{}),
 		catchupFailedPaths:  make(map[string]struct{}),
@@ -285,26 +336,56 @@ func (p *Puller) inflightAdd(path string) bool {
 	return true
 }
 
-// inflightRemove clears a path from the in-flight set. Safe to call on a
-// path that's not in the set (no-op). Called from processEntry via defer so
-// it runs on panic unwind too. Updates inflightCount only when an entry is
-// actually deleted to keep the counter exact. Also clears the catch-up tag
-// if the path was specifically enqueued by RunCatchUp, so FullyCaughtUp can
-// distinguish "cold-start batch still draining" from "steady-state ingest."
+// inflightRemove clears a path from the in-flight set and any catch-up tag.
+// Safe to call on a path that's not in either set (no-op). Updates
+// inflightCount only when an entry is actually deleted to keep the counter
+// exact.
 func (p *Puller) inflightRemove(path string) {
 	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	p.removeInflightLocked(path)
+}
+
+func (p *Puller) removeInflightLocked(path string) {
+	p.removeInflightOnlyLocked(path)
+	p.removeCatchUpTagLocked(path)
+}
+
+func (p *Puller) removeInflightOnlyLocked(path string) {
 	if _, ok := p.inflight[path]; ok {
 		delete(p.inflight, path)
 		p.inflightCount.Add(-1)
 	}
-	p.inflightMu.Unlock()
+}
 
-	p.catchupPathsMu.Lock()
+func (p *Puller) removeCatchUpTagLocked(path string) {
 	if _, ok := p.catchupPaths[path]; ok {
 		delete(p.catchupPaths, path)
 		p.catchupInflight.Add(-1)
 	}
-	p.catchupPathsMu.Unlock()
+}
+
+// finishEntry records a worker outcome and removes its in-flight state while
+// holding the same lock used by markCatchUp. This closes the race where a
+// startup walker adds a catch-up tag after a worker checks the tag but before
+// the worker removes its in-flight entry.
+func (p *Puller) finishEntry(path string, source enqueueSource, failed, succeeded bool) {
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+
+	if source != enqueueSourceReconciliation {
+		switch {
+		case failed && p.isCatchUpPathLocked(path):
+			p.recordCatchUpFailureLocked(path)
+		case succeeded:
+			p.clearCatchUpFailureLocked(path)
+			p.clearCatchUpDropLocked(path)
+		}
+	}
+	if source != enqueueSourceReconciliation {
+		p.removeCatchUpTagLocked(path)
+	}
+	p.removeInflightOnlyLocked(path)
 }
 
 // markCatchUp records that a path is being enqueued by the catch-up walker
@@ -319,8 +400,8 @@ func (p *Puller) inflightRemove(path string) {
 // (idempotent re-mark). RunCatchUp uses the return value to compensate
 // the increment if Enqueue ends up dropping the entry.
 func (p *Puller) markCatchUp(path string) bool {
-	p.catchupPathsMu.Lock()
-	defer p.catchupPathsMu.Unlock()
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
 	if _, ok := p.catchupPaths[path]; ok {
 		return false
 	}
@@ -334,8 +415,8 @@ func (p *Puller) markCatchUp(path string) bool {
 // pre-marked: with no inflight slot taken, no future inflightRemove will
 // run for this path, so the tag would otherwise leak.
 func (p *Puller) unmarkCatchUp(path string) {
-	p.catchupPathsMu.Lock()
-	defer p.catchupPathsMu.Unlock()
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
 	if _, ok := p.catchupPaths[path]; !ok {
 		return
 	}
@@ -348,8 +429,12 @@ func (p *Puller) unmarkCatchUp(path string) {
 // should bump catchupFailed (and therefore keep the query gate red until
 // a successful retry resolves the missing file).
 func (p *Puller) isCatchUpPath(path string) bool {
-	p.catchupPathsMu.Lock()
-	defer p.catchupPathsMu.Unlock()
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	return p.isCatchUpPathLocked(path)
+}
+
+func (p *Puller) isCatchUpPathLocked(path string) bool {
 	_, ok := p.catchupPaths[path]
 	return ok
 }
@@ -361,8 +446,12 @@ func (p *Puller) isCatchUpPath(path string) bool {
 // re-failure) does not double-count, so the gate's self-heal accounting
 // stays correct.
 func (p *Puller) recordCatchUpFailure(path string) {
-	p.catchupPathsMu.Lock()
-	defer p.catchupPathsMu.Unlock()
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	p.recordCatchUpFailureLocked(path)
+}
+
+func (p *Puller) recordCatchUpFailureLocked(path string) {
 	if _, ok := p.catchupFailedPaths[path]; ok {
 		return
 	}
@@ -372,12 +461,15 @@ func (p *Puller) recordCatchUpFailure(path string) {
 
 // clearCatchUpFailure decrements the catch-up failure counter if the given
 // path was previously recorded as failed. Called from processEntry's
-// success path so a reactive FSM callback (or any later successful pull)
-// can heal the gate without a process restart. No-op if the path was not
-// previously failed.
+// success path so a startup or reactive pull can heal the gate without a
+// process restart. No-op if the path was not previously failed.
 func (p *Puller) clearCatchUpFailure(path string) {
-	p.catchupPathsMu.Lock()
-	defer p.catchupPathsMu.Unlock()
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	p.clearCatchUpFailureLocked(path)
+}
+
+func (p *Puller) clearCatchUpFailureLocked(path string) {
 	if _, ok := p.catchupFailedPaths[path]; !ok {
 		return
 	}
@@ -389,10 +481,14 @@ func (p *Puller) clearCatchUpFailure(path string) {
 // the catch-up drop counter. Called from RunCatchUp when the queue is full
 // and the walker can't enqueue an entry — there's no inflight slot to
 // later decrement, so we track the path here and rely on a reactive FSM
-// callback (or subsequent catch-up scan) to eventually pull it. Idempotent.
+// callback to eventually pull it. Idempotent.
 func (p *Puller) recordCatchUpDrop(path string) {
-	p.catchupPathsMu.Lock()
-	defer p.catchupPathsMu.Unlock()
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	p.recordCatchUpDropLocked(path)
+}
+
+func (p *Puller) recordCatchUpDropLocked(path string) {
 	if _, ok := p.catchupDroppedPaths[path]; ok {
 		return
 	}
@@ -403,11 +499,15 @@ func (p *Puller) recordCatchUpDrop(path string) {
 // clearCatchUpDrop decrements the catch-up drop counter if the given path
 // was previously recorded as dropped. Called from processEntry's success
 // path so a reactive FSM callback succeeding for a previously-dropped
-// path can heal the gate without a process restart. No-op if the path
-// was not previously dropped.
+// path can heal the gate without a process restart. No-op if the path was not
+// previously dropped.
 func (p *Puller) clearCatchUpDrop(path string) {
-	p.catchupPathsMu.Lock()
-	defer p.catchupPathsMu.Unlock()
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	p.clearCatchUpDropLocked(path)
+}
+
+func (p *Puller) clearCatchUpDropLocked(path string) {
 	if _, ok := p.catchupDroppedPaths[path]; !ok {
 		return
 	}
@@ -435,12 +535,16 @@ func (p *Puller) Start(parentCtx context.Context) {
 		Msg("File puller started")
 }
 
+func (p *Puller) reconciliationAllowed() bool {
+	return p.cfg.ReconciliationGate == nil || p.cfg.ReconciliationGate()
+}
+
 // StartPeriodicReconciliation starts the repeatable manifest reconciliation
 // loop. The loop waits for the one-shot startup catch-up attempt to finish,
 // then runs once per interval. It is owned by the puller so Stop waits for a
 // pass that is already walking the manifest before returning.
 func (p *Puller) StartPeriodicReconciliation(fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error)) {
-	p.startPeriodicReconciliation(fetch, 5*time.Minute)
+	p.startPeriodicReconciliation(fetch, p.cfg.ReconciliationInterval)
 }
 
 // startPeriodicReconciliation is split out so tests can use a short interval
@@ -465,7 +569,7 @@ func (p *Puller) startPeriodicReconciliation(fetch func(cursor string, limit int
 		}
 
 		if interval <= 0 {
-			interval = 5 * time.Minute
+			interval = defaultReconciliationInterval
 		}
 		timer := time.NewTimer(interval)
 		defer timer.Stop()
@@ -474,7 +578,12 @@ func (p *Puller) startPeriodicReconciliation(fetch func(cursor string, limit int
 			case <-ctx.Done():
 				return
 			case <-timer.C:
-				if !p.RunReconciliation(ctx, fetch) {
+				if !p.reconciliationAllowed() {
+					p.recheckGated.Add(1)
+					p.logger.Info().
+						Str("replication_recheck_status", "gated").
+						Msg("Periodic file reconciliation gated")
+				} else if !p.RunReconciliation(ctx, fetch) {
 					p.logger.Debug().Msg("File puller reconciliation already running, skipping periodic pass")
 				}
 				if ctx.Err() != nil {
@@ -518,29 +627,40 @@ func (p *Puller) Stop() {
 // is also safe to call from the Phase 3 catch-up walker concurrently with
 // reactive callbacks — the inflight set dedups cross-path races.
 func (p *Puller) Enqueue(entry *raft.FileEntry) {
+	p.enqueue(entry, enqueueSourceReactive)
+}
+
+func (p *Puller) enqueue(entry *raft.FileEntry, source enqueueSource) enqueueResult {
 	if entry == nil {
-		return
+		return enqueueResultInvalid
 	}
 	// Fast-path: if origin is self there's nothing to pull.
 	if entry.OriginNodeID == p.cfg.SelfNodeID {
 		p.totalSkippedSelf.Add(1)
-		return
+		return enqueueResultSkippedSelf
 	}
 	// Dedup: if the path is already enqueued or being processed, don't add
 	// it again. The inflight slot is released by processEntry via defer.
 	if !p.inflightAdd(entry.Path) {
 		p.totalSkippedDup.Add(1)
-		return
+		return enqueueResultSkippedDuplicate
 	}
 	// Copy so the caller can't mutate the entry out from under the worker.
 	entryCopy := *entry
 	select {
-	case p.queue <- &entryCopy:
+	case p.queue <- &pullRequest{entry: &entryCopy, source: source}:
 		p.totalEnqueued.Add(1)
+		return enqueueResultEnqueued
 	default:
 		// Queue full — release the inflight slot so a future retry can
-		// re-enqueue this path, and count the drop.
-		p.inflightRemove(entry.Path)
+		// re-enqueue this path, and count the drop. A periodic request must
+		// not clear startup catch-up tags while releasing its own slot.
+		p.inflightMu.Lock()
+		p.removeInflightOnlyLocked(entry.Path)
+		if source != enqueueSourceReconciliation {
+			p.removeCatchUpTagLocked(entry.Path)
+		}
+		p.inflightMu.Unlock()
 		dropped := p.totalDropped.Add(1)
 		// Power-of-2 rate limiting, same pattern as CoordinatorFileRegistrar.
 		if dropped&(dropped-1) == 0 {
@@ -549,6 +669,7 @@ func (p *Puller) Enqueue(entry *raft.FileEntry) {
 				Int64("total_dropped", dropped).
 				Msg("File puller queue full, dropping entry (will be recovered by catch-up scanner)")
 		}
+		return enqueueResultDropped
 	}
 }
 
@@ -558,27 +679,36 @@ func (p *Puller) Enqueue(entry *raft.FileEntry) {
 // inflightCount, queue depth from len() on the buffered channel.
 func (p *Puller) Stats() map[string]int64 {
 	return map[string]int64{
-		"enqueued":               p.totalEnqueued.Load(),
-		"skipped_self":           p.totalSkippedSelf.Load(),
-		"skipped_local":          p.totalSkippedLocal.Load(),
-		"skipped_dup":            p.totalSkippedDup.Load(),
-		"pulled":                 p.totalPulled.Load(),
-		"failed":                 p.totalFailed.Load(),
-		"dropped":                p.totalDropped.Load(),
-		"checksum_mismatch":      p.totalChecksumMismatch.Load(),
-		"peer_lookup_failure":    p.totalPeerLookupFailure.Load(),
-		"bad_offset_server":      p.totalBadOffsetServer.Load(),
-		"bad_offset_backend":     p.totalBadOffsetBackend.Load(),
-		"queue_depth":            int64(len(p.queue)),
-		"inflight_count":         p.inflightCount.Load(),
-		"catchup_started_at":     p.catchupStartedAt.Load(),
-		"catchup_completed_at":   p.catchupCompletedAt.Load(),
-		"catchup_entries_walked": p.catchupEntriesWalked.Load(),
-		"catchup_enqueued":       p.catchupEnqueued.Load(),
-		"catchup_skipped_local":  p.catchupSkippedLocal.Load(),
-		"catchup_inflight":       p.catchupInflight.Load(),
-		"catchup_failed":         p.catchupFailed.Load(),
-		"catchup_dropped":        p.catchupDropped.Load(),
+		"enqueued":                           p.totalEnqueued.Load(),
+		"skipped_self":                       p.totalSkippedSelf.Load(),
+		"skipped_local":                      p.totalSkippedLocal.Load(),
+		"skipped_dup":                        p.totalSkippedDup.Load(),
+		"pulled":                             p.totalPulled.Load(),
+		"failed":                             p.totalFailed.Load(),
+		"dropped":                            p.totalDropped.Load(),
+		"checksum_mismatch":                  p.totalChecksumMismatch.Load(),
+		"peer_lookup_failure":                p.totalPeerLookupFailure.Load(),
+		"bad_offset_server":                  p.totalBadOffsetServer.Load(),
+		"bad_offset_backend":                 p.totalBadOffsetBackend.Load(),
+		"queue_depth":                        int64(len(p.queue)),
+		"inflight_count":                     p.inflightCount.Load(),
+		"catchup_started_at":                 p.catchupStartedAt.Load(),
+		"catchup_completed_at":               p.catchupCompletedAt.Load(),
+		"catchup_entries_walked":             p.catchupEntriesWalked.Load(),
+		"catchup_enqueued":                   p.catchupEnqueued.Load(),
+		"catchup_skipped_local":              p.catchupSkippedLocal.Load(),
+		"catchup_inflight":                   p.catchupInflight.Load(),
+		"catchup_failed":                     p.catchupFailed.Load(),
+		"catchup_dropped":                    p.catchupDropped.Load(),
+		"replication_recheck_started":        p.recheckStarted.Load(),
+		"replication_recheck_completed":      p.recheckCompleted.Load(),
+		"replication_recheck_aborted":        p.recheckAborted.Load(),
+		"replication_recheck_gated":          p.recheckGated.Load(),
+		"replication_recheck_busy":           p.recheckBusy.Load(),
+		"replication_recheck_entries_walked": p.recheckEntriesWalked.Load(),
+		"replication_recheck_enqueued":       p.recheckEnqueued.Load(),
+		"replication_recheck_skipped":        p.recheckSkipped.Load(),
+		"replication_recheck_dropped":        p.recheckDropped.Load(),
 	}
 }
 
@@ -607,14 +737,13 @@ func (p *Puller) CatchUpCompleted() bool {
 // "no pulls are happening anywhere right now."
 //
 // Self-heal: catchupFailed and catchupDropped both decrement when a later
-// pull (reactive FSM callback or otherwise) succeeds for a previously-
-// affected path, so transient peer outages or queue-saturation events
-// during catch-up don't require a process restart to clear the gate. The
-// puller tracks the affected paths in catchupFailedPaths and
-// catchupDroppedPaths respectively; processEntry's success path calls
-// clearCatchUpFailure and clearCatchUpDrop unconditionally (both are no-
-// ops when the path was never recorded), so any successful pull is a
-// recovery event regardless of the original failure mode.
+// startup or reactive pull succeeds for a previously-affected path, so
+// transient peer outages or queue-saturation events during catch-up don't
+// require a process restart to clear the gate. Periodic reconciliation is
+// deliberately excluded so it cannot reopen startup readiness. The puller
+// tracks the affected paths in catchupFailedPaths and catchupDroppedPaths;
+// startup/reactive worker success calls clearCatchUpFailure and
+// clearCatchUpDrop (both are no-ops when the path was never recorded).
 //
 // Returns false (not ready) if:
 //   - the catch-up walker never ran or hasn't completed, OR
@@ -687,6 +816,18 @@ func (p *Puller) CatchUpStatus() map[string]int64 {
 		// Live queue/inflight depth.
 		"queue_depth":    int64(len(p.queue)),
 		"inflight_count": p.inflightCount.Load(),
+
+		// Periodic reconciliation counters. These are prefixed so callers can
+		// distinguish them from the startup catch-up contract above.
+		"replication_recheck_started":        p.recheckStarted.Load(),
+		"replication_recheck_completed":      p.recheckCompleted.Load(),
+		"replication_recheck_aborted":        p.recheckAborted.Load(),
+		"replication_recheck_gated":          p.recheckGated.Load(),
+		"replication_recheck_busy":           p.recheckBusy.Load(),
+		"replication_recheck_entries_walked": p.recheckEntriesWalked.Load(),
+		"replication_recheck_enqueued":       p.recheckEnqueued.Load(),
+		"replication_recheck_skipped":        p.recheckSkipped.Load(),
+		"replication_recheck_dropped":        p.recheckDropped.Load(),
 	}
 }
 
@@ -700,11 +841,11 @@ func (p *Puller) worker(id int) {
 		case <-p.ctx.Done():
 			workerLog.Debug().Msg("File puller worker exiting")
 			return
-		case entry, ok := <-p.queue:
+		case request, ok := <-p.queue:
 			if !ok {
 				return
 			}
-			p.processEntry(workerLog, entry)
+			p.processEntry(workerLog, request)
 		}
 	}
 }
@@ -717,7 +858,8 @@ func (p *Puller) worker(id int) {
 // EXCEPT checksum mismatch — a corrupt body from one peer is a real data
 // integrity problem and shouldn't trigger pull-and-corrupt from every other
 // healthy peer in turn.
-func (p *Puller) processEntry(log zerolog.Logger, entry *raft.FileEntry) {
+func (p *Puller) processEntry(log zerolog.Logger, request *pullRequest) {
+	entry := request.entry
 	// failed and succeeded are local to this worker so a concurrent worker
 	// processing a different entry doesn't trip our defer — using a global
 	// counter delta would cross-pollinate outcomes across workers. Set by
@@ -730,30 +872,11 @@ func (p *Puller) processEntry(log zerolog.Logger, entry *raft.FileEntry) {
 	// panic unwind — and makes repeated catch-up walks idempotent with the
 	// reactive enqueue path.
 	//
-	// The catch-up tag check happens INSIDE the defer (not snapshotted at
-	// function entry) to close a race: a reactive pull may already be in
-	// flight when RunCatchUp starts, in which case the walker tags the
-	// path AFTER this worker began processing it. Reading isCatchUpPath
-	// at entry would miss that late tag and we'd silently drop the
-	// catch-up-failure signal — opening the gate while the file is
-	// missing. Reading it inside the defer (before inflightRemove clears
-	// the tag) sees whatever state the walker has converged on.
+	// finishEntry checks the catch-up tag and removes the in-flight state under
+	// one lock. A reactive pull may already be in flight when RunCatchUp starts,
+	// so the walker can add the tag after this worker began processing it.
 	defer func() {
-		switch {
-		case failed && p.isCatchUpPath(entry.Path):
-			// Catch-up-tagged pull gave up after all retries. Record the
-			// failure; the gate stays red until a later successful pull
-			// (reactive or otherwise) calls clearCatchUpFailure.
-			p.recordCatchUpFailure(entry.Path)
-		case succeeded:
-			// Pull succeeded. If this path had a prior catch-up failure or
-			// drop, heal it so the gate can clear without a process restart.
-			// Both are no-ops when the path was never in the corresponding
-			// set, so safe to call on every success regardless of history.
-			p.clearCatchUpFailure(entry.Path)
-			p.clearCatchUpDrop(entry.Path)
-		}
-		p.inflightRemove(entry.Path)
+		p.finishEntry(entry.Path, request.source, failed, succeeded)
 	}()
 
 	for attempt := 1; attempt <= p.cfg.RetryMaxAttempts; attempt++ {

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -137,9 +137,17 @@ type Puller struct {
 	mu      sync.Mutex
 	started bool
 
+	// reconciliationMu serializes manifest walks. The startup catch-up and
+	// periodic reconciliation share the same walker, so a periodic pass can
+	// never overlap another pass even if it is triggered concurrently.
+	reconciliationMu      sync.Mutex
+	reconciliationStarted bool
+	catchupFinished       chan struct{}
+
 	// inflight tracks paths currently enqueued or being processed. Enqueue
-	// consults it to dedup reactive callbacks against the Phase 3 catch-up
-	// walker (both can enqueue the same path during a race), and workers
+	// consults it to dedup reactive callbacks against manifest walkers (both
+	// startup and periodic passes can enqueue the same path during a race).
+	// Workers
 	// remove the entry via defer in processEntry so the set stays bounded
 	// even on panic.
 	//
@@ -256,6 +264,7 @@ func New(cfg Config) (*Puller, error) {
 		catchupPaths:        make(map[string]struct{}),
 		catchupFailedPaths:  make(map[string]struct{}),
 		catchupDroppedPaths: make(map[string]struct{}),
+		catchupFinished:     make(chan struct{}),
 		logger:              cfg.Logger.With().Str("component", "file-puller").Logger(),
 	}, nil
 }
@@ -426,9 +435,56 @@ func (p *Puller) Start(parentCtx context.Context) {
 		Msg("File puller started")
 }
 
+// StartPeriodicReconciliation starts the repeatable manifest reconciliation
+// loop. The loop waits for the one-shot startup catch-up attempt to finish,
+// then runs once per interval. It is owned by the puller so Stop waits for a
+// pass that is already walking the manifest before returning.
+func (p *Puller) StartPeriodicReconciliation(fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error)) {
+	p.startPeriodicReconciliation(fetch, 5*time.Minute)
+}
+
+// startPeriodicReconciliation is split out so tests can use a short interval
+// without adding a public configuration surface for a fixed lifecycle timer.
+func (p *Puller) startPeriodicReconciliation(fetch func(cursor string, limit int) ([]*raft.FileEntry, string, error), interval time.Duration) {
+	p.mu.Lock()
+	if !p.started || p.reconciliationStarted {
+		p.mu.Unlock()
+		return
+	}
+	p.reconciliationStarted = true
+	ctx := p.ctx
+	p.wg.Add(1)
+	p.mu.Unlock()
+
+	go func() {
+		defer p.wg.Done()
+		select {
+		case <-p.catchupFinished:
+		case <-ctx.Done():
+			return
+		}
+
+		if interval <= 0 {
+			interval = 5 * time.Minute
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if !p.RunReconciliation(ctx, fetch) {
+					p.logger.Debug().Msg("File puller reconciliation already running, skipping periodic pass")
+				}
+			}
+		}
+	}()
+}
+
 // Stop signals all workers to exit and waits for them to finish. In-flight
 // pulls are cancelled via the shared context. Pending queue entries are
-// dropped (Phase 3 catch-up or a later FSM callback will re-discover them).
+// dropped (a later manifest pass or FSM callback will re-discover them).
 func (p *Puller) Stop() {
 	p.mu.Lock()
 	if !p.started {

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -234,10 +234,9 @@ type Puller struct {
 	// catchupFailedPaths holds catch-up paths whose pull permanently gave up
 	// after retries. catchupDroppedPaths holds catch-up paths the walker
 	// could not enqueue because the queue was full. Both are tracked so a
-	// later successful startup or reactive pull after the underlying issue
-	// clears can decrement the
-	// corresponding scoped counter and let the gate self-heal without a
-	// process restart. All three sets share inflightMu with the in-flight map,
+	// later successful pull after the underlying issue clears can decrement the
+	// corresponding scoped counter and let the gate self-heal without a process
+	// restart. All three sets share inflightMu with the in-flight map,
 	// which keeps finish/tag bookkeeping atomic.
 	catchupPaths        map[string]struct{}
 	catchupFailedPaths  map[string]struct{}
@@ -247,9 +246,9 @@ type Puller struct {
 	// catchupFailed / catchupDropped count failures and drops scoped to the
 	// catch-up batch only. FullyCaughtUp uses these (not the cumulative
 	// totalFailed / totalDropped) so transient steady-state failures don't
-	// keep the gate red forever. Both self-heal when a later startup or
-	// reactive pull succeeds for the affected path — see clearCatchUpFailure /
-	// clearCatchUpDrop.
+	// keep the gate red forever. Both self-heal when a later startup, reactive,
+	// or reconciliation pull succeeds for the affected path — see
+	// clearCatchUpFailure / clearCatchUpDrop.
 	catchupFailed  atomic.Int64
 	catchupDropped atomic.Int64
 
@@ -368,19 +367,19 @@ func (p *Puller) removeCatchUpTagLocked(path string) {
 // finishEntry records a worker outcome and removes its in-flight state while
 // holding the same lock used by markCatchUp. This closes the race where a
 // startup walker adds a catch-up tag after a worker checks the tag but before
-// the worker removes its in-flight entry.
+// the worker removes its in-flight entry. Reconciliation failures stay outside
+// startup bookkeeping, while any successful pull can heal a prior path failure
+// or drop.
 func (p *Puller) finishEntry(path string, source enqueueSource, failed, succeeded bool) {
 	p.inflightMu.Lock()
 	defer p.inflightMu.Unlock()
 
-	if source != enqueueSourceReconciliation {
-		switch {
-		case failed && p.isCatchUpPathLocked(path):
-			p.recordCatchUpFailureLocked(path)
-		case succeeded:
-			p.clearCatchUpFailureLocked(path)
-			p.clearCatchUpDropLocked(path)
-		}
+	if failed && source != enqueueSourceReconciliation && p.isCatchUpPathLocked(path) {
+		p.recordCatchUpFailureLocked(path)
+	}
+	if succeeded {
+		p.clearCatchUpFailureLocked(path)
+		p.clearCatchUpDropLocked(path)
 	}
 	if source != enqueueSourceReconciliation {
 		p.removeCatchUpTagLocked(path)
@@ -460,9 +459,9 @@ func (p *Puller) recordCatchUpFailureLocked(path string) {
 }
 
 // clearCatchUpFailure decrements the catch-up failure counter if the given
-// path was previously recorded as failed. Called from processEntry's
-// success path so a startup or reactive pull can heal the gate without a
-// process restart. No-op if the path was not previously failed.
+// path was previously recorded as failed. Called from processEntry's success
+// path so any successful pull, including reconciliation, can heal the gate
+// without a process restart. No-op if the path was not previously failed.
 func (p *Puller) clearCatchUpFailure(path string) {
 	p.inflightMu.Lock()
 	defer p.inflightMu.Unlock()
@@ -496,11 +495,10 @@ func (p *Puller) recordCatchUpDropLocked(path string) {
 	p.catchupDropped.Add(1)
 }
 
-// clearCatchUpDrop decrements the catch-up drop counter if the given path
-// was previously recorded as dropped. Called from processEntry's success
-// path so a reactive FSM callback succeeding for a previously-dropped
-// path can heal the gate without a process restart. No-op if the path was not
-// previously dropped.
+// clearCatchUpDrop decrements the catch-up drop counter if the given path was
+// previously recorded as dropped. Called from processEntry's success path so
+// any successful pull, including reconciliation, can heal the gate without a
+// process restart. No-op if the path was not previously dropped.
 func (p *Puller) clearCatchUpDrop(path string) {
 	p.inflightMu.Lock()
 	defer p.inflightMu.Unlock()
@@ -737,13 +735,14 @@ func (p *Puller) CatchUpCompleted() bool {
 // "no pulls are happening anywhere right now."
 //
 // Self-heal: catchupFailed and catchupDropped both decrement when a later
-// startup or reactive pull succeeds for a previously-affected path, so
-// transient peer outages or queue-saturation events during catch-up don't
-// require a process restart to clear the gate. Periodic reconciliation is
-// deliberately excluded so it cannot reopen startup readiness. The puller
-// tracks the affected paths in catchupFailedPaths and catchupDroppedPaths;
-// startup/reactive worker success calls clearCatchUpFailure and
-// clearCatchUpDrop (both are no-ops when the path was never recorded).
+// successful pull resolves a previously-affected path, so transient peer
+// outages or queue-saturation events during catch-up don't require a process
+// restart to clear the gate. Periodic reconciliation cannot create or remove
+// startup tags, and its failures cannot reopen readiness, but its successful
+// pulls can heal existing path state. The puller tracks affected paths in
+// catchupFailedPaths and catchupDroppedPaths; worker success calls
+// clearCatchUpFailure and clearCatchUpDrop (both are no-ops when the path was
+// never recorded).
 //
 // Returns false (not ready) if:
 //   - the catch-up walker never ran or hasn't completed, OR

--- a/internal/cluster/filereplication/reconciliation_test.go
+++ b/internal/cluster/filereplication/reconciliation_test.go
@@ -1,0 +1,271 @@
+package filereplication
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+)
+
+func emptyManifest(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+	return nil, "", nil
+}
+
+// TestPeriodicReconciliationWaitsForStartupAndRepeats verifies that the
+// periodic loop cannot race the startup walk and continues to run after the
+// startup attempt has completed.
+func TestPeriodicReconciliationWaitsForStartupAndRepeats(t *testing.T) {
+	p := newTestPuller(t, newFakeBackend(),
+		newFakeFetcher(fakeFetchResult{body: []byte("unused")}),
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+
+	startupStarted := make(chan struct{})
+	startupRelease := make(chan struct{})
+	go p.RunCatchUp(context.Background(), func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		select {
+		case <-startupStarted:
+		default:
+			close(startupStarted)
+		}
+		<-startupRelease
+		return nil, "", nil
+	})
+
+	var periodicCalls atomic.Int64
+	p.startPeriodicReconciliation(func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		periodicCalls.Add(1)
+		return nil, "", nil
+	}, 10*time.Millisecond)
+
+	select {
+	case <-startupStarted:
+	case <-time.After(time.Second):
+		t.Fatal("startup catch-up did not start")
+	}
+	time.Sleep(40 * time.Millisecond)
+	if got := periodicCalls.Load(); got != 0 {
+		t.Fatalf("periodic reconciliation ran before startup finished: calls=%d", got)
+	}
+
+	close(startupRelease)
+	deadline := time.Now().Add(time.Second)
+	for periodicCalls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := periodicCalls.Load(); got < 2 {
+		t.Fatalf("periodic reconciliation did not repeat: calls=%d", got)
+	}
+	p.Stop()
+}
+
+// TestRunReconciliationPullsManifestEntryMissedAtStartup verifies the core
+// recovery case: a file absent from the startup snapshot is found by a later
+// paginated pass and still uses the normal worker path.
+func TestRunReconciliationPullsManifestEntryMissedAtStartup(t *testing.T) {
+	body := []byte("periodic body")
+	backend := newFakeBackend()
+	fetcher := newRepeatingFetcher(body)
+	p := newTestPuller(t, backend, fetcher,
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	defer p.Stop()
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	entry := makeEntry("testdb/cpu/missed-after-startup.parquet", "writer-1", int64(len(body)))
+	var manifestCalls atomic.Int64
+	fetch := func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		manifestCalls.Add(1)
+		if cursor != "" {
+			return nil, "", nil
+		}
+		return []*raft.FileEntry{entry}, "", nil
+	}
+
+	if !p.RunReconciliation(context.Background(), fetch) {
+		t.Fatal("first reconciliation was unexpectedly skipped")
+	}
+	waitStats(t, p, func(s map[string]int64) bool { return s["pulled"] == 1 })
+	if !p.RunReconciliation(context.Background(), fetch) {
+		t.Fatal("second reconciliation was unexpectedly skipped")
+	}
+	if got := manifestCalls.Load(); got != 2 {
+		t.Errorf("manifest fetch calls: got %d, want 2 (one per reconciliation pass)", got)
+	}
+	if got := p.Stats()["pulled"]; got != 1 {
+		t.Errorf("pulled after repeated reconciliation: got %d, want 1", got)
+	}
+}
+
+// TestPeriodicReconciliationDoesNotReopenStartupReadiness verifies that a
+// periodic pull is not added to the startup catch-up scope. A healthy reader
+// therefore remains ready while a later drift repair is in flight.
+func TestPeriodicReconciliationDoesNotReopenStartupReadiness(t *testing.T) {
+	backend := newFakeBackend()
+	block := make(chan struct{})
+	fetcher := &blockingFetcher{release: block}
+	p := newTestPuller(t, backend, fetcher,
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	defer func() {
+		close(block)
+		p.Stop()
+	}()
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	before := p.Stats()
+	entry := makeEntry("testdb/cpu/periodic-readiness.parquet", "writer-1", 100)
+	if !p.RunReconciliation(context.Background(), func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		return []*raft.FileEntry{entry}, "", nil
+	}) {
+		t.Fatal("reconciliation was unexpectedly skipped")
+	}
+	waitStats(t, p, func(s map[string]int64) bool { return s["inflight_count"] == 1 })
+
+	if !p.FullyCaughtUp() {
+		t.Fatal("periodic in-flight pull reopened startup readiness")
+	}
+	after := p.Stats()
+	for _, key := range []string{
+		"catchup_started_at", "catchup_completed_at", "catchup_entries_walked",
+		"catchup_enqueued", "catchup_skipped_local", "catchup_inflight",
+		"catchup_failed", "catchup_dropped",
+	} {
+		if after[key] != before[key] {
+			t.Errorf("periodic pass changed startup metric %s: before=%d after=%d", key, before[key], after[key])
+		}
+	}
+}
+
+// TestPeriodicReconciliationSelfHealsCatchUpBookkeeping verifies that a later
+// successful periodic pull clears startup failures and drops for the same
+// path, without making periodic work part of the startup scope.
+func TestPeriodicReconciliationSelfHealsCatchUpBookkeeping(t *testing.T) {
+	body := []byte("recovered periodic body")
+	p := newTestPuller(t, newFakeBackend(), newRepeatingFetcher(body),
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	defer p.Stop()
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	entry := makeEntry("testdb/cpu/periodic-self-heal.parquet", "writer-1", int64(len(body)))
+	p.recordCatchUpFailure(entry.Path)
+	p.recordCatchUpDrop(entry.Path)
+	if p.FullyCaughtUp() {
+		t.Fatal("precondition failed: catch-up bookkeeping should close readiness")
+	}
+
+	if !p.RunReconciliation(context.Background(), func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		return []*raft.FileEntry{entry}, "", nil
+	}) {
+		t.Fatal("reconciliation was unexpectedly skipped")
+	}
+	waitStats(t, p, func(s map[string]int64) bool { return s["pulled"] == 1 })
+	stats := p.Stats()
+	if stats["catchup_failed"] != 0 || stats["catchup_dropped"] != 0 {
+		t.Errorf("periodic success did not self-heal startup bookkeeping: failed=%d dropped=%d", stats["catchup_failed"], stats["catchup_dropped"])
+	}
+	if !p.FullyCaughtUp() {
+		t.Error("FullyCaughtUp remained false after successful periodic self-heal")
+	}
+}
+
+// TestRunReconciliationDeduplicatesReactiveEnqueue verifies that a reactive
+// callback already in flight wins the race with a periodic manifest pass.
+func TestRunReconciliationDeduplicatesReactiveEnqueue(t *testing.T) {
+	block := make(chan struct{})
+	fetcher := &blockingFetcher{release: block}
+	p := newTestPuller(t, newFakeBackend(), fetcher,
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	defer func() {
+		close(block)
+		p.Stop()
+	}()
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	entry := makeEntry("testdb/cpu/reactive-periodic-dedup.parquet", "writer-1", 100)
+	p.Enqueue(entry)
+	waitStats(t, p, func(s map[string]int64) bool { return fetcher.calls.Load() == 1 })
+	if !p.RunReconciliation(context.Background(), func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		return []*raft.FileEntry{entry}, "", nil
+	}) {
+		t.Fatal("reconciliation was unexpectedly skipped")
+	}
+	if got := fetcher.calls.Load(); got != 1 {
+		t.Errorf("fetch calls after reactive/periodic race: got %d, want 1", got)
+	}
+	if got := p.Stats()["skipped_dup"]; got == 0 {
+		t.Error("periodic pass did not observe the reactive inflight duplicate")
+	}
+}
+
+// TestRunReconciliationNoOverlap verifies the explicit walk guard rather than
+// relying only on the single goroutine used by the periodic loop.
+func TestRunReconciliationNoOverlap(t *testing.T) {
+	p := newTestPuller(t, newFakeBackend(),
+		newFakeFetcher(fakeFetchResult{body: []byte("unused")}),
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	fetch := func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		close(entered)
+		<-release
+		return nil, "", nil
+	}
+	done := make(chan bool)
+	go func() { done <- p.RunReconciliation(context.Background(), fetch) }()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("first reconciliation did not start")
+	}
+	if p.RunReconciliation(context.Background(), emptyManifest) {
+		t.Fatal("overlapping reconciliation was allowed")
+	}
+	close(release)
+	if !<-done {
+		t.Fatal("first reconciliation was unexpectedly skipped")
+	}
+}
+
+// TestPeriodicReconciliationStopsOnCancellation verifies that a pass blocked
+// in manifest fetch exits when Puller.Stop cancels its lifecycle context.
+func TestPeriodicReconciliationStopsOnCancellation(t *testing.T) {
+	p := newTestPuller(t, newFakeBackend(),
+		newFakeFetcher(fakeFetchResult{body: []byte("unused")}),
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	started := make(chan struct{})
+	var once atomic.Bool
+	p.startPeriodicReconciliation(func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		if once.CompareAndSwap(false, true) {
+			close(started)
+		}
+		<-p.ctx.Done()
+		return nil, "", p.ctx.Err()
+	}, time.Millisecond)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("periodic reconciliation did not start")
+	}
+	stopDone := make(chan struct{})
+	go func() {
+		p.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("Puller.Stop did not cancel periodic reconciliation")
+	}
+}

--- a/internal/cluster/filereplication/reconciliation_test.go
+++ b/internal/cluster/filereplication/reconciliation_test.go
@@ -387,10 +387,10 @@ func TestPeriodicReconciliationDoesNotReopenStartupReadiness(t *testing.T) {
 	}
 }
 
-// TestPeriodicReconciliationDoesNotModifyCatchUpBookkeeping verifies that a
-// later periodic pull does not clear or reopen startup readiness state for the
-// same path. Startup bookkeeping is healed only by startup/reactive work.
-func TestPeriodicReconciliationDoesNotModifyCatchUpBookkeeping(t *testing.T) {
+// TestPeriodicReconciliationHealsCatchUpBookkeeping verifies that a successful
+// periodic pull clears pre-existing path-scoped catch-up failure and drop
+// state without changing the rest of the startup bookkeeping.
+func TestPeriodicReconciliationHealsCatchUpBookkeeping(t *testing.T) {
 	body := []byte("recovered periodic body")
 	p := newTestPuller(t, newFakeBackend(), newRepeatingFetcher(body),
 		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
@@ -401,8 +401,11 @@ func TestPeriodicReconciliationDoesNotModifyCatchUpBookkeeping(t *testing.T) {
 	entry := makeEntry("testdb/cpu/periodic-self-heal.parquet", "writer-1", int64(len(body)))
 	p.recordCatchUpFailure(entry.Path)
 	p.recordCatchUpDrop(entry.Path)
-	p.markCatchUp(entry.Path)
 	before := p.Stats()
+	beforeCatchUpCompleted := p.CatchUpCompleted()
+	if before["catchup_failed"] != 1 || before["catchup_dropped"] != 1 {
+		t.Fatalf("precondition failed: catch-up bookkeeping = failed=%d dropped=%d, want 1/1", before["catchup_failed"], before["catchup_dropped"])
+	}
 	if p.FullyCaughtUp() {
 		t.Fatal("precondition failed: catch-up bookkeeping should close readiness")
 	}
@@ -412,15 +415,28 @@ func TestPeriodicReconciliationDoesNotModifyCatchUpBookkeeping(t *testing.T) {
 	}) {
 		t.Fatal("reconciliation was unexpectedly skipped")
 	}
-	waitStats(t, p, func(s map[string]int64) bool { return s["pulled"] == 1 })
-	stats := p.Stats()
-	for _, key := range []string{"catchup_failed", "catchup_dropped", "catchup_inflight", "catchup_completed_at"} {
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["pulled"] == 1 && s["catchup_failed"] == 0 && s["catchup_dropped"] == 0
+	})
+	if stats["catchup_failed"] != 0 {
+		t.Errorf("catchup_failed after periodic recovery: got %d, want 0", stats["catchup_failed"])
+	}
+	if stats["catchup_dropped"] != 0 {
+		t.Errorf("catchup_dropped after periodic recovery: got %d, want 0", stats["catchup_dropped"])
+	}
+	for _, key := range []string{
+		"catchup_started_at", "catchup_completed_at", "catchup_entries_walked",
+		"catchup_enqueued", "catchup_skipped_local", "catchup_inflight",
+	} {
 		if stats[key] != before[key] {
 			t.Errorf("periodic success changed startup bookkeeping %s: before=%d after=%d", key, before[key], stats[key])
 		}
 	}
-	if p.FullyCaughtUp() {
-		t.Error("periodic success unexpectedly reopened startup readiness")
+	if p.CatchUpCompleted() != beforeCatchUpCompleted {
+		t.Error("periodic success changed startup completion state")
+	}
+	if !p.FullyCaughtUp() {
+		t.Error("periodic success did not heal startup readiness")
 	}
 }
 

--- a/internal/cluster/filereplication/reconciliation_test.go
+++ b/internal/cluster/filereplication/reconciliation_test.go
@@ -2,6 +2,7 @@ package filereplication
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -59,6 +60,58 @@ func TestPeriodicReconciliationWaitsForStartupAndRepeats(t *testing.T) {
 		t.Fatalf("periodic reconciliation did not repeat: calls=%d", got)
 	}
 	p.Stop()
+}
+
+// TestPeriodicReconciliationResetsIntervalAfterSlowPass verifies that the
+// next pass is scheduled after a slow pass completes, not from the original
+// tick and not from a buffered ticker event.
+func TestPeriodicReconciliationResetsIntervalAfterSlowPass(t *testing.T) {
+	p := newTestPuller(t, newFakeBackend(),
+		newFakeFetcher(fakeFetchResult{body: []byte("unused")}),
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	defer p.Stop()
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	const interval = 20 * time.Millisecond
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	defer func() { releaseOnce.Do(func() { close(release) }) }()
+	var calls atomic.Int64
+	p.startPeriodicReconciliation(func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		switch calls.Add(1) {
+		case 1:
+			close(firstStarted)
+			<-release
+		case 2:
+			close(secondStarted)
+		}
+		return nil, "", nil
+	}, interval)
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first periodic reconciliation did not start")
+	}
+	// Keep the first pass running well beyond its interval. A ticker-based
+	// loop would have a follow-up tick waiting by the time this is released.
+	time.Sleep(5 * interval)
+	releasedAt := time.Now()
+	releaseOnce.Do(func() { close(release) })
+
+	select {
+	case <-secondStarted:
+		t.Fatalf("second reconciliation started immediately after slow pass: elapsed=%v", time.Since(releasedAt))
+	case <-time.After(interval / 2):
+	}
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * interval):
+		t.Fatal("second periodic reconciliation did not start after reset interval")
+	}
 }
 
 // TestRunReconciliationPullsManifestEntryMissedAtStartup verifies the core

--- a/internal/cluster/filereplication/reconciliation_test.go
+++ b/internal/cluster/filereplication/reconciliation_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/rs/zerolog"
 )
 
 func emptyManifest(cursor string, limit int) ([]*raft.FileEntry, string, error) {
@@ -152,6 +153,200 @@ func TestRunReconciliationPullsManifestEntryMissedAtStartup(t *testing.T) {
 	}
 }
 
+// TestRunReconciliationContinuesAfterEmptyPage verifies that a page with no
+// entries does not terminate the walk when the manifest supplies another
+// cursor. This can happen when entries disappear between page snapshots.
+func TestRunReconciliationContinuesAfterEmptyPage(t *testing.T) {
+	body := []byte("empty page continuation")
+	p := newTestPuller(t, newFakeBackend(), newRepeatingFetcher(body),
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	defer p.Stop()
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	entry := makeEntry("testdb/cpu/after-empty-page.parquet", "writer-1", int64(len(body)))
+	var calls atomic.Int64
+	if !p.RunReconciliation(context.Background(), func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		switch calls.Add(1) {
+		case 1:
+			return nil, "after-empty-page", nil
+		case 2:
+			if cursor != "after-empty-page" {
+				t.Errorf("second page cursor: got %q, want %q", cursor, "after-empty-page")
+			}
+			return []*raft.FileEntry{entry}, "", nil
+		default:
+			return nil, "", nil
+		}
+	}) {
+		t.Fatal("reconciliation was unexpectedly skipped")
+	}
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["pulled"] == 1 })
+	if got := calls.Load(); got != 2 {
+		t.Errorf("manifest fetch calls: got %d, want 2", got)
+	}
+	if stats["replication_recheck_entries_walked"] != 1 {
+		t.Errorf("recheck entries walked: got %d, want 1", stats["replication_recheck_entries_walked"])
+	}
+	if stats["replication_recheck_enqueued"] != 1 {
+		t.Errorf("recheck enqueued: got %d, want 1", stats["replication_recheck_enqueued"])
+	}
+}
+
+// TestRunReconciliationAbortsOnCursorStall verifies that a non-empty page
+// cannot make the walker spin forever by returning the same continuation
+// cursor repeatedly.
+func TestRunReconciliationAbortsOnCursorStall(t *testing.T) {
+	p := newTestPuller(t, newFakeBackend(),
+		newFakeFetcher(fakeFetchResult{body: []byte("unused")}),
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.Start(context.Background())
+	defer p.Stop()
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	entry := makeEntry("testdb/cpu/stalled-cursor.parquet", "writer-1", 1)
+	var calls atomic.Int64
+	if !p.RunReconciliation(context.Background(), func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		switch calls.Add(1) {
+		case 1:
+			return []*raft.FileEntry{entry}, "stalled-cursor", nil
+		case 2:
+			if cursor != "stalled-cursor" {
+				t.Errorf("stalled page cursor: got %q, want %q", cursor, "stalled-cursor")
+			}
+			return []*raft.FileEntry{entry}, "stalled-cursor", nil
+		default:
+			return nil, "", nil
+		}
+	}) {
+		t.Fatal("reconciliation was unexpectedly skipped")
+	}
+
+	stats := p.Stats()
+	if calls.Load() != 2 {
+		t.Errorf("manifest fetch calls: got %d, want 2", calls.Load())
+	}
+	if stats["replication_recheck_aborted"] != 1 {
+		t.Errorf("aborted rechecks: got %d, want 1", stats["replication_recheck_aborted"])
+	}
+	if stats["replication_recheck_completed"] != 0 {
+		t.Errorf("completed rechecks: got %d, want 0", stats["replication_recheck_completed"])
+	}
+}
+
+// TestPeriodicReconciliationSchedulerRestoresDeletedManifestFile exercises
+// the actual periodic scheduler rather than calling RunReconciliation
+// directly. A local file is deleted without an FSM callback, then the next
+// scheduled manifest pass must restore it through the normal pull path.
+func TestPeriodicReconciliationSchedulerRestoresDeletedManifestFile(t *testing.T) {
+	body := []byte("scheduled periodic body")
+	backend := newFakeBackend()
+	p, err := New(Config{
+		SelfNodeID:             "reader-1",
+		Backend:                backend,
+		Fetcher:                newRepeatingFetcher(body),
+		PeerResolver:           staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true},
+		Workers:                1,
+		QueueSize:              8,
+		RetryMaxAttempts:       1,
+		RetryInitialBackoff:    time.Millisecond,
+		FetchTimeout:           2 * time.Second,
+		ReconciliationInterval: 10 * time.Millisecond,
+		Logger:                 zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.Start(context.Background())
+	defer p.Stop()
+
+	entry := makeEntry("testdb/cpu/deleted-without-callback.parquet", "writer-1", int64(len(body)))
+	manifest := func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		if cursor == "" {
+			return []*raft.FileEntry{entry}, "", nil
+		}
+		return nil, "", nil
+	}
+	p.RunCatchUp(context.Background(), manifest)
+	waitStats(t, p, func(s map[string]int64) bool { return s["pulled"] == 1 })
+
+	if err := backend.Delete(context.Background(), entry.Path); err != nil {
+		t.Fatalf("delete local file: %v", err)
+	}
+	before := p.Stats()
+	p.StartPeriodicReconciliation(manifest)
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["replication_recheck_completed"] >= 1 && s["pulled"] == 2
+	})
+
+	if _, err := backend.Read(context.Background(), entry.Path); err != nil {
+		t.Fatalf("periodic reconciliation did not restore file: %v", err)
+	}
+	if stats["replication_recheck_enqueued"] < 1 {
+		t.Errorf("recheck enqueued: got %d, want at least 1", stats["replication_recheck_enqueued"])
+	}
+	for _, key := range []string{
+		"catchup_started_at", "catchup_completed_at", "catchup_entries_walked",
+		"catchup_enqueued", "catchup_skipped_local", "catchup_inflight",
+		"catchup_failed", "catchup_dropped",
+	} {
+		if stats[key] != before[key] {
+			t.Errorf("scheduled periodic pass changed startup metric %s: before=%d after=%d", key, before[key], stats[key])
+		}
+	}
+}
+
+// TestRunReconciliationGatesAndAbortsOnEligibilityChange verifies that a
+// gated tick does not fetch and that a pass already in progress aborts when
+// the node becomes ineligible before the next page.
+func TestRunReconciliationGatesAndAbortsOnEligibilityChange(t *testing.T) {
+	var eligible atomic.Bool
+	eligible.Store(true)
+	p := newTestPuller(t, newFakeBackend(), newRepeatingFetcher([]byte("gated body")),
+		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
+	p.cfg.ReconciliationGate = eligible.Load
+	p.Start(context.Background())
+	defer p.Stop()
+	p.RunCatchUp(context.Background(), emptyManifest)
+
+	eligible.Store(false)
+	var calls atomic.Int64
+	if !p.RunReconciliation(context.Background(), func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		calls.Add(1)
+		return nil, "", nil
+	}) {
+		t.Fatal("gated reconciliation was unexpectedly skipped")
+	}
+	stats := p.Stats()
+	if calls.Load() != 0 {
+		t.Errorf("gated reconciliation fetched manifest %d times, want 0", calls.Load())
+	}
+	if stats["replication_recheck_gated"] != 1 {
+		t.Errorf("gated rechecks: got %d, want 1", stats["replication_recheck_gated"])
+	}
+	if stats["replication_recheck_completed"] != 0 {
+		t.Errorf("gated rechecks completed: got %d, want 0", stats["replication_recheck_completed"])
+	}
+
+	eligible.Store(true)
+	entry := makeEntry("testdb/cpu/gate-changed-mid-pass.parquet", "writer-1", int64(len("gated body")))
+	if !p.RunReconciliation(context.Background(), func(cursor string, limit int) ([]*raft.FileEntry, string, error) {
+		calls.Add(1)
+		eligible.Store(false)
+		return []*raft.FileEntry{entry}, "next-page", nil
+	}) {
+		t.Fatal("eligible reconciliation was unexpectedly skipped")
+	}
+	stats = p.Stats()
+	if stats["replication_recheck_aborted"] != 1 {
+		t.Errorf("aborted rechecks: got %d, want 1", stats["replication_recheck_aborted"])
+	}
+	if stats["replication_recheck_gated"] != 2 {
+		t.Errorf("gated rechecks after mid-pass change: got %d, want 2", stats["replication_recheck_gated"])
+	}
+}
+
 // TestPeriodicReconciliationDoesNotReopenStartupReadiness verifies that a
 // periodic pull is not added to the startup catch-up scope. A healthy reader
 // therefore remains ready while a later drift repair is in flight.
@@ -192,10 +387,10 @@ func TestPeriodicReconciliationDoesNotReopenStartupReadiness(t *testing.T) {
 	}
 }
 
-// TestPeriodicReconciliationSelfHealsCatchUpBookkeeping verifies that a later
-// successful periodic pull clears startup failures and drops for the same
-// path, without making periodic work part of the startup scope.
-func TestPeriodicReconciliationSelfHealsCatchUpBookkeeping(t *testing.T) {
+// TestPeriodicReconciliationDoesNotModifyCatchUpBookkeeping verifies that a
+// later periodic pull does not clear or reopen startup readiness state for the
+// same path. Startup bookkeeping is healed only by startup/reactive work.
+func TestPeriodicReconciliationDoesNotModifyCatchUpBookkeeping(t *testing.T) {
 	body := []byte("recovered periodic body")
 	p := newTestPuller(t, newFakeBackend(), newRepeatingFetcher(body),
 		staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true})
@@ -206,6 +401,8 @@ func TestPeriodicReconciliationSelfHealsCatchUpBookkeeping(t *testing.T) {
 	entry := makeEntry("testdb/cpu/periodic-self-heal.parquet", "writer-1", int64(len(body)))
 	p.recordCatchUpFailure(entry.Path)
 	p.recordCatchUpDrop(entry.Path)
+	p.markCatchUp(entry.Path)
+	before := p.Stats()
 	if p.FullyCaughtUp() {
 		t.Fatal("precondition failed: catch-up bookkeeping should close readiness")
 	}
@@ -217,11 +414,13 @@ func TestPeriodicReconciliationSelfHealsCatchUpBookkeeping(t *testing.T) {
 	}
 	waitStats(t, p, func(s map[string]int64) bool { return s["pulled"] == 1 })
 	stats := p.Stats()
-	if stats["catchup_failed"] != 0 || stats["catchup_dropped"] != 0 {
-		t.Errorf("periodic success did not self-heal startup bookkeeping: failed=%d dropped=%d", stats["catchup_failed"], stats["catchup_dropped"])
+	for _, key := range []string{"catchup_failed", "catchup_dropped", "catchup_inflight", "catchup_completed_at"} {
+		if stats[key] != before[key] {
+			t.Errorf("periodic success changed startup bookkeeping %s: before=%d after=%d", key, before[key], stats[key])
+		}
 	}
-	if !p.FullyCaughtUp() {
-		t.Error("FullyCaughtUp remained false after successful periodic self-heal")
+	if p.FullyCaughtUp() {
+		t.Error("periodic success unexpectedly reopened startup readiness")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -660,12 +660,13 @@ type ClusterConfig struct {
 	ReplicationServeTimeoutMs   int // Origin-side body-stream timeout in milliseconds (default: 120000). Raise for large files or slow links.
 	ReplicationRetryMaxAttempts int // Max immediate retry attempts per enqueue (default: 3)
 
-	// Peer file replication catch-up (Phase 3). These control the startup
-	// reconciliation walker that brings a new or restarted node back into
-	// sync with the cluster manifest.
-	ReplicationCatchUpEnabled          bool    // Master switch for the catch-up walker. Emergency off-switch for pathologically large manifests. (default: true)
-	ReplicationCatchUpBarrierTimeoutMs int     // Raft barrier timeout before walking the manifest — ensures the local FSM has applied every committed entry. (default: 10000)
-	ReplicationCatchUpQueueHighWater   float64 // Queue-depth fraction above which the walker pauses enqueueing. Keeps the walker from racing workers on large manifests. (default: 0.8)
+	// Peer file replication catch-up and periodic reconciliation (Phase 3).
+	// These control the startup walker and the repeatable manifest rechecks
+	// that keep a node in sync with the cluster manifest.
+	ReplicationCatchUpEnabled                bool    // Master switch for the catch-up walker. Emergency off-switch for pathologically large manifests. (default: true)
+	ReplicationCatchUpBarrierTimeoutMs       int     // Raft barrier timeout before walking the manifest — ensures the local FSM has applied every committed entry. (default: 10000)
+	ReplicationCatchUpQueueHighWater         float64 // Queue-depth fraction above which the walker pauses enqueueing. Keeps the walker from racing workers on large manifests. (default: 0.8)
+	ReplicationReconciliationIntervalSeconds int     // Seconds between periodic manifest rechecks. (default: 300)
 
 	// Hard query gating during catch-up (#392). When true, the query path
 	// rejects reads with 503 until Coordinator.ReplicationReady() is true
@@ -1020,14 +1021,15 @@ func Load() (*Config, error) {
 			ReplicationBufferSize:  v.GetInt("cluster.replication_buffer_size"),
 			ReplicationAckInterval: v.GetInt("cluster.replication_ack_interval"),
 			// Peer file replication (Enterprise Phase 2)
-			ReplicationPullWorkers:             v.GetInt("cluster.replication_pull_workers"),
-			ReplicationQueueSize:               v.GetInt("cluster.replication_queue_size"),
-			ReplicationFetchTimeoutMs:          v.GetInt("cluster.replication_fetch_timeout_ms"),
-			ReplicationServeTimeoutMs:          v.GetInt("cluster.replication_serve_timeout_ms"),
-			ReplicationRetryMaxAttempts:        v.GetInt("cluster.replication_retry_max_attempts"),
-			ReplicationCatchUpEnabled:          v.GetBool("cluster.replication_catchup_enabled"),
-			ReplicationCatchUpBarrierTimeoutMs: v.GetInt("cluster.replication_catchup_barrier_timeout_ms"),
-			ReplicationCatchUpQueueHighWater:   v.GetFloat64("cluster.replication_catchup_queue_high_water"),
+			ReplicationPullWorkers:                   v.GetInt("cluster.replication_pull_workers"),
+			ReplicationQueueSize:                     v.GetInt("cluster.replication_queue_size"),
+			ReplicationFetchTimeoutMs:                v.GetInt("cluster.replication_fetch_timeout_ms"),
+			ReplicationServeTimeoutMs:                v.GetInt("cluster.replication_serve_timeout_ms"),
+			ReplicationRetryMaxAttempts:              v.GetInt("cluster.replication_retry_max_attempts"),
+			ReplicationCatchUpEnabled:                v.GetBool("cluster.replication_catchup_enabled"),
+			ReplicationCatchUpBarrierTimeoutMs:       v.GetInt("cluster.replication_catchup_barrier_timeout_ms"),
+			ReplicationCatchUpQueueHighWater:         v.GetFloat64("cluster.replication_catchup_queue_high_water"),
+			ReplicationReconciliationIntervalSeconds: v.GetInt("cluster.replication_reconciliation_interval_seconds"),
 			// Hard query gating during catch-up (#392)
 			QueryGateOnCatchup: v.GetBool("cluster.query_gate_on_catchup"),
 			// Sharding configuration (Phase 4)
@@ -1715,10 +1717,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("cluster.replication_serve_timeout_ms", 120000) // 120s origin-side body-stream timeout
 	v.SetDefault("cluster.replication_retry_max_attempts", 3)    // 3 immediate retries
 	// Peer file replication catch-up (Enterprise Phase 3)
-	v.SetDefault("cluster.replication_catchup_enabled", true)             // Walk the manifest on startup to reconcile missing files
-	v.SetDefault("cluster.replication_catchup_barrier_timeout_ms", 10000) // 10s Raft barrier before walking
-	v.SetDefault("cluster.replication_catchup_queue_high_water", 0.8)     // Pause walker when queue is >80% full
-	v.SetDefault("cluster.query_gate_on_catchup", false)                  // Off by default; opt-in correctness gate (#392)
+	v.SetDefault("cluster.replication_catchup_enabled", true)                // Walk the manifest on startup to reconcile missing files
+	v.SetDefault("cluster.replication_catchup_barrier_timeout_ms", 10000)    // 10s Raft barrier before walking
+	v.SetDefault("cluster.replication_catchup_queue_high_water", 0.8)        // Pause walker when queue is >80% full
+	v.SetDefault("cluster.replication_reconciliation_interval_seconds", 300) // Periodic manifest recheck interval
+	v.SetDefault("cluster.query_gate_on_catchup", false)                     // Off by default; opt-in correctness gate (#392)
 
 	// Sharding defaults (Phase 4)
 	v.SetDefault("cluster.sharding_enabled", false)        // Disabled by default

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -812,6 +812,36 @@ func TestLoad_ClusterSeedsEnvOverride(t *testing.T) {
 	}
 }
 
+func TestLoad_ClusterReplicationReconciliationInterval(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "arc-config-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	oldWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldWd)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Cluster.ReplicationReconciliationIntervalSeconds != 300 {
+		t.Errorf("default reconciliation interval = %d, want 300", cfg.Cluster.ReplicationReconciliationIntervalSeconds)
+	}
+
+	os.Setenv("ARC_CLUSTER_REPLICATION_RECONCILIATION_INTERVAL_SECONDS", "17")
+	defer os.Unsetenv("ARC_CLUSTER_REPLICATION_RECONCILIATION_INTERVAL_SECONDS")
+	cfg, err = Load()
+	if err != nil {
+		t.Fatalf("Load() with env override error = %v", err)
+	}
+	if cfg.Cluster.ReplicationReconciliationIntervalSeconds != 17 {
+		t.Errorf("env reconciliation interval = %d, want 17", cfg.Cluster.ReplicationReconciliationIntervalSeconds)
+	}
+}
+
 // QueryConfig Tests
 
 func TestQueryConfig_Defaults(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds periodic peer-replication reconciliation to recover files when FSM callbacks are missed.
- Reuses the existing paginated pull, deduplication, and retry path.
- Keeps startup catch-up one-shot: periodic failures never reopen readiness, while successful reconciliation may heal previously recorded startup failure/drop state.
- Gates each tick on current registry membership, role, and health.
- Adds a configurable 5-minute default interval and separate replication_recheck_* observability.
- Adds missed-callback regression coverage.
- Leaves #412 shared scheduling/status intentionally out of scope.

## Testing

- Passed: go test ./internal/cluster/filereplication -count=1
- Passed: focused periodic reconciliation tests in ./internal/cluster/filereplication
- Passed: go test ./internal/config -count=1
- Passed: go vet ./internal/cluster/filereplication
- Full coordinator tests, including the focused membership coverage, are blocked locally on Windows with CGO_ENABLED=0 because DuckDB requires CGO.

Fixes #393