### PR TITLE
feat(telemetry): report arcli installations seen per instance

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -1781,6 +1781,11 @@ func main() {
 		TLSCertFile:     cfg.Server.TLSCertFile,
 		TLSKeyFile:      cfg.Server.TLSKeyFile,
 	}
+	if telemetryCollector != nil {
+		// Only a live collector (typed nil would be a non-nil interface).
+		serverConfig.ClientRecorder = telemetryCollector
+		serverConfig.AuthRequired = authManager != nil
+	}
 
 	server := api.NewServer(serverConfig, logger.Get("server"))
 

--- a/internal/api/client_identity.go
+++ b/internal/api/client_identity.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"path"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/basekick-labs/arc/internal/auth"
+)
+
+// HeaderArcliInstallationID is sent by arcli on every request with a
+// random per-installation UUID (see arcli's README, "Privacy").
+const HeaderArcliInstallationID = "Arcli-Installation-Id"
+
+// ClientRecorder receives the identity of CLI installations that talk
+// to this node. The telemetry collector implements it; nil disables
+// the middleware entirely.
+type ClientRecorder interface {
+	RecordClient(id, version string)
+}
+
+// clientIdentity hands the arcli installation id and version to rec
+// after the request was served. Two gates keep anonymous callers out
+// of the bounded registry: the response must be < 400, and when the
+// server runs with authentication the auth middleware must have
+// validated a token on this request (auth.GetTokenInfo). Public routes
+// such as /health answer 200 without a token and are therefore never
+// counted (the path list below is only belt-and-braces: Fiber routes
+// case-insensitively and tolerates a trailing slash, so the path alone
+// is not a safe gate). Without authentication configured every caller
+// is trusted anyway, and the docs say so. Requests without the header
+// cost one header lookup. Header values are copied out of fasthttp's
+// request buffer before they outlive the request (Fiber runs without
+// Immutable), and are validated by the recorder; nothing is logged.
+func clientIdentity(rec ClientRecorder, authRequired bool) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		raw := c.Get(HeaderArcliInstallationID)
+		if raw == "" || len(raw) != 36 || isUnauthenticatedRoute(c.Path()) {
+			return c.Next()
+		}
+		id := strings.Clone(raw)
+		version := strings.Clone(arcliVersion(c.Get(fiber.HeaderUserAgent)))
+		err := c.Next()
+		// Fiber runs the error handler after the stack unwinds, so a
+		// handler that returns an error (401 via fiber.NewError, a 500,
+		// an unknown route's 404) still shows status 200 here; err must
+		// be nil as well.
+		if err == nil && c.Response().StatusCode() < 400 && (!authRequired || auth.GetTokenInfo(c) != nil) {
+			rec.RecordClient(id, version)
+		}
+		return err
+	}
+}
+
+// isUnauthenticatedRoute mirrors the auth middleware's default public
+// routes (internal/auth/middleware.go DefaultMiddlewareConfig) plus the
+// metrics route main.go adds, normalised the way Fiber matches them.
+func isUnauthenticatedRoute(p string) bool {
+	p = strings.ToLower(path.Clean("/" + p))
+	switch p {
+	case "/health", "/ready", "/api/v1/auth/verify":
+		return true
+	}
+	return strings.HasPrefix(p, "/metrics") || strings.HasPrefix(p, "/api/v1/metrics")
+}
+
+// arcliVersion extracts "26.09.1" from "arcli/26.09.1 (darwin/arm64)";
+// anything else yields "" and the recorder reports it as unknown.
+func arcliVersion(ua string) string {
+	const prefix = "arcli/"
+	if !strings.HasPrefix(ua, prefix) {
+		return ""
+	}
+	v := ua[len(prefix):]
+	if i := strings.IndexByte(v, ' '); i >= 0 {
+		v = v[:i]
+	}
+	return v
+}

