### PR TITLE
fix(query): enforce query governance on every user-SQL endpoint

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -182,6 +182,21 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### Every query endpoint now enforces query governance ([#702](https://github.com/Basekick-Labs/arc/issues/702))
+
+Enterprise query governance was enforced only on `POST /api/v1/query`, so
+a token with governance limits could bypass rate limits, quotas, the
+per-query row cap, and the per-token execution timeout through the three
+other user-SQL endpoints: `GET /api/v1/query/:measurement`,
+`POST /api/v1/query/arrow`, and `POST /api/v1/query/estimate` (whose
+`COUNT(*)` wrapper executes the full subquery, so it carries real scan
+cost). All four now share one enforcement path: rejected requests get 429
+(with `Retry-After` for rate limits), the policy's `max_rows_per_query`
+caps streamed rows on the row-returning endpoints (JSON, Arrow IPC, and
+the database/sql fallback), and `max_scan_duration_sec` overrides the
+global `query.timeout` everywhere. RBAC was never affected; this closes a
+limits and accounting gap, not an authorization hole.
+
 ### The measurement endpoint now honors the configured query timeout ([#308](https://github.com/Basekick-Labs/arc/issues/308))
 
 `GET /api/v1/query/:measurement` executed against `context.Background()` with

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -121,6 +121,15 @@ var (
 // Returns (rowCount, handled). If handled is false, the caller falls back to database/sql.
 var arrowJSONQueryFunc func(h *QueryHandler, c *fiber.Ctx, ctx context.Context, cancel context.CancelFunc, convertedSQL string, profileMode bool, governanceMaxRows int, start time.Time, timestamp string, onComplete func(int), onFail func(string), onTimeout func()) (int, bool)
 
+// queryGovernanceLicensed reports whether the Enterprise query-governance
+// gate is open for this handler. Package-level indirection (same seam style
+// as arrowJSONQueryFunc) because license.Client carries no injectable
+// license, so handler tests could otherwise never exercise the licensed
+// path of enforceQueryGovernance.
+var queryGovernanceLicensed = func(h *QueryHandler) bool {
+	return h.governanceManager != nil && h.licenseClient != nil && h.licenseClient.CanUseQueryGovernance()
+}
+
 // arrowMsgPackQueryFunc is set by query_msgpack.go init() when compiled with duckdb_arrow tag.
 // It executes a query via DuckDB's native Arrow API and streams a MessagePack response.
 // Returns (rowCount, handled). If handled is false, the caller MUST treat the request as
@@ -1512,36 +1521,9 @@ func (h *QueryHandler) executeQuery(c *fiber.Ctx) error {
 localProcessing:
 
 	// Query governance enforcement (Enterprise feature - rate limiting and quotas)
-	var governanceMaxRows int
-	var governanceTimeout time.Duration
-	if h.governanceManager != nil && h.licenseClient != nil && h.licenseClient.CanUseQueryGovernance() {
-		if tokenInfo := auth.GetTokenInfo(c); tokenInfo != nil {
-			if result := h.governanceManager.CheckRateLimit(tokenInfo.ID); !result.Allowed {
-				c.Set("Retry-After", strconv.Itoa(result.RetryAfterSec))
-				m.IncQueryErrors()
-				metrics.Get().IncGovernanceRateLimited()
-				h.logger.Warn().
-					Int64("token_id", tokenInfo.ID).
-					Str("token_name", tokenInfo.Name).
-					Str("reason", result.Reason).
-					Int("retry_after_sec", result.RetryAfterSec).
-					Msg("Query rejected: rate limit exceeded")
-				return respondError(c, fiber.StatusTooManyRequests, result.Reason, timestamp, start)
-			}
-			if result := h.governanceManager.CheckQuota(tokenInfo.ID); !result.Allowed {
-				m.IncQueryErrors()
-				metrics.Get().IncGovernanceQuotaExhausted()
-				h.logger.Warn().
-					Int64("token_id", tokenInfo.ID).
-					Str("token_name", tokenInfo.Name).
-					Str("reason", result.Reason).
-					Msg("Query rejected: quota exhausted")
-				return respondError(c, fiber.StatusTooManyRequests, result.Reason, timestamp, start)
-			} else {
-				governanceMaxRows = result.MaxRows
-				governanceTimeout = result.MaxDuration
-			}
-		}
+	governanceMaxRows, governanceTimeout, governanceRejection := h.checkQueryGovernance(c)
+	if governanceRejection != nil {
+		return respondError(c, fiber.StatusTooManyRequests, governanceRejection.reason, timestamp, start)
 	}
 
 	// Parse request body
@@ -4062,6 +4044,23 @@ func (h *QueryHandler) estimateQuery(c *fiber.Ctx) error {
 		})
 	}
 
+	// Enterprise query governance (#702): the COUNT(*) wrapper below forces
+	// full execution of the user's subquery, so this is real scan cost that
+	// must be rate-limited, charged against quota, and bounded by the
+	// policy timeout like any other user-SQL endpoint. MaxRows is
+	// irrelevant here (the response is a single count row). The 429 uses
+	// this endpoint's EstimateResponse shape so warning_level stays the
+	// severity channel for every error class.
+	_, governanceTimeout, governanceRejection := h.checkQueryGovernance(c)
+	if governanceRejection != nil {
+		return c.Status(fiber.StatusTooManyRequests).JSON(EstimateResponse{
+			Success:         false,
+			Error:           governanceRejection.reason,
+			WarningLevel:    "error",
+			ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
+		})
+	}
+
 	// Convert SQL to storage paths (with caching)
 	convertedSQL, _ := h.getTransformedSQL(c.Context(), req.SQL, headerDB)
 
@@ -4075,11 +4074,16 @@ func (h *QueryHandler) estimateQuery(c *fiber.Ctx) error {
 
 	m := metrics.Get()
 
-	// Create context with timeout if configured
+	// Create context with timeout if configured; a governance policy's
+	// MaxDuration overrides the global timeout (#702).
+	effectiveTimeout := h.queryTimeout
+	if governanceTimeout > 0 {
+		effectiveTimeout = governanceTimeout
+	}
 	ctx := c.UserContext()
 	var cancel context.CancelFunc
-	if h.queryTimeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, h.queryTimeout)
+	if effectiveTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, effectiveTimeout)
 		defer cancel()
 	}
 
@@ -4087,9 +4091,9 @@ func (h *QueryHandler) estimateQuery(c *fiber.Ctx) error {
 	rows, err := h.db.QueryContext(ctx, countSQL)
 	if err != nil {
 		// Check if it was a timeout
-		if h.queryTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
+		if effectiveTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
 			m.IncQueryTimeouts()
-			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(countSQL)).Dur("timeout", h.queryTimeout).Msg("Estimate query timed out")
+			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(countSQL)).Dur("timeout", effectiveTimeout).Msg("Estimate query timed out")
 			return c.Status(fiber.StatusGatewayTimeout).JSON(EstimateResponse{
 				Success:         false,
 				Error:           "Query timed out",
@@ -4319,6 +4323,64 @@ func (h *QueryHandler) listMeasurements(c *fiber.Ctx) error {
 	})
 }
 
+// governanceRejection describes a request rejected by query governance.
+// When it is returned, metrics and logging are already recorded and the
+// Retry-After header (rate limits only) is already set on the response;
+// the caller renders the 429 body in its endpoint's own error shape.
+type governanceRejection struct {
+	reason string
+}
+
+// checkQueryGovernance runs the Enterprise query-governance checks (rate
+// limit, then quota) for the request's token. A non-nil rejection means the
+// request must be answered with 429 and the returned reason; otherwise the
+// returned policy limits apply to the query: maxRows caps streamed rows and
+// timeout overrides the global query timeout (zero values mean no policy
+// limit, including when governance is unlicensed, unconfigured, or the
+// request carries no token, as on internal paths).
+//
+// Shared by every user-SQL endpoint (#702): POST /api/v1/query, POST
+// /api/v1/query/arrow, POST /api/v1/query/estimate, and GET
+// /api/v1/query/:measurement. Call-site placement differs deliberately:
+// POST /api/v1/query charges the budget before body parsing (pre-existing
+// order, kept for compatibility), the other three charge after their
+// validation and RBAC checks, so a malformed or forbidden request does not
+// burn a quota slot there.
+func (h *QueryHandler) checkQueryGovernance(c *fiber.Ctx) (maxRows int, timeout time.Duration, rejection *governanceRejection) {
+	if !queryGovernanceLicensed(h) {
+		return 0, 0, nil
+	}
+	tokenInfo := auth.GetTokenInfo(c)
+	if tokenInfo == nil {
+		return 0, 0, nil
+	}
+	m := metrics.Get()
+	if result := h.governanceManager.CheckRateLimit(tokenInfo.ID); !result.Allowed {
+		c.Set("Retry-After", strconv.Itoa(result.RetryAfterSec))
+		m.IncQueryErrors()
+		m.IncGovernanceRateLimited()
+		h.logger.Warn().
+			Int64("token_id", tokenInfo.ID).
+			Str("token_name", tokenInfo.Name).
+			Str("reason", result.Reason).
+			Int("retry_after_sec", result.RetryAfterSec).
+			Msg("Query rejected: rate limit exceeded")
+		return 0, 0, &governanceRejection{reason: result.Reason}
+	}
+	result := h.governanceManager.CheckQuota(tokenInfo.ID)
+	if !result.Allowed {
+		m.IncQueryErrors()
+		m.IncGovernanceQuotaExhausted()
+		h.logger.Warn().
+			Int64("token_id", tokenInfo.ID).
+			Str("token_name", tokenInfo.Name).
+			Str("reason", result.Reason).
+			Msg("Query rejected: quota exhausted")
+		return 0, 0, &governanceRejection{reason: result.Reason}
+	}
+	return result.MaxRows, result.MaxDuration, nil
+}
+
 // queryMeasurement handles GET /api/v1/query/:measurement - query a specific measurement
 func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	start := time.Now()
