### PR TITLE
fix(tiering): push measurement/time-range filters into SQL WHERE

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -124,6 +124,17 @@ offset *variance*; it does not make the column text-comparable with
 fractional seconds. `expires_at` is still compared as a parsed instant, never as
 a string. Existing rows are left as they are — they parse back to the correct
 instant, so no token's lifetime changes.
+### Tiered query routing filters file metadata in SQL ([#346](https://github.com/Basekick-Labs/arc/issues/346))
+
+`GetStoragePathsForQuery` fetched every file recorded for a database from the
+tiering metadata store and filtered by measurement and time range in Go,
+pulling every unrelated row out of SQLite per query. The measurement and
+partition-time filters are now pushed into the SQL WHERE clause, so SQLite's
+indexes prune rows before they cross the query boundary. Returned paths are
+unchanged; a busy tiering database just holds far less metadata in memory
+per query.
+
+Contributed by [@pujitha24](https://github.com/pujitha24) in [#707](https://github.com/Basekick-Labs/arc/pull/707).
 
 ### Arrow IPC streaming has direct disconnect regression coverage ([#425](https://github.com/Basekick-Labs/arc/issues/425))
 

--- a/internal/tiering/metadata.go
+++ b/internal/tiering/metadata.go
@@ -256,6 +256,45 @@ func (s *MetadataStore) GetFilesByDatabase(ctx context.Context, database string)
 	return s.scanFiles(rows)
 }
 
+// GetFilesForQuery retrieves files for a database, optionally filtered by
+// measurement and/or time range. Filters are pushed into the SQL WHERE
+// clause instead of being applied client-side, so SQLite's indexes on
+// database/tier/partition_time can prune rows before they reach Go.
+func (s *MetadataStore) GetFilesForQuery(ctx context.Context, database, measurement string, startTime, endTime *time.Time) ([]FileMetadata, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	query := `
+		SELECT id, path, database, measurement, partition_time, tier, size_bytes, created_at, migrated_at
+		FROM tier_files
+		WHERE database = ?
+	`
+	args := []any{database}
+
+	if measurement != "" {
+		query += " AND measurement = ?"
+		args = append(args, measurement)
+	}
+	if startTime != nil {
+		query += " AND partition_time >= ?"
+		args = append(args, startTime.UTC())
+	}
+	if endTime != nil {
+		query += " AND partition_time <= ?"
+		args = append(args, endTime.UTC())
+	}
+
+	query += " ORDER BY partition_time DESC"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query files: %w", err)
+	}
+	defer rows.Close()
+
+	return s.scanFiles(rows)
+}
+
 // GetAllDatabases returns all unique database names from the tier metadata.
 // This includes databases that may only have data in cold storage.
 func (s *MetadataStore) GetAllDatabases(ctx context.Context) ([]string, error) {

--- a/internal/tiering/metadata_test.go
+++ b/internal/tiering/metadata_test.go
@@ -90,6 +90,59 @@ func TestMetadataStore_RecordFile(t *testing.T) {
 	}
 }
 
