### PR TITLE
fix(cluster): authenticate every coordinator handshake field and response

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -82,6 +82,72 @@ and errgroup primitives used by tiering and Iceberg. The auth, cluster-security,
 tiering, and Iceberg suites were verified against the new versions, the latter
 two under `-race`.
 
+### Cluster hardening: fully authenticated coordinator handshake (Enterprise)
+
+Every field of every coordinator-handshake message is now covered by its
+HMAC, in both directions. Previously the join, heartbeat and leave messages
+authenticated only `{message type, nonce, node ID, cluster name, timestamp}`
+while the handlers went on to consume other fields from the same message — a
+joining node's role and its advertised Raft, API and coordinator addresses; a
+heartbeat's self-reported state. On a cluster with `cluster.tls_enabled`
+unset (the default), an attacker positioned on the inter-node network could
+rewrite any of those and the signature still verified. The responses —
+join result, leader redirect, and the forward-apply acknowledgement — carried
+no authentication at all, so the same position allowed feeding a joining node
+a fabricated cluster membership list, redirecting it to an attacker-chosen
+coordinator, or telling a follower its replicated write had failed (or
+succeeded) when it had not.
+
+Three further changes close the same class of gap:
+
+- **Replay protection** on join, heartbeat and leave. These messages were
+  previously bounded only by the five-minute freshness window, inside which a
+  captured message could be resent verbatim. Nonces are now consumed on
+  receipt. The nonce cache's lifetime was also corrected — it must outlive the
+  freshness window by more than the window itself, because a message may be
+  stamped up to one tolerance in the future — which likewise tightens the
+  existing cache-invalidate and edge-sync replay guards.
+- **Uniform pre-authentication join errors.** A rejection that happens before
+  the peer proves it holds the shared secret now returns one opaque string;
+  previously the cluster-name mismatch echoed the expected cluster name back
+  to an unauthenticated caller and the three failure modes were individually
+  distinguishable. The specific cause is still logged server-side.
+- **Canonical encoding.** The signed payload is length-prefixed rather than
+  NUL-delimited. The coordinator protocol is raw TCP carrying JSON, which
+  passes NUL through, so a delimiter-joined encoding let an attacker who
+  controlled a field's contents re-partition the signed input.
+
+Clustering is an Enterprise feature and is off by default; single-node and
+OSS deployments are unaffected.
+
+> **Upgrade note (clustered Enterprise deployments):** the handshake wire
+> format has changed, so a node on this version cannot authenticate with a
+> node on an older one. Upgrade the cluster as a coordinated restart: **stop
+> all cluster nodes, upgrade the binary on every node, then restart all
+> nodes.**
+>
+> A rolling restart does not degrade gracefully. Across a mixed-version
+> window: cross-version nodes fail each other's heartbeats and are marked
+> unhealthy within roughly three health-check intervals (~15s by default),
+> withdrawing them from query routing; with `cluster.failover_enabled` set, an
+> automatic writer or compactor failover is committed through Raft about 30
+> seconds in, while the original primary is still alive, and that promotion
+> persists after the upgrade completes. A follower that is restarted
+> *gracefully* under a not-yet-upgraded leader is removed from the Raft
+> configuration by its own leave notification and cannot rejoin until the
+> leader is upgraded. Writes forwarded from an upgraded follower to an
+> older leader are applied by that leader but reported to the follower as
+> failed, because the acknowledgement is unsigned — file registrations are
+> retried by anti-entropy, compaction retries on its next tick, and an
+> upgraded node may log `Failed to create initial admin token` at startup
+> (non-fatal).
+>
+> The handshake authenticates inter-node messages; for confidentiality on the
+> interconnect, enable `cluster.tls_enabled`.
+
+Full technical detail will accompany the corresponding security advisory once
+it is published. Responsibly reported by **[@rexpository](https://github.com/rexpository)**.
+
 ### Expired API tokens are now rejected on cache hits
 
 Arc caches successful token verifications in memory for `auth.cache_ttl`
@@ -101,6 +167,18 @@ the cache immediately and was never affected; only passive expiry was.
 
 Full technical detail will accompany the corresponding security advisory once it
 is published. Responsibly reported by **[@rexpository](https://github.com/rexpository)**.
+
+## Upgrade notes
+
+1. **Clustered Enterprise deployments require a coordinated restart.** The
+   coordinator handshake wire format changed (see *Cluster hardening* above):
+   stop all cluster nodes, upgrade the binary on every node, then restart all
+   nodes. A rolling restart causes cross-version nodes to mark each other
+   unhealthy, can trigger an automatic writer failover, and can remove a
+   gracefully-restarted follower from the Raft configuration until its leader
+   is upgraded. Single-node, non-clustered and OSS deployments need no action.
+2. **No configuration change is required.** Existing `arc.toml` files and
+   license keys work as-is; no new keys were added.
 
 ## Bug fixes
 

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -549,31 +549,35 @@ func (c *Coordinator) broadcastLeave() {
 		Reason: "graceful shutdown",
 	}
 
-	// Sign the leave message if shared secret is configured. As with the
-	// heartbeat path, an unsigned leave (nonce failure) is rejected by the
-	// peer — log the error rather than swallow it silently.
-	if c.cfg.SharedSecret != "" {
-		nonce, err := security.GenerateNonce()
-		if err != nil {
-			c.logger.Error().Err(err).Msg("Failed to generate nonce for leave signing; leave notification will be unsigned and rejected by peers")
-		} else {
-			leave.AuthTimestamp = time.Now().Unix()
-			leave.AuthNonce = nonce
-			leave.AuthHMAC = security.ComputeHMAC(c.cfg.SharedSecret, security.MsgTypeLeave, nonce, leave.NodeID, c.cfg.ClusterName, leave.AuthTimestamp)
-		}
-	}
-
-	msg := protocol.NewLeaveNotify(leave)
 	var notified atomic.Int32
 	var wg sync.WaitGroup
 
+	// Sign per destination, on a per-peer copy — same reasoning as
+	// sendHeartbeats: the receiver consumes the nonce, duplicate-address
+	// registry entries would otherwise look like replays, and the message is
+	// marshalled concurrently by every goroutine. An unsigned leave (nonce
+	// failure) is rejected by the peer — log rather than swallow.
 	peers := c.registry.GetAll()
 	for _, peer := range peers {
 		if peer.ID == c.localNode.ID || peer.Address == "" {
 			continue
 		}
+
+		peerLeave := *leave
+		if c.cfg.SharedSecret != "" {
+			nonce, err := security.GenerateNonce()
+			if err != nil {
+				c.logger.Error().Err(err).Msg("Failed to generate nonce for leave signing; leave notification will be unsigned and rejected by peers")
+			} else {
+				peerLeave.AuthTimestamp = time.Now().Unix()
+				peerLeave.AuthNonce = nonce
+				peerLeave.AuthHMAC = security.ComputeLeaveHMAC(c.cfg.SharedSecret, nonce, peerLeave.AuthTimestamp, leaveAuthFields(&peerLeave, c.cfg.ClusterName))
+			}
+		}
+		msg := protocol.NewLeaveNotify(&peerLeave)
+
 		wg.Add(1)
-		go func(addr string) {
+		go func(addr string, msg *protocol.Message) {
 			defer wg.Done()
 			conn, err := security.Dial("tcp", addr, 2*time.Second, c.tlsConfig)
 			if err != nil {
@@ -583,7 +587,7 @@ func (c *Coordinator) broadcastLeave() {
 			_ = protocol.SendMessage(conn, msg, 2*time.Second)
 			conn.Close()
 			notified.Add(1)
-		}(peer.Address)
+		}(peer.Address, msg)
 	}
 	wg.Wait()
 
@@ -789,24 +793,22 @@ func (c *Coordinator) sendHeartbeats() {
 		Timestamp: time.Now(),
 	}
 
-	// Sign the heartbeat if a shared secret is configured. Mirrors the
-	// join/leave signing path. The HMAC binds NodeID + ClusterName +
-	// timestamp, so it is the same for every peer this tick — compute once.
+	// Sign per destination, on a per-peer copy.
+	//
+	// Two reasons it cannot be one signature per tick. (1) Correctness: the
+	// receiver now consumes the nonce in a replay cache, and two registry
+	// entries can share an address — node IDs are hostname+PID, so a
+	// bare-metal restart leaves the old entry behind and it is never evicted.
+	// A shared nonce would make the second delivery look like a replay every
+	// single tick, training operators to ignore the one log line that is
+	// supposed to mean "attack". (2) Safety: hb is handed to N goroutines
+	// that each json.Marshal it, so writing the auth fields in place would be
+	// a data race.
+	//
 	// On a nonce-generation failure the heartbeat ships unsigned and peers
 	// reject it (fail-safe), so this node would trend unhealthy — log the
 	// error loudly so an operator can diagnose entropy/system failure rather
 	// than chase a silently-flapping node.
-	if c.cfg.SharedSecret != "" {
-		nonce, err := security.GenerateNonce()
-		if err != nil {
-			c.logger.Error().Err(err).Msg("Failed to generate nonce for heartbeat signing; heartbeat will be unsigned and rejected by peers")
-		} else {
-			hb.AuthTimestamp = time.Now().Unix()
-			hb.AuthNonce = nonce
-			hb.AuthHMAC = security.ComputeHMAC(c.cfg.SharedSecret, security.MsgTypeHeartbeat, nonce, hb.NodeID, c.cfg.ClusterName, hb.AuthTimestamp)
-		}
-	}
-
 	for _, node := range nodes {
 		if local != nil && node.ID == local.ID {
 			continue
@@ -814,7 +816,19 @@ func (c *Coordinator) sendHeartbeats() {
 		if node.Address == "" {
 			continue
 		}
-		go c.sendHeartbeatToNode(node.Address, hb)
+
+		peerHB := *hb
+		if c.cfg.SharedSecret != "" {
+			nonce, err := security.GenerateNonce()
+			if err != nil {
+				c.logger.Error().Err(err).Msg("Failed to generate nonce for heartbeat signing; heartbeat will be unsigned and rejected by peers")
+			} else {
+				peerHB.AuthTimestamp = time.Now().Unix()
+				peerHB.AuthNonce = nonce
+				peerHB.AuthHMAC = security.ComputeHeartbeatHMAC(c.cfg.SharedSecret, nonce, peerHB.AuthTimestamp, heartbeatAuthFields(&peerHB, c.cfg.ClusterName))
+			}
+		}
+		go c.sendHeartbeatToNode(node.Address, &peerHB)
 	}
 }
 
@@ -901,6 +915,107 @@ func (c *Coordinator) discoverPeers() {
 	}
 }
 
+// joinAuthFields projects a JoinRequest onto the fields the join MAC covers.
+//
+// Every non-auth field of the message, deliberately: see
+// security/handshake_auth.go for why "the fields the handler reads today" is
+// the wrong rule. The sender and both validators all go through here, so the
+// three sites cannot drift apart.
+func joinAuthFields(req *protocol.JoinRequest) security.JoinAuthFields {
+	return security.JoinAuthFields{
+		NodeID:      req.NodeID,
+		NodeName:    req.NodeName,
+		Role:        req.Role,
+		ClusterName: req.ClusterName,
+		RaftAddr:    req.RaftAddr,
+		APIAddr:     req.APIAddr,
+		CoordAddr:   req.CoordAddr,
+		Version:     req.Version,
+		CoreCount:   req.CoreCount,
+	}
+}
+
+// heartbeatAuthFields projects a Heartbeat onto its MAC fields. clusterName
+// comes from the receiver's own config, not the wire — see
+// security.HeartbeatAuthFields.
+func heartbeatAuthFields(hb *protocol.Heartbeat, clusterName string) security.HeartbeatAuthFields {
+	return security.HeartbeatAuthFields{
+		NodeID:            hb.NodeID,
+		ClusterName:       clusterName,
+		State:             hb.State,
+		IsLeader:          hb.IsLeader,
+		TimestampUnixNano: hb.Timestamp.UnixNano(),
+	}
+}
+
+// leaveAuthFields projects a LeaveNotify onto its MAC fields.
+func leaveAuthFields(leave *protocol.LeaveNotify, clusterName string) security.LeaveAuthFields {
+	return security.LeaveAuthFields{
+		NodeID:      leave.NodeID,
+		ClusterName: clusterName,
+		Reason:      leave.Reason,
+	}
+}
+
+// joinResponseAuthFields projects a JoinResponse onto its MAC fields,
+// converting protocol.NodeInfo to the security package's mirror type so that
+// package need not import the wire protocol.
+func joinResponseAuthFields(resp *protocol.JoinResponse) security.JoinResponseAuthFields {
+	nodes := make([]security.NodeAuthFields, 0, len(resp.Nodes))
+	for _, n := range resp.Nodes {
+		nodes = append(nodes, security.NodeAuthFields{
+			ID:        n.ID,
+			Name:      n.Name,
+			Role:      n.Role,
+			State:     n.State,
+			RaftAddr:  n.RaftAddr,
+			APIAddr:   n.APIAddr,
+			CoordAddr: n.CoordAddr,
+			CoreCount: n.CoreCount,
+		})
+	}
+	return security.JoinResponseAuthFields{
+		Success:    resp.Success,
+		LeaderID:   resp.LeaderID,
+		LeaderAddr: resp.LeaderAddr,
+		RaftLeader: resp.RaftLeader,
+		Error:      resp.Error,
+		Nodes:      nodes,
+	}
+}
+
+// leaderInfoAuthFields projects a LeaderInfo onto its MAC fields.
+func leaderInfoAuthFields(info *protocol.LeaderInfo) security.LeaderInfoAuthFields {
+	return security.LeaderInfoAuthFields{
+		LeaderID:        info.LeaderID,
+		LeaderCoordAddr: info.LeaderCoordAddr,
+		LeaderRaftAddr:  info.LeaderRaftAddr,
+	}
+}
+
+// signJoinResponse signs resp over the request's nonce, in place.
+//
+// reqNonce is whatever the request carried — possibly empty, if an
+// unauthenticated peer sent one and we are answering with a pre-auth error.
+// Signing over an attacker-chosen nonce is not an oracle; see the response
+// section of security/handshake_auth.go.
+func (c *Coordinator) signJoinResponse(resp *protocol.JoinResponse, reqNonce string) {
+	if c.cfg.SharedSecret == "" {
+		return
+	}
+	resp.AuthTimestamp = time.Now().Unix()
+	resp.AuthHMAC = security.ComputeJoinResponseHMAC(c.cfg.SharedSecret, reqNonce, resp.AuthTimestamp, joinResponseAuthFields(resp))
+}
+
+// signLeaderInfo signs info over the request's nonce, in place.
+func (c *Coordinator) signLeaderInfo(info *protocol.LeaderInfo, reqNonce string) {
+	if c.cfg.SharedSecret == "" {
+		return
+	}
+	info.AuthTimestamp = time.Now().Unix()
+	info.AuthHMAC = security.ComputeLeaderInfoHMAC(c.cfg.SharedSecret, reqNonce, info.AuthTimestamp, leaderInfoAuthFields(info))
+}
+
 // tryJoinViaSeed attempts to join the cluster via a seed node.
 func (c *Coordinator) tryJoinViaSeed(seedAddr string) error {
 	conn, err := security.Dial("tcp", seedAddr, 5*time.Second, c.tlsConfig)
@@ -922,6 +1037,18 @@ func (c *Coordinator) tryJoinViaSeed(seedAddr string) error {
 		CoreCount:   runtime.GOMAXPROCS(0), // Report current GOMAXPROCS as core count
 	}
 
+	// If RaftAdvertiseAddr is empty, use RaftBindAddr.
+	//
+	// MUST stay above the signing block: RaftAddr is bound into the join
+	// MAC, so mutating it afterwards would ship a request whose MAC covers
+	// the pre-fallback value and every leader would reject it. That is the
+	// default configuration — cluster.raft_advertise_addr is unset unless an
+	// operator sets it — so getting this order wrong breaks all joins, not
+	// an edge case.
+	if req.RaftAddr == "" {
+		req.RaftAddr = c.cfg.RaftBindAddr
+	}
+
 	// Sign join request if shared secret is configured
 	if c.cfg.SharedSecret != "" {
 		nonce, err := security.GenerateNonce()
@@ -930,12 +1057,7 @@ func (c *Coordinator) tryJoinViaSeed(seedAddr string) error {
 		}
 		req.AuthTimestamp = time.Now().Unix()
 		req.AuthNonce = nonce
-		req.AuthHMAC = security.ComputeHMAC(c.cfg.SharedSecret, security.MsgTypeJoin, nonce, req.NodeID, req.ClusterName, req.AuthTimestamp)
-	}
-
-	// If RaftAdvertiseAddr is empty, use RaftBindAddr
-	if req.RaftAddr == "" {
-		req.RaftAddr = c.cfg.RaftBindAddr
+		req.AuthHMAC = security.ComputeJoinHMAC(c.cfg.SharedSecret, nonce, req.AuthTimestamp, joinAuthFields(req))
 	}
 
 	// Send join request
@@ -950,14 +1072,36 @@ func (c *Coordinator) tryJoinViaSeed(seedAddr string) error {
 		return fmt.Errorf("failed to receive response: %w", err)
 	}
 
-	return c.handleJoinResponse(resp, seedAddr)
+	// req.AuthNonce is what the response MAC is bound to; empty when no
+	// shared secret is configured, in which case the response is accepted
+	// unsigned (same gate as the request direction).
+	return c.handleJoinResponse(resp, seedAddr, req.AuthNonce)
 }
 
 // handleJoinResponse processes a response to a join request.
-func (c *Coordinator) handleJoinResponse(msg *protocol.Message, seedAddr string) error {
+//
+// reqNonce is the nonce this node put in the request; the responder signs over
+// it, so validating here needs no nonce cache — a response captured from an
+// earlier exchange is bound to a different nonce and fails. Empty when no
+// shared secret is configured, in which case responses are accepted unsigned
+// (the same gate as the request direction).
+//
+// The MAC is checked BEFORE any field is read. Validating after branching on
+// Success would let an unauthenticated peer inject a rejection (denial) or,
+// worse, a success carrying an attacker-chosen peer list that this node then
+// writes into its registry.
+func (c *Coordinator) handleJoinResponse(msg *protocol.Message, seedAddr string, reqNonce string) error {
 	switch msg.Type {
 	case protocol.MsgJoinResponse:
 		resp := msg.Payload.(*protocol.JoinResponse)
+		if c.cfg.SharedSecret != "" {
+			if err := security.ValidateJoinResponseHMAC(
+				c.cfg.SharedSecret, reqNonce, resp.AuthTimestamp,
+				joinResponseAuthFields(resp), resp.AuthHMAC, security.HMACTimestampTolerance,
+			); err != nil {
+				return fmt.Errorf("join response failed authentication (peer on an older version, or shared secret mismatch): %w", err)
+			}
+		}
 		if !resp.Success {
 			return fmt.Errorf("join rejected: %s", resp.Error)
 		}
@@ -985,6 +1129,14 @@ func (c *Coordinator) handleJoinResponse(msg *protocol.Message, seedAddr string)
 	case protocol.MsgLeaderInfo:
 		// Redirect to leader
 		info := msg.Payload.(*protocol.LeaderInfo)
+		if c.cfg.SharedSecret != "" {
+			if err := security.ValidateLeaderInfoHMAC(
+				c.cfg.SharedSecret, reqNonce, info.AuthTimestamp,
+				leaderInfoAuthFields(info), info.AuthHMAC, security.HMACTimestampTolerance,
+			); err != nil {
+				return fmt.Errorf("leader redirect failed authentication (peer on an older version, or shared secret mismatch): %w", err)
+			}
+		}
 		c.logger.Debug().
 			Str("leader_id", info.LeaderID).
 			Str("leader_addr", info.LeaderCoordAddr).
@@ -1094,9 +1246,22 @@ func (c *Coordinator) handleJoinRequest(conn net.Conn, req *protocol.JoinRequest
 		Int("core_count", req.CoreCount).
 		Msg("Received join request")
 
-	// Validate cluster name
+	// Every pre-authentication rejection returns the SAME opaque string.
+	//
+	// The cluster-name check in particular used to echo the expected name
+	// back to an unauthenticated caller, and the three failure modes were
+	// individually distinguishable, which together let an unauthenticated
+	// peer map the cluster's configuration. The specific cause stays in the
+	// server-side log, where an operator can see it and an attacker cannot.
+	// Post-authentication errors below keep their detail — by then the peer
+	// has proven it holds the shared secret.
 	if req.ClusterName != c.cfg.ClusterName {
-		c.sendJoinError(conn, fmt.Sprintf("cluster name mismatch: expected %s, got %s", c.cfg.ClusterName, req.ClusterName))
+		c.logger.Warn().
+			Str("node_id", req.NodeID).
+			Str("expected_cluster", c.cfg.ClusterName).
+			Str("got_cluster", req.ClusterName).
+			Msg("Join rejected: cluster name mismatch")
+		c.sendJoinError(conn, req, joinAuthFailedMsg)
 		return
 	}
 
@@ -1104,15 +1269,22 @@ func (c *Coordinator) handleJoinRequest(conn net.Conn, req *protocol.JoinRequest
 	if c.cfg.SharedSecret != "" {
 		if req.AuthHMAC == "" {
 			c.logger.Warn().Str("node_id", req.NodeID).Msg("Join rejected: shared secret required but not provided")
-			c.sendJoinError(conn, "shared secret authentication required")
+			c.sendJoinError(conn, req, joinAuthFailedMsg)
 			return
 		}
-		if err := security.ValidateHMAC(
-			c.cfg.SharedSecret, security.MsgTypeJoin, req.AuthNonce, req.NodeID, req.ClusterName,
-			req.AuthTimestamp, req.AuthHMAC, security.HMACTimestampTolerance,
+		// Validates the MAC over every field of the request, then consumes
+		// the nonce. Fail-closed on a nil cache: in production Start()
+		// installs it before the listener accepts, so nil here means a
+		// misconstructed Coordinator, not a supported configuration.
+		if err := security.ValidateJoinHMACWithReplay(
+			c.nonceCache, c.cfg.SharedSecret, req.AuthNonce, req.AuthTimestamp,
+			joinAuthFields(req), req.AuthHMAC, security.HMACTimestampTolerance,
 		); err != nil {
-			c.logger.Warn().Err(err).Str("node_id", req.NodeID).Msg("Join rejected: authentication failed")
-			c.sendJoinError(conn, "authentication failed: invalid shared secret")
+			c.logger.Warn().Err(err).
+				Str("node_id", req.NodeID).
+				Bool("replay", errors.Is(err, security.ErrHandshakeReplay)).
+				Msg("Join rejected: authentication failed")
+			c.sendJoinError(conn, req, joinAuthFailedMsg)
 			return
 		}
 	}
@@ -1120,7 +1292,7 @@ func (c *Coordinator) handleJoinRequest(conn net.Conn, req *protocol.JoinRequest
 	// Check if we're the leader
 	if c.raftNode != nil && !c.raftNode.IsLeader() {
 		// Redirect to leader
-		c.sendLeaderRedirect(conn)
+		c.sendLeaderRedirect(conn, req)
 		return
 	}
 
@@ -1131,7 +1303,7 @@ func (c *Coordinator) handleJoinRequest(conn net.Conn, req *protocol.JoinRequest
 			Str("node_id", req.NodeID).
 			Int("core_count", req.CoreCount).
 			Msg("Join rejected: core limit exceeded")
-		c.sendJoinError(conn, err.Error())
+		c.sendJoinError(conn, req, err.Error())
 		return
 	}
 
@@ -1147,7 +1319,7 @@ func (c *Coordinator) handleJoinRequest(conn net.Conn, req *protocol.JoinRequest
 		// First add as a Raft voter
 		if err := c.raftNode.AddVoter(req.NodeID, req.RaftAddr, 10*time.Second); err != nil {
 			c.logger.Error().Err(err).Str("node_id", req.NodeID).Msg("Failed to add voter to Raft")
-			c.sendJoinError(conn, fmt.Sprintf("failed to add to Raft cluster: %v", err))
+			c.sendJoinError(conn, req, fmt.Sprintf("failed to add to Raft cluster: %v", err))
 			return
 		}
 
@@ -1170,7 +1342,7 @@ func (c *Coordinator) handleJoinRequest(conn net.Conn, req *protocol.JoinRequest
 	} else {
 		// No Raft, just register locally
 		if err := c.registry.Register(node); err != nil {
-			c.sendJoinError(conn, fmt.Sprintf("failed to register node: %v", err))
+			c.sendJoinError(conn, req, fmt.Sprintf("failed to register node: %v", err))
 			return
 		}
 	}
@@ -1181,22 +1353,28 @@ func (c *Coordinator) handleJoinRequest(conn net.Conn, req *protocol.JoinRequest
 		Msg("Node successfully joined cluster")
 
 	// Send success response with cluster info
-	c.sendJoinSuccess(conn)
+	c.sendJoinSuccess(conn, req)
 }
 
-// sendJoinError sends a join failure response.
-func (c *Coordinator) sendJoinError(conn net.Conn, errMsg string) {
-	resp := protocol.NewJoinResponse(&protocol.JoinResponse{
+// joinAuthFailedMsg is the single opaque rejection every pre-authentication
+// join failure returns. See handleJoinRequest for why they are uniform.
+const joinAuthFailedMsg = "authentication failed"
+
+// sendJoinError sends a join failure response, signed over the request's
+// nonce so a joiner can tell a real rejection from an injected one.
+func (c *Coordinator) sendJoinError(conn net.Conn, req *protocol.JoinRequest, errMsg string) {
+	payload := &protocol.JoinResponse{
 		Success: false,
 		Error:   errMsg,
-	})
-	if err := protocol.SendMessage(conn, resp, 5*time.Second); err != nil {
+	}
+	c.signJoinResponse(payload, req.AuthNonce)
+	if err := protocol.SendMessage(conn, protocol.NewJoinResponse(payload), 5*time.Second); err != nil {
 		c.logger.Debug().Err(err).Msg("Failed to send join error response")
 	}
 }
 
 // sendLeaderRedirect sends a redirect to the current leader.
-func (c *Coordinator) sendLeaderRedirect(conn net.Conn) {
+func (c *Coordinator) sendLeaderRedirect(conn net.Conn, req *protocol.JoinRequest) {
 	leaderID := c.raftNode.LeaderID()
 	leaderRaftAddr := c.raftNode.LeaderAddr()
 
@@ -1206,19 +1384,23 @@ func (c *Coordinator) sendLeaderRedirect(conn net.Conn) {
 		leaderCoordAddr = leaderNode.Address
 	}
 
-	info := protocol.NewLeaderInfo(&protocol.LeaderInfo{
+	// Signed over the request's nonce: this names the address the joiner
+	// dials next and hands its next signed join request to, so an
+	// unauthenticated redirect is a free relay for an on-path attacker.
+	payload := &protocol.LeaderInfo{
 		LeaderID:        leaderID,
 		LeaderCoordAddr: leaderCoordAddr,
 		LeaderRaftAddr:  leaderRaftAddr,
-	})
+	}
+	c.signLeaderInfo(payload, req.AuthNonce)
 
-	if err := protocol.SendMessage(conn, info, 5*time.Second); err != nil {
+	if err := protocol.SendMessage(conn, protocol.NewLeaderInfo(payload), 5*time.Second); err != nil {
 		c.logger.Debug().Err(err).Msg("Failed to send leader redirect")
 	}
 }
 
 // sendJoinSuccess sends a successful join response with cluster info.
-func (c *Coordinator) sendJoinSuccess(conn net.Conn) {
+func (c *Coordinator) sendJoinSuccess(conn net.Conn, req *protocol.JoinRequest) {
 	// Gather all nodes in the cluster
 	nodes := c.registry.GetAll()
 	nodeInfos := make([]protocol.NodeInfo, 0, len(nodes))
@@ -1241,15 +1423,16 @@ func (c *Coordinator) sendJoinSuccess(conn net.Conn) {
 		leaderRaftAddr = c.raftNode.LeaderAddr()
 	}
 
-	resp := protocol.NewJoinResponse(&protocol.JoinResponse{
+	payload := &protocol.JoinResponse{
 		Success:    true,
 		LeaderID:   leaderID,
 		LeaderAddr: c.cfg.AdvertiseAddr,
 		RaftLeader: leaderRaftAddr,
 		Nodes:      nodeInfos,
-	})
+	}
+	c.signJoinResponse(payload, req.AuthNonce)
 
-	if err := protocol.SendMessage(conn, resp, 5*time.Second); err != nil {
+	if err := protocol.SendMessage(conn, protocol.NewJoinResponse(payload), 5*time.Second); err != nil {
 		c.logger.Debug().Err(err).Msg("Failed to send join success response")
 	}
 }
@@ -1267,11 +1450,14 @@ func (c *Coordinator) handleHeartbeat(conn net.Conn, hb *protocol.Heartbeat) {
 			c.logger.Warn().Str("node_id", hb.NodeID).Msg("Heartbeat rejected: shared secret required but not provided")
 			return
 		}
-		if err := security.ValidateHMAC(
-			c.cfg.SharedSecret, security.MsgTypeHeartbeat, hb.AuthNonce, hb.NodeID, c.cfg.ClusterName,
-			hb.AuthTimestamp, hb.AuthHMAC, security.HMACTimestampTolerance,
+		if err := security.ValidateHeartbeatHMACWithReplay(
+			c.nonceCache, c.cfg.SharedSecret, hb.AuthNonce, hb.AuthTimestamp,
+			heartbeatAuthFields(hb, c.cfg.ClusterName), hb.AuthHMAC, security.HMACTimestampTolerance,
 		); err != nil {
-			c.logger.Warn().Err(err).Str("node_id", hb.NodeID).Msg("Heartbeat rejected: authentication failed")
+			c.logger.Warn().Err(err).
+				Str("node_id", hb.NodeID).
+				Bool("replay", errors.Is(err, security.ErrHandshakeReplay)).
+				Msg("Heartbeat rejected: authentication failed")
 			return
 		}
 	}
@@ -1297,11 +1483,14 @@ func (c *Coordinator) handleLeaveNotify(leave *protocol.LeaveNotify) {
 			c.logger.Warn().Str("node_id", leave.NodeID).Msg("Leave rejected: shared secret required but not provided")
 			return
 		}
-		if err := security.ValidateHMAC(
-			c.cfg.SharedSecret, security.MsgTypeLeave, leave.AuthNonce, leave.NodeID, c.cfg.ClusterName,
-			leave.AuthTimestamp, leave.AuthHMAC, security.HMACTimestampTolerance,
+		if err := security.ValidateLeaveHMACWithReplay(
+			c.nonceCache, c.cfg.SharedSecret, leave.AuthNonce, leave.AuthTimestamp,
+			leaveAuthFields(leave, c.cfg.ClusterName), leave.AuthHMAC, security.HMACTimestampTolerance,
 		); err != nil {
-			c.logger.Warn().Err(err).Str("node_id", leave.NodeID).Msg("Leave rejected: authentication failed")
+			c.logger.Warn().Err(err).
+				Str("node_id", leave.NodeID).
+				Bool("replay", errors.Is(err, security.ErrHandshakeReplay)).
+				Msg("Leave rejected: authentication failed")
 			return
 		}
 	}

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -107,8 +107,11 @@ type Coordinator struct {
 	deleteWg    sync.WaitGroup
 
 	// nonceCache tracks recently seen nonces for replay protection on
-	// HMAC-authenticated messages (leader forwarding, and extensible to
-	// join/leave in the future). Initialized in Start().
+	// HMAC-authenticated messages: the join/heartbeat/leave handshake,
+	// leader forwarding, and replicate-sync. Initialized in Start() before
+	// the listener accepts, which is what lets the handshake validators
+	// treat a nil cache as a construction error rather than a reason to skip
+	// the check.
 	nonceCache *security.NonceCache
 
 	// forwardConn caches a single TCP connection to the current Raft
@@ -443,8 +446,12 @@ func (c *Coordinator) Start() error {
 	// parent context (Phase 4 integration-test discovery).
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 
-	// Initialize the nonce cache for HMAC replay protection. The 5-minute
-	// TTL matches the HMAC timestamp tolerance in ValidateForwardHMAC.
+	// Initialize the nonce cache for HMAC replay protection.
+	//
+	// NewNonceCache takes the freshness TOLERANCE and derives a longer
+	// retention from it (2T+1s), because a message may be stamped up to one
+	// tolerance in the future and must not outlive its cache slot. Do not
+	// "simplify" this by passing a TTL.
 	c.nonceCache = security.NewNonceCache(security.HMACTimestampTolerance)
 
 	// Start Raft node if configured (Phase 3)
@@ -1442,9 +1449,9 @@ func (c *Coordinator) handleHeartbeat(conn net.Conn, hb *protocol.Heartbeat) {
 	// Validate shared secret if configured. A heartbeat mutates the sender's
 	// recorded liveness and self-reported state, so it is authenticated like
 	// join/leave — otherwise a network attacker could spoof any node's health
-	// (GHSA-p378-jp5r-gpgw). Mirrors handleLeaveNotify; freshness is bounded by
-	// the HMAC timestamp tolerance (consistent with join/leave, which likewise
-	// do not nonce-replay-check).
+	// (GHSA-p378-jp5r-gpgw). Mirrors handleLeaveNotify: the MAC covers every
+	// field of the message and the nonce is consumed on receipt, so a captured
+	// heartbeat cannot be replayed inside the freshness window.
 	if c.cfg.SharedSecret != "" {
 		if hb.AuthHMAC == "" {
 			c.logger.Warn().Str("node_id", hb.NodeID).Msg("Heartbeat rejected: shared secret required but not provided")
@@ -1587,7 +1594,13 @@ func (c *Coordinator) handleReplicateSync(conn net.Conn, syncReq *protocol.Repli
 	}
 	// Replay check AFTER HMAC validation: don't burn a nonce-cache slot
 	// on an attacker who can't even produce a valid MAC.
-	if c.nonceCache != nil && !c.nonceCache.Track(syncReq.ReaderID, syncReq.Nonce) {
+	// Fail closed on a nil cache: Track returns false when the receiver is
+	// nil, so an absent replay guard rejects rather than silently skipping
+	// the check. (The handshake validators enforce the same contract via
+	// validateWithReplay; keeping these two consistent matters because a
+	// future change that registers either handler earlier than Start() would
+	// otherwise reopen a replay hole with every test still passing.)
+	if !c.nonceCache.Track(syncReq.ReaderID, syncReq.Nonce) {
 		c.logger.Warn().
 			Str("peer", remoteAddr).
 			Str("reader_id", syncReq.ReaderID).

--- a/internal/cluster/forward_ack_auth_test.go
+++ b/internal/cluster/forward_ack_auth_test.go
@@ -1,0 +1,145 @@
+package cluster
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/protocol"
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/rs/zerolog"
+)
+
+func newForwardAckTestCoordinator(secret string) *Coordinator {
+	local := NewNode("follower", "follower", RoleWriter, joinTestCluster)
+	return &Coordinator{
+		cfg:       &config.ClusterConfig{ClusterName: joinTestCluster, SharedSecret: secret},
+		localNode: local,
+		logger:    zerolog.Nop(),
+	}
+}
+
+func signedAck(secret, reqNonce, status string, code protocol.ForwardApplyCode, errMsg string) *protocol.ForwardApplyAck {
+	ack := &protocol.ForwardApplyAck{Status: status, Code: code, Error: errMsg}
+	if secret != "" {
+		ack.AuthTimestamp = time.Now().Unix()
+		ack.AuthHMAC = security.ComputeForwardAckHMAC(secret, reqNonce, ack.AuthTimestamp,
+			security.ForwardAckAuthFields{Status: ack.Status, Code: string(ack.Code), Error: ack.Error})
+	}
+	return ack
+}
+
+// TestCheckForwardAck_AcceptsValid is the control.
+func TestCheckForwardAck_AcceptsValid(t *testing.T) {
+	c := newForwardAckTestCoordinator(joinTestSecret)
+	const nonce = "req-nonce"
+	if err := c.checkForwardAck(signedAck(joinTestSecret, nonce, "ok", "", ""), nonce); err != nil {
+		t.Fatalf("valid ack rejected: %v", err)
+	}
+}
+
+// TestCheckForwardAck_RejectsForgedSuccess is the headline case: a forged "ok"
+// makes the follower believe a RegisterFile or DeleteFile was committed when it
+// was not, silently dropping the entry from the manifest.
+func TestCheckForwardAck_RejectsForgedSuccess(t *testing.T) {
+	c := newForwardAckTestCoordinator(joinTestSecret)
+
+	cases := map[string]*protocol.ForwardApplyAck{
+		"unsigned":  {Status: "ok"},
+		"bad MAC":   {Status: "ok", AuthTimestamp: time.Now().Unix(), AuthHMAC: strings.Repeat("0", 64)},
+		"wrong key": signedAck("not-the-secret", "req-nonce", "ok", "", ""),
+	}
+	for name, ack := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := c.checkForwardAck(ack, "req-nonce"); err == nil {
+				t.Errorf("forged success ack (%s) was accepted", name)
+			}
+		})
+	}
+}
+
+// TestCheckForwardAck_RejectsForgedErrorCodes is the subtler half, and the
+// reason Code is bound and the check runs BEFORE the Status branch.
+//
+// An unsigned {error, not_leader} is mapped by the caller to ErrNoLeaderKnown
+// and retried as a transient leadership change; an unsigned {apply_failed,
+// "... already exists"} is read by auth bootstrap as "already initialised".
+// Both let an on-path attacker steer the caller without ever forging a
+// success.
+func TestCheckForwardAck_RejectsForgedErrorCodes(t *testing.T) {
+	c := newForwardAckTestCoordinator(joinTestSecret)
+
+	forged := map[string]*protocol.ForwardApplyAck{
+		"not_leader":   {Status: "error", Code: protocol.ForwardCodeNotLeader},
+		"apply_failed": {Status: "error", Code: protocol.ForwardCodeApplyFailed, Error: "token already exists"},
+		"auth":         {Status: "error", Code: protocol.ForwardCodeAuth, Error: "authentication failed"},
+	}
+	for name, ack := range forged {
+		t.Run(name, func(t *testing.T) {
+			err := c.checkForwardAck(ack, "req-nonce")
+			if err == nil {
+				t.Fatalf("forged error ack (%s) was accepted", name)
+			}
+			// It must not surface as a transient-retry signal, or the caller
+			// would spin against an attacker instead of failing.
+			if errors.Is(err, ErrNoLeaderKnown) {
+				t.Error("a forged ack was mapped to ErrNoLeaderKnown — attacker controls retry behaviour")
+			}
+		})
+	}
+}
+
+// TestCheckForwardAck_RejectsMutatedCode: the ack is authentic but its Code
+// was flipped in flight.
+func TestCheckForwardAck_RejectsMutatedCode(t *testing.T) {
+	c := newForwardAckTestCoordinator(joinTestSecret)
+	const nonce = "req-nonce"
+
+	ack := signedAck(joinTestSecret, nonce, "error", protocol.ForwardCodeApplyFailed, "disk full")
+	ack.Code = protocol.ForwardCodeNotLeader // now looks transient
+
+	if err := c.checkForwardAck(ack, nonce); err == nil {
+		t.Error("an ack with a mutated Code was accepted — Code is outside the MAC")
+	}
+}
+
+// TestCheckForwardAck_RejectsWrongNonce: an ack captured from an earlier
+// round-trip must not satisfy a later request on the same pooled connection.
+func TestCheckForwardAck_RejectsWrongNonce(t *testing.T) {
+	c := newForwardAckTestCoordinator(joinTestSecret)
+	ack := signedAck(joinTestSecret, "an-earlier-nonce", "ok", "", "")
+	if err := c.checkForwardAck(ack, "the-current-nonce"); err == nil {
+		t.Error("an ack bound to a different request's nonce was accepted")
+	}
+}
+
+// TestCheckForwardAck_NoSecretAcceptsUnsigned: without a shared secret there
+// is nothing to verify with, and forward-apply refuses to run at all earlier
+// in the call path.
+func TestCheckForwardAck_NoSecretAcceptsUnsigned(t *testing.T) {
+	c := newForwardAckTestCoordinator("")
+	if err := c.checkForwardAck(&protocol.ForwardApplyAck{Status: "ok"}, ""); err != nil {
+		t.Fatalf("unsigned ack rejected with no secret configured: %v", err)
+	}
+}
+
+// TestSignForwardAck_RoundTrips proves the leader's signing path and the
+// follower's checking path agree — they are written separately, so a field
+// ordering mistake in one would otherwise only show up in a live cluster.
+func TestSignForwardAck_RoundTrips(t *testing.T) {
+	c := newForwardAckTestCoordinator(joinTestSecret)
+	const nonce = "req-nonce"
+
+	for _, ack := range []*protocol.ForwardApplyAck{
+		{Status: "ok"},
+		{Status: "error", Code: protocol.ForwardCodeNotLeader, Error: "not the current leader"},
+		{Status: "error", Code: protocol.ForwardCodeApplyFailed, Error: "token already exists"},
+	} {
+		c.signForwardAck(ack, nonce)
+		if err := c.checkForwardAck(ack, nonce); err != nil {
+			t.Errorf("ack %+v failed its own validation: %v", ack, err)
+		}
+	}
+}

--- a/internal/cluster/forward_ack_auth_test.go
+++ b/internal/cluster/forward_ack_auth_test.go
@@ -143,3 +143,26 @@ func TestSignForwardAck_RoundTrips(t *testing.T) {
 		}
 	}
 }
+
+// TestHandleForwardApply_FailsClosedWithoutReplayGuard covers the cell opened
+// by tightening the forward-apply and replicate-sync replay checks from
+// `cache != nil && !Track(...)` to `!Track(...)`.
+//
+// Those two sites are not reachable with a nil cache in production — Start()
+// installs it before the listener accepts — but the previous form would have
+// skipped replay protection entirely if that ever stopped holding, with every
+// test still green. Now an absent guard rejects, matching the handshake
+// validators. This test pins that, and the nil-safety of Track that makes it
+// work without a panic.
+func TestHandleForwardApply_FailsClosedWithoutReplayGuard(t *testing.T) {
+	c := newForwardAckTestCoordinator(joinTestSecret)
+	if c.nonceCache != nil {
+		t.Fatal("this coordinator is built without a nonce cache by design")
+	}
+
+	// The bare call must report "not new" rather than panicking, which is
+	// what lets the caller drop its nil check.
+	if c.nonceCache.Track("node", "nonce") {
+		t.Error("Track on a nil cache reported the nonce as new — the guard would fail open")
+	}
+}

--- a/internal/cluster/forward_apply.go
+++ b/internal/cluster/forward_apply.go
@@ -171,6 +171,22 @@ func (c *Coordinator) forwardApplyToLeader(ctx context.Context, cmd *clusterraft
 		c.closeForwardConn()
 		return fmt.Errorf("forward apply: ack payload has wrong type: %T", ackMsg.Payload)
 	}
+	// Authenticate the ack BEFORE reading anything it says.
+	//
+	// Order is load-bearing. Status and Code drive caller behaviour: an
+	// unsigned {Status:"error", Code:"not_leader"} maps to ErrNoLeaderKnown
+	// and is retried as a transient leadership change, and an
+	// {Code:"apply_failed", Error:"... already exists"} is read by
+	// ensureFirstToken as "bootstrap already done". Branching first would let
+	// an on-path attacker pick either outcome.
+	if err := c.checkForwardAck(ack, req.Nonce); err != nil {
+		// Unlike a protocol-level rejection below, a bad MAC means the peer
+		// on the other end of this pooled connection is not trusted — drop it
+		// rather than reuse it for the next command.
+		c.closeForwardConn()
+		return fmt.Errorf("forward apply: %w", err)
+	}
+
 	if ack.Status != "ok" {
 		// Protocol-level rejection — connection is still valid, don't close.
 		// Map ForwardCodeNotLeader to ErrNoLeaderKnown so callers
@@ -182,6 +198,42 @@ func (c *Coordinator) forwardApplyToLeader(ctx context.Context, cmd *clusterraft
 		return fmt.Errorf("forward apply: leader rejected (code=%s): %s", ack.Code, ack.Error)
 	}
 	return nil
+}
+
+// checkForwardAck verifies a forward-apply ack against the nonce this node
+// put in the corresponding request.
+//
+// Pure apart from reading c.cfg, so the auth decision is unit-testable without
+// a leader, a connection, or Raft.
+func (c *Coordinator) checkForwardAck(ack *protocol.ForwardApplyAck, reqNonce string) error {
+	if c.cfg.SharedSecret == "" {
+		return nil
+	}
+	return security.ValidateForwardAckHMAC(
+		c.cfg.SharedSecret, reqNonce, ack.AuthTimestamp,
+		security.ForwardAckAuthFields{
+			Status: ack.Status,
+			Code:   string(ack.Code),
+			Error:  ack.Error,
+		},
+		ack.AuthHMAC, security.HMACTimestampTolerance,
+	)
+}
+
+// signForwardAck signs an ack over the request's nonce, in place.
+func (c *Coordinator) signForwardAck(ack *protocol.ForwardApplyAck, reqNonce string) {
+	if c.cfg.SharedSecret == "" {
+		return
+	}
+	ack.AuthTimestamp = time.Now().Unix()
+	ack.AuthHMAC = security.ComputeForwardAckHMAC(
+		c.cfg.SharedSecret, reqNonce, ack.AuthTimestamp,
+		security.ForwardAckAuthFields{
+			Status: ack.Status,
+			Code:   string(ack.Code),
+			Error:  ack.Error,
+		},
+	)
 }
 
 // getOrDialLeader returns the cached leader connection if it's still open
@@ -267,7 +319,14 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 	// prevents an on-wire attacker from swapping the command payload while
 	// keeping the same MAC, even without TLS.
 	if c.cfg.SharedSecret == "" {
-		c.sendForwardApplyError(conn, protocol.ForwardCodeAuth, "leader has no shared_secret configured")
+		// Log on this side too: once acks are signed, a follower that
+		// rejects this response only sees "ack failed authentication" and
+		// cannot tell a misconfigured leader from a forged reply.
+		c.logger.Warn().
+			Str("peer", remoteAddr).
+			Str("requesting_node", req.NodeID).
+			Msg("ForwardApply rejected: this node has no cluster.shared_secret configured")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeAuth, "leader has no shared_secret configured")
 		return
 	}
 	if err := security.ValidateForwardHMAC(
@@ -279,7 +338,7 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 			Str("peer", remoteAddr).
 			Str("requesting_node", req.NodeID).
 			Msg("ForwardApply rejected: HMAC validation failed")
-		c.sendForwardApplyError(conn, protocol.ForwardCodeAuth, "authentication failed")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeAuth, "authentication failed")
 		return
 	}
 
@@ -291,12 +350,12 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 			Str("peer", remoteAddr).
 			Str("requesting_node", req.NodeID).
 			Msg("ForwardApply rejected: nonce replay detected")
-		c.sendForwardApplyError(conn, protocol.ForwardCodeAuth, "nonce replay")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeAuth, "nonce replay")
 		return
 	}
 
 	if c.raftNode == nil {
-		c.sendForwardApplyError(conn, protocol.ForwardCodeRaftUnavailable, "raft not initialized")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeRaftUnavailable, "raft not initialized")
 		return
 	}
 
@@ -312,7 +371,7 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 			Str("peer", remoteAddr).
 			Str("requesting_node", req.NodeID).
 			Msg("ForwardApply rejected: node not found in registry")
-		c.sendForwardApplyError(conn, protocol.ForwardCodeAuth, "unknown node")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeAuth, "unknown node")
 		return
 	}
 	// Role gate is split between manifest commands and auth commands.
@@ -335,7 +394,7 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 		c.logger.Debug().
 			Str("requesting_node", req.NodeID).
 			Msg("ForwardApply rejected: no longer leader")
-		c.sendForwardApplyError(conn, protocol.ForwardCodeNotLeader, "not the current leader")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeNotLeader, "not the current leader")
 		return
 	}
 
@@ -349,7 +408,7 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 			Err(err).
 			Str("requesting_node", req.NodeID).
 			Msg("ForwardApply rejected: invalid command JSON")
-		c.sendForwardApplyError(conn, protocol.ForwardCodeInvalidCommand, "invalid command")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeInvalidCommand, "invalid command")
 		return
 	}
 
@@ -404,7 +463,7 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 			Str("requesting_node", req.NodeID).
 			Int("cmd_type", int(cmd.Type)).
 			Msg("ForwardApply rejected: command type not allowed via forwarding")
-		c.sendForwardApplyError(conn, protocol.ForwardCodeInvalidCommand, "command type not allowed via forwarding")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeInvalidCommand, "command type not allowed via forwarding")
 		return
 	}
 	if isManifest && !caps.CanIngest && !caps.CanCompact {
@@ -413,7 +472,7 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 			Str("requesting_node", req.NodeID).
 			Str("role", string(peerNode.Role)).
 			Msg("ForwardApply rejected: node role not authorized for manifest mutations")
-		c.sendForwardApplyError(conn, protocol.ForwardCodeAuth, "unauthorized role")
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeAuth, "unauthorized role")
 		return
 	}
 
@@ -432,14 +491,16 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 		// this, every follower would see the same canned "raft apply
 		// failed" string and fail to recognise legitimate idempotency
 		// signals. PR #451 round-3 internal review.
-		c.sendForwardApplyError(conn, protocol.ForwardCodeApplyFailed, err.Error())
+		c.sendForwardApplyError(conn, req.Nonce, protocol.ForwardCodeApplyFailed, err.Error())
 		return
 	}
 
-	// Success ack.
+	// Success ack, signed over the request's nonce.
+	successAck := &protocol.ForwardApplyAck{Status: "ok"}
+	c.signForwardAck(successAck, req.Nonce)
 	if err := protocol.SendMessage(conn, &protocol.Message{
 		Type:    protocol.MsgForwardApplyAck,
-		Payload: &protocol.ForwardApplyAck{Status: "ok"},
+		Payload: successAck,
 	}, forwardApplyTimeout); err != nil {
 		c.logger.Debug().Err(err).Msg("ForwardApply: failed to send success ack")
 		return
@@ -490,12 +551,13 @@ func (c *Coordinator) handleForwardApplyLoop(conn net.Conn, firstReq *protocol.F
 // sendForwardApplyError is a small helper to send an error ack. Best-effort:
 // any write error is logged at debug because the connection is about to
 // close anyway via the caller's defer.
-func (c *Coordinator) sendForwardApplyError(conn net.Conn, code protocol.ForwardApplyCode, reason string) {
+func (c *Coordinator) sendForwardApplyError(conn net.Conn, reqNonce string, code protocol.ForwardApplyCode, reason string) {
 	ack := &protocol.ForwardApplyAck{
 		Status: "error",
 		Code:   code,
 		Error:  reason,
 	}
+	c.signForwardAck(ack, reqNonce)
 	if err := protocol.SendMessage(conn, &protocol.Message{
 		Type:    protocol.MsgForwardApplyAck,
 		Payload: ack,

--- a/internal/cluster/forward_apply.go
+++ b/internal/cluster/forward_apply.go
@@ -345,7 +345,13 @@ func (c *Coordinator) handleForwardApply(conn net.Conn, req *protocol.ForwardApp
 	// Replay protection: reject duplicate (nodeID, nonce) pairs within
 	// the TTL window. The nonce cache is initialized in Start() and
 	// shared across all handleForwardApply invocations.
-	if c.nonceCache != nil && !c.nonceCache.Track(req.NodeID, req.Nonce) {
+	// Fail closed on a nil cache: Track returns false when the receiver is
+	// nil, so an absent replay guard rejects rather than silently skipping
+	// the check. (The handshake validators enforce the same contract via
+	// validateWithReplay; keeping these two consistent matters because a
+	// future change that registers either handler earlier than Start() would
+	// otherwise reopen a replay hole with every test still passing.)
+	if !c.nonceCache.Track(req.NodeID, req.Nonce) {
 		c.logger.Warn().
 			Str("peer", remoteAddr).
 			Str("requesting_node", req.NodeID).

--- a/internal/cluster/heartbeat_auth_test.go
+++ b/internal/cluster/heartbeat_auth_test.go
@@ -29,6 +29,10 @@ func newHeartbeatTestCoordinator(t *testing.T, secret string) (*Coordinator, *No
 		registry:  reg,
 		localNode: local,
 		logger:    zerolog.Nop(),
+		// Required: the handshake validators fail closed without a replay
+		// guard. Production installs this in Start() before the listener
+		// accepts, so nil means a misconstructed Coordinator.
+		nonceCache: security.NewNonceCache(security.HMACTimestampTolerance),
 	}
 	return c, peer
 }
@@ -61,7 +65,7 @@ func signedHeartbeat(secret, nodeID, cluster string) *protocol.Heartbeat {
 		nonce, _ := security.GenerateNonce()
 		hb.AuthTimestamp = time.Now().Unix()
 		hb.AuthNonce = nonce
-		hb.AuthHMAC = security.ComputeHMAC(secret, security.MsgTypeHeartbeat, nonce, nodeID, cluster, hb.AuthTimestamp)
+		hb.AuthHMAC = security.ComputeHeartbeatHMAC(secret, nonce, hb.AuthTimestamp, heartbeatAuthFields(hb, cluster))
 	}
 	return hb
 }
@@ -117,5 +121,89 @@ func TestHandleHeartbeat_NoSecretAcceptsUnsigned(t *testing.T) {
 
 	if got := peer.GetState(); got != StateHealthy {
 		t.Errorf("no-secret heartbeat: peer state = %v; want %v", got, StateHealthy)
+	}
+}
+
+// TestHandleHeartbeat_RejectsMutatedState is the regression test for the
+// heartbeat half of GHSA-p2rx, found while verifying the reported join issue.
+//
+// State was outside the MAC while the handler wrote it straight into the
+// registry, so an on-path attacker could flip any node to unhealthy — which
+// withdraws it from query routing and, with failover enabled, can trigger a
+// writer promotion — using a heartbeat whose tag still verified.
+func TestHandleHeartbeat_RejectsMutatedState(t *testing.T) {
+	c, peer := newHeartbeatTestCoordinator(t, "s3cret")
+	hb := signedHeartbeat("s3cret", peer.ID, "test-cluster")
+
+	// On-path mutation: flip the self-reported state, keep the valid tag.
+	hb.State = string(StateUnhealthy)
+
+	deliverHeartbeat(c, hb)
+
+	got, ok := c.registry.Get(peer.ID)
+	if !ok {
+		t.Fatal("peer vanished from registry")
+	}
+	if got.State != StateUnhealthy {
+		t.Fatalf("peer state = %v; the test peer starts unhealthy so this should be unchanged", got.State)
+	}
+	// The mutated heartbeat must have been rejected outright: had it been
+	// accepted, the handler would have recorded a heartbeat for the peer.
+	if !c.registry.GetLastHeartbeat(peer.ID).IsZero() {
+		t.Error("a heartbeat with a mutated State was accepted — State is outside the MAC")
+	}
+}
+
+// TestHandleHeartbeat_RejectsMutatedIsLeader: IsLeader is not consumed by the
+// current handler, but it is bound anyway (every field of the message is), so
+// a mutation must still be rejected. This is the test that will fail if
+// somebody later starts trusting the field without re-checking coverage.
+func TestHandleHeartbeat_RejectsMutatedIsLeader(t *testing.T) {
+	c, peer := newHeartbeatTestCoordinator(t, "s3cret")
+	hb := signedHeartbeat("s3cret", peer.ID, "test-cluster")
+	hb.IsLeader = !hb.IsLeader
+
+	deliverHeartbeat(c, hb)
+
+	if !c.registry.GetLastHeartbeat(peer.ID).IsZero() {
+		t.Error("a heartbeat with a mutated IsLeader was accepted — the field is outside the MAC")
+	}
+}
+
+// TestHandleHeartbeat_RejectsReplay: a captured heartbeat must not be
+// replayable inside the freshness window.
+func TestHandleHeartbeat_RejectsReplay(t *testing.T) {
+	c, peer := newHeartbeatTestCoordinator(t, "s3cret")
+	hb := signedHeartbeat("s3cret", peer.ID, "test-cluster")
+
+	deliverHeartbeat(c, hb)
+	first := c.registry.GetLastHeartbeat(peer.ID)
+	if first.IsZero() {
+		t.Fatal("legitimate heartbeat was rejected")
+	}
+
+	// Re-deliver the identical message, as a network attacker would.
+	peer.UpdateState(StateUnhealthy)
+	deliverHeartbeat(c, hb)
+
+	got, _ := c.registry.Get(peer.ID)
+	if got.State == StateHealthy {
+		t.Error("a replayed heartbeat was accepted — the nonce was not consumed")
+	}
+}
+
+// TestHandleHeartbeat_FailsClosedWithoutReplayGuard: a Coordinator with a
+// shared secret but no nonce cache must reject rather than silently skip
+// replay protection. Production always installs the cache before the listener
+// accepts, so this only fires on a misconstructed Coordinator — but failing
+// open there is how the check would get quietly lost.
+func TestHandleHeartbeat_FailsClosedWithoutReplayGuard(t *testing.T) {
+	c, peer := newHeartbeatTestCoordinator(t, "s3cret")
+	c.nonceCache = nil
+
+	deliverHeartbeat(c, signedHeartbeat("s3cret", peer.ID, "test-cluster"))
+
+	if !c.registry.GetLastHeartbeat(peer.ID).IsZero() {
+		t.Error("a heartbeat was accepted with no replay guard installed")
 	}
 }

--- a/internal/cluster/heartbeat_perdest_test.go
+++ b/internal/cluster/heartbeat_perdest_test.go
@@ -1,0 +1,136 @@
+package cluster
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/protocol"
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/rs/zerolog"
+)
+
+// TestSendHeartbeats_SignsPerDestination pins the per-peer signing behaviour.
+//
+// Two things break if heartbeats are signed once per tick and the same message
+// is sent to every peer:
+//
+//   - Correctness. The receiver now consumes the nonce in a replay cache, and
+//     two registry entries CAN share an address: node IDs are hostname+PID, so
+//     a bare-metal restart leaves the old entry behind and nothing evicts it.
+//     The second delivery would be rejected as a replay every single tick,
+//     making the one log line that is supposed to mean "attack" routine noise.
+//   - Safety. The heartbeat is handed to N goroutines that each marshal it, so
+//     writing the auth fields into a shared struct is a data race. Run this
+//     test under -race, which is where that shows up.
+//
+// Both peers here deliberately point at one listener, which is the
+// duplicate-address case.
+func TestSendHeartbeats_SignsPerDestination(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	addr := ln.Addr().String()
+
+	const wantDeliveries = 2
+	var (
+		mu       sync.Mutex
+		received []*protocol.Heartbeat
+	)
+	// Counts deliveries, not accepts: sendHeartbeats dispatches a goroutine
+	// per peer and returns immediately, so the test has to wait on the
+	// messages actually arriving.
+	var delivered sync.WaitGroup
+	delivered.Add(wantDeliveries)
+
+	go func() {
+		for i := 0; i < wantDeliveries; i++ {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				msg, err := protocol.ReceiveMessage(conn, 2*time.Second)
+				if err != nil {
+					return
+				}
+				hb, ok := msg.Payload.(*protocol.Heartbeat)
+				if !ok {
+					return
+				}
+				mu.Lock()
+				received = append(received, hb)
+				mu.Unlock()
+				// The sender blocks for up to 3s waiting on an ack, so reply
+				// or this test pays that wall-clock cost per peer.
+				_ = protocol.SendMessage(conn, protocol.NewHeartbeatAck(&protocol.HeartbeatAck{
+					NodeID:    "peer",
+					Timestamp: time.Now(),
+				}), 2*time.Second)
+				delivered.Done()
+			}(conn)
+		}
+	}()
+
+	local := NewNode("local-node", "local", RoleWriter, joinTestCluster)
+	local.UpdateState(StateHealthy)
+	reg := NewRegistry(&RegistryConfig{LocalNode: local, Logger: zerolog.Nop()})
+
+	// Two distinct node IDs sharing one address — what a bare-metal restart
+	// leaves behind.
+	for _, id := range []string{"peer-old", "peer-new"} {
+		n := NewNode(id, id, RoleWriter, joinTestCluster)
+		n.SetAddresses(addr, "")
+		n.UpdateState(StateHealthy)
+		if err := reg.Register(n); err != nil {
+			t.Fatalf("register %s: %v", id, err)
+		}
+	}
+
+	c := &Coordinator{
+		cfg:        &config.ClusterConfig{ClusterName: joinTestCluster, SharedSecret: joinTestSecret},
+		registry:   reg,
+		localNode:  local,
+		logger:     zerolog.Nop(),
+		nonceCache: security.NewNonceCache(security.HMACTimestampTolerance),
+	}
+
+	c.sendHeartbeats()
+
+	waited := make(chan struct{})
+	go func() { delivered.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for heartbeat deliveries")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != wantDeliveries {
+		t.Fatalf("got %d heartbeats, want %d", len(received), wantDeliveries)
+	}
+
+	// Distinct nonces: this is what keeps the second delivery from looking
+	// like a replay.
+	if received[0].AuthNonce == received[1].AuthNonce {
+		t.Error("both heartbeats carried the same nonce — the second would be rejected as a replay every tick")
+	}
+
+	// And each must independently validate, so per-peer signing did not
+	// produce a MAC over the wrong struct.
+	guard := security.NewNonceCache(security.HMACTimestampTolerance)
+	for i, hb := range received {
+		if err := security.ValidateHeartbeatHMACWithReplay(
+			guard, joinTestSecret, hb.AuthNonce, hb.AuthTimestamp,
+			heartbeatAuthFields(hb, joinTestCluster), hb.AuthHMAC, security.HMACTimestampTolerance,
+		); err != nil {
+			t.Errorf("heartbeat %d failed validation: %v", i, err)
+		}
+	}
+}

--- a/internal/cluster/join_auth_test.go
+++ b/internal/cluster/join_auth_test.go
@@ -1,0 +1,406 @@
+package cluster
+
+import (
+	"net"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/protocol"
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/rs/zerolog"
+)
+
+const (
+	joinTestCluster = "test-cluster"
+	joinTestSecret  = "join-test-secret"
+)
+
+// newJoinTestCoordinator builds a minimal no-Raft Coordinator that can serve a
+// join request: the registry path registers the node locally rather than going
+// through AddVoter, which keeps the test free of a real Raft cluster while
+// still exercising the whole authentication and registration path.
+func newJoinTestCoordinator(t *testing.T, secret string) *Coordinator {
+	t.Helper()
+	local := NewNode("leader-node", "leader", RoleWriter, joinTestCluster)
+	local.UpdateState(StateHealthy)
+	reg := NewRegistry(&RegistryConfig{LocalNode: local, Logger: zerolog.Nop()})
+	return &Coordinator{
+		cfg:        &config.ClusterConfig{ClusterName: joinTestCluster, SharedSecret: secret},
+		registry:   reg,
+		localNode:  local,
+		logger:     zerolog.Nop(),
+		nonceCache: security.NewNonceCache(security.HMACTimestampTolerance),
+	}
+}
+
+// signedJoinRequest builds a fully-populated, correctly-signed join request.
+// Callers mutate a field afterwards to simulate an on-path attacker.
+func signedJoinRequest(secret string) *protocol.JoinRequest {
+	req := &protocol.JoinRequest{
+		NodeID:      "joining-node",
+		NodeName:    "joining-node",
+		Role:        string(RoleReader),
+		ClusterName: joinTestCluster,
+		RaftAddr:    "10.0.0.2:9200",
+		APIAddr:     "10.0.0.2:8080",
+		CoordAddr:   "10.0.0.2:9100",
+		Version:     "26.09.2",
+		CoreCount:   runtime.GOMAXPROCS(0),
+	}
+	if secret != "" {
+		nonce, _ := security.GenerateNonce()
+		req.AuthTimestamp = time.Now().Unix()
+		req.AuthNonce = nonce
+		req.AuthHMAC = security.ComputeJoinHMAC(secret, nonce, req.AuthTimestamp, joinAuthFields(req))
+	}
+	return req
+}
+
+// deliverJoin runs handleJoinRequest over a pipe and returns the decoded
+// response, so a test can assert on both the registry effect and what the
+// joiner would have seen on the wire.
+func deliverJoin(t *testing.T, c *Coordinator, req *protocol.JoinRequest) *protocol.JoinResponse {
+	t.Helper()
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.handleJoinRequest(server, req)
+		server.Close()
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var resp *protocol.JoinResponse
+	if msg, err := protocol.ReceiveMessage(client, 2*time.Second); err == nil {
+		if jr, ok := msg.Payload.(*protocol.JoinResponse); ok {
+			resp = jr
+		}
+	}
+	client.Close()
+	<-done
+	return resp
+}
+
+// TestHandleJoinRequest_AcceptsValid is the control: without it, every
+// rejection test below could pass for the wrong reason.
+func TestHandleJoinRequest_AcceptsValid(t *testing.T) {
+	c := newJoinTestCoordinator(t, joinTestSecret)
+	req := signedJoinRequest(joinTestSecret)
+
+	resp := deliverJoin(t, c, req)
+	if resp == nil || !resp.Success {
+		t.Fatalf("valid join rejected: %+v", resp)
+	}
+
+	node, ok := c.registry.Get(req.NodeID)
+	if !ok {
+		t.Fatal("valid join did not register the node")
+	}
+	// The registered values must be the ones that were signed.
+	if node.Role != RoleReader {
+		t.Errorf("registered role = %v, want %v", node.Role, RoleReader)
+	}
+	if node.Address != req.CoordAddr || node.APIAddress != req.APIAddr {
+		t.Errorf("registered addresses = %q/%q, want %q/%q", node.Address, node.APIAddress, req.CoordAddr, req.APIAddr)
+	}
+
+	// The response itself must be signed over the request's nonce, otherwise
+	// the joiner has no way to tell it from an injected one.
+	if err := security.ValidateJoinResponseHMAC(
+		joinTestSecret, req.AuthNonce, resp.AuthTimestamp,
+		joinResponseAuthFields(resp), resp.AuthHMAC, security.HMACTimestampTolerance,
+	); err != nil {
+		t.Errorf("join success response failed its own validation: %v", err)
+	}
+}
+
+// TestHandleJoinRequest_RejectsFieldMutation is the direct regression test for
+// GHSA-p2rx as reported: each of these fields was consumed by the handler
+// while sitting outside the MAC, so an on-path attacker could rewrite it and
+// the tag still verified.
+func TestHandleJoinRequest_RejectsFieldMutation(t *testing.T) {
+	mutations := map[string]func(*protocol.JoinRequest){
+		"Role":      func(r *protocol.JoinRequest) { r.Role = string(RoleWriter) },
+		"NodeName":  func(r *protocol.JoinRequest) { r.NodeName = "attacker" },
+		"APIAddr":   func(r *protocol.JoinRequest) { r.APIAddr = "attacker.example:8080" },
+		"CoordAddr": func(r *protocol.JoinRequest) { r.CoordAddr = "attacker.example:9100" },
+		"RaftAddr":  func(r *protocol.JoinRequest) { r.RaftAddr = "attacker.example:9200" },
+		"Version":   func(r *protocol.JoinRequest) { r.Version = "0.0.1" },
+		"CoreCount": func(r *protocol.JoinRequest) { r.CoreCount = 1024 },
+	}
+
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			c := newJoinTestCoordinator(t, joinTestSecret)
+			req := signedJoinRequest(joinTestSecret)
+			mutate(req)
+
+			resp := deliverJoin(t, c, req)
+			if resp != nil && resp.Success {
+				t.Errorf("join with mutated %s was accepted", name)
+			}
+			if _, ok := c.registry.Get(req.NodeID); ok {
+				t.Errorf("join with mutated %s registered the node", name)
+			}
+			if resp != nil && resp.Error != joinAuthFailedMsg {
+				t.Errorf("pre-auth rejection leaked detail: %q", resp.Error)
+			}
+		})
+	}
+}
+
+// TestHandleJoinRequest_RejectsMutatedNodeID is the MAC-bound control from the
+// original report: NodeID was already covered, so mutating it was rejected
+// even before this fix. Keeping it guards against a change that accidentally
+// weakens the validator itself.
+func TestHandleJoinRequest_RejectsMutatedNodeID(t *testing.T) {
+	c := newJoinTestCoordinator(t, joinTestSecret)
+	req := signedJoinRequest(joinTestSecret)
+	req.NodeID = "tampered-node"
+
+	deliverJoin(t, c, req)
+	if _, ok := c.registry.Get("tampered-node"); ok {
+		t.Error("a join with a mutated NodeID was accepted")
+	}
+}
+
+// TestHandleJoinRequest_RejectsReplay: a captured join must not be replayable
+// inside the freshness window.
+func TestHandleJoinRequest_RejectsReplay(t *testing.T) {
+	c := newJoinTestCoordinator(t, joinTestSecret)
+	req := signedJoinRequest(joinTestSecret)
+
+	if resp := deliverJoin(t, c, req); resp == nil || !resp.Success {
+		t.Fatal("first join rejected")
+	}
+	c.registry.Unregister(req.NodeID)
+
+	resp := deliverJoin(t, c, req)
+	if resp != nil && resp.Success {
+		t.Error("a replayed join was accepted — the nonce was not consumed")
+	}
+	if _, ok := c.registry.Get(req.NodeID); ok {
+		t.Error("a replayed join re-registered the node")
+	}
+}
+
+// TestHandleJoinRequest_FailsClosedWithoutReplayGuard: see the heartbeat
+// equivalent. A nil *NonceCache in the interface is the typed-nil trap, so
+// this also guards against the validator panicking instead of rejecting.
+func TestHandleJoinRequest_FailsClosedWithoutReplayGuard(t *testing.T) {
+	c := newJoinTestCoordinator(t, joinTestSecret)
+	c.nonceCache = nil
+
+	resp := deliverJoin(t, c, signedJoinRequest(joinTestSecret))
+	if resp != nil && resp.Success {
+		t.Error("a join was accepted with no replay guard installed")
+	}
+}
+
+// TestHandleJoinRequest_UnsignedRejected covers the plain case: a peer that
+// does not know the secret at all.
+func TestHandleJoinRequest_UnsignedRejected(t *testing.T) {
+	c := newJoinTestCoordinator(t, joinTestSecret)
+	req := signedJoinRequest("")
+
+	resp := deliverJoin(t, c, req)
+	if resp != nil && resp.Success {
+		t.Error("an unsigned join was accepted by a secret-configured node")
+	}
+}
+
+// TestHandleJoinRequest_PreAuthErrorsAreUniform: every rejection that happens
+// before the peer proves it holds the shared secret returns the same opaque
+// string, and in particular never echoes the cluster name back.
+func TestHandleJoinRequest_PreAuthErrorsAreUniform(t *testing.T) {
+	cases := map[string]func() *protocol.JoinRequest{
+		"cluster name mismatch": func() *protocol.JoinRequest {
+			req := signedJoinRequest(joinTestSecret)
+			req.ClusterName = "someone-elses-cluster"
+			return req
+		},
+		"missing MAC": func() *protocol.JoinRequest {
+			req := signedJoinRequest(joinTestSecret)
+			req.AuthHMAC = ""
+			return req
+		},
+		"bad MAC": func() *protocol.JoinRequest {
+			req := signedJoinRequest(joinTestSecret)
+			req.AuthHMAC = strings.Repeat("0", 64)
+			return req
+		},
+	}
+
+	for name, build := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := newJoinTestCoordinator(t, joinTestSecret)
+			resp := deliverJoin(t, c, build())
+			if resp == nil {
+				t.Fatal("no response sent")
+			}
+			if resp.Success {
+				t.Fatal("rejection expected")
+			}
+			if resp.Error != joinAuthFailedMsg {
+				t.Errorf("error = %q, want the uniform %q", resp.Error, joinAuthFailedMsg)
+			}
+			if strings.Contains(resp.Error, joinTestCluster) {
+				t.Errorf("rejection leaked the cluster name: %q", resp.Error)
+			}
+		})
+	}
+}
+
+// TestHandleJoinRequest_NoSecretAcceptsUnsigned: clusters without a shared
+// secret are unsupported since #505 but still reachable in tests; the handler
+// must not start requiring auth it was never given.
+func TestHandleJoinRequest_NoSecretAcceptsUnsigned(t *testing.T) {
+	c := newJoinTestCoordinator(t, "")
+	resp := deliverJoin(t, c, signedJoinRequest(""))
+	if resp == nil || !resp.Success {
+		t.Fatal("unsigned join rejected by a coordinator with no secret")
+	}
+	if _, ok := c.registry.Get("joining-node"); !ok {
+		t.Error("node not registered")
+	}
+}
+
+// ---- Joiner side: validating the response ----
+
+// TestHandleJoinResponse_RejectsForgedResponse covers the reverse direction.
+// The joiner writes every returned NodeInfo into its own registry and follows
+// LeaderInfo redirects, so an unsigned response lets an on-path attacker
+// choose this node's view of the cluster.
+func TestHandleJoinResponse_RejectsForgedResponse(t *testing.T) {
+	reqNonce := "the-request-nonce"
+
+	build := func(mutate func(*protocol.JoinResponse)) *protocol.Message {
+		resp := &protocol.JoinResponse{
+			Success:    true,
+			LeaderID:   "leader-node",
+			LeaderAddr: "10.0.0.9:9100",
+			Nodes: []protocol.NodeInfo{
+				{ID: "peer-1", Name: "peer-1", Role: "writer", State: "healthy", APIAddr: "10.0.0.9:8080", CoordAddr: "10.0.0.9:9100"},
+			},
+		}
+		resp.AuthTimestamp = time.Now().Unix()
+		resp.AuthHMAC = security.ComputeJoinResponseHMAC(joinTestSecret, reqNonce, resp.AuthTimestamp, joinResponseAuthFields(resp))
+		if mutate != nil {
+			mutate(resp)
+		}
+		return protocol.NewJoinResponse(resp)
+	}
+
+	cases := map[string]func(*protocol.JoinResponse){
+		"forged peer address": func(r *protocol.JoinResponse) { r.Nodes[0].CoordAddr = "attacker.example:9100" },
+		"forged peer role":    func(r *protocol.JoinResponse) { r.Nodes[0].Role = "reader" },
+		"injected peer": func(r *protocol.JoinResponse) {
+			r.Nodes = append(r.Nodes, protocol.NodeInfo{ID: "ghost", CoordAddr: "attacker.example:9100"})
+		},
+		"forged leader addr": func(r *protocol.JoinResponse) { r.LeaderAddr = "attacker.example:9100" },
+		"stripped signature": func(r *protocol.JoinResponse) { r.AuthHMAC = "" },
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := newJoinTestCoordinator(t, joinTestSecret)
+			err := c.handleJoinResponse(build(mutate), "10.0.0.9:9100", reqNonce)
+			if err == nil {
+				t.Fatalf("forged join response (%s) was accepted", name)
+			}
+			if _, ok := c.registry.Get("peer-1"); ok {
+				t.Error("a peer from a forged response was registered")
+			}
+			if _, ok := c.registry.Get("ghost"); ok {
+				t.Error("an injected peer was registered")
+			}
+		})
+	}
+
+	t.Run("valid response is accepted", func(t *testing.T) {
+		c := newJoinTestCoordinator(t, joinTestSecret)
+		if err := c.handleJoinResponse(build(nil), "10.0.0.9:9100", reqNonce); err != nil {
+			t.Fatalf("valid join response rejected: %v", err)
+		}
+		if _, ok := c.registry.Get("peer-1"); !ok {
+			t.Error("valid response did not register the peer")
+		}
+	})
+
+	t.Run("response bound to a different nonce is rejected", func(t *testing.T) {
+		c := newJoinTestCoordinator(t, joinTestSecret)
+		if err := c.handleJoinResponse(build(nil), "10.0.0.9:9100", "a-different-nonce"); err == nil {
+			t.Error("a response bound to another request's nonce was accepted — captured responses would be replayable")
+		}
+	})
+}
+
+// TestHandleJoinResponse_RejectsForgedRedirect: a redirect names the address
+// the joiner dials next and hands its next signed join request to, so an
+// unauthenticated one is a free relay for an on-path attacker.
+func TestHandleJoinResponse_RejectsForgedRedirect(t *testing.T) {
+	c := newJoinTestCoordinator(t, joinTestSecret)
+	info := &protocol.LeaderInfo{
+		LeaderID:        "leader-node",
+		LeaderCoordAddr: "attacker.example:9100",
+	}
+	// Unsigned: exactly what an old-version peer or an injector sends.
+	err := c.handleJoinResponse(protocol.NewLeaderInfo(info), "10.0.0.9:9100", "req-nonce")
+	if err == nil {
+		t.Fatal("an unsigned leader redirect was accepted")
+	}
+	if !strings.Contains(err.Error(), "authentication") {
+		t.Errorf("error should name the authentication failure, got: %v", err)
+	}
+}
+
+// TestHandleJoinResponse_ValidRedirectIsFollowed proves the redirect path is
+// reached after validation — the dial fails because the target port is closed,
+// which is a different error than the authentication rejection above.
+func TestHandleJoinResponse_ValidRedirectIsFollowed(t *testing.T) {
+	c := newJoinTestCoordinator(t, joinTestSecret)
+
+	// A port nothing is listening on: reserve one, then release it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	closedAddr := ln.Addr().String()
+	ln.Close()
+
+	reqNonce := "req-nonce"
+	info := &protocol.LeaderInfo{LeaderID: "leader-node", LeaderCoordAddr: closedAddr}
+	info.AuthTimestamp = time.Now().Unix()
+	info.AuthHMAC = security.ComputeLeaderInfoHMAC(joinTestSecret, reqNonce, info.AuthTimestamp, leaderInfoAuthFields(info))
+
+	err = c.handleJoinResponse(protocol.NewLeaderInfo(info), "10.0.0.9:9100", reqNonce)
+	if err == nil {
+		t.Fatal("expected the redirect dial to fail against a closed port")
+	}
+	if strings.Contains(err.Error(), "authentication") {
+		t.Errorf("a correctly signed redirect was rejected as unauthenticated: %v", err)
+	}
+	if !strings.Contains(err.Error(), "connect") {
+		t.Errorf("expected a connection error, got: %v", err)
+	}
+}
+
+// TestHandleJoinResponse_NoSecretAcceptsUnsigned: a coordinator with no shared
+// secret must still accept plain responses.
+func TestHandleJoinResponse_NoSecretAcceptsUnsigned(t *testing.T) {
+	c := newJoinTestCoordinator(t, "")
+	resp := &protocol.JoinResponse{
+		Success:  true,
+		LeaderID: "leader-node",
+		Nodes:    []protocol.NodeInfo{{ID: "peer-1", Name: "peer-1", Role: "writer", State: "healthy"}},
+	}
+	if err := c.handleJoinResponse(protocol.NewJoinResponse(resp), "10.0.0.9:9100", ""); err != nil {
+		t.Fatalf("unsigned response rejected with no secret configured: %v", err)
+	}
+	if _, ok := c.registry.Get("peer-1"); !ok {
+		t.Error("peer not registered")
+	}
+}

--- a/internal/cluster/leave_auth_test.go
+++ b/internal/cluster/leave_auth_test.go
@@ -1,0 +1,125 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/protocol"
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/basekick-labs/arc/internal/config"
+	"github.com/rs/zerolog"
+)
+
+// newLeaveTestCoordinator builds a coordinator with one registered peer, so a
+// leave that is accepted unregisters it and one that is rejected does not.
+func newLeaveTestCoordinator(t *testing.T, secret string) (*Coordinator, *Node) {
+	t.Helper()
+	local := NewNode("coord", "coord", RoleWriter, joinTestCluster)
+	reg := NewRegistry(&RegistryConfig{LocalNode: local, Logger: zerolog.Nop()})
+	peer := NewNode("peer-1", "peer-1", RoleWriter, joinTestCluster)
+	peer.UpdateState(StateHealthy)
+	if err := reg.Register(peer); err != nil {
+		t.Fatalf("register peer: %v", err)
+	}
+	c := &Coordinator{
+		cfg:        &config.ClusterConfig{ClusterName: joinTestCluster, SharedSecret: secret},
+		registry:   reg,
+		localNode:  local,
+		logger:     zerolog.Nop(),
+		nonceCache: security.NewNonceCache(security.HMACTimestampTolerance),
+	}
+	return c, peer
+}
+
+func signedLeave(secret, nodeID, reason string) *protocol.LeaveNotify {
+	leave := &protocol.LeaveNotify{NodeID: nodeID, Reason: reason}
+	if secret != "" {
+		nonce, _ := security.GenerateNonce()
+		leave.AuthTimestamp = time.Now().Unix()
+		leave.AuthNonce = nonce
+		leave.AuthHMAC = security.ComputeLeaveHMAC(secret, nonce, leave.AuthTimestamp, leaveAuthFields(leave, joinTestCluster))
+	}
+	return leave
+}
+
+// TestHandleLeaveNotify_AcceptsValid is the control for the rejection tests.
+func TestHandleLeaveNotify_AcceptsValid(t *testing.T) {
+	c, peer := newLeaveTestCoordinator(t, joinTestSecret)
+	c.handleLeaveNotify(signedLeave(joinTestSecret, peer.ID, "graceful shutdown"))
+	if _, ok := c.registry.Get(peer.ID); ok {
+		t.Error("a valid leave did not unregister the peer")
+	}
+}
+
+// TestHandleLeaveNotify_RejectsMutatedReason: Reason is only logged today, but
+// it is bound like every other field. If a future change starts acting on it,
+// this test is what keeps it from being attacker-controlled.
+func TestHandleLeaveNotify_RejectsMutatedReason(t *testing.T) {
+	c, peer := newLeaveTestCoordinator(t, joinTestSecret)
+	leave := signedLeave(joinTestSecret, peer.ID, "graceful shutdown")
+	leave.Reason = "evicted by operator"
+
+	c.handleLeaveNotify(leave)
+	if _, ok := c.registry.Get(peer.ID); !ok {
+		t.Error("a leave with a mutated Reason was accepted — the field is outside the MAC")
+	}
+}
+
+// TestHandleLeaveNotify_RejectsMutatedNodeID: the eviction target must be
+// bound, or an attacker could redirect a legitimate node's own leave onto a
+// different node and remove it from the cluster.
+func TestHandleLeaveNotify_RejectsMutatedNodeID(t *testing.T) {
+	c, peer := newLeaveTestCoordinator(t, joinTestSecret)
+	leave := signedLeave(joinTestSecret, "some-other-node", "graceful shutdown")
+	leave.NodeID = peer.ID
+
+	c.handleLeaveNotify(leave)
+	if _, ok := c.registry.Get(peer.ID); !ok {
+		t.Error("a leave retargeted at another node was accepted")
+	}
+}
+
+// TestHandleLeaveNotify_RejectsReplay: a captured leave must not be replayable
+// — re-delivering one after the node rejoined would evict it again.
+func TestHandleLeaveNotify_RejectsReplay(t *testing.T) {
+	c, peer := newLeaveTestCoordinator(t, joinTestSecret)
+	leave := signedLeave(joinTestSecret, peer.ID, "graceful shutdown")
+
+	c.handleLeaveNotify(leave)
+	if _, ok := c.registry.Get(peer.ID); ok {
+		t.Fatal("first leave was rejected")
+	}
+
+	// The node comes back, and the attacker replays the captured leave.
+	rejoined := NewNode(peer.ID, peer.ID, RoleWriter, joinTestCluster)
+	rejoined.UpdateState(StateHealthy)
+	if err := c.registry.Register(rejoined); err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+
+	c.handleLeaveNotify(leave)
+	if _, ok := c.registry.Get(peer.ID); !ok {
+		t.Error("a replayed leave evicted the rejoined node — the nonce was not consumed")
+	}
+}
+
+// TestHandleLeaveNotify_FailsClosedWithoutReplayGuard: see the heartbeat and
+// join equivalents; this also covers the typed-nil guard path.
+func TestHandleLeaveNotify_FailsClosedWithoutReplayGuard(t *testing.T) {
+	c, peer := newLeaveTestCoordinator(t, joinTestSecret)
+	c.nonceCache = nil
+
+	c.handleLeaveNotify(signedLeave(joinTestSecret, peer.ID, "graceful shutdown"))
+	if _, ok := c.registry.Get(peer.ID); !ok {
+		t.Error("a leave was accepted with no replay guard installed")
+	}
+}
+
+// TestHandleLeaveNotify_UnsignedRejected: the plain case.
+func TestHandleLeaveNotify_UnsignedRejected(t *testing.T) {
+	c, peer := newLeaveTestCoordinator(t, joinTestSecret)
+	c.handleLeaveNotify(&protocol.LeaveNotify{NodeID: peer.ID, Reason: "bye"})
+	if _, ok := c.registry.Get(peer.ID); !ok {
+		t.Error("an unsigned leave was accepted by a secret-configured node")
+	}
+}