@@ -4412,6 +4474,15 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 		})
 	}
 
+	// Enterprise query governance (#702): rate limits, quotas, row caps, and
+	// the per-token timeout apply here the same as on POST /api/v1/query.
+	// This endpoint accepts a user-supplied where fragment, so these are
+	// real queries with real cost, not point lookups.
+	governanceMaxRows, governanceTimeout, governanceRejection := h.checkQueryGovernance(c)
+	if governanceRejection != nil {
+		return respondError(c, fiber.StatusTooManyRequests, governanceRejection.reason, time.Now().UTC().Format(time.RFC3339), start)
+	}
+
 	// Build SQL query with validated parameters
 	sql := fmt.Sprintf("SELECT * FROM %s.%s", database, measurement)
 	if where != "" {
@@ -4467,10 +4538,16 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	// Create context with timeout if configured (0 = no timeout).
 	// Same pattern as POST /api/v1/query: start from UserContext so client
 	// disconnects cancel the query, then wrap with queryTimeout (#308).
+	// A governance policy's MaxDuration overrides the global timeout (#702),
+	// matching the POST handler's effectiveTimeout semantics.
+	effectiveTimeout := h.queryTimeout
+	if governanceTimeout > 0 {
+		effectiveTimeout = governanceTimeout
+	}
 	ctx := c.UserContext()
 	var cancel context.CancelFunc
-	if h.queryTimeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, h.queryTimeout)
+	if effectiveTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, effectiveTimeout)
 		// cancel is invoked inside the stream writer callback (or on error
 		// paths below), not deferred here, because SetBodyStreamWriter runs
 		// asynchronously after this function returns.
@@ -4478,7 +4555,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 
 	// Arrow-native path: bypasses database/sql row scanning entirely.
 	if arrowJSONQueryFunc != nil {
-		_, handled := arrowJSONQueryFunc(h, c, ctx, cancel, convertedSQL, false, 0, start, timestamp, nil, nil, nil)
+		_, handled := arrowJSONQueryFunc(h, c, ctx, cancel, convertedSQL, false, governanceMaxRows, start, timestamp, nil, nil, nil)
 		if handled {
 			// Metrics are recorded inside the async stream callback — not here.
 			// cancel is owned by executeArrowJSONQuery when handled=true.
@@ -4493,9 +4570,9 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 			cancel()
 		}
 		m.IncQueryErrors()
-		if h.queryTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
+		if effectiveTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
 			m.IncQueryTimeouts()
-			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(sql)).Dur("timeout", h.queryTimeout).Msg("Measurement query timed out")
+			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(sql)).Dur("timeout", effectiveTimeout).Msg("Measurement query timed out")
 			return c.Status(fiber.StatusGatewayTimeout).JSON(QueryResponse{
 				Success:         false,
 				Error:           "Query timed out",
@@ -4546,7 +4623,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	streamCtx := ctx
 	c.Set("Content-Type", "application/json")
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-		rowCount, streamErr := streamTypedJSON(streamCtx, w, columns, colTypes, rows, 0, nil, start, timestamp)
+		rowCount, streamErr := streamTypedJSON(streamCtx, w, columns, colTypes, rows, governanceMaxRows, nil, start, timestamp)
 		w.Flush()
 
 		rows.Close()

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -40,6 +40,10 @@ const arrowBatchSize = 10000
 // streamArrowIPC writes Arrow record batches as IPC frames to w. It returns
 // the number of rows consumed and the error that stopped the stream, if any.
 // The caller retains ownership of reader and performs request-level cleanup.
+//
+// maxRows, when > 0, is the governance row cap (#702): the batch that would
+// cross it is sliced at the boundary and the stream stops there, matching the
+// truncation semantics drainArrowBatches applies on the msgpack path.
 func streamArrowIPC(
 	ctx context.Context,
 	w *bufio.Writer,
@@ -48,6 +52,7 @@ func streamArrowIPC(
 	castInfo *decimalCastInfo,
 	dictEnabled bool,
 	ipcCompression string,
+	maxRows int,
 	logger zerolog.Logger,
 ) (int64, error) {
 	// The IPC writer is created lazily on the first batch: when
@@ -91,6 +96,25 @@ streamLoop:
 		if batch == nil {
 			break
 		}
+
+		// Governance row cap (#702): slice the batch that would cross the
+		// cap and stop draining. slicedBatch is a new record this function
+		// owns; it is released alongside the other per-iteration records
+		// after Write, and on the error paths that break out before then.
+		var slicedBatch arrow.Record
+		if maxRows > 0 {
+			remaining := int64(maxRows) - totalRows
+			// Defensive: the post-flush break below means the loop should
+			// never re-enter with the cap already reached. This keeps the
+			// row count correct if that break is ever removed.
+			if remaining <= 0 {
+				break
+			}
+			if batch.NumRows() > remaining {
+				slicedBatch = batch.NewSlice(0, remaining)
+				batch = slicedBatch
+			}
+		}
 		totalRows += batch.NumRows()
 
 		// CRITICAL: when castInfo!=nil we replace `batch` with a new
@@ -107,6 +131,9 @@ streamLoop:
 			var castErr error
 			castedBatch, castErr = castDecimalBatch(batch, castInfo)
 			if castErr != nil {
+				if slicedBatch != nil {
+					slicedBatch.Release()
+				}
 				streamErr = fmt.Errorf("failed to cast decimal columns at row %d: %w", totalRows, castErr)
 				break streamLoop
 			}
@@ -137,6 +164,9 @@ streamLoop:
 				if castedBatch != nil {
 					castedBatch.Release()
 				}
+				if slicedBatch != nil {
+					slicedBatch.Release()
+				}
 				streamErr = fmt.Errorf("failed to dictionary-encode batch at row %d: %w", totalRows, encErr)
 				break streamLoop
 			}
@@ -150,6 +180,9 @@ streamLoop:
 		if castedBatch != nil {
 			castedBatch.Release()
 		}
+		if slicedBatch != nil {
+			slicedBatch.Release()
+		}
 		if err != nil {
 			streamErr = fmt.Errorf("failed to write arrow batch at row %d: %w", totalRows, err)
 			break streamLoop
@@ -162,6 +195,12 @@ streamLoop:
 		if err := w.Flush(); err != nil {
 			streamErr = fmt.Errorf("stream flush failed at row %d: %w: %w", totalRows, errClientDisconnected, err)
 			break streamLoop
+		}
+		// Cap reached: stop before reader.Next() materializes another
+		// DuckDB batch that would only be discarded (same early break as
+		// drainArrowBatches).
+		if maxRows > 0 && totalRows >= int64(maxRows) {
+			break
 		}
 	}
 
@@ -316,6 +355,18 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		})
 	}
 
+	// Enterprise query governance (#702): rate limits, quotas, the MaxRows
+	// row cap, and the policy timeout apply here the same as on
+	// POST /api/v1/query. The 429 uses this endpoint's fiber.Map error
+	// shape, matching every other error it returns.
+	governanceMaxRows, governanceTimeout, governanceRejection := h.checkQueryGovernance(c)
+	if governanceRejection != nil {
+		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+			"success": false,
+			"error":   governanceRejection.reason,
+		})
+	}
+
 	// Convert SQL to storage paths (with caching)
 	// If headerDB is set, uses optimized path that skips db.table regex patterns
 	convertedSQL, _ := h.getTransformedSQL(c.Context(), req.SQL, headerDB)
@@ -331,10 +382,15 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 	// runs asynchronously after the handler returns, and c.UserContext() would be cancelled
 	// Note: We don't use defer cancel() here because the streaming callback runs after
 	// this handler returns - cancel is called inside the callback after rows are consumed
+	// A governance policy's MaxDuration overrides the global timeout (#702).
+	effectiveTimeout := h.queryTimeout
+	if governanceTimeout > 0 {
+		effectiveTimeout = governanceTimeout
+	}
 	ctx := context.Background()
 	var cancel context.CancelFunc
-	if h.queryTimeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, h.queryTimeout)
+	if effectiveTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, effectiveTimeout)
 	}
 
 	// arcx router hook (Arrow-IPC variant). In serve mode a green shape is
@@ -345,6 +401,10 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 	// Pass `cancel` INTO the hook — the arcx serve path streams asynchronously in
 	// SetBodyStreamWriter (after this returns), so it owns calling cancel when the stream
 	// finishes. Calling cancel() here would cancel execCtx mid-stream → truncate to schema-only.
+	// Governance note (#702): rate limit, quota, and the policy timeout
+	// (via ctx) apply to an arcx-served response, but the MaxRows cap is
+	// enforced only by the DuckDB IPC loop below — the experimental arcx
+	// serve path streams uncapped until it learns to take a row cap.
 	if h.tryArcxRouterArrow(c, ctx, cancel, req.SQL, headerDB, convertedSQL) {
 		return nil
 	}
@@ -356,9 +416,9 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		if cancel != nil {
 			cancel()
 		}
-		if h.queryTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
+		if effectiveTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
 			m.IncQueryTimeouts()
-			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(req.SQL)).Dur("timeout", h.queryTimeout).Msg("Arrow query timed out")
+			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(req.SQL)).Dur("timeout", effectiveTimeout).Msg("Arrow query timed out")
 			return c.Status(fiber.StatusGatewayTimeout).JSON(fiber.Map{
 				"success": false,
 				"error":   "Query timed out",
@@ -422,7 +482,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			}
 		}()
 		totalRows, streamErr := streamArrowIPC(
-			streamCtx, w, reader, schema, castInfo, dictEnabled, ipcCompression, h.logger,
+			streamCtx, w, reader, schema, castInfo, dictEnabled, ipcCompression, governanceMaxRows, h.logger,
 		)
 		reader.Release()
 		conn.Close()

--- a/internal/api/query_arrow_test.go
+++ b/internal/api/query_arrow_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/rs/zerolog"
 )
