### PR TITLE
security(cluster): bind SupportsBinaryEntries into the replicate-sync HMAC

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -191,12 +191,16 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 ## Upgrade notes
 
 1. **Clustered Enterprise deployments require a coordinated restart.** The
-   coordinator handshake wire format changed (see *Cluster hardening* above):
-   stop all cluster nodes, upgrade the binary on every node, then restart all
-   nodes. A rolling restart causes cross-version nodes to mark each other
-   unhealthy, can trigger an automatic writer failover, and can remove a
-   gracefully-restarted follower from the Raft configuration until its leader
-   is upgraded. Single-node, non-clustered and OSS deployments need no action.
+   coordinator handshake **and the replicate-sync handshake** wire formats
+   changed (see *Cluster hardening* and *Replicate-sync now authenticates
+   `SupportsBinaryEntries`* above): stop all cluster nodes, upgrade the binary
+   on every node, then restart all nodes. A rolling restart causes
+   cross-version nodes to mark each other unhealthy, can trigger an automatic
+   writer failover, and can remove a gracefully-restarted follower from the
+   Raft configuration until its leader is upgraded. A cross-version reader
+   additionally cannot establish WAL replication with a writer and will fall
+   behind until both ends are upgraded. Single-node, non-clustered and OSS
+   deployments need no action.
 2. **No configuration change is required.** Existing `arc.toml` files and
    license keys work as-is; no new keys were added.
 

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -148,6 +148,26 @@ OSS deployments are unaffected.
 Full technical detail will accompany the corresponding security advisory once
 it is published. Responsibly reported by **[@rexpository](https://github.com/rexpository)**.
 
+### Replicate-sync now authenticates `SupportsBinaryEntries` ([#714](https://github.com/Basekick-Labs/arc/issues/714))
+
+The replicate-sync handshake (a reader requesting WAL replication from a
+writer) authenticates `{reader_id, last_known_seq, nonce, cluster_name,
+timestamp}`, but the `SupportsBinaryEntries` flag that negotiates binary-framed
+WAL entries (see *Replication can now carry WAL entries up to the full
+payload cap* below) rode outside the MAC. It was left unsigned on the
+reasoning that folding it in would break mixed-version handshakes; that
+reasoning no longer holds once the coordinator handshake above became a hard
+cutover regardless, so the flag is now bound into `ComputeReplicateSyncHMAC`
+and `ValidateReplicateSyncHMAC` alongside the rest of the message. An
+on-path tamperer who flipped the previously-unsigned flag could only force a
+framing downgrade or a dropped connection — both already available to anyone
+who can modify the stream — so this closes a completeness gap rather than a
+previously exploitable one. It carries the same replicate-sync wire format
+change and coordinated-restart requirement as the handshake hardening above,
+so it ships in the same release rather than forcing a second cutover.
+
+Contributed by [@pujitha24](https://github.com/pujitha24).
+
 ### Expired API tokens are now rejected on cache hits
 
 Arc caches successful token verifications in memory for `auth.cache_ttl`

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -166,7 +166,7 @@ previously exploitable one. It carries the same replicate-sync wire format
 change and coordinated-restart requirement as the handshake hardening above,
 so it ships in the same release rather than forcing a second cutover.
 
-Contributed by [@pujitha24](https://github.com/pujitha24).
+Contributed by [@pujitha24](https://github.com/pujitha24) in [#715](https://github.com/Basekick-Labs/arc/pull/715).
 
 ### Expired API tokens are now rejected on cache hits
 

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -1582,7 +1582,7 @@ func (c *Coordinator) handleReplicateSync(conn net.Conn, syncReq *protocol.Repli
 	}
 	if err := security.ValidateReplicateSyncHMAC(
 		c.cfg.SharedSecret, syncReq.Nonce, syncReq.ReaderID, syncReq.ClusterName,
-		syncReq.LastKnownSequence, syncReq.Timestamp, syncReq.HMAC, security.HMACTimestampTolerance,
+		syncReq.LastKnownSequence, syncReq.SupportsBinaryEntries, syncReq.Timestamp, syncReq.HMAC, security.HMACTimestampTolerance,
 	); err != nil {
 		c.logger.Warn().
 			Err(err).

--- a/internal/cluster/protocol/messages.go
+++ b/internal/cluster/protocol/messages.go
@@ -94,12 +94,12 @@ func (m MessageType) String() string {
 
 // ReplicateSync is sent by a reader node to request WAL replication.
 //
-// The five auth fields (Nonce / Timestamp / HMAC / ClusterName / and
-// the existing ReaderID acting as senderID) carry the application-layer
-// HMAC over the handshake. Computed by security.ComputeReplicateSyncHMAC
-// at the reader, validated by security.ValidateReplicateSyncHMAC at
-// the writer before the connection is accepted. See GHSA-wfgr-8x84-22q7
-// / CVE-2026-48106.
+// The six auth-bound fields (Nonce / Timestamp / HMAC / ClusterName /
+// the existing ReaderID acting as senderID / and SupportsBinaryEntries)
+// carry the application-layer HMAC over the handshake. Computed by
+// security.ComputeReplicateSyncHMAC at the reader, validated by
+// security.ValidateReplicateSyncHMAC at the writer before the
+// connection is accepted. See GHSA-wfgr-8x84-22q7 / CVE-2026-48106.
 //
 // The auth fields are required when cluster.shared_secret is configured;
 // when it's empty the receiver refuses every request (refuse-when-
@@ -121,16 +121,11 @@ type ReplicateSync struct {
 	// entry payloads as raw bytes instead of JSON + base64 (whose 4/3
 	// inflation made entries above ~75MB unsendable).
 	//
-	// NOT covered by the replicate-sync HMAC. The original reason — that
-	// folding it in would break mixed-version handshakes — no longer
-	// applies as stated: 26.09.2 made the coordinator handshake a hard
-	// cutover anyway. It is still unsigned because replicate-sync is a
-	// separate message and validator from the handshake family, and
-	// widening that cutover was out of scope for the security fix that
-	// forced it. The worst an on-path tamperer gains by flipping this is a
-	// framing downgrade or a dropped connection, both already available to
-	// anyone who can modify the stream; TLS covers integrity where
-	// configured. Tracked as a follow-up.
+	// Covered by the replicate-sync HMAC (#714). Originally left out
+	// because folding it in would break mixed-version handshakes —
+	// that no longer applies since 26.09.2 made the coordinator
+	// handshake a hard cutover anyway, so this rides along with the
+	// same coordinated-restart release.
 	SupportsBinaryEntries bool `json:"bin_entries,omitempty"`
 }
 

--- a/internal/cluster/replication/protocol.go
+++ b/internal/cluster/replication/protocol.go
@@ -41,8 +41,10 @@ const (
 	// which made every JSON-framed entry above ~75MB unsendable while
 	// the WAL happily stored it — a deterministic replication stall).
 	// Sent only to readers that advertised support in their handshake
-	// (protocol.ReplicateSync.SupportsBinaryEntries), so mixed-version
-	// pairs keep speaking JSON.
+	// (protocol.ReplicateSync.SupportsBinaryEntries, bound into the
+	// replicate-sync MAC since #714, so the advertisement cannot be
+	// flipped in transit). A reader that does not advertise it keeps
+	// receiving JSON-framed entries.
 	//
 	// Frame layout after the [4-byte length][1-byte type] header:
 	//   [8-byte sequence BE][8-byte timestampUS BE]

--- a/internal/cluster/replication/receiver.go
+++ b/internal/cluster/replication/receiver.go
@@ -274,21 +274,20 @@ func (r *Receiver) connect() error {
 	}
 	lastKnownSeq := r.lastSeq.Load()
 	timestamp := time.Now().Unix()
+	// Advertise MsgReplicateEntryBin support (#698), now bound into the
+	// HMAC (#714): a tamperer flipping this in transit invalidates the
+	// MAC instead of silently downgrading the framing.
+	const supportsBinaryEntries = true
 	syncReq := &protocol.ReplicateSync{
-		ReaderID:          r.cfg.ReaderID,
-		LastKnownSequence: lastKnownSeq,
-		Nonce:             nonce,
-		ClusterName:       r.cfg.ClusterName,
-		Timestamp:         timestamp,
-		// Advertise MsgReplicateEntryBin support (#698). Outside the
-		// HMAC tuple by design — see the field's doc in
-		// protocol/messages.go. An old writer ignores the field and
-		// keeps sending JSON entries, which this receiver still
-		// handles.
-		SupportsBinaryEntries: true,
+		ReaderID:              r.cfg.ReaderID,
+		LastKnownSequence:     lastKnownSeq,
+		Nonce:                 nonce,
+		ClusterName:           r.cfg.ClusterName,
+		Timestamp:             timestamp,
+		SupportsBinaryEntries: supportsBinaryEntries,
 		HMAC: security.ComputeReplicateSyncHMAC(
 			r.cfg.SharedSecret, nonce, r.cfg.ReaderID, r.cfg.ClusterName,
-			lastKnownSeq, timestamp,
+			lastKnownSeq, supportsBinaryEntries, timestamp,
 		),
 	}
 

--- a/internal/cluster/security/auth.go
+++ b/internal/cluster/security/auth.go
@@ -239,20 +239,25 @@ func ValidateCacheInvalidateHMAC(sharedSecret, nonce, nodeID, clusterName string
 // replication MsgReplicateSync message. The "replicate-sync" label
 // distinguishes this MAC from other cluster HMACs so a leaked MAC for
 // one endpoint cannot be replayed against another.
-// Format: "replicate-sync" \x00 nonce \x00 readerID \x00 clusterName \x00 lastKnownSeq \x00 timestamp
-func ComputeReplicateSyncHMAC(sharedSecret, nonce, readerID, clusterName string, lastKnownSeq uint64, timestamp int64) string {
-	return hex.EncodeToString(computeReplicateSyncHMACRaw(sharedSecret, nonce, readerID, clusterName, lastKnownSeq, timestamp))
+//
+// supportsBinaryEntries is bound into the MAC (#714): a tamperer who
+// flips it in transit now invalidates the MAC instead of silently
+// downgrading the framing or getting a mismatched writer expectation.
+//
+// Format: "replicate-sync" \x00 nonce \x00 readerID \x00 clusterName \x00 lastKnownSeq \x00 supportsBinaryEntries \x00 timestamp
+func ComputeReplicateSyncHMAC(sharedSecret, nonce, readerID, clusterName string, lastKnownSeq uint64, supportsBinaryEntries bool, timestamp int64) string {
+	return hex.EncodeToString(computeReplicateSyncHMACRaw(sharedSecret, nonce, readerID, clusterName, lastKnownSeq, supportsBinaryEntries, timestamp))
 }
 
-func computeReplicateSyncHMACRaw(sharedSecret, nonce, readerID, clusterName string, lastKnownSeq uint64, timestamp int64) []byte {
-	message := fmt.Sprintf("replicate-sync\x00%s\x00%s\x00%s\x00%d\x00%d", nonce, readerID, clusterName, lastKnownSeq, timestamp)
+func computeReplicateSyncHMACRaw(sharedSecret, nonce, readerID, clusterName string, lastKnownSeq uint64, supportsBinaryEntries bool, timestamp int64) []byte {
+	message := fmt.Sprintf("replicate-sync\x00%s\x00%s\x00%s\x00%d\x00%t\x00%d", nonce, readerID, clusterName, lastKnownSeq, supportsBinaryEntries, timestamp)
 	return computeRawHMAC(sharedSecret, message)
 }
 
 // ValidateReplicateSyncHMAC validates the handshake HMAC and checks
 // freshness. Same symmetric-drift semantics as the other validators —
 // both stale-past and future-dated timestamps are refused.
-func ValidateReplicateSyncHMAC(sharedSecret, nonce, readerID, clusterName string, lastKnownSeq uint64, timestamp int64, receivedMAC string, tolerance time.Duration) error {
+func ValidateReplicateSyncHMAC(sharedSecret, nonce, readerID, clusterName string, lastKnownSeq uint64, supportsBinaryEntries bool, timestamp int64, receivedMAC string, tolerance time.Duration) error {
 	now := time.Now().Unix()
 	drift := now - timestamp
 	if drift < 0 {
@@ -262,7 +267,7 @@ func ValidateReplicateSyncHMAC(sharedSecret, nonce, readerID, clusterName string
 		return fmt.Errorf("replicate-sync auth timestamp expired or out of tolerance (drift: %ds, tolerance: %ds)", drift, int64(tolerance.Seconds()))
 	}
 
-	expected := computeReplicateSyncHMACRaw(sharedSecret, nonce, readerID, clusterName, lastKnownSeq, timestamp)
+	expected := computeReplicateSyncHMACRaw(sharedSecret, nonce, readerID, clusterName, lastKnownSeq, supportsBinaryEntries, timestamp)
 	if !constantTimeHexEqual(expected, receivedMAC) {
 		return fmt.Errorf("replicate-sync HMAC validation failed: shared secret mismatch or malformed MAC")
 	}

--- a/internal/cluster/security/auth_test.go
+++ b/internal/cluster/security/auth_test.go
@@ -369,8 +369,8 @@ func TestValidateCacheInvalidateHMAC_FieldBinding(t *testing.T) {
 // constant.
 func TestComputeReplicateSyncHMAC_Determinism(t *testing.T) {
 	t.Parallel()
-	got := ComputeReplicateSyncHMAC("secret", "nonce-abc", "reader-1", "cluster-A", 42, 1700000000)
-	const want = "3fd418a80d9d94b8b36765a1026f3cabc360a5be2e4eb27c0f6ea6b190119d8c"
+	got := ComputeReplicateSyncHMAC("secret", "nonce-abc", "reader-1", "cluster-A", 42, true, 1700000000)
+	const want = "6da169ffe1cecd86dd6ab08faf641ac0276b85933480d7dde756a2f26b741c5b"
 	if got != want {
 		t.Errorf("replicate-sync MAC drift detected:\n  got  %s\n  want %s\nIf this fails, the handshake message format changed — coordinate with the deployed-version matrix before merging.", got, want)
 	}
@@ -495,7 +495,7 @@ func TestReplicationHMAC_LabelBinding_NoCrossEndpointReplay(t *testing.T) {
 		cumHash[i] = byte(i)
 	}
 
-	syncMAC := ComputeReplicateSyncHMAC(secret, nonce, nodeID, clusterName, lastSeq, ts)
+	syncMAC := ComputeReplicateSyncHMAC(secret, nonce, nodeID, clusterName, lastSeq, true, ts)
 	checkpointMAC := ComputeReplicationCheckpointHMAC(secret, nonce, nodeID, clusterName, cumHash, lastSeq, ts)
 	cacheMAC := ComputeCacheInvalidateHMAC(secret, nonce, nodeID, clusterName, ts)
 	forwardMAC := ComputeForwardHMAC(secret, nonce, nodeID, clusterName, []byte{}, ts)
@@ -523,7 +523,7 @@ func TestReplicationHMAC_LabelBinding_NoCrossEndpointReplay(t *testing.T) {
 		if name == "sync" {
 			continue
 		}
-		if err := ValidateReplicateSyncHMAC(secret, nonce, nodeID, clusterName, lastSeq, ts, mac, 5*time.Minute); err == nil {
+		if err := ValidateReplicateSyncHMAC(secret, nonce, nodeID, clusterName, lastSeq, true, ts, mac, 5*time.Minute); err == nil {
 			t.Errorf("%s MAC accepted by replicate-sync validator — label binding broken", name)
 		}
 	}
@@ -572,15 +572,46 @@ func TestValidateReplicateSyncHMAC_StaleAndFuture(t *testing.T) {
 	)
 
 	staleTS := time.Now().Add(-10 * time.Minute).Unix()
-	mac := ComputeReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, staleTS)
-	if err := ValidateReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, staleTS, mac, 5*time.Minute); err == nil {
+	mac := ComputeReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, true, staleTS)
+	if err := ValidateReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, true, staleTS, mac, 5*time.Minute); err == nil {
 		t.Error("stale timestamp accepted by replicate-sync validator")
 	}
 
 	futureTS := time.Now().Add(10 * time.Minute).Unix()
-	mac = ComputeReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, futureTS)
-	if err := ValidateReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, futureTS, mac, 5*time.Minute); err == nil {
+	mac = ComputeReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, true, futureTS)
+	if err := ValidateReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, true, futureTS, mac, 5*time.Minute); err == nil {
 		t.Error("future timestamp accepted by replicate-sync validator")
+	}
+}
+
+// TestValidateReplicateSyncHMAC_RejectsFlippedSupportsBinaryEntries pins
+// that SupportsBinaryEntries is bound into the replicate-sync MAC
+// (https://github.com/Basekick-Labs/arc/issues/714): a MAC computed with
+// one value must not validate once the field is flipped, since an
+// on-path tamperer who could flip it undetected would force either a
+// silent framing downgrade or a writer/reader mismatch.
+func TestValidateReplicateSyncHMAC_RejectsFlippedSupportsBinaryEntries(t *testing.T) {
+	t.Parallel()
+	const (
+		secret      = "secret"
+		nonce       = "nonce-abc"
+		readerID    = "reader-1"
+		clusterName = "cluster-A"
+		lastSeq     = uint64(42)
+	)
+	ts := time.Now().Unix()
+
+	mac := ComputeReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, true, ts)
+	if err := ValidateReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, true, ts, mac, 5*time.Minute); err != nil {
+		t.Fatalf("untampered MAC rejected: %v", err)
+	}
+	if err := ValidateReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, false, ts, mac, 5*time.Minute); err == nil {
+		t.Error("MAC computed with supportsBinaryEntries=true validated after the field was flipped to false")
+	}
+
+	mac = ComputeReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, false, ts)
+	if err := ValidateReplicateSyncHMAC(secret, nonce, readerID, clusterName, lastSeq, true, ts, mac, 5*time.Minute); err == nil {
+		t.Error("MAC computed with supportsBinaryEntries=false validated after the field was flipped to true")
 	}
 }
 


### PR DESCRIPTION
Motivation:
protocol.ReplicateSync.SupportsBinaryEntries negotiates binary-framed
(MsgReplicateEntryBin) vs JSON+base64 WAL entry replication, but rode
outside the replicate-sync HMAC while every other field of the message
was covered. It was left unsigned on the reasoning that folding it in
would break mixed-version handshakes; that reasoning no longer holds
now that the coordinator handshake is a hard cutover regardless, so
this rides along with the same already-mandated coordinated-restart
release rather than forcing a second cutover.

Impact is low, not a new exploitable gap: an on-path tamperer who
flips the unsigned flag can only force a framing downgrade (binary to
JSON) or a dropped connection, both already available to anyone who
can modify the stream. This closes a completeness gap, matching the
"the MAC covers every non-auth field" rule the handshake family
already follows.

FetchFileRequest.ByteOffset, flagged in the same report as similarly
unsigned, is intentionally left alone: a resumed fetch would otherwise
invalidate the MAC, and that rationale still holds.

Approach:
- ComputeReplicateSyncHMAC / ValidateReplicateSyncHMAC (security/auth.go)
  take a new supportsBinaryEntries bool, folded into the signed message
  right before the timestamp.
- Both call sites updated: the writer (coordinator.go, validates) now
  passes syncReq.SupportsBinaryEntries; the reader (replication/receiver.go,
  computes) uses one local constant for both the struct field and the MAC
  input, so the two can't drift apart.
- Doc comments on ReplicateSync / SupportsBinaryEntries (protocol/messages.go)
  updated to say the field is now covered.

Validation:
- go build ./... and go vet ./internal/cluster/... — clean.
- gofmt -l on every changed file — clean.
- go test -tags=duckdb_arrow -race ./internal/cluster/... — all packages
  pass, including internal/cluster/security.
- Updated TestComputeReplicateSyncHMAC_Determinism's pinned hash for the
  new wire format (independently recomputed, matches).
- Added TestValidateReplicateSyncHMAC_RejectsFlippedSupportsBinaryEntries:
  computes a MAC with the field true, confirms it validates, then confirms
  validation now fails once the field is flipped to false (and the
  symmetric case). It does not compile against the pre-fix code, since the
  old function signature ignored the field entirely — a weaker guarantee
  than "fails on the pre-fix code," but it still pins the signed-tuple
  property directly and would catch a future change that dropped the field.

Report: https://github.com/Basekick-Labs/arc/issues/714
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #714