--- a/internal/api/client_identity_test.go
+++ b/internal/api/client_identity_test.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/basekick-labs/arc/internal/auth"
+)
+
+type recSpy struct {
+	id, version         string
+	first, firstVersion string // the third recorded pair, kept to detect buffer reuse
+	calls               int
+}
+
+func (r *recSpy) RecordClient(id, version string) {
+	r.id, r.version, r.calls = id, version, r.calls+1
+	if r.calls == 3 {
+		r.first, r.firstVersion = id, version
+	}
+}
+
+func TestClientIdentityMiddleware(t *testing.T) {
+	spy := &recSpy{}
+	app := fiber.New()
+	app.Use(clientIdentity(spy, false))
+	app.Get("/x", func(c *fiber.Ctx) error { return c.SendString("ok") })
+	app.Get("/denied", func(c *fiber.Ctx) error { return c.SendStatus(401) })
+	for _, p := range []string{"/health", "/ready", "/metrics", "/api/v1/metrics", "/api/v1/auth/verify"} {
+		app.Get(p, func(c *fiber.Ctx) error { return c.SendString("public") })
+	}
+
+	req := httptest.NewRequest("GET", "/x", nil)
+	req.Header.Set(HeaderArcliInstallationID, "0f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f")
+	req.Header.Set("User-Agent", "arcli/26.09.1 (darwin/arm64)")
+	if resp, err := app.Test(req); err != nil || resp.StatusCode != 200 {
+		t.Fatalf("resp=%v err=%v", resp, err)
+	}
+	if spy.calls != 1 || spy.id != "0f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f" || spy.version != "26.09.1" {
+		t.Errorf("spy: %+v", spy)
+	}
+	// No header: recorder untouched.
+	_, _ = app.Test(httptest.NewRequest("GET", "/x", nil))
+	if spy.calls != 1 {
+		t.Errorf("no header must not record: %+v", spy)
+	}
+	// Foreign user agent: id still recorded, version empty (→ unknown).
+	req = httptest.NewRequest("GET", "/x", nil)
+	req.Header.Set(HeaderArcliInstallationID, "1f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f")
+	req.Header.Set("User-Agent", "curl/8.0")
+	_, _ = app.Test(req)
+	if spy.calls != 2 || spy.version != "" {
+		t.Errorf("foreign UA: %+v", spy)
+	}
+	// Handlers that return an error (Fiber renders the status after the
+	// stack unwinds) and unknown routes are not "served".
+	app.Get("/errs", func(c *fiber.Ctx) error { return fiber.NewError(401, "no") })
+	app.Get("/boom", func(c *fiber.Ctx) error { return fmt.Errorf("boom") })
+	for _, p := range []string{"/errs", "/boom", "/no-such-route"} {
+		req = httptest.NewRequest("GET", p, nil)
+		req.Header.Set(HeaderArcliInstallationID, "7f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f")
+		_, _ = app.Test(req)
+		if spy.calls != 2 {
+			t.Errorf("%s must not record: %+v", p, spy)
+		}
+	}
+	// Rejected requests (401/403/…) never reach the recorder.
+	req = httptest.NewRequest("GET", "/denied", nil)
+	req.Header.Set(HeaderArcliInstallationID, "2f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f")
+	_, _ = app.Test(req)
+	if spy.calls != 2 {
+		t.Errorf("401 must not record: %+v", spy)
+	}
+	// Public (token-less) routes answer 200 but are never counted, in
+	// any of the spellings Fiber's case-insensitive, slash-tolerant
+	// router accepts.
+	for _, p := range []string{"/health", "/health/", "/HEALTH", "/Health/", "/ready", "/metrics", "/api/v1/metrics", "/API/v1/metrics/", "/api/v1/auth/verify"} {
+		req = httptest.NewRequest("GET", p, nil)
+		req.Header.Set(HeaderArcliInstallationID, "5f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f")
+		if resp, _ := app.Test(req); resp.StatusCode != 200 || spy.calls != 2 {
+			t.Errorf("%s: status=%d calls=%d", p, resp.StatusCode, spy.calls)
+		}
+	}
+	// Wrong length is dropped before any copy.
+	req = httptest.NewRequest("GET", "/x", nil)
+	req.Header.Set(HeaderArcliInstallationID, "short")
+	_, _ = app.Test(req)
+	if spy.calls != 2 {
+		t.Errorf("short id must not record: %+v", spy)
+	}
+	// The recorded strings survive the request buffer being reused.
+	req = httptest.NewRequest("GET", "/x", nil)
+	req.Header.Set(HeaderArcliInstallationID, "3f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f")
+	req.Header.Set("User-Agent", "arcli/1.2.3")
+	_, _ = app.Test(req)
+	for i := 0; i < 50; i++ {
+		r2 := httptest.NewRequest("GET", "/x", nil)
+		r2.Header.Set("User-Agent", strings.Repeat("z", 64))
+		r2.Header.Set(HeaderArcliInstallationID, "4f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f")
+		_, _ = app.Test(r2)
+	}
+	if spy.first != "3f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f" || spy.firstVersion != "1.2.3" {
+		t.Errorf("stored strings mutated: %q %q", spy.first, spy.firstVersion)
+	}
+}
+
+func TestArcliVersion(t *testing.T) {
+	for in, want := range map[string]string{
+		"arcli/26.09.1 (darwin/arm64)": "26.09.1",
+		"arcli/dev":                    "dev",
+		"arcli":                        "",
+		"Arc/26.09.1":                  "",
+		"":                             "",
+	} {
+		if got := arcliVersion(in); got != want {
+			t.Errorf("%q: got %q want %q", in, got, want)
+		}
+	}
+}
+
+func TestClientIdentityRequiresValidatedToken(t *testing.T) {
+	spy := &recSpy{}
+	app := fiber.New()
+	app.Use(clientIdentity(spy, true))
+	// A route the auth middleware would guard: without token_info set the
+	// request is not counted even though it answers 200.
+	app.Get("/open200", func(c *fiber.Ctx) error { return c.SendString("ok") })
+	app.Get("/authed", func(c *fiber.Ctx) error {
+		c.Locals("token_info", &auth.TokenInfo{Name: "t"})
+		return c.SendString("ok")
+	})
+	for _, tc := range []struct {
+		path  string
+		calls int
+	}{{"/open200", 0}, {"/authed", 1}, {"/AUTHED/", 2}} {
+		req := httptest.NewRequest("GET", tc.path, nil)
+		req.Header.Set(HeaderArcliInstallationID, "6f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f")
+		if resp, _ := app.Test(req); resp.StatusCode != 200 || spy.calls != tc.calls {
+			t.Errorf("%s: status=%d calls=%d want %d", tc.path, resp.StatusCode, spy.calls, tc.calls)
+		}
+	}
+}