@@ -43,7 +44,7 @@ func TestStreamArrowIPCFlushErrorBreaksLoop(t *testing.T) {
 	w := bufio.NewWriterSize(failingWriter, 1<<20)
 
 	rows, err := streamArrowIPC(
-		context.Background(), w, reader, schema, nil, false, "", zerolog.Nop(),
+		context.Background(), w, reader, schema, nil, false, "", 0, zerolog.Nop(),
 	)
 	reader.Release()
 
@@ -70,7 +71,7 @@ func TestStreamArrowIPCCancelledContextStopsBeforeWritingBatch(t *testing.T) {
 
 	var output bytes.Buffer
 	rows, err := streamArrowIPC(
-		ctx, bufio.NewWriter(&output), reader, schema, nil, false, "", zerolog.Nop(),
+		ctx, bufio.NewWriter(&output), reader, schema, nil, false, "", 0, zerolog.Nop(),
 	)
 	reader.Release()
 
@@ -92,7 +93,7 @@ func TestStreamArrowIPCSurfacesReaderError(t *testing.T) {
 
 	var output bytes.Buffer
 	rows, err := streamArrowIPC(
-		context.Background(), bufio.NewWriter(&output), reader, schema, nil, false, "", zerolog.Nop(),
+		context.Background(), bufio.NewWriter(&output), reader, schema, nil, false, "", 0, zerolog.Nop(),
 	)
 	reader.Release()
 
@@ -127,7 +128,7 @@ func TestStreamArrowIPCReleasesCastedBatchOnFlushError(t *testing.T) {
 	w := bufio.NewWriterSize(failingWriter, 1<<20)
 
 	rows, err := streamArrowIPC(
-		context.Background(), w, reader, castInfo.schema, castInfo, false, "", zerolog.Nop(),
+		context.Background(), w, reader, castInfo.schema, castInfo, false, "", 0, zerolog.Nop(),
 	)
 	reader.Release()
 
@@ -136,5 +137,134 @@ func TestStreamArrowIPCReleasesCastedBatchOnFlushError(t *testing.T) {
 	}
 	if rows != 1 {
 		t.Fatalf("expected one casted row before the flush failure, got %d", rows)
+	}
+}
+
+// TestStreamArrowIPCGovernanceRowCap covers the #702 row cap on the IPC path:
+// the batch that crosses maxRows is sliced at the boundary, the stream stops
+// there instead of draining the rest, and the sliced record is released (the
+// checked allocator fails the test if it is not).
+//
+// Releases are deferred rather than called after the assertions so a failing
+// assertion reports the cap problem instead of surfacing as allocator leak
+// noise and an AssertSize panic on the way out.
+func TestStreamArrowIPCGovernanceRowCap(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer alloc.AssertSize(t, 0)
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	records := make([]arrow.Record, 3)
+	for batch := range records {
+		rows := make([][]interface{}, 100)
+		for row := range rows {
+			rows[row] = []interface{}{int64(batch*len(rows) + row)}
+		}
+		records[batch] = buildArrowBatch(alloc, schema, rows)
+	}
+	reader := newSimpleRecordReader(schema, records)
+	defer reader.Release()
+
+	var output bytes.Buffer
+	// 150 splits the second batch, so the cap exercises the slice path.
+	rows, err := streamArrowIPC(
+		context.Background(), bufio.NewWriter(&output), reader, schema, nil, false, "", 150, zerolog.Nop(),
+	)
+	if err != nil {
+		t.Fatalf("streamArrowIPC() error = %v", err)
+	}
+	if rows != 150 {
+		t.Errorf("rows streamed = %d, want the cap of 150", rows)
+	}
+	// The third batch must never be consumed: the loop stops at the cap
+	// rather than materializing a batch it would only discard.
+	if reader.idx != 1 {
+		t.Errorf("reader consumed up to index %d, want 1 (third batch untouched)", reader.idx)
+	}
+
+	// The emitted stream must actually carry the capped rows, in order, with
+	// no slice-offset corruption.
+	ipcReader, err := ipc.NewReader(&output, ipc.WithAllocator(alloc))
+	if err != nil {
+		t.Fatalf("ipc.NewReader() error = %v", err)
+	}
+	defer ipcReader.Release()
+	var decoded int64
+	for ipcReader.Next() {
+		rec := ipcReader.Record()
+		col := rec.Column(0).(*array.Int64)
+		for i := 0; i < col.Len(); i++ {
+			if col.Value(i) != decoded {
+				t.Fatalf("row %d has id %d, want %d (slice offset corruption)", decoded, col.Value(i), decoded)
+			}
+			decoded++
+		}
+	}
+	if err := ipcReader.Err(); err != nil {
+		t.Fatalf("reading back the IPC stream: %v", err)
+	}
+	if decoded != 150 {
+		t.Errorf("decoded %d rows from the IPC stream, want 150", decoded)
+	}
+}
+
+// TestStreamArrowIPCGovernanceCapExactBoundary pins the off-by-one edge: a cap
+// landing exactly on a batch boundary stops there, consuming whole batches and
+// leaving the next one untouched. reader.idx is what catches a cap comparison
+// that is off by one in either direction. Whether the boundary batch is also
+// passed through NewSlice is deliberately not asserted: a full-length slice
+// would emit identical bytes and is released on the same path, so it is a
+// spare allocation rather than a behavior worth pinning.
+func TestStreamArrowIPCGovernanceCapExactBoundary(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer alloc.AssertSize(t, 0)
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	records := make([]arrow.Record, 3)
+	for batch := range records {
+		rows := make([][]interface{}, 50)
+		for row := range rows {
+			rows[row] = []interface{}{int64(batch*len(rows) + row)}
+		}
+		records[batch] = buildArrowBatch(alloc, schema, rows)
+	}
+	reader := newSimpleRecordReader(schema, records)
+	defer reader.Release()
+
+	var output bytes.Buffer
+	rows, err := streamArrowIPC(
+		context.Background(), bufio.NewWriter(&output), reader, schema, nil, false, "", 100, zerolog.Nop(),
+	)
+	if err != nil {
+		t.Fatalf("streamArrowIPC() error = %v", err)
+	}
+	if rows != 100 {
+		t.Errorf("rows streamed = %d, want exactly 100", rows)
+	}
+	// Two full batches consume the cap exactly, so the third is untouched.
+	if reader.idx != 1 {
+		t.Errorf("reader consumed up to index %d, want 1", reader.idx)
+	}
+
+	ipcReader, err := ipc.NewReader(&output, ipc.WithAllocator(alloc))
+	if err != nil {
+		t.Fatalf("ipc.NewReader() error = %v", err)
+	}
+	defer ipcReader.Release()
+	var decoded int64
+	batches := 0
+	for ipcReader.Next() {
+		batches++
+		decoded += ipcReader.Record().NumRows()
+	}
+	if err := ipcReader.Err(); err != nil {
+		t.Fatalf("reading back the IPC stream: %v", err)
+	}
+	if decoded != 100 {
+		t.Errorf("decoded %d rows, want 100", decoded)
+	}
+	// Two whole batches reach the cap, so the stream must carry exactly two:
+	// a third would mean the loop ran past the boundary.
+	if batches != 2 {
+		t.Errorf("stream carries %d batches, want 2", batches)
 	}
 }

--- a/internal/api/query_governance_arrow_test.go
+++ b/internal/api/query_governance_arrow_test.go
@@ -1,0 +1,44 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/governance"
+	"github.com/gofiber/fiber/v2"
+)
+
+// TestExecuteQueryArrowGovernanceRateLimit pins that POST /api/v1/query/arrow
+// consults governance (#702). The Arrow IPC endpoint previously executed
+// arbitrary user SQL with no rate limit, quota, row cap, or policy timeout.
+// The budget is pre-consumed through the manager so the handler rejects
+// before ever touching h.db; the MaxRows slice in the IPC stream loop is
+// covered by the live end-to-end run (it needs a real Arrow reader).
+func TestExecuteQueryArrowGovernanceRateLimit(t *testing.T) {
+	m := newGovernanceTestManager(t, &governance.Policy{TokenID: 42, RateLimitPerMinute: 1})
+	h := newGovernanceTestHandler(m, 0)
+	app := newGovernanceTestApp(t, h, &auth.TokenInfo{ID: 42, Name: "limited"}, nil, nil)
+	app.Post("/api/v1/query/arrow", h.executeQueryArrow)
+
+	if res := m.CheckRateLimit(42); !res.Allowed {
+		t.Fatal("precondition failed: first rate-limit slot should be allowed")
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/query/arrow", strings.NewReader(`{"sql":"SELECT * FROM default.cpu"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != fiber.StatusTooManyRequests {
+		t.Fatalf("arrow query over the rate limit: got %d, want 429", resp.StatusCode)
+	}
+	if resp.Header.Get("Retry-After") == "" {
+		t.Error("429 response is missing the Retry-After header")
+	}
+}

--- a/internal/api/query_governance_test.go
+++ b/internal/api/query_governance_test.go
@@ -1,0 +1,250 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/governance"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/pruning"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Tests for #702: GET /api/v1/query/:measurement must enforce the same
+// Enterprise query-governance policy set as POST /api/v1/query — rate
+// limits, quotas, the MaxRows streaming cap, and the MaxDuration timeout
+// override. The license gate is opened through the queryGovernanceLicensed
+// seam because license.Client carries no injectable license.
+
+func newGovernanceTestManager(t *testing.T, policy *governance.Policy) *governance.Manager {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	m, err := governance.NewManager(&governance.ManagerConfig{
+		DB:     db,
+		Config: &config.GovernanceConfig{},
+		Logger: zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Start()
+	t.Cleanup(func() { m.Stop() })
+	if policy != nil {
+		if _, err := m.CreatePolicy(context.Background(), policy); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return m
+}
+
+// newGovernanceTestApp opens the license seam, stubs the Arrow dispatch to
+// capture the governance arguments, and returns an app whose requests carry
+// the given token.
+func newGovernanceTestApp(t *testing.T, h *QueryHandler, token *auth.TokenInfo, gotMaxRows *int, gotCtx *context.Context) *fiber.App {
+	t.Helper()
+	metrics.Init(zerolog.Nop())
+
+	origLicensed := queryGovernanceLicensed
+	queryGovernanceLicensed = func(*QueryHandler) bool { return true }
+	t.Cleanup(func() { queryGovernanceLicensed = origLicensed })
+
+	origArrow := arrowJSONQueryFunc
+	arrowJSONQueryFunc = func(h *QueryHandler, c *fiber.Ctx, ctx context.Context, cancel context.CancelFunc, convertedSQL string, profileMode bool, governanceMaxRows int, start time.Time, timestamp string, onComplete func(int), onFail func(string), onTimeout func()) (int, bool) {
+		if gotMaxRows != nil {
+			*gotMaxRows = governanceMaxRows
+		}
+		if gotCtx != nil {
+			*gotCtx = ctx
+		}
+		if cancel != nil {
+			cancel()
+		}
+		return 0, true
+	}
+	t.Cleanup(func() { arrowJSONQueryFunc = origArrow })
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("token_info", token)
+		return c.Next()
+	})
+	app.Get("/api/v1/query/:measurement", h.queryMeasurement)
+	return app
+}
+
+func newGovernanceTestHandler(m *governance.Manager, queryTimeout time.Duration) *QueryHandler {
+	return &QueryHandler{
+		logger:            zerolog.Nop(),
+		queryTimeout:      queryTimeout,
+		queryCache:        database.NewQueryCache(database.QueryCacheTTL, database.DefaultQueryCacheMaxSize),
+		storage:           &mockLocalBackend{basePath: "./data"},
+		pruner:            pruning.NewPartitionPruner(zerolog.Nop()),
+		governanceManager: m,
+	}
+}
+
+func TestQueryMeasurementGovernanceRateLimit(t *testing.T) {
+	m := newGovernanceTestManager(t, &governance.Policy{TokenID: 42, RateLimitPerMinute: 2})
+	h := newGovernanceTestHandler(m, 0)
+	app := newGovernanceTestApp(t, h, &auth.TokenInfo{ID: 42, Name: "limited"}, nil, nil)
+
+	for i := 1; i <= 2; i++ {
+		resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/query/cpu?database=default", nil))
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("request %d within the rate limit: got %d, want 200", i, resp.StatusCode)
+		}
+	}
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/query/cpu?database=default", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != fiber.StatusTooManyRequests {
+		t.Fatalf("request over the rate limit: got %d, want 429", resp.StatusCode)
+	}
+	if resp.Header.Get("Retry-After") == "" {
+		t.Error("429 response is missing the Retry-After header")
+	}
+}
+
+func TestQueryMeasurementGovernanceQuota(t *testing.T) {
+	m := newGovernanceTestManager(t, &governance.Policy{TokenID: 42, MaxQueriesPerHour: 1})
+	h := newGovernanceTestHandler(m, 0)
+	app := newGovernanceTestApp(t, h, &auth.TokenInfo{ID: 42, Name: "quotaed"}, nil, nil)
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/query/cpu?database=default", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("request within quota: got %d, want 200", resp.StatusCode)
+	}
+
+	resp, err = app.Test(httptest.NewRequest("GET", "/api/v1/query/cpu?database=default", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != fiber.StatusTooManyRequests {
+		t.Fatalf("request over quota: got %d, want 429", resp.StatusCode)
+	}
+}
+
+func TestQueryMeasurementGovernanceMaxRowsAndTimeout(t *testing.T) {
+	const globalTimeout = 5 * time.Minute
+	m := newGovernanceTestManager(t, &governance.Policy{
+		TokenID:            42,
+		MaxRowsPerQuery:    7,
+		MaxScanDurationSec: 2,
+	})
+	h := newGovernanceTestHandler(m, globalTimeout)
+
+	var gotMaxRows int
+	var gotCtx context.Context
+	app := newGovernanceTestApp(t, h, &auth.TokenInfo{ID: 42, Name: "capped"}, &gotMaxRows, &gotCtx)
+
+	before := time.Now()
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/query/cpu?database=default", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if gotMaxRows != 7 {
+		t.Errorf("governanceMaxRows passed to Arrow dispatch: got %d, want 7", gotMaxRows)
+	}
+	if gotCtx == nil {
+		t.Fatal("Arrow dispatch was not invoked with a context")
+	}
+	deadline, ok := gotCtx.Deadline()
+	if !ok {
+		t.Fatal("context has no deadline; effectiveTimeout was not applied")
+	}
+	// The policy's 2s MaxDuration must override the 5m global timeout.
+	if deadline.After(before.Add(10 * time.Second)) {
+		t.Errorf("deadline %v reflects the global timeout; governance MaxDuration did not override", deadline)
+	}
+}
+
+// TestEstimateQueryGovernanceRateLimit pins that POST /api/v1/query/estimate
+// consults governance (#702): its COUNT(*) wrapper executes the full user
+// subquery, so it must be rate-limited like any other user-SQL endpoint. The
+// budget is pre-consumed through the manager so the handler rejects before
+// ever touching h.db.
+func TestEstimateQueryGovernanceRateLimit(t *testing.T) {
+	m := newGovernanceTestManager(t, &governance.Policy{TokenID: 42, RateLimitPerMinute: 1})
+	h := newGovernanceTestHandler(m, 0)
+	app := newGovernanceTestApp(t, h, &auth.TokenInfo{ID: 42, Name: "limited"}, nil, nil)
+	app.Post("/api/v1/query/estimate", h.estimateQuery)
+
+	if res := m.CheckRateLimit(42); !res.Allowed {
+		t.Fatal("precondition failed: first rate-limit slot should be allowed")
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/query/estimate", strings.NewReader(`{"sql":"SELECT * FROM default.cpu"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != fiber.StatusTooManyRequests {
+		t.Fatalf("estimate over the rate limit: got %d, want 429", resp.StatusCode)
+	}
+	if resp.Header.Get("Retry-After") == "" {
+		t.Error("429 response is missing the Retry-After header")
+	}
+	// The 429 must use the endpoint's own error shape: warning_level is the
+	// estimate endpoint's severity channel for every error class.
+	if !strings.Contains(string(body), `"warning_level":"error"`) {
+		t.Errorf("429 body missing warning_level=error: %s", body)
+	}
+}
+
+func TestQueryMeasurementGovernanceNoToken(t *testing.T) {
+	m := newGovernanceTestManager(t, &governance.Policy{TokenID: 42, RateLimitPerMinute: 1})
+	h := newGovernanceTestHandler(m, 0)
+	// nil token: internal paths carry no token_info; governance must be a
+	// no-op rather than a rejection or a panic.
+	var gotCtx context.Context
+	app := newGovernanceTestApp(t, h, nil, nil, &gotCtx)
+
+	for i := 1; i <= 3; i++ {
+		resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/query/cpu?database=default", nil))
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("tokenless request %d: got %d, want 200", i, resp.StatusCode)
+		}
+	}
+	if _, ok := gotCtx.Deadline(); ok {
+		t.Error("tokenless request with queryTimeout=0 must not carry a deadline")
+	}
+}


