### PR TITLE
feat(cla): require a signed CLA on every pull request

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,55 @@
+# Contributor License Agreement gate.
+#
+# Arc is AGPL-3.0, and Basekick Labs also ships commercially licensed builds.
+# Distributing a contribution under both requires the contributor to grant the
+# relicensing right in CLA.md section 4 — without it, external code can only
+# ever be AGPL, which permanently constrains where that code can live.
+#
+# Signatures are stored in a private repo (Basekick-Labs/cla-signatures), not in
+# this one, so signature churn stays out of the Arc history and contributor
+# emails are not published.
+#
+# Bot-authored PRs (dependabot, claude) are allow-listed: they are not legal
+# persons and cannot sign.
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: CLA signed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CLA signature
+        if: (github.event.issue.pull_request && contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-document: https://github.com/Basekick-Labs/arc/blob/main/CLA.md
+          path-to-signatures: signatures/arc.json
+          remote-organization-name: Basekick-Labs
+          remote-repository-name: cla-signatures
+          branch: main
+          allowlist: xe-nvdk,dependabot[bot],claude[bot],*[bot]
+          custom-notsigned-prcomment: |
+            Thanks for the contribution!
+
+            Before this can be merged, please sign the [Contributor License Agreement](https://github.com/Basekick-Labs/arc/blob/main/CLA.md).
+            Arc is AGPL-3.0 and Basekick Labs also ships commercially licensed builds; the CLA is what lets your contribution be included in both. You keep full ownership of your work.
+
+            To sign, reply to this thread with exactly:
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. Thanks!'
+          lock-pullrequest-aftermerge: false

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,127 @@
+# Arc Contributor License Agreement
+
+Thank you for your interest in contributing to Arc, a project of Basekick Labs
+("Basekick Labs", "we", "us").
+
+This Contributor License Agreement ("Agreement") documents the rights granted by
+contributors to Basekick Labs. It protects you as a contributor as well as
+Basekick Labs and its users. It does **not** change your rights to use your own
+contributions for any other purpose.
+
+You accept and agree to the following terms for your past, present, and future
+contributions submitted to Basekick Labs. Except for the licenses granted here,
+you reserve all right, title, and interest in and to your contributions.
+
+## 1. Definitions
+
+**"You"** means the individual who submits a Contribution, or the legal entity on
+behalf of whom this Agreement is signed. For legal entities, the entity making a
+Contribution and all other entities that control, are controlled by, or are under
+common control with that entity are considered a single Contributor.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to Basekick Labs for inclusion in, or documentation of, any of the
+products owned or managed by Basekick Labs (the "Work"). "Submitted" means any
+form of electronic, verbal, or written communication sent to Basekick Labs or its
+representatives, including but not limited to communication on electronic mailing
+lists, source code control systems, and issue tracking systems that are managed
+by, or on behalf of, Basekick Labs for the purpose of discussing and improving
+the Work.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+Basekick Labs and to recipients of software distributed by Basekick Labs a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+Basekick Labs and to recipients of software distributed by Basekick Labs a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use, offer
+to sell, sell, import, and otherwise transfer the Work. This license applies only
+to those patent claims licensable by You that are necessarily infringed by Your
+Contribution alone or by combination of Your Contribution with the Work to which
+such Contribution was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that entity
+under this Agreement for that Contribution or Work shall terminate as of the date
+such litigation is filed.
+
+## 4. Right to Relicense
+
+You acknowledge that Basekick Labs distributes the Work under one or more
+licenses of its choosing, and may change those licenses in the future. You grant
+Basekick Labs the right to license Your Contributions under any license terms,
+including open source licenses, source-available licenses, and proprietary or
+commercial licenses, and to include Your Contributions in commercial products and
+in closed-source distributions.
+
+This is the clause that allows Arc to be offered both as an open source project
+and as a commercially licensed product. Your Contributions remain Yours: nothing
+in this section limits Your own right to use, license, or distribute Your
+Contributions however You wish.
+
+## 5. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+
+2. Each of Your Contributions is Your original creation, or You have the right to
+   submit it under the terms of this Agreement.
+
+3. If Your employer has rights to intellectual property that You create, You
+   represent that You have received permission to make the Contributions on
+   behalf of that employer, that Your employer has waived such rights for Your
+   Contributions to Basekick Labs, or that Your employer has executed a separate
+   Corporate CLA with Basekick Labs.
+
+4. Your Contributions include complete details of any third-party license or
+   other restriction (including related patents and trademarks) of which You are
+   personally aware and which are associated with any part of Your Contributions.
+
+## 6. Contributions Are Provided As-Is
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Unless required by applicable law or agreed
+to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Notice of Change
+
+You agree to notify Basekick Labs of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any respect.
+
+## 8. AI-Assisted Contributions
+
+Arc accepts AI-assisted contributions (see `CONTRIBUTING.md`). If You used an AI
+tool to help produce a Contribution, the representations in Section 5 still apply
+in full: You are the author, You are responsible for the Contribution being Your
+original creation or properly licensed, and You are responsible for it not
+carrying third-party code or license restrictions You have not disclosed.
+
+## How to sign
+
+Signing is handled automatically on pull requests. When You open Your first pull
+request, a bot will comment with instructions. You sign by replying to that
+comment with:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your signature is recorded against Your GitHub username, and You will not be
+asked again for subsequent pull requests unless this Agreement changes.
+
+Questions about this Agreement: **ignacio@vandroogenbroeck.net**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Thanks for your interest in improving Arc. Contributions of all sizes are welcom
    Merged contributions are also credited in the README and in the release blog post.
 5. **Match the house style.** Run `gofmt` and `go vet`. Reuse the patterns the surrounding code already uses (for example struct logger fields, not context-carried loggers) rather than introducing new ones.
 6. **Leave "Allow edits by maintainers" enabled.** We often resolve release-notes conflicts and small fixups directly on your branch so your PR can merge without another round trip.
+7. **Sign the CLA.** A bot comments on your first PR with a one-line reply to post. See [Contributor License Agreement](#contributor-license-agreement) below for what it covers and why it exists. You sign once, not per PR.
 
 ## AI-assisted contributions
 
@@ -31,6 +32,33 @@ AI patches and contributions are welcome. Two conditions:
 - **Review it yourself first.** Read the whole diff, run the tests, and cut anything you cannot defend before submitting. We review every PR the same way regardless of how it was written, and unverified AI output wastes the review cycle that could have gone to your next contribution.
 
 The same size rule applies double here: AI tools make it easy to generate large diffs, and we will ask you to split them.
+
+## Contributor License Agreement
+
+Arc is licensed under AGPL-3.0, and Basekick Labs also ships commercially
+licensed builds of Arc. Including a contribution in both requires your explicit
+permission, which is what the [CLA](CLA.md) grants.
+
+In short:
+
+- **You keep ownership of your contribution.** The CLA is a license grant, not a
+  copyright assignment. You can use, relicense, or redistribute your own work
+  anywhere else, with no restriction.
+- **You grant Basekick Labs the right to license your contribution under other
+  terms**, including in commercial and closed-source builds of Arc.
+- **You confirm the work is yours to give** — that it is your original creation,
+  and that if your employer owns your work output, you have permission to submit
+  it.
+
+Signing takes one comment. On your first PR a bot posts instructions; you reply
+with the sign-off line it gives you, and your signature is recorded against your
+GitHub username. You will not be asked again on later PRs.
+
+If you cannot sign (for example, your employer will not permit it), say so on the
+issue before writing code and we will find another way to get the fix in —
+usually by reimplementing it from the described behavior rather than the patch.
+
+Read the full text in [CLA.md](CLA.md).
 
 ## Building and testing
 


### PR DESCRIPTION
## Summary

- Adds `CLA.md`, an Apache-style Individual CLA. The operative clause is **section 4, Right to Relicense**: contributors grant Basekick Labs the right to license their contribution under any terms, including commercial and closed-source. It is a **license grant, not a copyright assignment** — contributors keep full ownership and can use their own work anywhere else.
- Adds `.github/workflows/cla.yml` using `contributor-assistant/github-action@v2.6.1`. Contributors sign by replying once to a bot comment; they are not asked again on later PRs.
- Updates `CONTRIBUTING.md` with a pre-PR checklist item and a plain-language section on what the CLA covers, plus what to do if signing is not possible.

## Why

Arc's OSS core stays AGPL-3.0. Enterprise features move to a separate license, and shipping contributed code under non-AGPL terms requires an explicit grant from its author. AGPL does not provide one, and a CLA only works **prospectively** — it cannot cover code already merged, which is why this lands before the enterprise split rather than alongside it.

## Design notes

**Signatures live in a separate private repo** (`Basekick-Labs/cla-signatures`, `signatures/arc.json`) rather than in this one, so signature commits stay out of Arc's history and contributor emails are not published.

**Allowlist** is `xe-nvdk,dependabot[bot],claude[bot],*[bot]`. The maintainer's commits appear under two emails but one GitHub username, which is what the action matches on. Bots cannot sign a legal agreement.

**`pull_request_target` is required** so fork PRs can reach the signatures token. This workflow never checks out or executes fork code — it only reads PR metadata — so the usual privilege-escalation footgun of that trigger does not apply here. Do not copy the trigger into other workflows without the same property.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| Fork PR, contributor unsigned | Yes — `pull_request_target` runs in base-repo context | Token resolves; fork code never checked out |
| Fork PR, contributor signed | Yes | Signature read from `cla-signatures`; repo + `main` exist |
| PR from a branch in origin | Yes, then allow-listed out via `xe-nvdk` | Allowlist matches GitHub username, not commit email |
| dependabot / claude PR | Yes, allow-listed | `dependabot[bot]`, `claude[bot]`, `*[bot]` |
| `CLA_SIGNATURES_TOKEN` absent/expired (non-default) | Yes | Set on **arc** (secrets are readable only by workflows in the repo holding them). **Expiry blocks every PR** — calendar reminder set |
| `cla-signatures` missing `main` (non-default) | Yes | Repo was created empty, so `main` did not physically exist despite `default_branch: main`. Seeded with a README |

The last two rows were genuinely unguarded when first written and are the reason for the setup steps below; both are now satisfied.

## Setup completed

- [x] `Basekick-Labs/cla-signatures` created, private
- [x] `main` seeded (empty repo left `branches: []`; the action writes to `branch: main` and would have failed on the first signature)
- [x] `CLA_SIGNATURES_TOKEN` set on `Basekick-Labs/arc`

`signatures/` is intentionally absent — git does not track empty directories, and the action creates `signatures/arc.json` on the first signature.

## Test plan

- [x] YAML parses; every `with:` key cross-checked against the action's own `action.yml` at v2.6.1 (no invented inputs)
- [x] v2.6.1 confirmed as the current release
- [x] Sign-off phrase is byte-identical across the workflow trigger condition, `custom-pr-sign-comment`, and `CLA.md`
- [x] `CONTRIBUTING.md` anchor link resolves to the new section
- [ ] After merge: open a throwaway PR from a non-allowlisted account → bot comments → reply with the sign-off line → check flips green → `signatures/arc.json` appears
- [ ] Second PR from the same account → no re-prompt
- [ ] Maintainer PR → allow-listed, no prompt

**Unproven until that first live PR:** the PAT's scope. It is set, but `Contents: read-only` fails identically to a correct token right up to the first signature *write*. The test PR is what proves it.

## Follow-up

The CLA is prospective, so existing contributions stay AGPL-only unless their authors sign. Scoped against the enterprise packages, only two signatures actually gate the split — **@bferanmi806-sketch** (`internal/iceberg`) and **@mah1104ahm** (`internal/tiering`). `internal/cluster`, `audit`, `license`, `rbac`, and `aggregation` have zero external commits. Remaining contributors touch OSS-core only, which stays AGPL regardless; collecting their signatures is hygiene, not a blocker.