### PR TITLE
docs(release-notes): record the gRPC 1.83.2 bump in 26.09.2

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -63,6 +63,25 @@ an indirect dependency reached through arrow-go's Parquet metadata decoding
 (Parquet footers are Thrift-encoded), so the vulnerable code is in Arc's build.
 The ingest, API, query, and Iceberg test suites were verified against 0.24.0.
 
+### Dependency bump: gRPC-Go 1.83.1 → 1.83.2 ([#710](https://github.com/Basekick-Labs/arc/pull/710))
+
+`google.golang.org/grpc` is bumped to 1.83.2, which rejects requests missing
+both the `:authority` and `Host` headers instead of serving them. The fix is
+server-side, and Arc never starts a gRPC server or client — the library is
+linked in transitively through arrow-go's Flight package — so the vulnerable
+path was not reachable, but the code is no longer in the binary and dependency
+scanners come up clean.
+
+The upgrade carries gRPC's own minimum-version requirements with it, so the
+same bump moves `golang.org/x/net` (0.55.0 → 0.58.0), `golang.org/x/crypto`
+(0.53.0 → 0.55.0), `golang.org/x/text` (0.39.0 → 0.41.0), `golang.org/x/sync`
+(0.21.0 → 0.22.0), `golang.org/x/sys` (0.46.0 → 0.47.0), plus `golang.org/x/mod`
+and `golang.org/x/term`. Two of those are load-bearing for Arc: `x/crypto`
+supplies bcrypt for auth password hashing, and `x/sync` supplies the semaphore
+and errgroup primitives used by tiering and Iceberg. The auth, cluster-security,
+tiering, and Iceberg suites were verified against the new versions, the latter
+two under `-race`.
+
 ## Bug fixes
 
 ### Arrow IPC streaming has direct disconnect regression coverage ([#425](https://github.com/Basekick-Labs/arc/issues/425))


### PR DESCRIPTION
Documents the dependency bump merged in #710 (`b28611a`) in the 26.09.2 release notes.

## Summary

- Adds an entry under **Security fixes** in `RELEASE_NOTES_2026.09.2.md`, alongside the existing Thrift entry, following the wording precedent set by the previous gRPC bump (#628 in 26.09.1).
- Records the server-side nature of the fix (requests missing both `:authority` and `Host` are now rejected) and notes that the path was **not reachable** in Arc: Arc starts no gRPC server or client, and grpc is linked transitively through arrow-go's Flight package.
- Spells out **all eight** modules the bump moves. The PR title on #710 mentions only grpc, which hides that `golang.org/x/net` and `golang.org/x/crypto` each moved two minor versions; anyone auditing the release diff against the notes would otherwise hit an unexplained gap.
- Calls out the two load-bearing modules — `x/crypto` (bcrypt, auth password hashing) and `x/sync` (semaphore/errgroup in tiering and Iceberg) — and the verification they got.

No CVE/GHSA identifier is cited: gRPC's release notes reference only grpc-go#9365, with no advisory assigned.

Docs-only change; no code touched.

## Test plan

- [x] All eight version strings in the note verified against the merged `go.mod` on main (grpc 1.83.2, x/net 0.58.0, x/crypto 0.55.0, x/text 0.41.0, x/sync 0.22.0, x/sys 0.47.0, x/mod 0.38.0, x/term 0.45.0)
- [x] Entry placed under the existing `## Security fixes` heading, above `## Bug fixes`
- [x] Verified on #710 before merge: `go mod tidy` produced zero drift, `go build ./cmd/... ./internal/...` OK, `go vet` clean
- [x] `go test ./internal/auth/... ./internal/cluster/security/...` pass
- [x] `go test -race ./internal/tiering/... ./internal/iceberg/...` pass