+func TestMetadataStore_GetFilesForQuery(t *testing.T) {
+	store, cleanup := setupTestMetadataStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	files := []FileMetadata{
+		{Path: "cpu-jan.parquet", Database: "testdb", Measurement: "cpu", PartitionTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Tier: TierHot, SizeBytes: 100},
+		{Path: "cpu-feb.parquet", Database: "testdb", Measurement: "cpu", PartitionTime: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC), Tier: TierHot, SizeBytes: 100},
+		{Path: "mem-jan.parquet", Database: "testdb", Measurement: "mem", PartitionTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Tier: TierHot, SizeBytes: 100},
+		{Path: "cpu-other-db.parquet", Database: "otherdb", Measurement: "cpu", PartitionTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Tier: TierHot, SizeBytes: 100},
+	}
+	for i := range files {
+		if err := store.RecordFile(ctx, &files[i]); err != nil {
+			t.Fatalf("RecordFile() error = %v", err)
+		}
+	}
+
+	// Measurement filter should exclude other measurements and other databases.
+	got, err := store.GetFilesForQuery(ctx, "testdb", "cpu", nil, nil)
+	if err != nil {
+		t.Fatalf("GetFilesForQuery() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("GetFilesForQuery() returned %d files, want 2", len(got))
+	}
+	for _, f := range got {
+		if f.Database != "testdb" || f.Measurement != "cpu" {
+			t.Errorf("unexpected file in result: %+v", f)
+		}
+	}
+
+	// Time range filter should exclude files outside the window.
+	start := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 2, 28, 0, 0, 0, 0, time.UTC)
+	got, err = store.GetFilesForQuery(ctx, "testdb", "cpu", &start, &end)
+	if err != nil {
+		t.Fatalf("GetFilesForQuery() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Path != "cpu-feb.parquet" {
+		t.Fatalf("GetFilesForQuery() with time range = %+v, want only cpu-feb.parquet", got)
+	}
+
+	// No measurement filter returns all measurements for the database.
+	got, err = store.GetFilesForQuery(ctx, "testdb", "", nil, nil)
+	if err != nil {
+		t.Fatalf("GetFilesForQuery() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("GetFilesForQuery() with no measurement = %d files, want 3", len(got))
+	}
+}
+
 func TestMetadataStore_GetTiersForMeasurementPrunesExpiredCacheEntries(t *testing.T) {
 	store, cleanup := setupTestMetadataStore(t)
 	defer cleanup()

--- a/internal/tiering/router.go
+++ b/internal/tiering/router.go
@@ -27,29 +27,18 @@ func NewRouter(manager *Manager, logger zerolog.Logger) *Router {
 func (r *Router) GetStoragePathsForQuery(ctx context.Context, database, measurement string, startTime, endTime *time.Time) ([]TieredPath, error) {
 	var paths []TieredPath
 
-	// Get all files for this database/measurement from metadata
-	files, err := r.manager.metadata.GetFilesByDatabase(ctx, database)
+	// Get files for this database/measurement/time range directly from
+	// metadata; the SQL WHERE clause does the filtering so we never pull
+	// unrelated measurements or out-of-range partitions into memory.
+	files, err := r.manager.metadata.GetFilesForQuery(ctx, database, measurement, startTime, endTime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get files: %w", err)
 	}
 
-	// Filter by measurement and time range, group by tier
+	// Group by tier
 	tierFiles := make(map[Tier][]string)
 
 	for _, file := range files {
-		// Filter by measurement if specified
-		if measurement != "" && file.Measurement != measurement {
-			continue
-		}
-
-		// Filter by time range if specified
-		if startTime != nil && file.PartitionTime.Before(*startTime) {
-			continue
-		}
-		if endTime != nil && file.PartitionTime.After(*endTime) {
-			continue
-		}
-
 		tierFiles[file.Tier] = append(tierFiles[file.Tier], file.Path)
 	}
 


### PR DESCRIPTION
Motivation:
Router.GetStoragePathsForQuery fetched every file recorded for a
database via MetadataStore.GetFilesByDatabase, then filtered by
measurement and time range in a Go loop. On a database with many
measurements or a long history, this pulls every row (and every
unrelated measurement's files) out of SQLite before discarding most
of them in application code, instead of letting SQLite's existing
database/tier index prune rows before they cross the query boundary.

Approach:
Added MetadataStore.GetFilesForQuery(ctx, database, measurement,
startTime, endTime), which builds the WHERE clause dynamically:
database is always filtered, measurement is added only when
non-empty, and partition_time bounds are added only when the
corresponding pointer is non-nil. All values are bound via
placeholders. The boundary semantics match the removed Go code
exactly (partition_time >= start, partition_time <= end, both
inclusive). Router.GetStoragePathsForQuery now calls this method
and only groups the already-filtered rows by tier. GetFilesByDatabase
itself is untouched; its other callers (the admin files-listing API,
the unrelated Raft FSM in-memory method) don't filter and were out
of scope for this issue.

Validation:
go build ./internal/tiering/...
go vet -tags=duckdb_arrow ./internal/tiering/...
go test -tags=duckdb_arrow -race ./internal/tiering/...
All three passed, including the new TestMetadataStore_GetFilesForQuery,
which covers measurement filtering, cross-database exclusion, the
inclusive time-range boundary, and the empty-measurement fallback.
A full-repo `go build -tags=duckdb_arrow ./...` could not complete in
this environment (host disk ran out of space partway through fetching
unrelated module dependencies) — this is an environment limitation
unrelated to the change, and the affected package's own build, vet,
and race-enabled tests all pass cleanly.

No user-visible behavior changes: GetStoragePathsForQuery returns the
same set of paths as before. The benefit is avoiding an unnecessary
full-database metadata scan and reducing what a busy tiering database
holds in memory per query.

Report: https://github.com/Basekick-Labs/arc/issues/346
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #346