### PR TITLE
fix(auth): enforce token expiry on cache hits

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -82,7 +82,45 @@ and errgroup primitives used by tiering and Iceberg. The auth, cluster-security,
 tiering, and Iceberg suites were verified against the new versions, the latter
 two under `-race`.
 
+### Expired API tokens are now rejected on cache hits
+
+Arc caches successful token verifications in memory for `auth.cache_ttl`
+seconds (default 300) so that ingestion does not pay a SQLite lookup per
+request. That cache checked only its own entry deadline, not the token's
+`expires_at`, so a token that expired *while cached* kept authorizing requests
+until the entry aged out — up to one cache TTL past the expiry an operator
+configured. The same token was correctly rejected whenever the lookup reached
+the database, so the behaviour depended on cache state rather than on the
+credential.
+
+Token expiry is now enforced on every request regardless of cache state: an
+entry whose token has expired is evicted and re-validated against the database,
+which rejects it. Cache entries are additionally never held past the token's own
+expiry. Revoking, deleting, updating, or rotating a token already invalidated
+the cache immediately and was never affected; only passive expiry was.
+
+Full technical detail will accompany the corresponding security advisory once it
+is published. Responsibly reported by **[@rexpository](https://github.com/rexpository)**.
+
 ## Bug fixes
+
+### Token `expires_at` is now stored in UTC
+
+`api_tokens.created_at` is filled by SQLite's `CURRENT_TIMESTAMP` and is always
+UTC, but `expires_at` was bound as a Go `time.Time` and text-encoded using the
+caller's own location — so an Arc running in a non-UTC zone stored
+`2026-09-10 15:32:45.958903-06:00` in one column and `2026-09-10 21:32:41` in
+the other. Both denote the same instant and expiry enforcement compares parsed
+values in Go, so no token was ever accepted or rejected incorrectly; the effect
+was two timezone domains in one table and the two columns rendering in
+different zones over the token API.
+
+Writes now normalize to UTC on both the create and update paths, matching the
+clustered apply path, which already did this ([#459](https://github.com/Basekick-Labs/arc/pull/459) /
+[#460](https://github.com/Basekick-Labs/arc/issues/460)), and the "Arc-stamped timestamps are
+UTC" rule from [#546](https://github.com/Basekick-Labs/arc/issues/546). Existing rows are left as
+they are — they parse back correctly and are compared as instants, never as
+strings.
 
 ### Arrow IPC streaming has direct disconnect regression coverage ([#425](https://github.com/Basekick-Labs/arc/issues/425))
 

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -106,21 +106,24 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ### Token `expires_at` is now stored in UTC
 
-`api_tokens.created_at` is filled by SQLite's `CURRENT_TIMESTAMP` and is always
-UTC, but `expires_at` was bound as a Go `time.Time` and text-encoded using the
-caller's own location — so an Arc running in a non-UTC zone stored
-`2026-09-10 15:32:45.958903-06:00` in one column and `2026-09-10 21:32:41` in
-the other. Both denote the same instant and expiry enforcement compares parsed
-values in Go, so no token was ever accepted or rejected incorrectly; the effect
-was two timezone domains in one table and the two columns rendering in
-different zones over the token API.
+`api_tokens.expires_at` is written as a Go `time.Time`, and go-sqlite3
+text-encodes those using the value's own location. An Arc running in a non-UTC
+zone therefore stored `2026-09-10 15:32:45.958903-06:00` where a UTC one stored
+`2026-09-10 21:32:45.958903+00:00` for the very same instant. Both parse back
+correctly and expiry is compared as a parsed instant in Go, so no token was ever
+accepted or rejected incorrectly — but two rows holding the same moment sorted
+differently as text, so any future SQL comparison on the column would have
+disagreed with itself depending on which node wrote the row.
 
-Writes now normalize to UTC on both the create and update paths, matching the
+Writes now normalize to UTC on the create and update paths, matching the
 clustered apply path, which already did this ([#459](https://github.com/Basekick-Labs/arc/pull/459) /
 [#460](https://github.com/Basekick-Labs/arc/issues/460)), and the "Arc-stamped timestamps are
-UTC" rule from [#546](https://github.com/Basekick-Labs/arc/issues/546). Existing rows are left as
-they are — they parse back correctly and are compared as instants, never as
-strings.
+UTC" rule from [#546](https://github.com/Basekick-Labs/arc/issues/546). Note this removes the
+offset *variance*; it does not make the column text-comparable with
+`created_at`, which SQLite's `CURRENT_TIMESTAMP` writes without an offset or
+fractional seconds. `expires_at` is still compared as a parsed instant, never as
+a string. Existing rows are left as they are — they parse back to the correct
+instant, so no token's lifetime changes.
 
 ### Arrow IPC streaming has direct disconnect regression coverage ([#425](https://github.com/Basekick-Labs/arc/issues/425))
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -72,7 +72,19 @@ type TokenInfo struct {
 	ExpiresAt  *time.Time `json:"expires_at"`
 }
 
-// cacheEntry represents a cached token
+// cacheEntry represents a cached token.
+//
+// Two distinct expiries are in play and must not be confused:
+//
+//   - expiresAt (this struct) is the CACHE deadline — how long this memoized
+//     lookup may be reused before it must be re-read from SQLite. Derived from
+//     cacheTTL, capped at the token's own expiry (see VerifyToken).
+//   - info.ExpiresAt is the TOKEN's credential expiry — the point past which
+//     the token is no longer a valid credential at all, regardless of caching.
+//
+// VerifyToken enforces info.ExpiresAt on the cache-hit path as well as the
+// database path. Checking only the cache deadline let a token that expired
+// while cached stay authorized for up to cacheTTL.
 type cacheEntry struct {
 	info      *TokenInfo
 	expiresAt time.Time
@@ -720,9 +732,19 @@ func generateToken() (string, error) {
 // sentinel is never double-resolved.
 func (am *AuthManager) insertToken(hash, prefix, name, description, permissions string, expiresAt *time.Time) error {
 
+	// .UTC(): go-sqlite3 text-encodes a time.Time using the value's own
+	// location, so a caller in a non-UTC zone would store
+	// "2026-09-10 15:32:45.958903-06:00" here while the sibling created_at,
+	// filled by SQLite's CURRENT_TIMESTAMP, is always UTC ("2026-09-10
+	// 21:32:41"). Both denote the same instant and Go parses either back
+	// correctly, but storing two formats in one table invites a future
+	// string-domain comparison to silently disagree, and the API then renders
+	// the two columns in different zones. Normalize on write, matching the
+	// cluster apply path (ApplyCreateToken, #459/#460) and the "Arc-stamped
+	// timestamps are UTC" rule from #546.
 	var expiresAtVal interface{}
 	if expiresAt != nil {
-		expiresAtVal = *expiresAt
+		expiresAtVal = expiresAt.UTC()
 	}
 
 	_, err := am.db.Exec(`
@@ -830,13 +852,31 @@ func (am *AuthManager) VerifyToken(token string) *TokenInfo {
 
 	// Check cache first
 	am.cacheMu.RLock()
-	if entry, ok := am.cache[key]; ok && now.Before(entry.expiresAt) {
-		am.cacheMu.RUnlock()
-		am.cacheHits.Add(1)
-		metrics.Get().IncAuthCacheHit()
-		return entry.info
-	}
+	entry, cached := am.cache[key]
 	am.cacheMu.RUnlock()
+
+	if cached && now.Before(entry.expiresAt) {
+		if entry.info.ExpiresAt != nil && now.After(*entry.info.ExpiresAt) {
+			// The token expired while this entry was still within its cache
+			// TTL. The cache deadline alone does not imply the credential is
+			// still valid, so evict and fall through to the database path,
+			// which owns the "token has expired" decision and its log line.
+			//
+			// The pointer comparison keeps this safe against a concurrent
+			// refill: the map holds cacheEntry by value and every insert below
+			// allocates a fresh *TokenInfo, so a newer entry for the same key
+			// is never mistaken for the one just read.
+			am.cacheMu.Lock()
+			if cur, still := am.cache[key]; still && cur.info == entry.info {
+				delete(am.cache, key)
+			}
+			am.cacheMu.Unlock()
+		} else {
+			am.cacheHits.Add(1)
+			metrics.Get().IncAuthCacheHit()
+			return entry.info
+		}
+	}
 
 	am.cacheMisses.Add(1)
 	metrics.Get().IncAuthCacheMiss()
@@ -928,9 +968,20 @@ func (am *AuthManager) VerifyToken(token string) *TokenInfo {
 				am.cacheEvictions.Add(1)
 			}
 		}
+		// Cap the cache deadline at the token's own expiry. Defense in depth:
+		// the read path already rejects an entry whose token has expired, and
+		// this additionally keeps cleanupExpiredCache and the size-eviction
+		// scan above (both of which order by the cache deadline) from holding
+		// or preferring entries that can no longer authorize anything. The
+		// expiry is always in the future here — the database path above
+		// rejects an already-expired token before reaching this point.
+		deadline := now.Add(am.cacheTTL)
+		if info.ExpiresAt != nil && info.ExpiresAt.Before(deadline) {
+			deadline = *info.ExpiresAt
+		}
 		am.cache[key] = cacheEntry{
 			info:      info,
-			expiresAt: now.Add(am.cacheTTL),
+			expiresAt: deadline,
 		}
 		am.cacheMu.Unlock()
 
@@ -1114,7 +1165,9 @@ func (am *AuthManager) UpdateToken(ctx context.Context, id int64, name, descript
 	}
 	if expiresAt != nil {
 		updates = append(updates, "expires_at = ?")
-		args = append(args, *expiresAt)
+		// .UTC() for the same reason as insertToken: keep one timezone
+		// domain in the column.
+		args = append(args, expiresAt.UTC())
 	}
 
 	if len(updates) == 0 {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -733,15 +733,20 @@ func generateToken() (string, error) {
 func (am *AuthManager) insertToken(hash, prefix, name, description, permissions string, expiresAt *time.Time) error {
 
 	// .UTC(): go-sqlite3 text-encodes a time.Time using the value's own
-	// location, so a caller in a non-UTC zone would store
-	// "2026-09-10 15:32:45.958903-06:00" here while the sibling created_at,
-	// filled by SQLite's CURRENT_TIMESTAMP, is always UTC ("2026-09-10
-	// 21:32:41"). Both denote the same instant and Go parses either back
-	// correctly, but storing two formats in one table invites a future
-	// string-domain comparison to silently disagree, and the API then renders
-	// the two columns in different zones. Normalize on write, matching the
-	// cluster apply path (ApplyCreateToken, #459/#460) and the "Arc-stamped
-	// timestamps are UTC" rule from #546.
+	// location, so without this a caller in a non-UTC zone stores
+	// "2026-09-10 15:32:45.958903-06:00" while the same instant from a UTC
+	// caller stores "2026-09-10 21:32:45.958903+00:00". Go parses either back
+	// to the correct instant, but the varying offset means two rows holding
+	// the same moment sort differently as text — so a future
+	// `WHERE expires_at > ?` would silently disagree with itself depending on
+	// which node wrote the row. Normalizing on write removes that variance,
+	// matching the cluster apply path (ApplyCreateToken, #459/#460) and the
+	// "Arc-stamped timestamps are UTC" rule from #546.
+	//
+	// This does NOT make the column string-comparable with created_at, which
+	// SQLite's CURRENT_TIMESTAMP writes without an offset or fractional
+	// seconds ("2026-09-10 21:32:45"). expires_at must keep being compared as
+	// a parsed instant (see VerifyToken), never as text.
 	var expiresAtVal interface{}
 	if expiresAt != nil {
 		expiresAtVal = expiresAt.UTC()

--- a/internal/auth/cache_expiry_test.go
+++ b/internal/auth/cache_expiry_test.go
@@ -193,8 +193,7 @@ func TestVerifyToken_CacheDeadlineCappedAtTokenExpiry(t *testing.T) {
 }
 
 // TestVerifyToken_ExpiresWhileCached_EndToEnd is the real-path proof: no
-// planted state, a token that genuinely expires between two verifications
-// while its cache entry is still live.
+// planted state, a token that genuinely expires between two verifications.
 //
 // The window is seconds rather than milliseconds because CreateToken and the
 // first VerifyToken each run PBKDF2 at pbkdf2Iterations, which is materially
@@ -216,9 +215,16 @@ func TestVerifyToken_ExpiresWhileCached_EndToEnd(t *testing.T) {
 
 	missesBefore := am.cacheMisses.Load()
 
-	// Wait for the credential to expire. The cache entry is capped at the
-	// token expiry, so this also proves the entry is not simply gone: the
-	// assertions below distinguish the two paths.
+	// Wait for the credential to expire.
+	//
+	// Note which half of the fix this exercises: because cache entries are
+	// capped at the token's expiry, the entry is still in the map but its
+	// deadline has passed, so this second call takes a natural cache miss and
+	// is rejected by the database path. That makes this an end-to-end proof of
+	// the CAP, not of the cache-hit expiry check — the deterministic
+	// TestVerifyToken_CachedTokenRejectedAfterExpiry and
+	// TestMiddleware_CachedExpiredToken cover that branch, where the entry's
+	// own deadline is still live.
 	time.Sleep(time.Until(expiresAt) + 250*time.Millisecond)
 
 	if info := am.VerifyToken(token); info != nil {
@@ -260,16 +266,30 @@ func TestCreateToken_ExpiresAtStoredInUTC(t *testing.T) {
 
 	assertStoredUTC := func(stage string) {
 		t.Helper()
-		var stored string
-		if err := am.db.QueryRow("SELECT expires_at FROM api_tokens WHERE name = ?", "utc-storage").Scan(&stored); err != nil {
+
+		// Assert on the parsed value's zone offset, not on any text form.
+		// Scanning into a string would show the driver's RFC3339
+		// re-rendering ("...Z" / "...-06:00") rather than the bytes on
+		// disk, so a string assertion tests the driver, not the write.
+		// The offset is what actually matters and is encoding-independent.
+		var parsed time.Time
+		if err := am.db.QueryRow("SELECT expires_at FROM api_tokens WHERE name = ?", "utc-storage").Scan(&parsed); err != nil {
 			t.Fatalf("%s: read expires_at: %v", stage, err)
 		}
-		// go-sqlite3 appends the zone offset for non-UTC values ("-06:00")
-		// and writes a bare "...Z"-less UTC string otherwise. Either an
-		// explicit offset or a trailing zone name means the value did not
-		// land in UTC.
-		if strings.Contains(stored, "+") || strings.Contains(stored, "-06:00") {
-			t.Errorf("%s: expires_at stored with a zone offset, expected UTC: %q", stage, stored)
+		if _, offset := parsed.Zone(); offset != 0 {
+			t.Errorf("%s: expires_at stored with a non-zero zone offset (%+d seconds), expected UTC: %v", stage, offset, parsed)
+		}
+
+		// Belt and braces: pin the bytes actually on disk. go-sqlite3
+		// text-encodes using the value's own location, so a UTC write
+		// lands as "2026-09-10 21:32:45.958903+00:00" — space-separated,
+		// with an explicit +00:00 rather than a bare Z.
+		var raw string
+		if err := am.db.QueryRow("SELECT CAST(expires_at AS TEXT) FROM api_tokens WHERE name = ?", "utc-storage").Scan(&raw); err != nil {
+			t.Fatalf("%s: read raw expires_at: %v", stage, err)
+		}
+		if !strings.HasSuffix(raw, "+00:00") {
+			t.Errorf("%s: expires_at not stored with a +00:00 offset: %q", stage, raw)
 		}
 	}
 

--- a/internal/auth/cache_expiry_test.go
+++ b/internal/auth/cache_expiry_test.go
@@ -1,0 +1,288 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression tests for the token cache honoring the token's own expiry.
+//
+// VerifyToken memoizes a successful lookup for up to cacheTTL. The cache-hit
+// branch used to test only that cache deadline, so a token that expired while
+// cached stayed authorized until the entry aged out — a cache miss rejected the
+// same credential that a cache hit accepted. These tests pin the invariant that
+// an expired token is rejected on every path.
+
+// expireToken moves a token's expiry to the given instant in BOTH the database
+// row and the live cache entry, simulating "time passed and the token expired"
+// without sleeping.
+//
+// Both must move together. Rewriting only the cached copy does not model
+// expiry: the cache-hit check would reject and fall through to the database,
+// which still holds the original expiry, so the token would be re-validated and
+// re-cached — the token is genuinely still valid, and the test would be
+// asserting the wrong thing. Writing the row directly (rather than via
+// UpdateToken) deliberately skips the automatic cache invalidation, which is
+// what leaves a live cache entry for an expired credential — precisely the
+// state this fix is about.
+//
+// The cache entry's own deadline is left untouched and in the future, so these
+// tests exercise the cache-hit branch rather than a natural cache miss.
+func expireToken(t *testing.T, am *AuthManager, token string, expiresAt time.Time) {
+	t.Helper()
+
+	if _, err := am.db.Exec("UPDATE api_tokens SET expires_at = ? WHERE token_prefix = ?", expiresAt, tokenPrefix(token)); err != nil {
+		t.Fatalf("update expires_at: %v", err)
+	}
+
+	am.cacheMu.Lock()
+	defer am.cacheMu.Unlock()
+
+	entry, ok := am.cache[cacheKey(token)]
+	if !ok {
+		t.Fatal("token is not cached; the test needs a populated cache entry to be meaningful")
+	}
+	entry.info.ExpiresAt = &expiresAt
+}
+
+func cachedEntryCount(am *AuthManager) int {
+	am.cacheMu.RLock()
+	defer am.cacheMu.RUnlock()
+	return len(am.cache)
+}
+
+// TestVerifyToken_CachedTokenRejectedAfterExpiry is the primary regression
+// proof. It is deterministic: expiry is moved rather than waited for.
+func TestVerifyToken_CachedTokenRejectedAfterExpiry(t *testing.T) {
+	am, cleanup := setupTestAuthManager(t)
+	defer cleanup()
+
+	expiresAt := time.Now().Add(time.Hour)
+	token, err := am.CreateToken(context.Background(), "cached-expiry", "Expires while cached", "admin", &expiresAt)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	// Populate the cache while the token is still valid.
+	if info := am.VerifyToken(token); info == nil {
+		t.Fatal("VerifyToken returned nil for a valid token")
+	}
+	if cachedEntryCount(am) == 0 {
+		t.Fatal("expected the successful verification to populate the cache")
+	}
+
+	// The token expires; the cache entry's own TTL is still live.
+	expireToken(t, am, token, time.Now().Add(-time.Second))
+
+	if info := am.VerifyToken(token); info != nil {
+		t.Error("VerifyToken accepted a token that expired while cached")
+	}
+
+	// The stale entry must not linger.
+	if cachedEntryCount(am) != 0 {
+		t.Error("expected the expired entry to be evicted from the cache")
+	}
+
+	// And it stays rejected once the database is consulted again.
+	if info := am.VerifyToken(token); info != nil {
+		t.Error("VerifyToken accepted an expired token on the database path")
+	}
+}
+
+// TestVerifyToken_CachedTokenValidBeforeExpiry is the negative control: the
+// fix must not reject tokens that are merely close to expiring.
+func TestVerifyToken_CachedTokenValidBeforeExpiry(t *testing.T) {
+	am, cleanup := setupTestAuthManager(t)
+	defer cleanup()
+
+	expiresAt := time.Now().Add(time.Hour)
+	token, err := am.CreateToken(context.Background(), "not-yet-expired", "Still valid", "read", &expiresAt)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	if info := am.VerifyToken(token); info == nil {
+		t.Fatal("VerifyToken returned nil for a valid token")
+	}
+
+	// Expiry moved close, but still in the future.
+	expireToken(t, am, token, time.Now().Add(2*time.Second))
+
+	if info := am.VerifyToken(token); info == nil {
+		t.Error("VerifyToken rejected a token that has not expired yet")
+	}
+	if cachedEntryCount(am) == 0 {
+		t.Error("a still-valid token should remain cached")
+	}
+}
+
+// TestVerifyToken_NonExpiringTokenUnaffected guards the common case: tokens
+// created without an expiry must keep the full cache TTL.
+func TestVerifyToken_NonExpiringTokenUnaffected(t *testing.T) {
+	am, cleanup := setupTestAuthManager(t)
+	defer cleanup()
+
+	token, err := am.CreateToken(context.Background(), "no-expiry", "Never expires", "read", nil)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	info := am.VerifyToken(token)
+	if info == nil {
+		t.Fatal("VerifyToken returned nil for a valid token")
+	}
+	if info.ExpiresAt != nil {
+		t.Fatalf("expected no expiry, got %v", info.ExpiresAt)
+	}
+
+	am.cacheMu.RLock()
+	entry, ok := am.cache[cacheKey(token)]
+	am.cacheMu.RUnlock()
+	if !ok {
+		t.Fatal("expected the token to be cached")
+	}
+
+	// Deadline should be the full cache TTL, not capped by anything.
+	if remaining := time.Until(entry.expiresAt); remaining < am.cacheTTL-time.Minute {
+		t.Errorf("non-expiring token got a shortened cache deadline: %v remaining, cacheTTL %v", remaining, am.cacheTTL)
+	}
+
+	// Repeated verification keeps succeeding from cache.
+	if info := am.VerifyToken(token); info == nil {
+		t.Error("VerifyToken rejected a non-expiring token on a cache hit")
+	}
+}
+
+// TestVerifyToken_CacheDeadlineCappedAtTokenExpiry pins the defense-in-depth
+// half of the fix: an entry is never cached past the credential's own life.
+func TestVerifyToken_CacheDeadlineCappedAtTokenExpiry(t *testing.T) {
+	am, cleanup := setupTestAuthManager(t)
+	defer cleanup()
+
+	// Well inside the 5-minute cache TTL the test manager uses.
+	expiresAt := time.Now().Add(30 * time.Second)
+	token, err := am.CreateToken(context.Background(), "short-lived", "Expires before the cache TTL", "read", &expiresAt)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	info := am.VerifyToken(token)
+	if info == nil {
+		t.Fatal("VerifyToken returned nil for a valid token")
+	}
+	if info.ExpiresAt == nil {
+		t.Fatal("expected the token to carry an expiry")
+	}
+
+	am.cacheMu.RLock()
+	entry, ok := am.cache[cacheKey(token)]
+	am.cacheMu.RUnlock()
+	if !ok {
+		t.Fatal("expected the token to be cached")
+	}
+
+	// SQLite round-trips the timestamp, so compare instants, not structs.
+	if !entry.expiresAt.Equal(*info.ExpiresAt) {
+		t.Errorf("cache deadline should be capped at the token expiry:\n  cache deadline %v\n  token expiry   %v", entry.expiresAt, *info.ExpiresAt)
+	}
+	if entry.expiresAt.After(time.Now().Add(am.cacheTTL)) {
+		t.Error("cache deadline exceeds the cache TTL")
+	}
+}
+
+// TestVerifyToken_ExpiresWhileCached_EndToEnd is the real-path proof: no
+// planted state, a token that genuinely expires between two verifications
+// while its cache entry is still live.
+//
+// The window is seconds rather than milliseconds because CreateToken and the
+// first VerifyToken each run PBKDF2 at pbkdf2Iterations, which is materially
+// slower under the race detector used in CI.
+func TestVerifyToken_ExpiresWhileCached_EndToEnd(t *testing.T) {
+	am, cleanup := setupTestAuthManager(t)
+	defer cleanup()
+
+	expiresAt := time.Now().Add(4 * time.Second)
+	token, err := am.CreateToken(context.Background(), "expiring", "Expires mid-test", "admin", &expiresAt)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	info := am.VerifyToken(token)
+	if info == nil {
+		t.Fatal("VerifyToken returned nil before expiry; the token window was too short for this machine")
+	}
+
+	missesBefore := am.cacheMisses.Load()
+
+	// Wait for the credential to expire. The cache entry is capped at the
+	// token expiry, so this also proves the entry is not simply gone: the
+	// assertions below distinguish the two paths.
+	time.Sleep(time.Until(expiresAt) + 250*time.Millisecond)
+
+	if info := am.VerifyToken(token); info != nil {
+		t.Error("VerifyToken accepted the token after it expired")
+	}
+	if am.cacheMisses.Load() <= missesBefore {
+		t.Error("expected the expired token to fall through to the database path")
+	}
+
+	am.InvalidateCache()
+	if info := am.VerifyToken(token); info != nil {
+		t.Error("VerifyToken accepted the expired token after cache invalidation")
+	}
+}
+
+// TestCreateToken_ExpiresAtStoredInUTC pins the storage timezone for
+// expires_at.
+//
+// created_at is filled by SQLite's CURRENT_TIMESTAMP and is therefore always
+// UTC, while expires_at is bound as a Go time.Time — and go-sqlite3 text-encodes
+// those using the value's own location. A caller in a non-UTC zone used to
+// store an offset-bearing string next to a UTC one in the same table. Both are
+// the same instant and Go parses either correctly, so this is not an expiry
+// bypass, but the mixed domain is exactly what the SQLite review checklist
+// warns about and it makes the two columns render in different zones over the
+// API. The cluster apply path already normalizes (#459/#460); this covers the
+// standalone path.
+func TestCreateToken_ExpiresAtStoredInUTC(t *testing.T) {
+	am, cleanup := setupTestAuthManager(t)
+	defer cleanup()
+
+	// A deliberately non-UTC expiry, as a caller in any other zone would pass.
+	loc := time.FixedZone("UTC-6", -6*60*60)
+	expiresAt := time.Now().In(loc).Add(time.Hour)
+
+	if _, err := am.CreateToken(context.Background(), "utc-storage", "Zone check", "read", &expiresAt); err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	assertStoredUTC := func(stage string) {
+		t.Helper()
+		var stored string
+		if err := am.db.QueryRow("SELECT expires_at FROM api_tokens WHERE name = ?", "utc-storage").Scan(&stored); err != nil {
+			t.Fatalf("%s: read expires_at: %v", stage, err)
+		}
+		// go-sqlite3 appends the zone offset for non-UTC values ("-06:00")
+		// and writes a bare "...Z"-less UTC string otherwise. Either an
+		// explicit offset or a trailing zone name means the value did not
+		// land in UTC.
+		if strings.Contains(stored, "+") || strings.Contains(stored, "-06:00") {
+			t.Errorf("%s: expires_at stored with a zone offset, expected UTC: %q", stage, stored)
+		}
+	}
+
+	assertStoredUTC("after create")
+
+	// The same rule applies to updates.
+	newExpiry := time.Now().In(loc).Add(2 * time.Hour)
+	var id int64
+	if err := am.db.QueryRow("SELECT id FROM api_tokens WHERE name = ?", "utc-storage").Scan(&id); err != nil {
+		t.Fatalf("lookup id: %v", err)
+	}
+	if err := am.UpdateToken(context.Background(), id, nil, nil, nil, &newExpiry); err != nil {
+		t.Fatalf("UpdateToken: %v", err)
+	}
+	assertStoredUTC("after update")
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -647,4 +648,50 @@ func containsHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestMiddleware_CachedExpiredToken rejects a token that expired while its
+// cache entry was still live. TestMiddleware_ExpiredToken above covers the
+// token that was already expired on first use, which reaches the database
+// path; this covers the cache-hit path, which used to skip the expiry check.
+func TestMiddleware_CachedExpiredToken(t *testing.T) {
+	config := DefaultMiddlewareConfig()
+	am, app, cleanup := setupMiddlewareTest(t, config)
+	defer cleanup()
+
+	expiresAt := time.Now().Add(time.Hour)
+	token, err := am.CreateToken(context.Background(), "cached-expiry", "Expires while cached", "read", &expiresAt)
+	if err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	newRequest := func() *http.Request {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		return req
+	}
+
+	// First request succeeds and populates the token cache.
+	resp, err := app.Test(newRequest(), testTimeoutMS)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("Expected status 200 before expiry, got %d", resp.StatusCode)
+	}
+
+	// The token expires while the cache entry is still within its TTL. The
+	// database row and the cached copy move together (see expireToken in
+	// cache_expiry_test.go): moving only the cached copy would leave the
+	// database saying the token is still valid, so it would simply be
+	// re-validated and re-cached.
+	expireToken(t, am, token, time.Now().Add(-time.Second))
+
+	resp, err = app.Test(newRequest(), testTimeoutMS)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("Expected status 401 for a token that expired while cached, got %d", resp.StatusCode)
+	}
 }


### PR DESCRIPTION
Closes a token-expiry gap in `AuthManager.VerifyToken`, plus a timezone inconsistency found while verifying it on a live binary.

Detail accompanies the forthcoming security advisory. Reported by @rexpository.

## Summary

- **Expiry is now enforced on the cache-hit path.** `VerifyToken` memoizes a successful lookup for up to `auth.cache_ttl` (default 300s). The cache-hit branch checked only that entry deadline, never the token's own `expires_at`, so a token that expired *while cached* kept authorizing requests until the entry aged out. The same token was correctly rejected whenever the lookup reached SQLite, so authorization depended on cache state rather than on the credential. An entry whose token has expired is now evicted and re-validated against the database, which rejects it.
- **Cache entries are never held past the token's own expiry** (defense in depth), so `cleanupExpiredCache` and the size-eviction scan — both of which order by the cache deadline — cannot prefer entries that can no longer authorize anything.
- **`expires_at` now stored in UTC** on the standalone create and update paths. `created_at` comes from SQLite's `CURRENT_TIMESTAMP` (always UTC) while `expires_at` was text-encoded in the caller's own location, so a non-UTC deployment stored `2026-09-10 15:32:45.958903-06:00` beside `2026-09-10 21:32:41` in the same table. The clustered apply path already normalized ([#459](https://github.com/Basekick-Labs/arc/pull/459)/[#460](https://github.com/Basekick-Labs/arc/issues/460)); this matches it and the "Arc-stamped timestamps are UTC" rule from [#546](https://github.com/Basekick-Labs/arc/issues/546).

**Scope:** revoke, delete, update and rotate all call `InvalidateCache()` and were never affected — only passive expiry was. No token was ever accepted or rejected incorrectly by the timezone issue: expiry is compared as parsed instants in Go, never as strings, and there is no SQL-level comparison on the column. Existing rows are left as they are.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| `auth.enabled=false` | No — `authManager == nil`, middleware calls `c.Next()` (`middleware.go:114`) | n/a |
| Auth on, `auth.cache_ttl=300` (default) | Yes — cache-hit branch `auth.go:855` | `entry.info` non-nil by construction (`auth.go:983`) |
| **Auth on, `auth.cache_ttl=600` (NON-DEFAULT)** | Yes — exercised in the live binary run below; startup log confirms `"cache_ttl":600` | 200 while valid, 401 after expiry |
| `auth.cache_ttl=0` / negative (non-default) | No hit ever (`now.Before(now)` is false) → DB lookup each time | No panic; `cleanupLoop` clamps its ticker to 10s (`auth.go:468`) |
| `auth.max_cache_size` small (non-default) | Yes — victim is the soonest `expiresAt`, now capped at token expiry | Expiring tokens evicted first; harmless |
| Non-expiring token (`ExpiresAt == nil`) | Nil-guarded before deref (`auth.go:856`) | Full cache TTL preserved (test) |
| Token already expired at first verify | No — DB path rejects before caching (`auth.go:915`) | Unchanged |
| Cluster mode, FSM-applied tokens | Same `VerifyToken`; those writes already UTC (`cluster_apply.go:159`) | `InvalidateCache` on apply unchanged |
| `GET /api/v1/auth/verify` | Yes — second caller of `VerifyToken` | Live-verified 401 after expiry |

## Test plan

- [x] **Pre-fix proof (revert-run-restore):** with `auth.go` reverted to `HEAD`, the four new regression tests FAIL for the right reasons — `200` instead of `401`, uncapped cache deadline, no eviction, offset-bearing `expires_at`. Two negative controls pass in both states.
- [x] `go test -race ./internal/auth/...` — **ok, 179s**, full package
- [x] `gofmt -l ./internal/auth` empty; `go vet ./internal/auth/...` clean
- [x] **Live binary** (`go build -tags=duckdb_arrow`), `auth.cache_ttl=600`, token created via `POST /api/v1/auth/tokens` with `expires_in`: `200/200/200` while valid → `401/401` after expiry on both `/api/v1/databases` and `/api/v1/auth/verify`. With the entry still well inside its 600s TTL, unfixed code would have returned 200 for ~10 more minutes.

New tests: `TestVerifyToken_CachedTokenRejectedAfterExpiry` (deterministic), `TestVerifyToken_ExpiresWhileCached_EndToEnd` (real timing), `TestVerifyToken_CacheDeadlineCappedAtTokenExpiry`, `TestCreateToken_ExpiresAtStoredInUTC`, `TestMiddleware_CachedExpiredToken`, plus negative controls for still-valid and non-expiring tokens.