### PR TITLE
fix(query): release Arrow IPC resources when the stream panics

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -206,6 +206,21 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### A panic while streaming Arrow IPC no longer leaks a database connection ([#716](https://github.com/Basekick-Labs/arc/issues/716))
+
+`POST /api/v1/query/arrow` streams its response from a callback that fasthttp
+runs on its own goroutine, where an unrecovered panic would take down the
+process, so the callback recovers. The cleanup that released the DuckDB result
+reader, returned the pooled connection and stopped the query timeout timer ran
+as ordinary statements after the streaming call, and a panic unwound straight
+past them. The connection was the costly one: it was never returned to the
+pool, so each occurrence permanently shrank the pool and repeated occurrences
+would starve the endpoint until a restart. Cleanup now also runs on the
+recovery path, and the per-batch records the stream owns (row-cap slices,
+decimal casts, dictionary-encoded batches) are released through a defer so a
+panic mid-batch cannot strand their buffers either, which for DuckDB-backed
+records are C-allocated and not reclaimed by the garbage collector.
+
 ### Every query endpoint now enforces query governance ([#702](https://github.com/Basekick-Labs/arc/issues/702))
 
 Enterprise query governance was enforced only on `POST /api/v1/query`, so

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -22,6 +22,10 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// streamArrowIPCFunc indirects streamArrowIPC so tests can drive the
+// response writer's panic path (#716). Production always uses the real one.
+var streamArrowIPCFunc = streamArrowIPC
+
 // arrowTrailerWarnOnce gates the AddTrailer failure log so a fasthttp
 // upgrade that ever rejects the trailer name does not produce a Warn per
 // request.
@@ -36,6 +40,42 @@ const arrowExecutionTimeTrailer = "Arc-Execution-Time-Ms"
 // Smaller batches reduce peak memory usage and enable streaming.
 // 10K rows is a good balance between overhead and memory efficiency.
 const arrowBatchSize = 10000
+
+// releaseArrowStreamResources frees everything the Arrow IPC response owns:
+// the DuckDB-backed reader, the pooled connection behind it, and the query
+// timeout context. Order matters — the reader's Release closes the result set
+// and statement that live on this connection, so returning the connection to
+// the pool first would hand another query a connection with an open result.
+//
+// It recovers on its own behalf (#716). It is called from the panic path,
+// where it runs on a bare fasthttp goroutine while a panic is already in
+// flight: a second panic raised here would either kill the process or, if
+// caught by the caller's recover, replace the root-cause panic value, since
+// recover() only ever yields the most recent one.
+func releaseArrowStreamResources(
+	reader array.RecordReader,
+	conn interface{ Close() error },
+	cancel context.CancelFunc,
+	logger zerolog.Logger,
+) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error().Interface("panic", r).
+				Msg("Arrow IPC resource cleanup panicked; connection or reader may be leaked")
+		}
+	}()
+	// Nil checks are not academic: conn is held as an interface, so a typed
+	// nil pointer is itself non-nil here and would nil-panic inside cleanup.
+	if reader != nil {
+		reader.Release()
+	}
+	if conn != nil {
+		conn.Close()
+	}
+	if cancel != nil {
+		cancel()
+	}
+}
 
 // streamArrowIPC writes Arrow record batches as IPC frames to w. It returns
 // the number of rows consumed and the error that stopped the stream, if any.
@@ -97,109 +137,106 @@ streamLoop:
 			break
 		}
 