--- a/internal/api/routing.go
+++ b/internal/api/routing.go
@@ -57,6 +57,10 @@ var clientForwardingHeaders = map[string]bool{
 	"Forwarded":           true, // RFC 7239
 	"X-Arc-Forwarded-By":  true, // internal loop marker; only the peer may set it
 	"X-Arc-Original-Host": true,
+	// arcli's installation id is recorded by the node that received the
+	// request (telemetry, client_identity.go); stripped here so a
+	// forwarded request is not counted a second time on the peer.
+	"Arcli-Installation-Id": true,
 	// CDN / proxy client-IP headers. Not read by Arc today (identity is
 	// socket-only), stripped defensively so they cannot be trusted later.
 	"True-Client-Ip":   true, // canonical form of True-Client-IP (Akamai/Cloudflare)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -93,6 +93,15 @@ type ServerConfig struct {
 	TLSEnabled  bool
 	TLSCertFile string
 	TLSKeyFile  string
+
+	// ClientRecorder, when set, receives the installation id + version
+	// of arcli clients (Arcli-Installation-Id header) for telemetry.
+	// nil (telemetry disabled) installs no middleware.
+	ClientRecorder ClientRecorder
+	// AuthRequired tells the client-identity middleware that the auth
+	// middleware runs on this server, so only requests it validated are
+	// recorded. False (auth disabled) trusts every served request.
+	AuthRequired bool
 }
 
 // DefaultServerConfig returns default server configuration