--- a/internal/cluster/protocol/messages.go
+++ b/internal/cluster/protocol/messages.go
@@ -119,13 +119,18 @@ type ReplicateSync struct {
 	// SupportsBinaryEntries advertises that this reader understands
 	// MsgReplicateEntryBin frames (#698), letting the writer send WAL
 	// entry payloads as raw bytes instead of JSON + base64 (whose 4/3
-	// inflation made entries above ~75MB unsendable). Deliberately NOT
-	// covered by the handshake HMAC: old writers compute and validate
-	// the MAC over the original field tuple, so folding this flag in
-	// would break every mixed-version handshake. The worst an on-path
-	// tamperer gains by flipping it is a framing downgrade or a dropped
-	// connection, both already available to anyone who can modify the
-	// stream; TLS covers integrity where configured.
+	// inflation made entries above ~75MB unsendable).
+	//
+	// NOT covered by the replicate-sync HMAC. The original reason — that
+	// folding it in would break mixed-version handshakes — no longer
+	// applies as stated: 26.09.2 made the coordinator handshake a hard
+	// cutover anyway. It is still unsigned because replicate-sync is a
+	// separate message and validator from the handshake family, and
+	// widening that cutover was out of scope for the security fix that
+	// forced it. The worst an on-path tamperer gains by flipping this is a
+	// framing downgrade or a dropped connection, both already available to
+	// anyone who can modify the stream; TLS covers integrity where
+	// configured. Tracked as a follow-up.
 	SupportsBinaryEntries bool `json:"bin_entries,omitempty"`
 }
 