### PR DESCRIPTION
## Summary

Enterprise query governance (rate limits, quotas, `max_rows_per_query`, `max_scan_duration_sec`) was enforced only on `POST /api/v1/query`. This PR hoists that block into a shared `checkQueryGovernance` helper and enforces it on the three endpoints that were open: `GET /api/v1/query/:measurement`, `POST /api/v1/query/arrow`, and `POST /api/v1/query/estimate` (its `COUNT(*)` wrapper executes the full user subquery, so it carries real scan cost).

- The helper records metrics/logging and sets `Retry-After`; each endpoint renders the 429 in its own error shape (`EstimateResponse` keeps `warning_level` as the severity channel, the arrow endpoint keeps its `fiber.Map` shape, POST keeps msgpack adaptation via `respondError`).
- `max_rows_per_query` caps streamed rows on every row-returning path: Arrow JSON, the database/sql fallback, and the Arrow IPC stream via a batch slice mirroring `drainArrowBatches`, with an early break so DuckDB stops materializing batches at the cap.
- `max_scan_duration_sec` overrides the global `query.timeout` with the same `effectiveTimeout` semantics as POST on all four endpoints.
- The license gate sits behind a package-level test seam (`queryGovernanceLicensed`), same style as the existing `arrowJSONQueryFunc` seam, since `license.Client` carries no injectable license.