@@ -160,11 +169,16 @@ func NewServer(config *ServerConfig, logger zerolog.Logger) *Server {
 	app.Use(cors.New(cors.Config{
 		AllowOrigins: "*",
 		AllowMethods: "GET,POST,PUT,DELETE,OPTIONS",
-		AllowHeaders: "Origin,Content-Type,Accept,Authorization,x-api-key,x-arc-database,Content-Encoding",
+		AllowHeaders: "Origin,Content-Type,Accept,Authorization,x-api-key,x-arc-database,Content-Encoding,Arcli-Installation-Id",
 	}))
 
 	// Security headers middleware (pass TLS flag for HSTS)
 	app.Use(securityHeaders(config.TLSEnabled))
+
+	// arcli installation ids for telemetry (see client_identity.go).
+	if config.ClientRecorder != nil {
+		app.Use(clientIdentity(config.ClientRecorder, config.AuthRequired))
+	}
 
 	// NOTE: Compression middleware is disabled to allow manual decompression in handlers
 	// This prevents double-decompression issues with gzip-compressed MessagePack payloads

--- a/internal/telemetry/clients.go
+++ b/internal/telemetry/clients.go
@@ -1,0 +1,177 @@
+package telemetry
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Client-side identity, as reported by arcli.
+//
+// arcli sends a random per-installation UUID on every request
+// (Arcli-Installation-Id) together with its version in User-Agent.
+// The API server hands both to RecordClient for requests that were
+// served (status < 400, so unauthenticated probes cannot fill the set);
+// the collector includes the distinct installations seen since the
+// last successful report in its payload, so the telemetry database can
+// correlate CLI installations with Arc instances. Nothing about the
+// request itself (path, database, token) is recorded.
+
+// maxClients bounds the registry. Beyond it new ids are dropped and
+// the report says Truncated, so a flood of random ids cannot grow
+// memory (256 entries ≈ 25 KB).
+const maxClients = 256
+
+var installationIDRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// ClientsInfo is the "clients" object in the telemetry payload.
+type ClientsInfo struct {
+	Arcli *ArcliClients `json:"arcli,omitempty"`
+}
+
+// ArcliClients lists the arcli installations seen since the last report.
+type ArcliClients struct {
+	Installations int           `json:"installations"` // == len(List)
+	Truncated     bool          `json:"truncated"`     // at least one more distinct id was seen and dropped
+	List          []ArcliClient `json:"list"`
+}
+
+// ArcliClient is one installation.
+type ArcliClient struct {
+	ID       string `json:"id"`
+	Version  string `json:"version"`
+	LastSeen string `json:"last_seen"` // RFC 3339, UTC
+}
+
+type clientEntry struct {
+	version  string
+	lastSeen time.Time
+}
+
+// clientRegistry is the bounded, mutex-protected set behind
+// Collector.RecordClient. One lock per recorded request; requests
+// without the header never touch it.
+type clientRegistry struct {
+	mu        sync.Mutex
+	seen      map[string]clientEntry
+	truncated bool
+}
+
+func newClientRegistry() *clientRegistry {
+	return &clientRegistry{seen: make(map[string]clientEntry)}
+}
+
+// record stores or refreshes an installation. Invalid ids and
+// over-long versions are rejected before the lock is taken; the strings
+// must already be owned by the caller (not fasthttp buffer views).
+func (r *clientRegistry) record(id, version string, now time.Time) {
+	if len(id) != 36 || !installationIDRe.MatchString(id) {
+		return
+	}
+	version = cleanVersion(version)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.seen[id]; !ok && len(r.seen) >= maxClients {
+		r.truncated = true
+		return
+	}
+	r.seen[id] = clientEntry{version: version, lastSeen: now}
+}
+
+// take returns the current set rendered for the payload and starts a
+// fresh window, so records arriving during the send are not lost. The
+// returned window is handed back to restore() if the send fails; nil
+// means nothing was seen (the payload omits "clients").
+func (r *clientRegistry) take() (*ClientsInfo, *clientWindow) {
+	if r == nil {
+		return nil, nil
+	}
+	r.mu.Lock()
+	seen, truncated := r.seen, r.truncated
+	r.seen, r.truncated = make(map[string]clientEntry), false
+	r.mu.Unlock()
+	if len(seen) == 0 {
+		return nil, nil
+	}
+	list := make([]ArcliClient, 0, len(seen))
+	for id, e := range seen {
+		list = append(list, ArcliClient{ID: id, Version: e.version, LastSeen: e.lastSeen.UTC().Format(time.RFC3339)})
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].ID < list[j].ID })
+	return &ClientsInfo{Arcli: &ArcliClients{Installations: len(list), Truncated: truncated, List: list}},
+		&clientWindow{seen: seen, truncated: truncated}
+}
+
+type clientWindow struct {
+	seen      map[string]clientEntry
+	truncated bool
+}
+
+// restore merges a window back after a failed send. Entries recorded
+// since (newer) win; the bound still applies.
+func (r *clientRegistry) restore(w *clientWindow) {
+	if r == nil || w == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, e := range w.seen {
+		if _, ok := r.seen[id]; ok {
+			continue
+		}
+		if len(r.seen) >= maxClients {
+			r.truncated = true
+			break
+		}
+		r.seen[id] = e
+	}
+	r.truncated = r.truncated || w.truncated
+}
+
+// pending reports whether anything is waiting to be sent.
+func (r *clientRegistry) pending() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.seen) > 0
+}
+
+// cleanVersion keeps a short printable-ASCII version string; anything
+// else becomes "unknown" rather than a payload full of junk.
+func cleanVersion(v string) string {
+	if v == "" || len(v) > 32 {
+		return "unknown"
+	}
+	for i := 0; i < len(v); i++ {
+		if v[i] < 0x21 || v[i] > 0x7e {
+			return "unknown"
+		}
+	}
+	return v
+}
+
+// RecordClient notes that an arcli installation was served by this
+// node. Safe on a nil collector (telemetry disabled): it does nothing.
+func (c *Collector) RecordClient(id, version string) {
+	if c == nil || c.clients == nil {
+		return
+	}
+	c.clients.record(id, version, time.Now())
+}
+
+// flushClients sends one last report at shutdown when clients are
+// waiting, so nodes restarted more often than the interval still report
+// the CLI installations they served. Best effort, bounded by timeout.
+func (c *Collector) flushClients(timeout time.Duration) {
+	if c == nil || c.clients == nil || !c.clients.pending() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	c.logger.Info().Msg("Sending final telemetry beacon (pending CLI clients)")
+	c.sendTelemetryCtx(ctx)
+}