-		// Governance row cap (#702): slice the batch that would cross the
-		// cap and stop draining. slicedBatch is a new record this function
-		// owns; it is released alongside the other per-iteration records
-		// after Write, and on the error paths that break out before then.
-		var slicedBatch arrow.Record
-		if maxRows > 0 {
-			remaining := int64(maxRows) - totalRows
-			// Defensive: the post-flush break below means the loop should
-			// never re-enter with the cap already reached. This keeps the
-			// row count correct if that break is ever removed.
-			if remaining <= 0 {
-				break
-			}
-			if batch.NumRows() > remaining {
-				slicedBatch = batch.NewSlice(0, remaining)
-				batch = slicedBatch
-			}
-		}
-		totalRows += batch.NumRows()
-
-		// CRITICAL: when castInfo!=nil we replace `batch` with a new
-		// arrow.Record that we own and must Release before the next
-		// iteration. The previous code used `defer batch.Release()`
-		// inside the loop, which holds every casted batch alive
-		// until the closure exits — pinning all Arrow buffers and
-		// defeating the streaming contract. Explicit release after
-		// Write is the right pattern for per-iteration ownership.
-		// The original reader.Record() does NOT need releasing here:
-		// reader.Next() releases the prior record automatically.
-		var castedBatch arrow.Record
-		if castInfo != nil {
-			var castErr error
-			castedBatch, castErr = castDecimalBatch(batch, castInfo)
-			if castErr != nil {
-				if slicedBatch != nil {
-					slicedBatch.Release()
+		// Each iteration runs as its own function so the records it owns
+		// are freed by one defer (#716). Straight-line releases are
+		// skipped when anything inside panics, and DuckDB-backed records
+		// hold C-allocated buffers the GC will not reclaim. The cgo
+		// reader path, castDecimalBatch, the dictionary transformer and
+		// NewSlice can all raise, so this is the panic surface that a
+		// caller-side defer cannot cover.
+		//
+		// Returns true when the caller should stop iterating; streamErr
+		// carries the reason when stopping is a failure.
+		stop := func() bool {
+			var slicedBatch, castedBatch, encodedBatch arrow.Record
+			defer func() {
+				if encodedBatch != nil {
+					encodedBatch.Release()
 				}
-				streamErr = fmt.Errorf("failed to cast decimal columns at row %d: %w", totalRows, castErr)
-				break streamLoop
-			}
-			batch = castedBatch
-		}
-
-		// First batch: decide dictionary columns (if requested) and
-		// create the writer with the final output schema.
-		if ipcWriter == nil {
-			outSchema := schema
-			if dictEnabled {
-				// Analysis runs on the (possibly decimal-casted) batch so
-				// the transformer's schema matches what it will receive.
-				dictXform = newArrowDictTransformer(batch, &logger)
-				if dictXform != nil {
-					outSchema = dictXform.schema
-				}
-			}
-			ipcWriter = newIPCWriter(outSchema)
-		}
-
-		writeBatch := batch
-		var encodedBatch arrow.Record
-		if dictXform != nil {
-			var encErr error
-			encodedBatch, encErr = dictXform.transform(batch)
-			if encErr != nil {
 				if castedBatch != nil {
 					castedBatch.Release()
 				}
 				if slicedBatch != nil {
 					slicedBatch.Release()
 				}
-				streamErr = fmt.Errorf("failed to dictionary-encode batch at row %d: %w", totalRows, encErr)
-				break streamLoop
-			}
-			writeBatch = encodedBatch
-		}
+			}()
 
-		err := ipcWriter.Write(writeBatch)
-		if encodedBatch != nil {
-			encodedBatch.Release()
-		}
-		if castedBatch != nil {
-			castedBatch.Release()
-		}
-		if slicedBatch != nil {
-			slicedBatch.Release()
-		}
-		if err != nil {
-			streamErr = fmt.Errorf("failed to write arrow batch at row %d: %w", totalRows, err)
-			break streamLoop
-		}
-		// Capture Flush error: fasthttp's RequestCtx.Done() only fires on
-		// server shutdown (not per-request client disconnect), so the
-		// underlying bufio.Writer's error on the closed connection is our
-		// signal that the client has gone away. Wrap with the sentinel so
-		// the caller logs at Warn (not Error) for this expected ops noise.
-		if err := w.Flush(); err != nil {
-			streamErr = fmt.Errorf("stream flush failed at row %d: %w: %w", totalRows, errClientDisconnected, err)
-			break streamLoop
-		}
-		// Cap reached: stop before reader.Next() materializes another
-		// DuckDB batch that would only be discarded (same early break as
-		// drainArrowBatches).
-		if maxRows > 0 && totalRows >= int64(maxRows) {
+			// Governance row cap (#702): slice the batch that would cross
+			// the cap and stop draining.
+			if maxRows > 0 {
+				remaining := int64(maxRows) - totalRows
+				// Defensive: the post-flush stop below means the loop
+				// should never re-enter with the cap already reached.
+				// This keeps the row count correct if that is removed.
+				if remaining <= 0 {
+					return true
+				}
+				if batch.NumRows() > remaining {
+					slicedBatch = batch.NewSlice(0, remaining)
+					batch = slicedBatch
+				}
+			}
+			totalRows += batch.NumRows()
+
+			// castInfo != nil replaces batch with a record this iteration
+			// owns. The original reader.Record() is NOT released here:
+			// reader.Next() releases the prior record automatically.
+			if castInfo != nil {
+				var castErr error
+				castedBatch, castErr = castDecimalBatch(batch, castInfo)
+				if castErr != nil {
+					streamErr = fmt.Errorf("failed to cast decimal columns at row %d: %w", totalRows, castErr)
+					return true
+				}
+				batch = castedBatch
+			}
+
+			// First batch: decide dictionary columns (if requested) and
+			// create the writer with the final output schema.
+			if ipcWriter == nil {
+				outSchema := schema
+				if dictEnabled {
+					// Analysis runs on the (possibly decimal-casted) batch
+					// so the transformer's schema matches what it receives.
+					dictXform = newArrowDictTransformer(batch, &logger)
+					if dictXform != nil {
+						outSchema = dictXform.schema
+					}
+				}
+				ipcWriter = newIPCWriter(outSchema)
+			}
+
+			writeBatch := batch
+			if dictXform != nil {
+				var encErr error
+				encodedBatch, encErr = dictXform.transform(batch)
+				if encErr != nil {
+					streamErr = fmt.Errorf("failed to dictionary-encode batch at row %d: %w", totalRows, encErr)
+					return true
+				}
+				writeBatch = encodedBatch
+			}
+
+			if err := ipcWriter.Write(writeBatch); err != nil {
+				streamErr = fmt.Errorf("failed to write arrow batch at row %d: %w", totalRows, err)
+				return true
+			}
+			// Capture Flush error: fasthttp's RequestCtx.Done() only fires
+			// on server shutdown (not per-request client disconnect), so
+			// the underlying bufio.Writer's error on the closed connection
+			// is our signal that the client has gone away. Wrap with the
+			// sentinel so the caller logs at Warn (not Error) for this
+			// expected ops noise.
+			if err := w.Flush(); err != nil {
+				streamErr = fmt.Errorf("stream flush failed at row %d: %w: %w", totalRows, errClientDisconnected, err)
+				return true
+			}
+			// Cap reached: stop before reader.Next() materializes another
+			// DuckDB batch that would only be discarded (same early break
+			// as drainArrowBatches).
+			return maxRows > 0 && totalRows >= int64(maxRows)
+		}()
+		if stop {
 			break
 		}
 	}
@@ -477,18 +514,23 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		defer func() {
 			if r := recover(); r != nil {
 				m.IncQueryErrors()
+				// Log the root cause BEFORE cleaning up, so this value is
+				// on record even if cleanup then has trouble of its own.
 				h.logger.Error().Interface("panic", r).
 					Msg("Arrow IPC stream writer panicked; stream truncated")
+				// The unwind skipped the straight-line release below, which
+				// stranded the reader, leaked a pooled connection for the
+				// process lifetime, and left the timeout timer running
+				// (#716). Cleanup stays out of a plain defer so the success
+				// path keeps releasing before the trailer is set, rather
+				// than after it.
+				releaseArrowStreamResources(reader, conn, cancel, h.logger)
 			}
 		}()
-		totalRows, streamErr := streamArrowIPC(
+		totalRows, streamErr := streamArrowIPCFunc(
 			streamCtx, w, reader, schema, castInfo, dictEnabled, ipcCompression, governanceMaxRows, h.logger,
 		)
-		reader.Release()
-		conn.Close()
-		if cancel != nil {
-			cancel()
-		}
+		releaseArrowStreamResources(reader, conn, cancel, h.logger)
 
 		// Publish authoritative server-side timing as a chunked-transfer
 		// trailer. Set even on the error path so partial results carry

--- a/internal/api/query_arrow_cleanup_test.go
+++ b/internal/api/query_arrow_cleanup_test.go
@@ -1,0 +1,156 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/pruning"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// Tests for #716: a panic inside the Arrow IPC stream writer is recovered so
+// the process survives, but the cleanup that followed it in straight-line code
+// was skipped, stranding the DuckDB reader, leaking a pooled connection for the
+// life of the process, and leaving the query timeout timer running.
+
+// recordingConn counts Close calls so a test can tell "released once" from
+// "never released" and from "double released".
+type recordingConn struct{ closes int }
+
+func (c *recordingConn) Close() error { c.closes++; return nil }
+
+// panicOnReleaseReader lets a test drive the cleanup helper's own recover.
+type panicOnReleaseReader struct {
+	array.RecordReader
+	released bool
+}
+
+func (r *panicOnReleaseReader) Release() { r.released = true; panic("release exploded") }
+
+func TestReleaseArrowStreamResources(t *testing.T) {
+	t.Run("releases everything exactly once", func(t *testing.T) {
+		alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer alloc.AssertSize(t, 0)
+		schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+		reader := newSimpleRecordReader(schema, []arrow.Record{
+			buildArrowBatch(alloc, schema, [][]interface{}{{int64(1)}}),
+		})
+		conn := &recordingConn{}
+		cancelled := false
+
+		releaseArrowStreamResources(reader, conn, func() { cancelled = true }, zerolog.Nop())
+
+		if conn.closes != 1 {
+			t.Errorf("conn.Close called %d times, want 1", conn.closes)
+		}
+		if !cancelled {
+			t.Error("cancel was not called, the timeout timer would leak")
+		}
+	})
+
+	t.Run("tolerates nil reader, conn and cancel", func(t *testing.T) {
+		// conn is held as an interface, so a typed-nil pointer is non-nil
+		// here; the guard has to be on the value, not just the interface.
+		releaseArrowStreamResources(nil, nil, nil, zerolog.Nop())
+	})
+
+	t.Run("contains a panic raised while releasing", func(t *testing.T) {
+		reader := &panicOnReleaseReader{}
+		conn := &recordingConn{}
+		// Must not propagate: on the panic path this runs on a bare
+		// fasthttp goroutine where a second panic kills the process.
+		releaseArrowStreamResources(reader, conn, nil, zerolog.Nop())
+		if !reader.released {
+			t.Fatal("Release was not attempted")
+		}
+	})
+}
+
+// TestExecuteQueryArrowReturnsConnectionOnPanic is the #716 regression proper.
+// It runs the real handler against a real DuckDB, forces the stream writer to
+// panic, and asserts the pooled connection goes back to the pool. Reverting the
+// cleanup to straight-line code leaves InUse at 1 and fails this test.
+func TestExecuteQueryArrowReturnsConnectionOnPanic(t *testing.T) {
+	metrics.Init(zerolog.Nop())
+
+	tmpDir, err := os.MkdirTemp("", "arc-arrow-cleanup-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	backend, err := storage.NewLocalBackend(tmpDir, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duckdb, err := database.New(&database.Config{
+		MemoryLimit:      "256MB",
+		ThreadCount:      2,
+		MaxConnections:   2,
+		LocalStorageRoot: tmpDir,
+	}, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer duckdb.Close()
+
+	h := &QueryHandler{
+		db:         duckdb,
+		logger:     logger,
+		storage:    backend,
+		queryCache: database.NewQueryCache(database.QueryCacheTTL, database.DefaultQueryCacheMaxSize),
+		pruner:     pruning.NewPartitionPruner(zerolog.Nop()),
+	}
+
+	orig := streamArrowIPCFunc
+	defer func() { streamArrowIPCFunc = orig }()
+	streamArrowIPCFunc = func(context.Context, *bufio.Writer, array.RecordReader, *arrow.Schema,
+		*decimalCastInfo, bool, string, int, zerolog.Logger) (int64, error) {
+		panic("simulated failure inside the Arrow IPC stream")
+	}
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Post("/api/v1/query/arrow", h.executeQueryArrow)
+
+	before := duckdb.Stats()
+	req := httptest.NewRequest("POST", "/api/v1/query/arrow", strings.NewReader(`{"sql":"SELECT 1 AS id"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, 10000)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	// Draining the body runs the stream writer goroutine to completion, which
+	// is where the panic and the recovery happen.
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// The pool is the operational impact: a leaked connection is gone for the
+	// life of the process, so repeated panics starve the endpoint.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		inUse := duckdb.Stats().InUse
+		if inUse == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("connection never returned to the pool after the stream panicked: InUse=%d (was %d before the request)", inUse, before.InUse)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Fixes #716.

## Summary

`POST /api/v1/query/arrow` writes its response from a fasthttp stream-writer callback. fasthttp runs that callback as a bare goroutine (`NewStreamReader`, stream.go:43, reached from `SetBodyStreamWriter`, http.go:290), so an unrecovered panic there takes down the process, which is why the callback recovers. The cleanup that released the DuckDB reader, returned the pooled `*sql.Conn` and stopped the timeout timer was straight-line code after the streaming call, and the unwind skipped all of it. The connection is the expensive one: a leaked connection never returns to the pool, so repeated panics starve the endpoint until a restart.

## What changed

- Cleanup now also runs from the recovery path, through `releaseArrowStreamResources`, which recovers on its own behalf and nil-guards each resource. Release order is reader, then connection: the reader's `Release` closes the result set and statement living on that connection, so returning the connection first would hand another query a connection with an open result.
- It is deliberately **not** a plain `defer`. That would move the release after the trailer is set on the success path, and the stream-writer goroutine and the connection goroutine both touch the response header there, so the existing release timing is worth preserving.
- The root-cause panic is logged **before** cleanup runs, because `recover()` yields only the most recent panic value; a failure during cleanup would otherwise replace the reason the stream died in the only log line that records it.
- The same unwind also stranded the records each iteration owns (the governance row-cap slice, the decimal cast, the dictionary-encoded batch). For DuckDB-backed records those buffers are C-allocated and the garbage collector does not reclaim them. The loop body now runs as a function with one deferred release, which also collapses three duplicated release blocks across its error paths.
- `streamArrowIPC` is reached through a package-level variable purely so a test can drive the panic path.

## Test plan

- [x] `TestExecuteQueryArrowReturnsConnectionOnPanic` runs the real handler against a real DuckDB, forces the stream writer to panic, and asserts the connection returns to the pool. Reverting the fix fails it with `InUse` stuck at 1.
- [x] `TestReleaseArrowStreamResources` covers release-exactly-once, nil inputs (a typed-nil conn is non-nil behind the interface), and a panic raised while releasing.
- [x] All six pre-existing leak-checked `TestStreamArrowIPC*` tests still pass after the loop rewrite.
- [x] Full `internal/api` suite green under `-race` with `-tags=duckdb_arrow`; build, vet, gofmt clean.
- [x] Live Enterprise-licensed server: the Arrow endpoint streams correct values on the plain, dictionary-encoded and zstd paths; the governance row cap still applies; 60 consecutive requests left the pool healthy.

## Notes

The plan for this went through an adversarial review before implementation, which corrected three things worth recording: `recover()` returning only the newest panic value (so cleanup cannot be allowed to overwrite the root cause), the response-header race that ruled out a plain defer, and the stranded per-iteration records that made the original fix incomplete.

Sibling sweep is filed separately as #717: eight other streaming callbacks in `internal/api` have no panic recovery at all, so a panic there crashes the process rather than leaking. Wider blast radius and a different bug class, so it is not riding along here.