### PR TITLE
fix(helm): protect WAL recovery with a startup probe

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1491,6 +1491,8 @@ jobs:
             --set persistence.enabled=false \
             --wait --timeout=2m
 
+          bash scripts/test_startup_probe.sh helm/arc
+
           # Check if deployment is ready
           kubectl rollout status deployment/arc-test --timeout=2m
 

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -73,7 +73,7 @@ The default 10Gi PVC is documented as development-scale; object-storage
 deployments should size it for peak ingest, WAL flush lag, cache, and recovery
 headroom.
 
-Contributed by [@atirna](https://github.com/atirna) in [#676](https://github.com/Basekick-Labs/arc/issues/676).
+Contributed by [@atirna](https://github.com/atirna) in [#700](https://github.com/Basekick-Labs/arc/pull/700).
 
 ### Periodic peer file replication reconciliation repairs missed FSM callbacks ([#393](https://github.com/Basekick-Labs/arc/issues/393))
 

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -65,6 +65,16 @@ The ingest, API, query, and Iceberg test suites were verified against 0.24.0.
 
 ## Bug fixes
 
+### Helm recovery no longer crash-loops during long WAL replay ([#676](https://github.com/Basekick-Labs/arc/issues/676))
+
+The OSS Helm chart now uses a five-minute startup probe before liveness starts,
+so a pod replaying its WAL can recover without Kubernetes repeatedly killing it.
+The default 10Gi PVC is documented as development-scale; object-storage
+deployments should size it for peak ingest, WAL flush lag, cache, and recovery
+headroom.
+
+Contributed by [@atirna](https://github.com/atirna) in [#676](https://github.com/Basekick-Labs/arc/issues/676).
+
 ### Periodic peer file replication reconciliation repairs missed FSM callbacks ([#393](https://github.com/Basekick-Labs/arc/issues/393))
 
 Cluster nodes now re-walk the Raft file manifest every five minutes by default

--- a/helm/arc/templates/deployment.yaml
+++ b/helm/arc/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
             {{- with .Values.arc.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          startupProbe:
+            # WAL replay runs before the listener binds. Keep liveness from
+            # turning a long recovery into a crash loop.
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: {{ .Values.startupProbeFailureThreshold | default 30 }}
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health

--- a/helm/arc/values.yaml
+++ b/helm/arc/values.yaml
@@ -68,6 +68,10 @@ resources: {}
   #   cpu: 1000m
   #   memory: 2Gi
 
+# startupProbe allowance: failureThreshold x 10 seconds of boot grace before
+# liveness arms. Raise this when WAL recovery needs more than five minutes.
+startupProbeFailureThreshold: 30
+
 # Arc-specific configuration
 arc:
   # Optional arc.toml override. When enabled, `contents` (the full arc.toml
@@ -89,6 +93,8 @@ persistence:
   enabled: true
   # storageClass: "-"
   accessMode: ReadWriteOnce
+  # 10Gi is a dev-scale default. For object storage, size this PVC for peak
+  # ingest rate x worst-case WAL flush lag, plus cache and recovery headroom.
   size: 10Gi
   # existingClaim: ""
 

--- a/scripts/test_startup_probe.sh
+++ b/scripts/test_startup_probe.sh
@@ -7,14 +7,15 @@ trap 'rm -f "$manifest"' EXIT
 
 check_probe() {
   local threshold="$1"
-  helm template arc "$chart" --set "startupProbeFailureThreshold=${threshold}" > "$manifest"
+  shift
+  helm template arc "$chart" "$@" > "$manifest"
   local probe
   probe=$(sed -n '/startupProbe:/,/livenessProbe:/p' "$manifest")
 
-  [[ "$probe" == *'path: /health'* ]]
-  [[ "$probe" == *"failureThreshold: ${threshold}"* ]]
-  [[ "$probe" == *'periodSeconds: 10'* ]]
+  [[ "$probe" == *'path: /health'* ]] || { echo 'startupProbe must target /health' >&2; return 1; }
+  [[ "$probe" == *"failureThreshold: ${threshold}"* ]] || { echo "startupProbe must use failureThreshold ${threshold}" >&2; return 1; }
+  [[ "$probe" == *'periodSeconds: 10'* ]] || { echo 'startupProbe must use a 10-second period' >&2; return 1; }
 }
 
 check_probe 30
-check_probe 45
+check_probe 45 --set startupProbeFailureThreshold=45

--- a/scripts/test_startup_probe.sh
+++ b/scripts/test_startup_probe.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart="${1:-helm/arc}"
+manifest=$(mktemp)
+trap 'rm -f "$manifest"' EXIT
+
+check_probe() {
+  local threshold="$1"
+  helm template arc "$chart" --set "startupProbeFailureThreshold=${threshold}" > "$manifest"
+  local probe
+  probe=$(sed -n '/startupProbe:/,/livenessProbe:/p' "$manifest")
+
+  [[ "$probe" == *'path: /health'* ]]
+  [[ "$probe" == *"failureThreshold: ${threshold}"* ]]
+  [[ "$probe" == *'periodSeconds: 10'* ]]
+}
+
+check_probe 30
+check_probe 45


### PR DESCRIPTION
## Summary

- Add a five-minute startup probe before the OSS chart's liveness probe starts, so WAL replay can finish without a crash loop.
- Document the 10Gi PVC as development-scale and describe the WAL sizing inputs for object-storage deployments.
- Check the installed Deployment's startup-probe contract in the existing Helm integration job.

Refs #676

## Test plan

- `helm lint ./helm/arc`
- `helm template arc ./helm/arc` checks the default `/health` startup probe and the unchanged liveness/readiness probes.
- `helm template arc ./helm/arc --set startupProbeFailureThreshold=45` checks the grace-period override.
- The startup-probe assertion fails against the pre-fix chart and passes after restoring the chart change.