--- a/internal/telemetry/clients_test.go
+++ b/internal/telemetry/clients_test.go
@@ -1,0 +1,155 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+const goodID = "0f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f"
+
+func TestClientRegistry_RecordSnapshotClear(t *testing.T) {
+	r := newClientRegistry()
+	if r.snapshot() != nil {
+		t.Fatal("empty registry must snapshot to nil so the payload omits clients")
+	}
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	r.record(goodID, "26.09.1", now)
+	r.record(goodID, "26.09.2", now.Add(time.Minute)) // refresh keeps one entry, latest version
+	r.record("1f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f", "", now)
+	s := r.snapshot()
+	if s == nil || s.Arcli.Installations != 2 || s.Arcli.Truncated || len(s.Arcli.List) != 2 {
+		t.Fatalf("snapshot: %+v", s)
+	}
+	if !r.pending() {
+		t.Error("pending must be true before the window is taken")
+	}
+	if s.Arcli.List[0].ID != goodID || s.Arcli.List[0].Version != "26.09.2" || s.Arcli.List[0].LastSeen != "2026-09-07T12:01:00Z" {
+		t.Errorf("entry: %+v", s.Arcli.List[0])
+	}
+	if s.Arcli.List[1].Version != "unknown" {
+		t.Errorf("empty version must read unknown: %+v", s.Arcli.List[1])
+	}
+	b, _ := json.Marshal(s)
+	if !strings.Contains(string(b), `"arcli":{"installations":2,"truncated":false,"list":[{"id":"`) {
+		t.Errorf("json: %s", b)
+	}
+	// take() starts a new window; restore() merges back after a failed send.
+	info, win := r.take()
+	if info == nil || len(info.Arcli.List) != 2 || r.snapshot() != nil || r.pending() {
+		t.Fatalf("take: info=%+v after=%+v", info, r.snapshot())
+	}
+	r.record("2f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f", "26.09.3", now) // arrives mid-send
+	r.restore(win)
+	if s := r.snapshot(); s == nil || len(s.Arcli.List) != 3 {
+		t.Errorf("restore must merge: %+v", s)
+	}
+	if _, w := r.take(); w == nil {
+		t.Error("window expected")
+	}
+	r.restore(nil) // no-op
+}
+
+// snapshot renders without starting a new window (test helper).
+func (r *clientRegistry) snapshot() *ClientsInfo {
+	info, win := r.take()
+	r.restore(win)
+	return info
+}
+
+func TestClientRegistry_RejectsGarbage(t *testing.T) {
+	r := newClientRegistry()
+	now := time.Now()
+	for _, bad := range []string{"", "abc", strings.Repeat("a", 36), "0F0F0F0F-0F0F-4F0F-8F0F-0F0F0F0F0F0F", goodID + "x", "0f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0\n", strings.Repeat("0", 10000)} {
+		r.record(bad, "26.09.1", now)
+	}
+	if r.snapshot() != nil {
+		t.Errorf("garbage ids must be dropped: %+v", r.snapshot())
+	}
+	r.record(goodID, strings.Repeat("v", 33), now)
+	r.record("2f0f0f0f-0f0f-4f0f-8f0f-0f0f0f0f0f0f", "26.09.1\x1b[31m", now)
+	s := r.snapshot()
+	for _, e := range s.Arcli.List {
+		if e.Version != "unknown" {
+			t.Errorf("bad version must read unknown: %+v", e)
+		}
+	}
+}
+
+func TestClientRegistry_Bounded(t *testing.T) {
+	r := newClientRegistry()
+	now := time.Now()
+	for i := 0; i < maxClients+1000; i++ {
+		r.record(fmt.Sprintf("%08x-0000-4000-8000-000000000000", i), "26.09.1", now)
+	}
+	s := r.snapshot()
+	if len(s.Arcli.List) != maxClients || !s.Arcli.Truncated || s.Arcli.Installations != maxClients {
+		t.Errorf("bounded: listed=%d truncated=%v installations=%d", len(s.Arcli.List), s.Arcli.Truncated, s.Arcli.Installations)
+	}
+	// Known ids still refresh when the map is full.
+	r.record("00000000-0000-4000-8000-000000000000", "26.09.9", now)
+	if r.snapshot().Arcli.List[0].Version != "26.09.9" {
+		t.Error("existing entry must refresh when full")
+	}
+}
+
+func TestRecordClient_NilCollector(t *testing.T) {
+	var c *Collector
+	c.RecordClient(goodID, "x") // must not panic
+	c.flushClients(time.Second)
+	c = &Collector{}
+	c.RecordClient(goodID, "x") // no registry: no-op
+	c.flushClients(time.Second)
+	if info, w := c.clients.take(); info != nil || w != nil || c.clients.pending() {
+		t.Error("nil registry must be inert")
+	}
+	c.clients.restore(nil)
+}
+
+func TestSendTelemetry_WindowSemantics(t *testing.T) {
+	var got []string
+	var status = 500
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		got = append(got, string(b))
+		w.WriteHeader(status)
+	}))
+	defer srv.Close()
+	dir := t.TempDir()
+	c, err := New(&Config{Enabled: true, Endpoint: srv.URL, Interval: time.Hour, DataDir: dir}, "test", zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.RecordClient(goodID, "26.09.1")
+	c.sendTelemetryCtx(context.Background()) // 500: window restored
+	if !strings.Contains(got[0], `"clients":{"arcli":{"installations":1`) || !c.clients.pending() {
+		t.Fatalf("failed send: body=%s pending=%v", got[0], c.clients.pending())
+	}
+	status = 200
+	c.sendTelemetryCtx(context.Background()) // 200: window cleared
+	if !strings.Contains(got[1], goodID) || c.clients.pending() {
+		t.Fatalf("ok send: body=%s pending=%v", got[1], c.clients.pending())
+	}
+	c.sendTelemetryCtx(context.Background()) // nothing pending: no clients key
+	if strings.Contains(got[2], `"clients"`) {
+		t.Errorf("empty window must omit clients: %s", got[2])
+	}
+	// Shutdown flush only when something is pending.
+	c.flushClients(time.Second)
+	if len(got) != 3 {
+		t.Errorf("flush with nothing pending must not send (got %d)", len(got))
+	}
+	c.RecordClient(goodID, "26.09.1")
+	c.flushClients(time.Second)
+	if len(got) != 4 {
+		t.Errorf("flush with pending must send (got %d)", len(got))
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -58,6 +58,8 @@ type Collector struct {
 
 	client *http.Client
 	logger zerolog.Logger
+
+	clients *clientRegistry
 }
 
 // TelemetryPayload represents the data sent to the telemetry endpoint
@@ -69,6 +71,10 @@ type TelemetryPayload struct {
 	OS         OSInfo  `json:"os"`
 	CPU        CPUInfo `json:"cpu"`
 	Memory     MemInfo `json:"memory"`
+
+	// Clients lists the arcli installations seen since the last
+	// successful report (see clients.go). Omitted when none.
+	Clients *ClientsInfo `json:"clients,omitempty"`
 }
 
 // OSInfo contains operating system information
@@ -115,7 +121,8 @@ func New(cfg *Config, version string, logger zerolog.Logger) (*Collector, error)
 		client: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		logger: logger.With().Str("component", "telemetry").Logger(),
+		logger:  logger.With().Str("component", "telemetry").Logger(),
+		clients: newClientRegistry(),
 	}
 
 	return c, nil
@@ -142,6 +149,7 @@ func (c *Collector) Start() {
 func (c *Collector) Stop() {
 	c.cancel()
 	c.wg.Wait()
+	c.flushClients(5 * time.Second)
 	c.logger.Info().Msg("Telemetry collector stopped")
 }
 
@@ -172,8 +180,21 @@ func (c *Collector) run() {
 	}
 }
 
-func (c *Collector) sendTelemetry() {
+func (c *Collector) sendTelemetry() { c.sendTelemetryCtx(c.ctx) }
+
+// sendTelemetryCtx builds and posts one report. The client window is
+// taken before marshalling and restored if the post fails, so a
+// transient outage loses nothing and a success starts a fresh window.
+func (c *Collector) sendTelemetryCtx(ctx context.Context) {
 	payload := c.collectPayload()
+	clients, window := c.clients.take()
+	payload.Clients = clients
+	ok := false
+	defer func() {
+		if !ok {
+			c.clients.restore(window)
+		}
+	}()
 
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -186,7 +207,7 @@ func (c *Collector) sendTelemetry() {
 		Str("instance_id", c.instanceID).
 		Msg("Sending telemetry")
 
-	req, err := http.NewRequestWithContext(c.ctx, "POST", c.config.Endpoint, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.config.Endpoint, bytes.NewReader(data))
 	if err != nil {
 		c.logger.Error().Err(err).Msg("Failed to create telemetry request")
 		return
@@ -208,6 +229,7 @@ func (c *Collector) sendTelemetry() {
 	}
 
 	c.logger.Info().Int("status", resp.StatusCode).Msg("Telemetry sent successfully")
+	ok = true
 }
 
 func (c *Collector) collectPayload() *TelemetryPayload {


### PR DESCRIPTION
## Summary
Companion to Basekick-Labs/arcli#19. arcli now sends a random per-installation UUID (`Arcli-Installation-Id`) and a versioned `User-Agent`. This PR makes Arc record the installations it served and include them in its existing opt-out telemetry, so the telemetry database can correlate CLI installations with instances.

- `internal/telemetry`: bounded registry (256 ids, `truncated` beyond), `RecordClient` (nil-safe), take/restore windows around each send (records arriving mid-send survive, a failed send restores), best-effort 5 s flush at shutdown, payload gains `"clients": {"arcli": {"installations", "truncated", "list": [{id, version, last_seen}]}}` — omitted when nothing was seen. Telemetry disabled → no middleware at all.
- `internal/api`: `clientIdentity` middleware records only after the request was served (`err == nil`, status < 400) **and** only when the auth middleware validated a token on that request (`auth.GetTokenInfo`), so unauthenticated probes (`/health` in any spelling) can never fill or evict the registry; header values are `strings.Clone`d out of the fasthttp buffer (Fiber runs without `Immutable`); the header is added to `clientForwardingHeaders` so a forwarded request counts once, on the entry node.
- `cmd/arc/main.go`: `ServerConfig.ClientRecorder`/`AuthRequired` set only for a live collector.
- Nothing about the request (database, query, token) is recorded; the id is never logged. Docs PR on docs.basekick.net updates both telemetry pages.

## Test plan
- [x] `go test -race ./internal/telemetry/` (registry bounds, garbage rejection, take/restore, window semantics against a fake endpoint incl. failed send + shutdown flush)
- [x] `go test ./internal/api/ -run 'ClientIdentity|ArcliVersion'` (records on served requests; ignores 401s, error-returning handlers, unknown routes, public routes in any casing/trailing slash, short ids; requires a validated token when auth is on; stored strings survive buffer reuse)
- [x] `make build`; end-to-end on a laptop with `ARC_TELEMETRY_INTERVAL_SECONDS=25` against the patched telemetry server: anonymous probes and bad-token requests → nothing; one authenticated arcli query → one correlated row
- [ ] CI