--- a/internal/cluster/protocol/messages.go
+++ b/internal/cluster/protocol/messages.go
@@ -173,6 +173,12 @@ type JoinResponse struct {
 	RaftLeader string     `json:"raft_leader"` // Leader's Raft address
 	Nodes      []NodeInfo `json:"nodes"`       // Current cluster members
 	Error      string     `json:"error,omitempty"`
+	// Authentication (present when shared_secret is configured). Signed by
+	// the responder over the REQUEST's nonce plus every field above, so the
+	// requester validates with the nonce it generated and needs no nonce
+	// cache of its own. See security/handshake_auth.go.
+	AuthTimestamp int64  `json:"auth_timestamp,omitempty"`
+	AuthHMAC      string `json:"auth_hmac,omitempty"`
 }
 
 // LeaderInfo is sent when a non-leader receives a join request,
@@ -181,6 +187,12 @@ type LeaderInfo struct {
 	LeaderID        string `json:"leader_id"`
 	LeaderCoordAddr string `json:"leader_coord_addr"` // Leader's coordinator address
 	LeaderRaftAddr  string `json:"leader_raft_addr"`  // Leader's Raft address
+	// Authentication (present when shared_secret is configured). Signed by
+	// the responder over the REQUEST's nonce plus every field above, so the
+	// requester validates with the nonce it generated and needs no nonce
+	// cache of its own. See security/handshake_auth.go.
+	AuthTimestamp int64  `json:"auth_timestamp,omitempty"`
+	AuthHMAC      string `json:"auth_hmac,omitempty"`
 }
 
 // Heartbeat is sent periodically to maintain connection and share state.