**Stacked on #701** (it builds on that PR's timeout context wiring in `queryMeasurement`); this PR sits until #701 merges, then rebases to a single commit. Fixes #702.

## Notes for review

- POST deliberately keeps its pre-existing charge-before-parse ordering; the other three charge after validation and RBAC, so malformed or forbidden requests do not burn quota there (documented on the helper).
- Pre-existing semantics kept deliberately: a policy `MaxDuration` larger than the global timeout raises the effective timeout for that token (matches POST today); worth a separate decision if we ever want min() semantics.
- The experimental arcx Arrow serve path (arcx_engine builds only) is not row-capped yet; documented inline. It does get the policy timeout via ctx.

## Test plan

- [x] 6 new handler tests: rate-limit 429 + Retry-After, quota 429, MaxRows + MaxDuration flow-through, tokenless no-op, and rejection tests for the estimate and arrow endpoints (budget pre-consumed through the manager so no DB is needed)
- [x] `go test -tags=duckdb_arrow -race ./internal/api/ ./internal/governance/` green; vet/gofmt clean
- [x] Live E2E on an Enterprise-licensed dev server: arrow returned exactly 10 of 50 rows under a 10-row policy (verified with an Arrow IPC reader); arrow and estimate both 504 at a 1s policy timeout against a 300s global; one shared rate budget across all four endpoints (burst arithmetic matches `arc_governance_rate_limited_total` exactly); POST still 429s through the shared helper
- [x] Two adversarial review rounds; round 1 caught the arrow/estimate coverage gap, round 2 verified the IPC slice ownership on every exit path and found nothing above LOW