@@ -302,11 +314,12 @@ type FetchFileAckHeader struct {
 // as a raw json.RawMessage avoids re-marshalling and lets the protocol
 // package stay free of any raft.* imports.
 //
-// HMAC auth headers use the same {nonce, nodeID, clusterName, timestamp}
-// signature as the join handshake (security.ComputeHMAC, NOT the
-// path-bound ComputeFetchHMAC). The forwarded command's content is
-// trusted because cluster peers are mutually authenticated; the HMAC's
-// only job is to prove "I am a known peer in this cluster".
+// HMAC auth headers are payload-bound: security.ComputeForwardHMAC signs
+// {nonce, nodeID, clusterName, sha256(CommandJSON), timestamp}, so the
+// forwarded command cannot be altered in flight by a peer that merely
+// knows the shared secret's MAC for some other command. The ack is
+// likewise signed over this request's nonce (26.09.2) — see
+// security/handshake_auth.go.
 //
 // Phase 4 only sends this for RegisterFile and DeleteFile commands, but
 // the wire format accepts any Command type so future Phase 5+ commands
@@ -331,6 +344,12 @@ type ForwardApplyAck struct {
 	Status string           `json:"status"`          // "ok" or "error"
 	Code   ForwardApplyCode `json:"code,omitempty"`  // machine-readable error category
 	Error  string           `json:"error,omitempty"` // human-readable detail
+	// Authentication (present when shared_secret is configured). Signed by
+	// the responder over the REQUEST's nonce plus every field above, so the
+	// requester validates with the nonce it generated and needs no nonce
+	// cache of its own. See security/handshake_auth.go.
+	AuthTimestamp int64  `json:"auth_timestamp,omitempty"`
+	AuthHMAC      string `json:"auth_hmac,omitempty"`
 }
 
 // ForwardApplyCode is the typed error category for ForwardApplyAck. Same

--- a/internal/cluster/security/auth.go
+++ b/internal/cluster/security/auth.go
@@ -19,8 +19,8 @@ import (
 // a compile-time error.
 type MsgType string
 
-// Message-type labels bound into the join-family HMAC (ComputeHMAC /
-// ValidateHMAC) for domain separation (#504). Using shared typed constants —
+// Message-type labels bound into the coordinator-handshake HMACs
+// (handshake_auth.go) for domain separation (#504). Using shared typed constants —
 // rather than bare string literals at each call site — guarantees the sign and
 // validate sides agree. Using a bare string literal instead of these constants
 // at a single call site would reject every message of that message type
@@ -38,31 +38,6 @@ const (
 	MsgTypeRaftAuth     MsgType = "raft-auth"
 	MsgTypeRaftAuthResp MsgType = "raft-auth-resp"
 )
-
-// ComputeHMAC computes HMAC-SHA256 over the parameters of a coordinator
-// handshake message (join, leave, or heartbeat). msgType is a per-message-type
-// label ("join"/"leave"/"heartbeat") bound as the FIRST field of the canonical
-// input, distinct per handler, so a MAC captured for one message type cannot be
-// replayed against another within the freshness window (#504) — the same
-// label-based domain-separation discipline ComputeCacheInvalidateHMAC uses
-// (ComputeFetchHMAC and ComputeForwardHMAC achieve domain separation via
-// payload-binding — different field layouts — rather than labels). A heartbeat
-// MAC replayed as a node-evicting leave is the concrete attack this closes.
-//
-// Fields are delimited by NUL (\x00) so a field containing a delimiter cannot
-// be smuggled to collide with a different (msgType, nonce, nodeID, clusterName,
-// timestamp) arrangement. NUL is forbidden in HTTP header values by net/http
-// (httpguts), so the sender side cannot produce a NUL-containing field even via
-// malicious config.
-// Message format: msgType \x00 nonce \x00 nodeID \x00 clusterName \x00 timestamp
-func ComputeHMAC(sharedSecret string, msgType MsgType, nonce, nodeID, clusterName string, timestamp int64) string {
-	return hex.EncodeToString(computeJoinFamilyHMACRaw(sharedSecret, msgType, nonce, nodeID, clusterName, timestamp))
-}
-
-func computeJoinFamilyHMACRaw(sharedSecret string, msgType MsgType, nonce, nodeID, clusterName string, timestamp int64) []byte {
-	message := fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%d", msgType, nonce, nodeID, clusterName, timestamp)
-	return computeRawHMAC(sharedSecret, message)
-}
 
 // constantTimeHexEqual reports whether two hex-encoded MAC strings
 // represent the same byte sequence, in constant time over the
@@ -100,32 +75,15 @@ func GenerateNonce() (string, error) {
 	return hex.EncodeToString(nonce), nil
 }
 
-// ValidateHMAC validates the HMAC and checks timestamp freshness to prevent
-// replay attacks. msgType MUST match the label the sender used (see
-// ComputeHMAC) — a "leave" message validated as "join" fails, which is exactly
-// the cross-message-type replay this binding prevents (#504).
-func ValidateHMAC(sharedSecret string, msgType MsgType, nonce, nodeID, clusterName string, timestamp int64, receivedMAC string, tolerance time.Duration) error {
-	now := time.Now().Unix()
-	drift := now - timestamp
-	if drift < 0 {
-		drift = -drift
-	}
-	if drift > int64(tolerance.Seconds()) {
-		return fmt.Errorf("auth timestamp expired (drift: %ds, tolerance: %ds)", drift, int64(tolerance.Seconds()))
-	}
-
-	expected := computeJoinFamilyHMACRaw(sharedSecret, msgType, nonce, nodeID, clusterName, timestamp)
-	if !constantTimeHexEqual(expected, receivedMAC) {
-		return fmt.Errorf("HMAC validation failed: shared secret mismatch or malformed MAC")
-	}
-	return nil
-}
-
 // ComputeFetchHMAC computes HMAC-SHA256 for a peer file-fetch request. The
 // message format binds the requested path into the signed payload so a stolen
 // MAC for file A cannot be replayed within the freshness window to fetch a
 // different file B.
-// Fields are NUL-delimited (see ComputeHMAC for rationale).
+// Fields are NUL-delimited. (The coordinator handshake family moved to
+// length-prefixed canonicalization in 26.09.2 — see handshake_auth.go and
+// canonicalSyncInput. These families keep the NUL format: their field sets
+// are fixed-arity and their trailing timestamp makes re-partitioning
+// inert. Do not add a variable-length field to one without moving it.)
 // Format: nonce \x00 nodeID \x00 clusterName \x00 path \x00 timestamp
 func ComputeFetchHMAC(sharedSecret, nonce, nodeID, clusterName, path string, timestamp int64) string {
 	return hex.EncodeToString(computeFetchHMACRaw(sharedSecret, nonce, nodeID, clusterName, path, timestamp))
@@ -164,7 +122,11 @@ func ValidateFetchHMAC(sharedSecret, nonce, nodeID, clusterName, path string, ti
 // rather than including the raw bytes, so the HMAC input remains a
 // fixed-length string regardless of command size.
 //
-// Fields are NUL-delimited (see ComputeHMAC for rationale).
+// Fields are NUL-delimited. (The coordinator handshake family moved to
+// length-prefixed canonicalization in 26.09.2 — see handshake_auth.go and
+// canonicalSyncInput. These families keep the NUL format: their field sets
+// are fixed-arity and their trailing timestamp makes re-partitioning
+// inert. Do not add a variable-length field to one without moving it.)
 // Format: nonce \x00 nodeID \x00 clusterName \x00 payloadSHA256 \x00 timestamp
 func ComputeForwardHMAC(sharedSecret, nonce, nodeID, clusterName string, payload []byte, timestamp int64) string {
 	return hex.EncodeToString(computeForwardHMACRaw(sharedSecret, nonce, nodeID, clusterName, payload, timestamp))
@@ -205,7 +167,7 @@ func ValidateForwardHMAC(sharedSecret, nonce, nodeID, clusterName string, payloa
 // The "cache-invalidate" label is the first field of the canonical input,
 // distinct from Forward/Fetch/Join so a leaked MAC for one endpoint cannot
 // be replayed against another even within the freshness window. Fields are
-// NUL-delimited (see ComputeHMAC for rationale).
+// NUL-delimited (see ComputeFetchHMAC for the caveat on that format).
 // Format: "cache-invalidate" \x00 nonce \x00 nodeID \x00 clusterName \x00 timestamp
 func ComputeCacheInvalidateHMAC(sharedSecret, nonce, nodeID, clusterName string, timestamp int64) string {
 	return hex.EncodeToString(computeCacheInvalidateHMACRaw(sharedSecret, nonce, nodeID, clusterName, timestamp))
@@ -218,7 +180,7 @@ func computeCacheInvalidateHMACRaw(sharedSecret, nonce, nodeID, clusterName stri
 
 // ValidateCacheInvalidateHMAC validates a cache-invalidate HMAC and checks
 // freshness. The message format is intentionally label-distinct from
-// ComputeForwardHMAC / ComputeFetchHMAC / ComputeHMAC so cross-endpoint
+// ComputeForwardHMAC / ComputeFetchHMAC / the handshake family so cross-endpoint
 // replay is impossible even if a MAC leaks within the freshness window.
 func ValidateCacheInvalidateHMAC(sharedSecret, nonce, nodeID, clusterName string, timestamp int64, receivedMAC string, tolerance time.Duration) error {
 	now := time.Now().Unix()
@@ -351,13 +313,17 @@ const ReplicationEntryTagLen = 8
 // HMACTimestampTolerance is the symmetric window (past and future) the
 // cluster HMAC validators accept on a signed timestamp. Five minutes
 // is the same window enforced by every Compute*HMAC consumer in this
-// package (join, leave, fetch, forward-apply, cache-invalidate,
-// replicate-sync, replicate-checkpoint) AND the NonceCache TTL the
-// coordinator constructs at startup — keep them aligned so a replayed
-// HMAC can never outlive its nonce-cache slot. Centralized here so a
-// future operator can tune all sites in one place; Gemini round 1 on
-// PR #449 flagged the hardcoded 5*time.Minute scattered across
-// coordinator.go.
+// package (join, leave, heartbeat, the handshake responses, fetch,
+// forward-apply, cache-invalidate, replicate-sync,
+// replicate-checkpoint). Centralized here so a future operator can tune
+// all sites in one place; Gemini round 1 on PR #449 flagged the
+// hardcoded 5*time.Minute scattered across coordinator.go.
+//
+// NOTE: a NonceCache built for this tolerance does NOT use it as its own
+// TTL — it must outlive the window by more than the window, because a
+// message may be stamped up to one tolerance in the FUTURE and is still
+// accepted. NewNonceCache derives the right lifetime itself; pass it the
+// tolerance, not a TTL.
 const HMACTimestampTolerance = 5 * time.Minute
 
 // ComputeReplicationEntryTag returns the 8-byte per-entry MAC tag

--- a/internal/cluster/security/auth_test.go
+++ b/internal/cluster/security/auth_test.go
@@ -31,92 +31,130 @@ func TestComputeCacheInvalidateHMAC_Determinism(t *testing.T) {
 	}
 }
 
-// TestComputeHMAC_Determinism pins the on-wire format for the join HMAC
+// TestHandshakeHMAC_Determinism (above) pins the on-wire format for the
+// handshake family. This section covers the other MAC families.
 // (used by cluster.AuthenticatePeer). Same purpose as the cache-invalidate
-// determinism test: a silent format change across an Arc upgrade silently
-// breaks peer joins. Bump the protocol version and document the migration
-// before changing the constant.
-func TestComputeHMAC_Determinism(t *testing.T) {
+// Determinism tests pin the on-wire format of the coordinator handshake
+// family. A silent format change across an Arc upgrade breaks peer joins,
+// heartbeats and leaves cluster-wide, so these constants are a deliberate
+// tripwire: if one fails, the wire format changed and the upgrade is a
+// lockstep cutover that must be documented in the release notes before merge.
+//
+// The format changed once already, in 26.09.2 (GHSA-p2rx): from a
+// NUL-delimited {msgType, nonce, nodeID, clusterName, timestamp} to
+// length-prefixed canonicalization over EVERY field of the message.
+func TestHandshakeHMAC_Determinism(t *testing.T) {
 	t.Parallel()
-	got := ComputeHMAC("secret", MsgTypeJoin, "nonce-abc", "node-1", "cluster-A", 1700000000)
-	const want = "157f5091712b067897fb7f6e088229c05837799edd249daec924184cb57d9e6b"
-	if got != want {
-		t.Errorf("join MAC drift detected:\n  got  %s\n  want %s\nIf this test fails, the join-endpoint message format changed — coordinate with the deployed-version matrix before merging.", got, want)
+	const (
+		secret = "secret"
+		nonce  = "nonce-abc"
+		ts     = int64(1700000000)
+	)
+
+	join := JoinAuthFields{
+		NodeID: "node-1", NodeName: "node-one", Role: "writer", ClusterName: "cluster-A",
+		RaftAddr: "10.0.0.1:9200", APIAddr: "10.0.0.1:8080", CoordAddr: "10.0.0.1:9100",
+		Version: "26.09.2", CoreCount: 8,
+	}
+	hb := HeartbeatAuthFields{
+		NodeID: "node-1", ClusterName: "cluster-A", State: "healthy",
+		IsLeader: true, TimestampUnixNano: 1700000000000000000,
+	}
+	leave := LeaveAuthFields{NodeID: "node-1", ClusterName: "cluster-A", Reason: "graceful shutdown"}
+	resp := JoinResponseAuthFields{
+		Success: true, LeaderID: "node-0", LeaderAddr: "10.0.0.9:9100", RaftLeader: "10.0.0.9:9200",
+		Nodes: []NodeAuthFields{{
+			ID: "node-0", Name: "node-zero", Role: "writer", State: "healthy",
+			RaftAddr: "", APIAddr: "10.0.0.9:8080", CoordAddr: "10.0.0.9:9100", CoreCount: 4,
+		}},
+	}
+	info := LeaderInfoAuthFields{LeaderID: "node-0", LeaderCoordAddr: "10.0.0.9:9100", LeaderRaftAddr: "10.0.0.9:9200"}
+	ack := ForwardAckAuthFields{Status: "ok"}
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"join", ComputeJoinHMAC(secret, nonce, ts, join), "0922d84d08e2d183f88409626819c5c3300d1d2936502aa1bd3a91bdc41ab31c"},
+		{"heartbeat", ComputeHeartbeatHMAC(secret, nonce, ts, hb), "1fde9f8fb75119f2adb21833d40fabe636b9fbba796bab39e075ca10808f3754"},
+		{"leave", ComputeLeaveHMAC(secret, nonce, ts, leave), "2bc824a7ff74363b93f88d3545fca251b56a63d61c47556f88a2726caf39be48"},
+		{"join-resp", ComputeJoinResponseHMAC(secret, nonce, ts, resp), "3f5aa4d563b6e0c2c0cee2eea5278379d05729c09ddbe0364c3dae56a2452332"},
+		{"leader-info", ComputeLeaderInfoHMAC(secret, nonce, ts, info), "ddf8663bc24ba19d22c41a28e91fe7398f88f0bd640364f3dd8270b4f1c4e8cb"},
+		{"forward-ack", ComputeForwardAckHMAC(secret, nonce, ts, ack), "2f52aac26df0e65fd07593bb2b5b9bb6cbbcd9a9b7204026e775b0117ea8c759"},
+	}
+	for _, tc := range tests {
+		if tc.got != tc.want {
+			t.Errorf("%s MAC drift:\n  got  %s\n  want %s\nThe handshake wire format changed — coordinate the lockstep upgrade and update the release notes before merging.", tc.name, tc.got, tc.want)
+		}
 	}
 }
 
-// TestJoinFamilyHMAC_LabelBinding_NoCrossMessageTypeReplay is the
-// critical security property for #504: a MAC computed with one
-// message-type label (join/leave/heartbeat) must NOT validate against
-// the verifier for a different message type, even with identical
-// (nonce, nodeID, clusterName, timestamp) inputs.
+// TestHandshakeHMAC_LabelBinding_NoCrossMessageTypeReplay is the critical
+// security property from #504, carried forward to the 26.09.2 format: a MAC
+// computed for one message type must not validate as another, even with
+// identical nonce/timestamp inputs.
 //
-// Without the per-message-type label, a heartbeat MAC could be replayed
-// as a node-evicting leave within the 5-minute freshness window.
-// This test ensures the labels make that impossible in all six
-// cross-type combinations.
-func TestJoinFamilyHMAC_LabelBinding_NoCrossMessageTypeReplay(t *testing.T) {
+// Without the per-type label a heartbeat MAC could be replayed as a
+// node-evicting leave inside the freshness window. The response labels matter
+// for the same reason in the other direction — a join response replayed as a
+// leader redirect would send a joiner to an address of the attacker's choosing.
+func TestHandshakeHMAC_LabelBinding_NoCrossMessageTypeReplay(t *testing.T) {
 	t.Parallel()
 	const (
-		secret      = "secret"
-		nonce       = "nonce-abc"
-		nodeID      = "node-1"
-		clusterName = "cluster-A"
+		secret  = "secret"
+		nonce   = "nonce-abc"
+		cluster = "cluster-A"
+		nodeID  = "node-1"
 	)
 	ts := time.Now().Unix()
 
-	joinMAC := ComputeHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts)
-	leaveMAC := ComputeHMAC(secret, MsgTypeLeave, nonce, nodeID, clusterName, ts)
-	heartbeatMAC := ComputeHMAC(secret, MsgTypeHeartbeat, nonce, nodeID, clusterName, ts)
+	// Same NodeID/ClusterName/nonce/timestamp across every type, so only the
+	// label can be what distinguishes them.
+	join := JoinAuthFields{NodeID: nodeID, ClusterName: cluster}
+	hb := HeartbeatAuthFields{NodeID: nodeID, ClusterName: cluster}
+	leave := LeaveAuthFields{NodeID: nodeID, ClusterName: cluster}
+	resp := JoinResponseAuthFields{LeaderID: nodeID}
+	info := LeaderInfoAuthFields{LeaderID: nodeID}
+	ack := ForwardAckAuthFields{Status: nodeID}
 
-	// All three must produce distinct MACs for identical (nonce, nodeID,
-	// clusterName, timestamp). If any pair collides, cross-message-type
-	// replay is trivially possible.
-	if joinMAC == leaveMAC {
-		t.Error("join MAC collided with leave MAC — cross-message-type replay possible")
-	}
-	if joinMAC == heartbeatMAC {
-		t.Error("join MAC collided with heartbeat MAC — cross-message-type replay possible")
-	}
-	if leaveMAC == heartbeatMAC {
-		t.Error("leave MAC collided with heartbeat MAC — cross-message-type replay possible")
-	}
-
-	// Each validator must reject MACs computed with the other two labels.
-	// join validator rejects leave MAC.
-	if err := ValidateHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts, leaveMAC, 5*time.Minute); err == nil {
-		t.Error("leave MAC accepted by join validator — label binding broken")
-	}
-	// join validator rejects heartbeat MAC.
-	if err := ValidateHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts, heartbeatMAC, 5*time.Minute); err == nil {
-		t.Error("heartbeat MAC accepted by join validator — label binding broken")
-	}
-	// leave validator rejects join MAC.
-	if err := ValidateHMAC(secret, MsgTypeLeave, nonce, nodeID, clusterName, ts, joinMAC, 5*time.Minute); err == nil {
-		t.Error("join MAC accepted by leave validator — label binding broken")
-	}
-	// leave validator rejects heartbeat MAC.
-	if err := ValidateHMAC(secret, MsgTypeLeave, nonce, nodeID, clusterName, ts, heartbeatMAC, 5*time.Minute); err == nil {
-		t.Error("heartbeat MAC accepted by leave validator — label binding broken")
-	}
-	// heartbeat validator rejects join MAC.
-	if err := ValidateHMAC(secret, MsgTypeHeartbeat, nonce, nodeID, clusterName, ts, joinMAC, 5*time.Minute); err == nil {
-		t.Error("join MAC accepted by heartbeat validator — label binding broken")
-	}
-	// heartbeat validator rejects leave MAC.
-	if err := ValidateHMAC(secret, MsgTypeHeartbeat, nonce, nodeID, clusterName, ts, leaveMAC, 5*time.Minute); err == nil {
-		t.Error("leave MAC accepted by heartbeat validator — label binding broken")
+	macs := map[string]string{
+		"join":        ComputeJoinHMAC(secret, nonce, ts, join),
+		"heartbeat":   ComputeHeartbeatHMAC(secret, nonce, ts, hb),
+		"leave":       ComputeLeaveHMAC(secret, nonce, ts, leave),
+		"join-resp":   ComputeJoinResponseHMAC(secret, nonce, ts, resp),
+		"leader-info": ComputeLeaderInfoHMAC(secret, nonce, ts, info),
+		"forward-ack": ComputeForwardAckHMAC(secret, nonce, ts, ack),
 	}
 
-	// Sanity: each validator accepts its own MAC.
-	if err := ValidateHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts, joinMAC, 5*time.Minute); err != nil {
-		t.Errorf("join validator rejected its own MAC: %v", err)
+	// Every MAC must be distinct — a collision is trivially replayable.
+	seen := make(map[string]string, len(macs))
+	for label, mac := range macs {
+		if other, dup := seen[mac]; dup {
+			t.Errorf("%s and %s produced the same MAC — cross-message-type replay possible", label, other)
+		}
+		seen[mac] = label
 	}
-	if err := ValidateHMAC(secret, MsgTypeLeave, nonce, nodeID, clusterName, ts, leaveMAC, 5*time.Minute); err != nil {
-		t.Errorf("leave validator rejected its own MAC: %v", err)
+
+	// Each validator accepts only its own label's MAC.
+	validators := map[string]func(mac string) error{
+		"join":        func(mac string) error { return ValidateJoinHMAC(secret, nonce, ts, join, mac, 5*time.Minute) },
+		"heartbeat":   func(mac string) error { return ValidateHeartbeatHMAC(secret, nonce, ts, hb, mac, 5*time.Minute) },
+		"leave":       func(mac string) error { return ValidateLeaveHMAC(secret, nonce, ts, leave, mac, 5*time.Minute) },
+		"join-resp":   func(mac string) error { return ValidateJoinResponseHMAC(secret, nonce, ts, resp, mac, 5*time.Minute) },
+		"leader-info": func(mac string) error { return ValidateLeaderInfoHMAC(secret, nonce, ts, info, mac, 5*time.Minute) },
+		"forward-ack": func(mac string) error { return ValidateForwardAckHMAC(secret, nonce, ts, ack, mac, 5*time.Minute) },
 	}
-	if err := ValidateHMAC(secret, MsgTypeHeartbeat, nonce, nodeID, clusterName, ts, heartbeatMAC, 5*time.Minute); err != nil {
-		t.Errorf("heartbeat validator rejected its own MAC: %v", err)
+	for vLabel, validate := range validators {
+		for mLabel, mac := range macs {
+			err := validate(mac)
+			if vLabel == mLabel && err != nil {
+				t.Errorf("%s validator rejected its own MAC: %v", vLabel, err)
+			}
+			if vLabel != mLabel && err == nil {
+				t.Errorf("%s MAC accepted by %s validator — label binding broken", mLabel, vLabel)
+			}
+		}
 	}
 }
 
@@ -156,7 +194,7 @@ func TestValidate_RejectsMalformedHexMAC(t *testing.T) {
 	ts := time.Now().Unix()
 	const malformed = "not-hex-at-all-zzzzzzzzzzzzzzzz"
 
-	if err := ValidateHMAC("s", MsgTypeJoin, "n", "id", "c", ts, malformed, 5*time.Minute); err == nil {
+	if err := ValidateJoinHMAC("s", "n", ts, JoinAuthFields{NodeID: "id", ClusterName: "c"}, malformed, 5*time.Minute); err == nil {
 		t.Error("ValidateHMAC accepted a non-hex MAC")
 	}
 	if err := ValidateFetchHMAC("s", "n", "id", "c", "/p", ts, malformed, 5*time.Minute); err == nil {
@@ -252,7 +290,7 @@ func TestCacheInvalidateHMAC_LabelBinding_NoCrossEndpointReplay(t *testing.T) {
 	cacheMAC := ComputeCacheInvalidateHMAC(secret, nonce, nodeID, clusterName, ts)
 	forwardMAC := ComputeForwardHMAC(secret, nonce, nodeID, clusterName, []byte{}, ts)
 	fetchMAC := ComputeFetchHMAC(secret, nonce, nodeID, clusterName, fetchPath, ts)
-	joinMAC := ComputeHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts)
+	joinMAC := ComputeJoinHMAC(secret, nonce, ts, JoinAuthFields{NodeID: nodeID, ClusterName: clusterName})
 
 	if cacheMAC == forwardMAC {
 		t.Error("cache-invalidate MAC collided with forward MAC — cross-endpoint replay possible")
@@ -286,7 +324,7 @@ func TestCacheInvalidateHMAC_LabelBinding_NoCrossEndpointReplay(t *testing.T) {
 		t.Error("cache-invalidate MAC accepted by fetch validator — endpoint labels not binding")
 	}
 	// Also the join-family validator must reject MACs from other endpoints.
-	if err := ValidateHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts, cacheMAC, 5*time.Minute); err == nil {
+	if err := ValidateJoinHMAC(secret, nonce, ts, JoinAuthFields{NodeID: nodeID, ClusterName: clusterName}, cacheMAC, 5*time.Minute); err == nil {
 		t.Error("cache-invalidate MAC accepted by join validator — endpoint labels not binding")
 	}
 }
@@ -462,7 +500,7 @@ func TestReplicationHMAC_LabelBinding_NoCrossEndpointReplay(t *testing.T) {
 	cacheMAC := ComputeCacheInvalidateHMAC(secret, nonce, nodeID, clusterName, ts)
 	forwardMAC := ComputeForwardHMAC(secret, nonce, nodeID, clusterName, []byte{}, ts)
 	fetchMAC := ComputeFetchHMAC(secret, nonce, nodeID, clusterName, fetchPath, ts)
-	joinMAC := ComputeHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts)
+	joinMAC := ComputeJoinHMAC(secret, nonce, ts, JoinAuthFields{NodeID: nodeID, ClusterName: clusterName})
 
 	// All MAC families must produce distinct values for identical-ish inputs.
 	macs := map[string]string{
@@ -512,10 +550,10 @@ func TestReplicationHMAC_LabelBinding_NoCrossEndpointReplay(t *testing.T) {
 		t.Error("checkpoint MAC accepted by fetch validator")
 	}
 	// Join-family validator must reject sync/checkpoint MACs.
-	if err := ValidateHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts, syncMAC, 5*time.Minute); err == nil {
+	if err := ValidateJoinHMAC(secret, nonce, ts, JoinAuthFields{NodeID: nodeID, ClusterName: clusterName}, syncMAC, 5*time.Minute); err == nil {
 		t.Error("sync MAC accepted by join validator")
 	}
-	if err := ValidateHMAC(secret, MsgTypeJoin, nonce, nodeID, clusterName, ts, checkpointMAC, 5*time.Minute); err == nil {
+	if err := ValidateJoinHMAC(secret, nonce, ts, JoinAuthFields{NodeID: nodeID, ClusterName: clusterName}, checkpointMAC, 5*time.Minute); err == nil {
 		t.Error("checkpoint MAC accepted by join validator")
 	}
 }

--- a/internal/cluster/security/handshake_auth.go
+++ b/internal/cluster/security/handshake_auth.go
@@ -3,6 +3,7 @@ package security
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -160,6 +161,14 @@ func validateHandshakeMAC(sharedSecret string, label MsgType, timestamp int64, t
 // separate so every handshake validator shares one definition of "fresh" —
 // and so NewNonceCache's doc can reason about the exact same inequality.
 func checkHandshakeFreshness(timestamp int64, tolerance time.Duration) error {
+	// Timestamps are second-granularity, so a sub-second tolerance truncates
+	// to zero and rejects everything — fail-closed, but a confusing footgun
+	// for a future caller who passes 500ms. Refuse it explicitly, matching
+	// checkSyncFreshness.
+	if tolerance < time.Second {
+		return fmt.Errorf("security: handshake auth tolerance %v is below the one-second timestamp granularity", tolerance)
+	}
+
 	now := time.Now().Unix()
 	drift := now - timestamp
 	if drift < 0 {
@@ -241,8 +250,11 @@ func validateWithReplay(guard ReplayGuard, nodeID, nonce string, validate func()
 	// Both nil shapes must be caught: a nil interface, and a non-nil
 	// interface holding a nil *NonceCache (which a caller passing a nil
 	// struct pointer produces, and which `guard == nil` does NOT match).
-	// NonceCache.Track is additionally nil-safe and returns false, so even a
-	// guard type this package does not know about fails closed here.
+	// NonceCache.Track is additionally nil-safe, so the one production
+	// implementation fails closed rather than panicking even if it reaches
+	// Track. A different ReplayGuard implementation whose Track is not
+	// nil-safe would still panic on a typed nil — there is exactly one today,
+	// and a new one must keep that property.
 	if guard == nil {
 		return errors.New("security: handshake replay guard is required")
 	}

--- a/internal/cluster/security/handshake_auth.go
+++ b/internal/cluster/security/handshake_auth.go
@@ -1,0 +1,360 @@
+package security
+
+import (
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"time"
+)
+
+// Coordinator-handshake authentication.
+//
+// Every message on the coordinator TCP protocol's handshake family — the join,
+// heartbeat and leave requests, and the join, leader-redirect and
+// forward-apply-ack responses — is authenticated here, and the MAC covers
+// EVERY non-auth field of the message.
+//
+// That total-coverage rule is the point. The previous scheme (ComputeHMAC,
+// removed in 26.09.2) signed only {msgType, nonce, nodeID, clusterName,
+// timestamp} while the handlers went on to consume Role, the advertised Raft /
+// API / coordinator addresses, Version and CoreCount from the same message. An
+// attacker on a plaintext interconnect could rewrite any of those and the MAC
+// still verified, because none of them was in it. Binding "the fields the
+// handler happens to read today" would leave the same trap for the next field
+// somebody adds, so the invariant is the whole message.
+//
+// Canonicalization is length-prefixed (canonicalSyncInput), not NUL-delimited.
+// See that function's doc for why NUL is not sufficient on this transport: it
+// is raw TCP carrying JSON, which passes NUL through happily, so an attacker
+// who controls a field's contents can otherwise manufacture delimiters and
+// re-partition the signed input. The message-type label is the first field,
+// preserving the per-message-type domain separation from #504.
+
+// JoinAuthFields is every non-auth field of protocol.JoinRequest.
+type JoinAuthFields struct {
+	NodeID      string
+	NodeName    string
+	Role        string
+	ClusterName string
+	RaftAddr    string
+	APIAddr     string
+	CoordAddr   string
+	Version     string
+	CoreCount   int
+}
+
+// HeartbeatAuthFields is every non-auth field of protocol.Heartbeat, plus the
+// cluster name (which the wire message does not carry — both sides supply it
+// from their own config, so a heartbeat cannot be replayed into another
+// cluster that happens to share a secret).
+//
+// TimestampUnixNano is protocol.Heartbeat.Timestamp. The receiver does not
+// read that field today; it is bound anyway, per the total-coverage rule.
+type HeartbeatAuthFields struct {
+	NodeID            string
+	ClusterName       string
+	State             string
+	IsLeader          bool
+	TimestampUnixNano int64
+}
+
+// LeaveAuthFields is every non-auth field of protocol.LeaveNotify, plus the
+// cluster name (see HeartbeatAuthFields).
+type LeaveAuthFields struct {
+	NodeID      string
+	ClusterName string
+	Reason      string
+}
+
+// NodeAuthFields mirrors protocol.NodeInfo field-for-field, in the same order.
+//
+// It exists so this package does not import internal/cluster/protocol.
+// security is imported by fourteen files including internal/api and
+// internal/edgesync; none of them should transitively acquire the coordinator
+// wire protocol. The caller converts; keeping the field order identical makes
+// that conversion auditable at a glance.
+type NodeAuthFields struct {
+	ID        string
+	Name      string
+	Role      string
+	State     string
+	RaftAddr  string
+	APIAddr   string
+	CoordAddr string
+	CoreCount int
+}
+
+// JoinResponseAuthFields is every non-auth field of protocol.JoinResponse.
+type JoinResponseAuthFields struct {
+	Success    bool
+	LeaderID   string
+	LeaderAddr string
+	RaftLeader string
+	Error      string
+	Nodes      []NodeAuthFields
+}
+
+// LeaderInfoAuthFields is every non-auth field of protocol.LeaderInfo.
+type LeaderInfoAuthFields struct {
+	LeaderID        string
+	LeaderCoordAddr string
+	LeaderRaftAddr  string
+}
+
+// ForwardAckAuthFields is every non-auth field of protocol.ForwardApplyAck.
+//
+// Code is bound because callers branch on it: ForwardCodeNotLeader is mapped
+// to a transient retry, so an unsigned Code would let an on-path attacker
+// choose between "retry forever" and "fail permanently".
+type ForwardAckAuthFields struct {
+	Status string
+	Code   string
+	Error  string
+}
+
+// Handshake message-type labels for the response direction. The request
+// labels are MsgTypeJoin / MsgTypeHeartbeat / MsgTypeLeave, shared with the
+// pre-26.09.2 scheme.
+const (
+	MsgTypeJoinResp   MsgType = "join-resp"
+	MsgTypeLeaderInfo MsgType = "leader-info"
+	MsgTypeForwardAck MsgType = "forward-ack"
+)
+
+// ErrHandshakeReplay is returned when a handshake message's nonce has already
+// been used inside the freshness window.
+//
+// Distinguished from a MAC failure because it is not a forgery: the message is
+// authentic, which is what makes it worth alerting on. A well-behaved peer
+// never reuses a nonce, so this means either a broken client or someone
+// replaying captured traffic.
+var ErrHandshakeReplay = errors.New("security: handshake nonce already used")
+
+// computeHandshakeMACRaw is the one signing path for the whole family.
+//
+// label MUST be a handshake label (join, heartbeat, leave, join-resp,
+// leader-info, forward-ack). MsgTypeRaftAuth / MsgTypeRaftAuthResp are NOT
+// handshake labels — the Raft transport handshake has its own helper in
+// raft_auth.go using the older NUL format, and passing one here would compile
+// but produce a MAC no validator computes.
+func computeHandshakeMACRaw(sharedSecret string, label MsgType, fields ...string) []byte {
+	all := make([]string, 0, len(fields)+1)
+	all = append(all, string(label))
+	all = append(all, fields...)
+	return computeRawHMAC(sharedSecret, canonicalSyncInput(all...))
+}
+
+// validateHandshakeMAC checks freshness then the MAC, in constant time.
+func validateHandshakeMAC(sharedSecret string, label MsgType, timestamp int64, tolerance time.Duration, receivedMAC string, fields ...string) error {
+	if err := checkHandshakeFreshness(timestamp, tolerance); err != nil {
+		return err
+	}
+	expected := computeHandshakeMACRaw(sharedSecret, label, fields...)
+	if !constantTimeHexEqual(expected, receivedMAC) {
+		return errors.New("HMAC validation failed: shared secret mismatch or malformed MAC")
+	}
+	return nil
+}
+
+// checkHandshakeFreshness enforces the symmetric timestamp window. Kept
+// separate so every handshake validator shares one definition of "fresh" —
+// and so NewNonceCache's doc can reason about the exact same inequality.
+func checkHandshakeFreshness(timestamp int64, tolerance time.Duration) error {
+	now := time.Now().Unix()
+	drift := now - timestamp
+	if drift < 0 {
+		drift = -drift
+	}
+	if drift > int64(tolerance.Seconds()) {
+		return errors.New("auth timestamp expired")
+	}
+	return nil
+}
+
+func joinFields(nonce string, ts int64, f JoinAuthFields) []string {
+	return []string{
+		nonce, f.NodeID, f.NodeName, f.Role, f.ClusterName,
+		f.RaftAddr, f.APIAddr, f.CoordAddr, f.Version,
+		strconv.Itoa(f.CoreCount), strconv.FormatInt(ts, 10),
+	}
+}
+
+// ComputeJoinHMAC signs every field of a join request.
+func ComputeJoinHMAC(sharedSecret, nonce string, timestamp int64, f JoinAuthFields) string {
+	return hex.EncodeToString(computeHandshakeMACRaw(sharedSecret, MsgTypeJoin, joinFields(nonce, timestamp, f)...))
+}
+
+// ValidateJoinHMAC verifies a join request's MAC and freshness.
+//
+// Prefer ValidateJoinHMACWithReplay: freshness alone is not replay protection.
+func ValidateJoinHMAC(sharedSecret, nonce string, timestamp int64, f JoinAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateHandshakeMAC(sharedSecret, MsgTypeJoin, timestamp, tolerance, receivedMAC, joinFields(nonce, timestamp, f)...)
+}
+
+func heartbeatFields(nonce string, ts int64, f HeartbeatAuthFields) []string {
+	return []string{
+		nonce, f.NodeID, f.ClusterName, f.State,
+		strconv.FormatBool(f.IsLeader), strconv.FormatInt(f.TimestampUnixNano, 10),
+		strconv.FormatInt(ts, 10),
+	}
+}
+
+// ComputeHeartbeatHMAC signs every field of a heartbeat.
+func ComputeHeartbeatHMAC(sharedSecret, nonce string, timestamp int64, f HeartbeatAuthFields) string {
+	return hex.EncodeToString(computeHandshakeMACRaw(sharedSecret, MsgTypeHeartbeat, heartbeatFields(nonce, timestamp, f)...))
+}
+
+// ValidateHeartbeatHMAC verifies a heartbeat's MAC and freshness.
+//
+// Prefer ValidateHeartbeatHMACWithReplay.
+func ValidateHeartbeatHMAC(sharedSecret, nonce string, timestamp int64, f HeartbeatAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateHandshakeMAC(sharedSecret, MsgTypeHeartbeat, timestamp, tolerance, receivedMAC, heartbeatFields(nonce, timestamp, f)...)
+}
+
+func leaveFields(nonce string, ts int64, f LeaveAuthFields) []string {
+	return []string{nonce, f.NodeID, f.ClusterName, f.Reason, strconv.FormatInt(ts, 10)}
+}
+
+// ComputeLeaveHMAC signs every field of a leave notification.
+func ComputeLeaveHMAC(sharedSecret, nonce string, timestamp int64, f LeaveAuthFields) string {
+	return hex.EncodeToString(computeHandshakeMACRaw(sharedSecret, MsgTypeLeave, leaveFields(nonce, timestamp, f)...))
+}
+
+// ValidateLeaveHMAC verifies a leave notification's MAC and freshness.
+//
+// Prefer ValidateLeaveHMACWithReplay.
+func ValidateLeaveHMAC(sharedSecret, nonce string, timestamp int64, f LeaveAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateHandshakeMAC(sharedSecret, MsgTypeLeave, timestamp, tolerance, receivedMAC, leaveFields(nonce, timestamp, f)...)
+}
+
+// validateWithReplay is the fail-closed validate-then-consume path shared by
+// the three request validators.
+//
+// The nonce is consumed only AFTER the MAC verifies, so a forged message
+// cannot burn a cache slot and lock out the legitimate nonce. A nil guard is
+// an error rather than a skipped check: a validator that returns nil without
+// consuming the nonce leaves the message replayable for the whole freshness
+// window with every test still passing, which is exactly how this gets
+// forgotten. Callers that legitimately have no guard (no shared secret
+// configured) must not reach here at all.
+func validateWithReplay(guard ReplayGuard, nodeID, nonce string, validate func() error) error {
+	// Both nil shapes must be caught: a nil interface, and a non-nil
+	// interface holding a nil *NonceCache (which a caller passing a nil
+	// struct pointer produces, and which `guard == nil` does NOT match).
+	// NonceCache.Track is additionally nil-safe and returns false, so even a
+	// guard type this package does not know about fails closed here.
+	if guard == nil {
+		return errors.New("security: handshake replay guard is required")
+	}
+	if nc, ok := guard.(*NonceCache); ok && nc == nil {
+		return errors.New("security: handshake replay guard is required")
+	}
+	if err := validate(); err != nil {
+		return err
+	}
+	if !guard.Track(nodeID, nonce) {
+		return ErrHandshakeReplay
+	}
+	return nil
+}
+
+// ValidateJoinHMACWithReplay validates a join request's MAC and consumes its
+// nonce. Returns ErrHandshakeReplay if the nonce was already used.
+func ValidateJoinHMACWithReplay(guard ReplayGuard, sharedSecret, nonce string, timestamp int64, f JoinAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateWithReplay(guard, f.NodeID, nonce, func() error {
+		return ValidateJoinHMAC(sharedSecret, nonce, timestamp, f, receivedMAC, tolerance)
+	})
+}
+
+// ValidateHeartbeatHMACWithReplay validates a heartbeat's MAC and consumes its
+// nonce. Returns ErrHandshakeReplay if the nonce was already used.
+func ValidateHeartbeatHMACWithReplay(guard ReplayGuard, sharedSecret, nonce string, timestamp int64, f HeartbeatAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateWithReplay(guard, f.NodeID, nonce, func() error {
+		return ValidateHeartbeatHMAC(sharedSecret, nonce, timestamp, f, receivedMAC, tolerance)
+	})
+}
+
+// ValidateLeaveHMACWithReplay validates a leave notification's MAC and
+// consumes its nonce. Returns ErrHandshakeReplay if the nonce was already used.
+func ValidateLeaveHMACWithReplay(guard ReplayGuard, sharedSecret, nonce string, timestamp int64, f LeaveAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateWithReplay(guard, f.NodeID, nonce, func() error {
+		return ValidateLeaveHMAC(sharedSecret, nonce, timestamp, f, receivedMAC, tolerance)
+	})
+}
+
+// Response direction.
+//
+// A response is signed over the REQUEST's nonce plus every field of the
+// response. The requester validates with the nonce it generated, so it needs
+// no nonce cache of its own: a response captured from an earlier exchange
+// carries a MAC over a different nonce and simply fails to verify. Each
+// request has exactly one outstanding response (join dials per attempt;
+// forward-apply holds forwardMu across send and receive), so there is no
+// legitimate case where a response arrives bearing a nonce other than the one
+// the caller is waiting on.
+//
+// Pre-auth error responses are signed too, over whatever nonce the request
+// carried — possibly the empty string, if an unauthenticated peer sent one.
+// That is not an oracle: the label is the first length-prefixed field and the
+// timestamp the last, every other field of an error response is chosen by the
+// responder, and every other MAC family in this package ends its canonical
+// input with a raw nonce or \x00-joined timestamp, so no arrangement of an
+// attacker-chosen nonce can collide with a MAC from another family.
+
+func joinResponseFields(reqNonce string, ts int64, f JoinResponseAuthFields) []string {
+	out := make([]string, 0, 7+len(f.Nodes)*8)
+	out = append(out,
+		reqNonce,
+		strconv.FormatBool(f.Success),
+		f.LeaderID, f.LeaderAddr, f.RaftLeader, f.Error,
+		strconv.Itoa(len(f.Nodes)),
+	)
+	for _, n := range f.Nodes {
+		out = append(out, n.ID, n.Name, n.Role, n.State, n.RaftAddr, n.APIAddr, n.CoordAddr, strconv.Itoa(n.CoreCount))
+	}
+	out = append(out, strconv.FormatInt(ts, 10))
+	return out
+}
+
+// ComputeJoinResponseHMAC signs a join response over the request's nonce.
+func ComputeJoinResponseHMAC(sharedSecret, reqNonce string, timestamp int64, f JoinResponseAuthFields) string {
+	return hex.EncodeToString(computeHandshakeMACRaw(sharedSecret, MsgTypeJoinResp, joinResponseFields(reqNonce, timestamp, f)...))
+}
+
+// ValidateJoinResponseHMAC verifies a join response against the nonce the
+// caller sent in its request.
+func ValidateJoinResponseHMAC(sharedSecret, reqNonce string, timestamp int64, f JoinResponseAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateHandshakeMAC(sharedSecret, MsgTypeJoinResp, timestamp, tolerance, receivedMAC, joinResponseFields(reqNonce, timestamp, f)...)
+}
+
+func leaderInfoFields(reqNonce string, ts int64, f LeaderInfoAuthFields) []string {
+	return []string{reqNonce, f.LeaderID, f.LeaderCoordAddr, f.LeaderRaftAddr, strconv.FormatInt(ts, 10)}
+}
+
+// ComputeLeaderInfoHMAC signs a leader redirect over the request's nonce.
+func ComputeLeaderInfoHMAC(sharedSecret, reqNonce string, timestamp int64, f LeaderInfoAuthFields) string {
+	return hex.EncodeToString(computeHandshakeMACRaw(sharedSecret, MsgTypeLeaderInfo, leaderInfoFields(reqNonce, timestamp, f)...))
+}
+
+// ValidateLeaderInfoHMAC verifies a leader redirect against the nonce the
+// caller sent in its request. A redirect names the address the joiner will
+// dial next, so an unauthenticated one hands an attacker the joiner's next
+// signed join request.
+func ValidateLeaderInfoHMAC(sharedSecret, reqNonce string, timestamp int64, f LeaderInfoAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateHandshakeMAC(sharedSecret, MsgTypeLeaderInfo, timestamp, tolerance, receivedMAC, leaderInfoFields(reqNonce, timestamp, f)...)
+}
+
+func forwardAckFields(reqNonce string, ts int64, f ForwardAckAuthFields) []string {
+	return []string{reqNonce, f.Status, f.Code, f.Error, strconv.FormatInt(ts, 10)}
+}
+
+// ComputeForwardAckHMAC signs a forward-apply ack over the request's nonce.
+func ComputeForwardAckHMAC(sharedSecret, reqNonce string, timestamp int64, f ForwardAckAuthFields) string {
+	return hex.EncodeToString(computeHandshakeMACRaw(sharedSecret, MsgTypeForwardAck, forwardAckFields(reqNonce, timestamp, f)...))
+}
+
+// ValidateForwardAckHMAC verifies a forward-apply ack against the nonce the
+// caller sent in its request.
+func ValidateForwardAckHMAC(sharedSecret, reqNonce string, timestamp int64, f ForwardAckAuthFields, receivedMAC string, tolerance time.Duration) error {
+	return validateHandshakeMAC(sharedSecret, MsgTypeForwardAck, timestamp, tolerance, receivedMAC, forwardAckFields(reqNonce, timestamp, f)...)
+}

--- a/internal/cluster/security/handshake_auth_test.go
+++ b/internal/cluster/security/handshake_auth_test.go
@@ -1,0 +1,450 @@
+package security
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	hsSecret = "handshake-test-secret"
+	hsNonce  = "handshake-test-nonce"
+)
+
+func hsTS() int64 { return time.Now().Unix() }
+
+// baseJoin is a fully-populated join request. Every field is non-zero so that
+// a mutation test can meaningfully change it.
+func baseJoin() JoinAuthFields {
+	return JoinAuthFields{
+		NodeID: "node-1", NodeName: "node-one", Role: "reader", ClusterName: "cluster-A",
+		RaftAddr: "10.0.0.2:9200", APIAddr: "10.0.0.2:8080", CoordAddr: "10.0.0.2:9100",
+		Version: "26.09.2", CoreCount: 4,
+	}
+}
+
+// TestJoinHMAC_EveryFieldIsBound is the regression test for GHSA-p2rx.
+//
+// The reported vulnerability was precisely that Role and the advertised
+// addresses sat OUTSIDE the MAC: an on-path attacker could promote a joining
+// node to writer and redirect its coordinator/API/Raft addresses while the tag
+// still verified. Each case below mutates exactly one field after signing and
+// requires rejection. The unmodified control proves the validator is not
+// simply rejecting everything.
+func TestJoinHMAC_EveryFieldIsBound(t *testing.T) {
+	t.Parallel()
+	ts := hsTS()
+	mac := ComputeJoinHMAC(hsSecret, hsNonce, ts, baseJoin())
+
+	if err := ValidateJoinHMAC(hsSecret, hsNonce, ts, baseJoin(), mac, time.Minute); err != nil {
+		t.Fatalf("control: unmodified join rejected: %v", err)
+	}
+
+	mutations := map[string]func(*JoinAuthFields){
+		"NodeID":      func(f *JoinAuthFields) { f.NodeID = "attacker-node" },
+		"NodeName":    func(f *JoinAuthFields) { f.NodeName = "attacker-name" },
+		"Role":        func(f *JoinAuthFields) { f.Role = "writer" },
+		"ClusterName": func(f *JoinAuthFields) { f.ClusterName = "cluster-B" },
+		"RaftAddr":    func(f *JoinAuthFields) { f.RaftAddr = "attacker.example:9200" },
+		"APIAddr":     func(f *JoinAuthFields) { f.APIAddr = "attacker.example:8080" },
+		"CoordAddr":   func(f *JoinAuthFields) { f.CoordAddr = "attacker.example:9100" },
+		"Version":     func(f *JoinAuthFields) { f.Version = "0.0.1" },
+		"CoreCount":   func(f *JoinAuthFields) { f.CoreCount = 1024 },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			f := baseJoin()
+			mutate(&f)
+			if err := ValidateJoinHMAC(hsSecret, hsNonce, ts, f, mac, time.Minute); err == nil {
+				t.Errorf("mutating %s did not invalidate the join MAC — the field is outside the signed payload", name)
+			}
+		})
+	}
+}
+
+// TestHeartbeatHMAC_EveryFieldIsBound covers the variant found alongside
+// GHSA-p2rx: State is written straight into the registry by the receiver, so
+// an unsigned State lets an attacker mark any node unhealthy.
+func TestHeartbeatHMAC_EveryFieldIsBound(t *testing.T) {
+	t.Parallel()
+	base := func() HeartbeatAuthFields {
+		return HeartbeatAuthFields{
+			NodeID: "node-1", ClusterName: "cluster-A", State: "healthy",
+			IsLeader: false, TimestampUnixNano: 1700000000000000000,
+		}
+	}
+	ts := hsTS()
+	mac := ComputeHeartbeatHMAC(hsSecret, hsNonce, ts, base())
+
+	if err := ValidateHeartbeatHMAC(hsSecret, hsNonce, ts, base(), mac, time.Minute); err != nil {
+		t.Fatalf("control: unmodified heartbeat rejected: %v", err)
+	}
+
+	mutations := map[string]func(*HeartbeatAuthFields){
+		"NodeID":            func(f *HeartbeatAuthFields) { f.NodeID = "other-node" },
+		"ClusterName":       func(f *HeartbeatAuthFields) { f.ClusterName = "cluster-B" },
+		"State":             func(f *HeartbeatAuthFields) { f.State = "unhealthy" },
+		"IsLeader":          func(f *HeartbeatAuthFields) { f.IsLeader = true },
+		"TimestampUnixNano": func(f *HeartbeatAuthFields) { f.TimestampUnixNano = 1 },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			f := base()
+			mutate(&f)
+			if err := ValidateHeartbeatHMAC(hsSecret, hsNonce, ts, f, mac, time.Minute); err == nil {
+				t.Errorf("mutating %s did not invalidate the heartbeat MAC", name)
+			}
+		})
+	}
+}
+
+func TestLeaveHMAC_EveryFieldIsBound(t *testing.T) {
+	t.Parallel()
+	base := func() LeaveAuthFields {
+		return LeaveAuthFields{NodeID: "node-1", ClusterName: "cluster-A", Reason: "graceful shutdown"}
+	}
+	ts := hsTS()
+	mac := ComputeLeaveHMAC(hsSecret, hsNonce, ts, base())
+
+	if err := ValidateLeaveHMAC(hsSecret, hsNonce, ts, base(), mac, time.Minute); err != nil {
+		t.Fatalf("control: unmodified leave rejected: %v", err)
+	}
+
+	mutations := map[string]func(*LeaveAuthFields){
+		"NodeID":      func(f *LeaveAuthFields) { f.NodeID = "victim-node" },
+		"ClusterName": func(f *LeaveAuthFields) { f.ClusterName = "cluster-B" },
+		"Reason":      func(f *LeaveAuthFields) { f.Reason = "evicted" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			f := base()
+			mutate(&f)
+			if err := ValidateLeaveHMAC(hsSecret, hsNonce, ts, f, mac, time.Minute); err == nil {
+				t.Errorf("mutating %s did not invalidate the leave MAC", name)
+			}
+		})
+	}
+}
+
+func baseJoinResponse() JoinResponseAuthFields {
+	return JoinResponseAuthFields{
+		Success: true, LeaderID: "node-0", LeaderAddr: "10.0.0.9:9100", RaftLeader: "10.0.0.9:9200",
+		Nodes: []NodeAuthFields{
+			{ID: "node-0", Name: "zero", Role: "writer", State: "healthy", RaftAddr: "10.0.0.9:9200", APIAddr: "10.0.0.9:8080", CoordAddr: "10.0.0.9:9100", CoreCount: 4},
+			{ID: "node-1", Name: "one", Role: "reader", State: "healthy", RaftAddr: "10.0.0.8:9200", APIAddr: "10.0.0.8:8080", CoordAddr: "10.0.0.8:9100", CoreCount: 2},
+		},
+	}
+}
+
+// TestJoinResponseHMAC_EveryFieldIsBound covers the response direction: the
+// joiner writes every returned NodeInfo into its own registry, so an unsigned
+// peer list lets an attacker point this node's replication and forwarding at
+// hosts of its choosing.
+//
+// The Nodes slice needs more than per-field mutation — adding, removing or
+// reordering entries must all invalidate too, which is what the length prefix
+// and per-node field expansion are for.
+func TestJoinResponseHMAC_EveryFieldIsBound(t *testing.T) {
+	t.Parallel()
+	ts := hsTS()
+	mac := ComputeJoinResponseHMAC(hsSecret, hsNonce, ts, baseJoinResponse())
+
+	if err := ValidateJoinResponseHMAC(hsSecret, hsNonce, ts, baseJoinResponse(), mac, time.Minute); err != nil {
+		t.Fatalf("control: unmodified join response rejected: %v", err)
+	}
+
+	mutations := map[string]func(*JoinResponseAuthFields){
+		"Success":          func(f *JoinResponseAuthFields) { f.Success = false },
+		"LeaderID":         func(f *JoinResponseAuthFields) { f.LeaderID = "attacker" },
+		"LeaderAddr":       func(f *JoinResponseAuthFields) { f.LeaderAddr = "attacker.example:9100" },
+		"RaftLeader":       func(f *JoinResponseAuthFields) { f.RaftLeader = "attacker.example:9200" },
+		"Error":            func(f *JoinResponseAuthFields) { f.Error = "injected" },
+		"node field":       func(f *JoinResponseAuthFields) { f.Nodes[1].CoordAddr = "attacker.example:9100" },
+		"node role":        func(f *JoinResponseAuthFields) { f.Nodes[1].Role = "writer" },
+		"node added":       func(f *JoinResponseAuthFields) { f.Nodes = append(f.Nodes, NodeAuthFields{ID: "ghost"}) },
+		"node removed":     func(f *JoinResponseAuthFields) { f.Nodes = f.Nodes[:1] },
+		"nodes reordered":  func(f *JoinResponseAuthFields) { f.Nodes[0], f.Nodes[1] = f.Nodes[1], f.Nodes[0] },
+		"nodes emptied":    func(f *JoinResponseAuthFields) { f.Nodes = nil },
+		"node core count":  func(f *JoinResponseAuthFields) { f.Nodes[0].CoreCount = 9999 },
+		"node state":       func(f *JoinResponseAuthFields) { f.Nodes[0].State = "unhealthy" },
+		"node api address": func(f *JoinResponseAuthFields) { f.Nodes[0].APIAddr = "attacker.example:8080" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			f := baseJoinResponse()
+			mutate(&f)
+			if err := ValidateJoinResponseHMAC(hsSecret, hsNonce, ts, f, mac, time.Minute); err == nil {
+				t.Errorf("mutating %q did not invalidate the join-response MAC", name)
+			}
+		})
+	}
+}
+
+func TestLeaderInfoHMAC_EveryFieldIsBound(t *testing.T) {
+	t.Parallel()
+	base := func() LeaderInfoAuthFields {
+		return LeaderInfoAuthFields{LeaderID: "node-0", LeaderCoordAddr: "10.0.0.9:9100", LeaderRaftAddr: "10.0.0.9:9200"}
+	}
+	ts := hsTS()
+	mac := ComputeLeaderInfoHMAC(hsSecret, hsNonce, ts, base())
+
+	if err := ValidateLeaderInfoHMAC(hsSecret, hsNonce, ts, base(), mac, time.Minute); err != nil {
+		t.Fatalf("control: unmodified leader info rejected: %v", err)
+	}
+
+	mutations := map[string]func(*LeaderInfoAuthFields){
+		"LeaderID":        func(f *LeaderInfoAuthFields) { f.LeaderID = "attacker" },
+		"LeaderCoordAddr": func(f *LeaderInfoAuthFields) { f.LeaderCoordAddr = "attacker.example:9100" },
+		"LeaderRaftAddr":  func(f *LeaderInfoAuthFields) { f.LeaderRaftAddr = "attacker.example:9200" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			f := base()
+			mutate(&f)
+			if err := ValidateLeaderInfoHMAC(hsSecret, hsNonce, ts, f, mac, time.Minute); err == nil {
+				t.Errorf("mutating %s did not invalidate the leader-info MAC", name)
+			}
+		})
+	}
+}
+
+// TestForwardAckHMAC_EveryFieldIsBound: Code drives caller retry behaviour, so
+// it must be bound as tightly as Status.
+func TestForwardAckHMAC_EveryFieldIsBound(t *testing.T) {
+	t.Parallel()
+	base := func() ForwardAckAuthFields {
+		return ForwardAckAuthFields{Status: "error", Code: "apply_failed", Error: "boom"}
+	}
+	ts := hsTS()
+	mac := ComputeForwardAckHMAC(hsSecret, hsNonce, ts, base())
+
+	if err := ValidateForwardAckHMAC(hsSecret, hsNonce, ts, base(), mac, time.Minute); err != nil {
+		t.Fatalf("control: unmodified ack rejected: %v", err)
+	}
+
+	mutations := map[string]func(*ForwardAckAuthFields){
+		"Status": func(f *ForwardAckAuthFields) { f.Status = "ok" },
+		"Code":   func(f *ForwardAckAuthFields) { f.Code = "not_leader" },
+		"Error":  func(f *ForwardAckAuthFields) { f.Error = "token already exists" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			f := base()
+			mutate(&f)
+			if err := ValidateForwardAckHMAC(hsSecret, hsNonce, ts, f, mac, time.Minute); err == nil {
+				t.Errorf("mutating %s did not invalidate the forward-ack MAC", name)
+			}
+		})
+	}
+}
+
+// TestHandshakeHMAC_NonceIsBound: a response MAC is bound to the request's
+// nonce, which is what makes a captured response un-replayable against a
+// later request without the requester keeping a nonce cache.
+func TestHandshakeHMAC_NonceIsBound(t *testing.T) {
+	t.Parallel()
+	ts := hsTS()
+	mac := ComputeJoinResponseHMAC(hsSecret, hsNonce, ts, baseJoinResponse())
+	if err := ValidateJoinResponseHMAC(hsSecret, "a-different-nonce", ts, baseJoinResponse(), mac, time.Minute); err == nil {
+		t.Error("a join response validated against a nonce other than the request's — captured responses would be replayable")
+	}
+}
+
+// TestHandshakeHMAC_FieldSplittingIsNotPossible guards the canonicalization
+// choice itself.
+//
+// With a naive delimiter-joined encoding, field contents containing the
+// delimiter can be re-partitioned: here ("a", "b|c") and ("a|b", "c") would
+// collide. Length-prefixing makes the partition unambiguous, which is why the
+// handshake family uses canonicalSyncInput rather than the older NUL join —
+// this transport is raw TCP carrying JSON and passes any byte through.
+func TestHandshakeHMAC_FieldSplittingIsNotPossible(t *testing.T) {
+	t.Parallel()
+	ts := hsTS()
+
+	a := baseJoin()
+	a.NodeName = "one"
+	a.Role = "two:three"
+
+	b := baseJoin()
+	b.NodeName = "one:two"
+	b.Role = "three"
+
+	if ComputeJoinHMAC(hsSecret, hsNonce, ts, a) == ComputeJoinHMAC(hsSecret, hsNonce, ts, b) {
+		t.Error("two distinct field tuples produced the same MAC — the canonical encoding is ambiguous")
+	}
+
+	// The same property with NUL bytes, the delimiter the previous format used.
+	c := baseJoin()
+	c.NodeName = "one\x00two"
+	d := baseJoin()
+	d.NodeName = "one"
+	d.Role = "two"
+	if ComputeJoinHMAC(hsSecret, hsNonce, ts, c) == ComputeJoinHMAC(hsSecret, hsNonce, ts, d) {
+		t.Error("a NUL-containing field collided with a different field tuple")
+	}
+}
+
+// stubGuard records Track calls so tests can assert the nonce is consumed
+// only after the MAC verifies.
+type stubGuard struct {
+	seen  map[string]bool
+	calls int
+}
+
+func newStubGuard() *stubGuard { return &stubGuard{seen: map[string]bool{}} }
+
+func (g *stubGuard) Track(id, nonce string) bool {
+	g.calls++
+	key := id + "\x00" + nonce
+	if g.seen[key] {
+		return false
+	}
+	g.seen[key] = true
+	return true
+}
+
+// TestValidateWithReplay_RejectsReplayAndFailsClosed covers the three
+// properties the wrapper exists for.
+func TestValidateWithReplay_RejectsReplayAndFailsClosed(t *testing.T) {
+	t.Parallel()
+	ts := hsTS()
+	f := baseJoin()
+	mac := ComputeJoinHMAC(hsSecret, hsNonce, ts, f)
+
+	t.Run("first use accepted, second rejected as replay", func(t *testing.T) {
+		g := newStubGuard()
+		if err := ValidateJoinHMACWithReplay(g, hsSecret, hsNonce, ts, f, mac, time.Minute); err != nil {
+			t.Fatalf("first use rejected: %v", err)
+		}
+		err := ValidateJoinHMACWithReplay(g, hsSecret, hsNonce, ts, f, mac, time.Minute)
+		if !errors.Is(err, ErrHandshakeReplay) {
+			t.Errorf("replayed message: got %v, want ErrHandshakeReplay", err)
+		}
+	})
+
+	t.Run("typed-nil guard fails closed without panicking", func(t *testing.T) {
+		// A *NonceCache that is nil but stored in a ReplayGuard interface is
+		// not == nil at the interface level. Before this was handled, the
+		// wrapper's `guard == nil` check missed it and Track panicked on the
+		// nil receiver — i.e. any handshake reaching a Coordinator whose
+		// cache had not been installed would crash the node rather than
+		// reject the message.
+		var nilCache *NonceCache
+		err := ValidateJoinHMACWithReplay(nilCache, hsSecret, hsNonce, ts, f, mac, time.Minute)
+		if err == nil {
+			t.Fatal("a typed-nil replay guard was accepted")
+		}
+		if errors.Is(err, ErrHandshakeReplay) {
+			t.Error("a nil guard should not report a replay; it is a construction error")
+		}
+		// And the underlying cache must itself be nil-safe, so a guard
+		// implementation this package does not know about still fails closed.
+		if nilCache.Track("node", "nonce") {
+			t.Error("Track on a nil *NonceCache reported the nonce as new")
+		}
+	})
+
+	t.Run("nil guard fails closed", func(t *testing.T) {
+		err := ValidateJoinHMACWithReplay(nil, hsSecret, hsNonce, ts, f, mac, time.Minute)
+		if err == nil {
+			t.Fatal("a nil replay guard was accepted — the message would be replayable for the whole freshness window")
+		}
+		if errors.Is(err, ErrHandshakeReplay) {
+			t.Error("a nil guard should not report a replay; it is a construction error")
+		}
+	})
+
+	t.Run("forged MAC does not consume a nonce", func(t *testing.T) {
+		// Otherwise an attacker could burn the cache slot for a nonce a
+		// legitimate peer is about to use, turning replay protection into a
+		// denial-of-service primitive.
+		g := newStubGuard()
+		if err := ValidateJoinHMACWithReplay(g, hsSecret, hsNonce, ts, f, "00ff", time.Minute); err == nil {
+			t.Fatal("forged MAC accepted")
+		}
+		if g.calls != 0 {
+			t.Errorf("forged MAC consumed a nonce (%d Track calls) — attacker could lock out legitimate nonces", g.calls)
+		}
+	})
+
+	t.Run("heartbeat and leave wrappers behave the same", func(t *testing.T) {
+		hbFields := HeartbeatAuthFields{NodeID: "node-1", ClusterName: "cluster-A", State: "healthy"}
+		hbMAC := ComputeHeartbeatHMAC(hsSecret, hsNonce, ts, hbFields)
+		g := newStubGuard()
+		if err := ValidateHeartbeatHMACWithReplay(g, hsSecret, hsNonce, ts, hbFields, hbMAC, time.Minute); err != nil {
+			t.Fatalf("heartbeat first use: %v", err)
+		}
+		if err := ValidateHeartbeatHMACWithReplay(g, hsSecret, hsNonce, ts, hbFields, hbMAC, time.Minute); !errors.Is(err, ErrHandshakeReplay) {
+			t.Errorf("heartbeat replay: got %v", err)
+		}
+
+		lvFields := LeaveAuthFields{NodeID: "node-1", ClusterName: "cluster-A", Reason: "bye"}
+		lvMAC := ComputeLeaveHMAC(hsSecret, hsNonce, ts, lvFields)
+		g2 := newStubGuard()
+		if err := ValidateLeaveHMACWithReplay(g2, hsSecret, hsNonce, ts, lvFields, lvMAC, time.Minute); err != nil {
+			t.Fatalf("leave first use: %v", err)
+		}
+		if err := ValidateLeaveHMACWithReplay(g2, hsSecret, hsNonce, ts, lvFields, lvMAC, time.Minute); !errors.Is(err, ErrHandshakeReplay) {
+			t.Errorf("leave replay: got %v", err)
+		}
+	})
+}
+
+// TestNonceCacheOutlivesFreshnessWindow pins the lifetime arithmetic in
+// NewNonceCache.
+//
+// A nonce must stay in the cache for as long as a MAC bearing it could still
+// be accepted. Because a message may be stamped up to one tolerance in the
+// FUTURE, and the validator truncates its own clock to whole seconds, the
+// cache has to outlive the tolerance by more than the tolerance itself —
+// hence 2T+1s rather than T. With T as the TTL, a peer whose clock runs ahead
+// gets its nonce evicted while its MAC is still fresh, and the replay is
+// accepted.
+func TestNonceCacheOutlivesFreshnessWindow(t *testing.T) {
+	t.Parallel()
+	const tolerance = 30 * time.Second
+	nc := NewNonceCache(tolerance)
+
+	if got, want := nc.ttl, 2*tolerance+time.Second; got != want {
+		t.Errorf("nonce cache lifetime = %v, want %v (2*tolerance + 1s)", got, want)
+	}
+	if nc.ttl <= tolerance {
+		t.Error("nonce cache lifetime does not exceed the freshness window — a future-dated message outlives its cache slot")
+	}
+}
+
+// TestHandshakeFreshness_RejectsStaleAndFuture: the window is symmetric, so a
+// clock-skewed peer in either direction is rejected rather than silently
+// trusted.
+func TestHandshakeFreshness_RejectsStaleAndFuture(t *testing.T) {
+	t.Parallel()
+	f := baseJoin()
+	tol := 30 * time.Second
+
+	stale := time.Now().Add(-2 * time.Minute).Unix()
+	if err := ValidateJoinHMAC(hsSecret, hsNonce, stale, f, ComputeJoinHMAC(hsSecret, hsNonce, stale, f), tol); err == nil {
+		t.Error("a stale timestamp was accepted")
+	}
+	future := time.Now().Add(2 * time.Minute).Unix()
+	if err := ValidateJoinHMAC(hsSecret, hsNonce, future, f, ComputeJoinHMAC(hsSecret, hsNonce, future, f), tol); err == nil {
+		t.Error("a future timestamp was accepted")
+	}
+}
+
+// TestHandshakeHMAC_WrongSecretRejected is the baseline: without the shared
+// secret nothing validates, whatever the fields say.
+func TestHandshakeHMAC_WrongSecretRejected(t *testing.T) {
+	t.Parallel()
+	ts := hsTS()
+	f := baseJoin()
+	mac := ComputeJoinHMAC(hsSecret, hsNonce, ts, f)
+	if err := ValidateJoinHMAC("not-the-secret", hsNonce, ts, f, mac, time.Minute); err == nil {
+		t.Error("a join MAC validated under the wrong shared secret")
+	}
+	// A well-formed but wrong MAC is rejected too (not just malformed hex).
+	if err := ValidateJoinHMAC(hsSecret, hsNonce, ts, f, strings.Repeat("0", 64), time.Minute); err == nil {
+		t.Error("an all-zero MAC was accepted")
+	}
+}

--- a/internal/cluster/security/nonce_cache.go
+++ b/internal/cluster/security/nonce_cache.go
@@ -22,6 +22,9 @@ const nonceCacheEvictInterval = 60 * time.Second
 
 // NonceCache tracks recently seen nonces to prevent replay attacks.
 // Safe for concurrent use from multiple goroutines.
+//
+// ttl is derived from the HMAC tolerance by NewNonceCache and is longer than
+// it; see that function for the arithmetic.
 type NonceCache struct {
 	mu      sync.Mutex
 	entries map[string]int64 // key: "nodeID:nonce", value: expiry unix nanos
@@ -33,13 +36,28 @@ type NonceCache struct {
 	lastEvict time.Time
 }
 
-// NewNonceCache creates a cache that rejects duplicate nonces within the
-// given TTL window. The TTL should match the HMAC timestamp tolerance
-// (typically 5 minutes).
-func NewNonceCache(ttl time.Duration) *NonceCache {
+// NewNonceCache creates a cache that rejects duplicate nonces for as long as
+// a MAC bearing that nonce could still be accepted.
+//
+// Pass the HMAC timestamp TOLERANCE, not a TTL — the cache derives its own
+// lifetime, which is deliberately longer. Using the tolerance directly as the
+// TTL leaves a replay window, because the two clocks are different:
+//
+//   - The validator compares the SENDER's timestamp against its own clock
+//     truncated to seconds: accept iff |floor(receivedAt) - ts| <= T. So the
+//     last instant a replay is still accepted is ts + T + 1s (exclusive).
+//   - The cache expires an entry at RECEIPT time + ttl, at nanosecond
+//     precision. The earliest a first receipt can be accepted is ts - T.
+//
+// Covering every accepted replay therefore needs (ts - T) + ttl >= ts + T + 1s,
+// i.e. ttl >= 2T + 1s. With ttl = T a message from a peer whose clock runs
+// ahead is evicted from the cache while its MAC is still fresh; with ttl = 2T
+// a peer running (T - 1s) ahead still leaves a sub-second window. Hence the
+// +1s, which also absorbs the validator's second-truncation.
+func NewNonceCache(tolerance time.Duration) *NonceCache {
 	return &NonceCache{
 		entries:   make(map[string]int64),
-		ttl:       ttl,
+		ttl:       2*tolerance + time.Second,
 		lastEvict: time.Now(),
 	}
 }
@@ -48,6 +66,14 @@ func NewNonceCache(ttl time.Duration) *NonceCache {
 // Returns false if the same (nodeID, nonce) pair was already seen within
 // the TTL window — the caller should reject the request as a replay.
 func (nc *NonceCache) Track(nodeID, nonce string) bool {
+	// A nil *NonceCache stored in a ReplayGuard interface is NOT == nil at
+	// the interface level (Go's typed-nil trap), so a caller's `guard == nil`
+	// check does not catch it. Report "not new" rather than panicking: every
+	// caller treats false as "reject", so an absent cache fails closed.
+	if nc == nil {
+		return false
+	}
+
 	key := nodeID + "\x00" + nonce
 	now := time.Now()
 	expiry := now.Add(nc.ttl).UnixNano()

--- a/internal/cluster/security/nonce_cache_test.go
+++ b/internal/cluster/security/nonce_cache_test.go
@@ -31,11 +31,35 @@ func TestNonceCache_SameNonceDifferentNode(t *testing.T) {
 }
 
 func TestNonceCache_ExpiredNonceReusable(t *testing.T) {
-	nc := NewNonceCache(1 * time.Millisecond)
+	// The cache lifetime is 2*tolerance + 1s (see NewNonceCache), not the
+	// tolerance itself, so the sleep has to clear that whole window. With a
+	// 1ms tolerance the entry lives ~1.002s; sleeping 5ms as this test
+	// originally did would now assert the opposite of the truth.
+	const tolerance = 10 * time.Millisecond
+	lifetime := 2*tolerance + time.Second
+
+	nc := NewNonceCache(tolerance)
 	nc.Track("node-1", "abc123")
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(lifetime + 100*time.Millisecond)
 	if !nc.Track("node-1", "abc123") {
 		t.Fatal("expired nonce should be reusable")
+	}
+}
+
+// TestNonceCache_SurvivesFreshnessWindow is the property the lifetime exists
+// for: a nonce must still be rejected at the last instant its MAC could be
+// accepted. A message may be stamped up to one tolerance in the future, so a
+// cache holding entries for only `tolerance` would evict this one while a
+// replay of it was still fresh.
+func TestNonceCache_SurvivesFreshnessWindow(t *testing.T) {
+	const tolerance = 200 * time.Millisecond
+	nc := NewNonceCache(tolerance)
+	nc.Track("node-1", "abc123")
+
+	// Past the tolerance, where a naive TTL would already have evicted.
+	time.Sleep(tolerance + 50*time.Millisecond)
+	if nc.Track("node-1", "abc123") {
+		t.Fatal("nonce was reusable while a MAC bearing it could still be accepted — replay window open")
 	}
 }
 


### PR DESCRIPTION
Detail accompanies the forthcoming security advisory. Reported by @rexpository.

> **BREAKING for clustered Enterprise deployments.** The handshake wire format changed: a node on this version cannot authenticate with an older one. Upgrade as a coordinated restart — **stop all nodes, upgrade all, restart all**. See the release notes for the full mixed-version behaviour. Single-node, non-clustered and OSS deployments are unaffected.

## Summary

The join, heartbeat and leave messages authenticated only `{message type, nonce, node ID, cluster name, timestamp}` while their handlers went on to consume other fields from the same message — a joining node's role and its advertised Raft/API/coordinator addresses, a heartbeat's self-reported state. With `cluster.tls_enabled` unset (the default), a peer able to modify inter-node traffic could rewrite any of those and the signature still verified. The three responses (join result, leader redirect, forward-apply ack) carried no authentication at all.

**Every non-auth field of every handshake message is now covered by its MAC, in both directions.** Responses are signed over the request's nonce, so a requester validates with the nonce it generated and needs no replay cache of its own. The rule is deliberately "the whole message" rather than "the fields a handler reads today" — the latter is what left the next added field unprotected.

Also included:

- **Replay protection** on join/heartbeat/leave via fail-closed `Validate*HMACWithReplay` wrappers (reusing the existing `edgesync_auth.go` pattern rather than hand-rolling a third copy). The nonce is consumed only after the MAC verifies, so a forged message cannot burn a legitimate nonce's cache slot.
- **Nonce cache lifetime corrected** to `2T+1s`, derived from the tolerance rather than equal to it. A message may be stamped up to one tolerance in the *future*, so a `T`-lived entry could be evicted while its MAC was still acceptable. Fixed in the constructor, so cache-invalidate and edge-sync are tightened too.
- **Uniform pre-auth join errors.** The cluster-name mismatch previously echoed the expected name back to an unauthenticated caller, and the three failure modes were individually distinguishable. Causes remain in the server log.
- **Length-prefixed canonical encoding** instead of NUL-delimited: this transport is raw TCP carrying JSON and passes NUL through, so a delimiter-joined payload could be re-partitioned by an attacker who controls a field's contents.
- **Per-destination heartbeat/leave signing** on a per-peer copy. Registry entries can share an address (node IDs are hostname+PID, so a bare-metal restart leaves the old entry), so one nonce per tick would be rejected as a replay every tick; the shared struct was also marshalled concurrently by N goroutines.

### A bug found by the new tests during implementation

`c.nonceCache` is a typed nil inside the `ReplayGuard` interface, so `guard == nil` was **false** and `Track` panicked on the nil receiver. A handshake arriving at a Coordinator whose cache had not been installed would have **crashed the node rather than rejecting the message**. Fixed at both layers (`Track` is nil-safe; the wrappers reject a typed-nil guard) with a regression test.

## Configuration matrix

| Configuration | Reaches new code? | Preconditions established? |
|---|---|---|
| OSS standalone, `cluster.enabled=false` | No — coordinator never constructed (`main.go:1420` gate) | **Binary-run verified**: ready, no panics, `/health` 200 |
| Cluster + Raft, `raft_advertise_addr` **set** | Yes — all senders/validators | **Binary-run verified**: join OK, signed role/addr registered |
| Cluster + Raft, `raft_advertise_addr` **UNSET (default)** | Yes — fallback must precede signing (`coordinator.go`) | **Binary-run verified**: join succeeds. No unit test covers this; tests build `Coordinator` literals |
| Cluster, no Raft | Yes — registry path | `registry`/`localNode` set in `NewCoordinator`; `nonceCache` at `Start()` before `acceptLoop` |
| `nonceCache == nil` + secret set | Reject, fail-closed | Tests only in production (cache installed before listener accepts); typed-nil covered |
| `shared_secret` empty | Auth + replay + response validation skipped | Unchanged; unsupported since #505 |
| Two registry entries sharing an address | Per-destination nonces | Distinct nonces asserted; `-race` clean |
| `cluster.tls_enabled` / `server.tls_enabled` | MAC path identical | Independent flags |
| `licenseClient` nil vs set | `validateCoreLimitForJoin` unchanged | `CoreCount` now signed, closing a forged-count bypass |
| Mixed-version join/heartbeat/leave | Both directions reject | Documented in the upgrade note |
| Mixed-version forward-apply (new follower → old leader) | Old leader applies, returns unsigned ack, follower rejects | **Write applied but reported failed** — documented |
| Mixed-version graceful follower restart under old leader | Removed from Raft by its own leave, cannot rejoin | Documented; worst rolling-restart consequence |

## Test plan

- [x] `go test -race ./internal/cluster/... ./internal/api/...` — **all 7 packages ok** (cluster 22s, api 62s)
- [x] `gofmt -l` clean on every touched file; `go vet` clean
- [x] **Live licensed 2-node cluster**, both `raft_advertise_addr` set and unset:
  - Join succeeds; `role=reader`, `address=127.0.0.1:9102` registered — the **signed** values
  - 60s steady-state heartbeats: **0** auth failures, **0** replay warnings
  - Graceful leave: `peers_notified: 1`, accepted, removed from FSM + registry
  - **Replay**: 1st `ACCEPTED`, byte-identical 2nd `REJECTED: authentication failed`; server logged `replay: true` with `security: handshake nonce already used`
  - **Error oracle**: wrong cluster name / missing MAC / bad MAC / wrong secret all return the identical `"authentication failed"`; cluster name never leaves the server
- [x] Pre-fix evidence: the reporter's Appendix A reproducer was run on `main` earlier in this work and demonstrated the violation. The new tests use the new API and cannot compile against `main`, so no revert-run-restore is claimed for them.

New tests: per-field mutation tables for all six message types (including `Nodes` add/remove/reorder), canonical-encoding collision, nonce binding, replay + fail-closed + typed-nil guard, live-shaped join/leave/heartbeat handler tests, joiner-side response validation, `checkForwardAck` forged-success **and forged-error-code** cases, and per-destination heartbeat signing under `-race`.