### PR TITLE
fix(api): recover from panics in every response stream writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,21 @@ jobs:
 
       - name: Test (race)
         run: go test -tags=duckdb_arrow -race ./...
+
+      # fasthttp runs body-stream writers on a bare goroutine with no recovery,
+      # so a panic in one crashes the process rather than failing the request
+      # (#717). Every writer must go through QueryHandler.safeStream. arcx_hook.go
+      # is excluded because it builds only under the arcx_engine tag, which no
+      # CI or release build uses, so it cannot be compile-checked here; it is
+      # tracked separately.
+      - name: Body-stream writers are panic-safe
+        run: |
+          unwrapped=$(grep -rn "SetBodyStreamWriter(" internal/api/*.go \
+            | grep -v "_test.go" \
+            | grep -v "internal/api/arcx_hook.go" \
+            | grep -v "safeStream(" || true)
+          if [ -n "$unwrapped" ]; then
+            echo "These body-stream writers bypass safeStream, so a panic in them would crash the process:"
+            echo "$unwrapped"
+            exit 1
+          fi

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -214,6 +214,26 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### A panic while streaming a response no longer crashes the server ([#717](https://github.com/Basekick-Labs/arc/issues/717))
+
+Query responses are streamed from a callback that fasthttp runs on its own
+goroutine, where an unrecovered panic takes down the whole process rather than
+failing the one request. Only the Arrow IPC writer recovered; the JSON, msgpack,
+parallel-partition and measurement writers did not, so a panic on any of those
+paths (the DuckDB cgo boundary, a decimal cast, an encoder) would stop the
+server. Every streaming writer now recovers, logs the panic, and counts it as a
+query error, and the client sees a truncated response instead of a dropped
+service.
+
+Recovering also exposed what the unwind had been skipping. Those writers
+released their result set, pooled connection and query timeout in ordinary
+statements after the streaming call, so the fix moves each into a deferred block
+that keeps the original release order. Six of the writers also disposed of their
+query-registry entry only on the normal path, which meant a panicking query would
+have sat in `GET /api/v1/queries/active` as `running` forever, holding its SQL
+text and inflating the active-query gauge, with no reaper to clear it; those
+entries are now failed on the panic path.
+
 ### A panic while streaming Arrow IPC no longer leaks a database connection ([#716](https://github.com/Basekick-Labs/arc/issues/716))
 
 `POST /api/v1/query/arrow` streams its response from a callback that fasthttp

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1814,14 +1814,25 @@ localProcessing:
 		// is fired inside the callback after streaming completes.
 		streamCtx := execCtx
 		c.Set("Content-Type", "application/json")
-		c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-			rowCount, streamErr := streamTypedJSON(streamCtx, w, columns, colTypes, iter, governanceMaxRows, profile, start, timestamp)
-			w.Flush()
-
-			iter.Close()
-			if cancelTimeout != nil {
-				cancelTimeout()
+		c.Context().SetBodyStreamWriter(h.safeStream("query_json_parallel", func() {
+			// A panic leaves the registry entry in "running" forever: the
+			// disposition calls below are skipped by the unwind and nothing
+			// reaps active entries (#717). Fail is a no-op if the normal
+			// path already disposed of it.
+			if h.queryRegistry != nil && queryID != "" {
+				h.queryRegistry.Fail(queryID, "stream writer panicked")
 			}
+		}, func(w *bufio.Writer) {
+			// One defer, in the original order: separate defers would run
+			// LIFO and cancel the timeout before the iterator is closed.
+			defer func() {
+				iter.Close()
+				if cancelTimeout != nil {
+					cancelTimeout()
+				}
+			}()
+			rowCount, streamErr := streamTypedJSONFunc(streamCtx, w, columns, colTypes, iter, governanceMaxRows, profile, start, timestamp)
+			w.Flush()
 
 			// Record metrics after streaming completes. If the stream
 			// terminated mid-flight (Scan / Err / ctx cancel), record as
@@ -1861,7 +1872,7 @@ localProcessing:
 				Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 				Msg("Query completed")
 			h.logSlowQuery(convertedSQL, start, rowCount, tokenName)
-		})
+		}))
 		return nil
 	} else {
 		// Standard single-query execution
@@ -2061,17 +2072,24 @@ localProcessing:
 		// can fire inside the streaming callback. See C5.
 		streamCtx := ctx
 		c.Set("Content-Type", "application/json")
-		c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-			rowCount, streamErr := streamTypedJSON(streamCtx, w, columns, colTypes, rows, governanceMaxRows, profile, start, timestamp)
+		c.Context().SetBodyStreamWriter(h.safeStream("query_json", func() {
+			if h.queryRegistry != nil && queryID != "" {
+				h.queryRegistry.Fail(queryID, "stream writer panicked")
+			}
+		}, func(w *bufio.Writer) {
+			// One defer preserving the original order: rows first, then the
+			// pinned profiling connection, then the timeout context.
+			defer func() {
+				rows.Close()
+				if profileConn != nil {
+					profileConn.Close()
+				}
+				if cancel != nil {
+					cancel()
+				}
+			}()
+			rowCount, streamErr := streamTypedJSONFunc(streamCtx, w, columns, colTypes, rows, governanceMaxRows, profile, start, timestamp)
 			w.Flush()
-
-			rows.Close()
-			if profileConn != nil {
-				profileConn.Close()
-			}
-			if cancel != nil {
-				cancel()
-			}
 
 			// If the stream terminated mid-flight (Scan / Err / ctx
 			// cancel) record as failure even though the JSON envelope
@@ -2112,7 +2130,7 @@ localProcessing:
 				Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 				Msg("Query completed")
 			h.logSlowQuery(convertedSQL, start, rowCount, tokenName)
-		})
+		}))
 		return nil
 	}
 }
@@ -4622,14 +4640,17 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	// fires inside the streaming callback (#308).
 	streamCtx := ctx
 	c.Set("Content-Type", "application/json")
-	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-		rowCount, streamErr := streamTypedJSON(streamCtx, w, columns, colTypes, rows, governanceMaxRows, nil, start, timestamp)
+	c.Context().SetBodyStreamWriter(h.safeStream("query_measurement", nil, func(w *bufio.Writer) {
+		// The measurement endpoint never registers with the query registry,
+		// so there is nothing to dispose of on the panic path.
+		defer func() {
+			rows.Close()
+			if cancel != nil {
+				cancel()
+			}
+		}()
+		rowCount, streamErr := streamTypedJSONFunc(streamCtx, w, columns, colTypes, rows, governanceMaxRows, nil, start, timestamp)
 		w.Flush()
-
-		rows.Close()
-		if cancel != nil {
-			cancel()
-		}
 
 		if streamErr != nil {
 			m.IncQueryErrors()
@@ -4660,6 +4681,6 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 			Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 			Msg("Measurement query completed")
 		h.logSlowQuery(convertedSQL, start, rowCount, tokenName)
-	})
+	}))
 	return nil
 }

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -505,28 +505,13 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 	}
 
 	streamCtx := ctx
-	fctx.SetBodyStreamWriter(func(w *bufio.Writer) {
-		// This closure runs on a bare fasthttp goroutine: an unrecovered
-		// panic here kills the whole process (fiber's recover middleware
-		// only wraps the handler, which has already returned). Convert
-		// panics to a logged error; the connection dies mid-stream, which
-		// the client sees as a truncated Arrow stream.
-		defer func() {
-			if r := recover(); r != nil {
-				m.IncQueryErrors()
-				// Log the root cause BEFORE cleaning up, so this value is
-				// on record even if cleanup then has trouble of its own.
-				h.logger.Error().Interface("panic", r).
-					Msg("Arrow IPC stream writer panicked; stream truncated")
-				// The unwind skipped the straight-line release below, which
-				// stranded the reader, leaked a pooled connection for the
-				// process lifetime, and left the timeout timer running
-				// (#716). Cleanup stays out of a plain defer so the success
-				// path keeps releasing before the trailer is set, rather
-				// than after it.
-				releaseArrowStreamResources(reader, conn, cancel, h.logger)
-			}
-		}()
+	// Cleanup runs from safeStream's panic path rather than an ordinary
+	// defer inside the writer: on the success path the release must stay
+	// ahead of the trailer set below, because the stream-writer goroutine
+	// and the connection goroutine both touch the response header (#716).
+	fctx.SetBodyStreamWriter(h.safeStream("query_arrow_ipc", func() {
+		releaseArrowStreamResources(reader, conn, cancel, h.logger)
+	}, func(w *bufio.Writer) {
 		totalRows, streamErr := streamArrowIPCFunc(
 			streamCtx, w, reader, schema, castInfo, dictEnabled, ipcCompression, governanceMaxRows, h.logger,
 		)
@@ -565,7 +550,7 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			Int64("row_count", totalRows).
 			Int64("execution_time_ms", execMs).
 			Msg("Arrow streaming query completed")
-	})
+	}))
 
 	return nil
 }

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -146,7 +146,22 @@ func executeArrowJSONQuery(
 	if respEncoding != "" {
 		c.Set(fiber.HeaderContentEncoding, respEncoding)
 	}
-	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+	c.Context().SetBodyStreamWriter(h.safeStream("query_arrow_json", func() {
+		// A panic skips the onComplete/onFail/onTimeout dispositions below,
+		// which would leave the query registered as running forever (#717).
+		if onFail != nil {
+			onFail("stream writer panicked")
+		}
+	}, func(w *bufio.Writer) {
+		// One defer in the original order; separate defers would run LIFO
+		// and cancel the timeout before the reader and connection are freed.
+		defer func() {
+			reader.Release()
+			conn.Close()
+			if cancel != nil {
+				cancel()
+			}
+		}()
 		// With compression the body is produced into a pooled encoder that
 		// feeds w; a fresh bufio in front batches the per-value writes
 		// before compression. Without it, sink == w and this is the
@@ -166,12 +181,6 @@ func executeArrowJSONQuery(
 			}
 		}
 		w.Flush()
-
-		reader.Release()
-		conn.Close()
-		if cancel != nil {
-			cancel()
-		}
 
 		if streamErr != nil {
 			m.IncQueryErrors()
@@ -213,7 +222,7 @@ func executeArrowJSONQuery(
 			Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 			Msg("Arrow JSON query completed")
 		h.logSlowQuery(convertedSQL, start, rc, tokenName)
-	})
+	}))
 
 	// Return 0 — actual row count is only known after async streaming completes.
 	// Metrics are recorded in the callback above.

--- a/internal/api/query_json_writer.go
+++ b/internal/api/query_json_writer.go
@@ -99,6 +99,11 @@ func mapColumnType(dbType string) colType {
 //     stream stops. Operator must treat this as a partial-result failure.
 //   - scanner.Err() after the row loop exits cleanly (e.g. underlying
 //     *sql.Rows ran into a deferred error). Same partial-result class.
+//
+// streamTypedJSONFunc indirects streamTypedJSON so tests can drive the
+// stream writers' panic path (#717). Production always uses the real one.
+var streamTypedJSONFunc = streamTypedJSON
+
 func streamTypedJSON(
 	ctx context.Context,
 	w *bufio.Writer,

--- a/internal/api/query_msgpack.go
+++ b/internal/api/query_msgpack.go
@@ -216,11 +216,22 @@ func executeArrowMsgPackQuery(
 	if respEncoding != "" {
 		c.Set(fiber.HeaderContentEncoding, respEncoding)
 	}
-	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-		// Release retained batches when the stream finishes (or fails).
+	c.Context().SetBodyStreamWriter(h.safeStream("query_msgpack", func() {
+		// A panic skips the dispositions below, leaving the query registered
+		// as running forever (#717).
+		if onFail != nil {
+			onFail("stream writer panicked")
+		}
+	}, func(w *bufio.Writer) {
+		// Release retained batches and the timeout context when the stream
+		// finishes, fails, or panics. cancel was previously straight-line
+		// below and leaked on the panic path.
 		defer func() {
 			for _, b := range batches {
 				b.Release()
+			}
+			if cancel != nil {
+				cancel()
 			}
 		}()
 
@@ -239,10 +250,6 @@ func executeArrowMsgPackQuery(
 			streamErr = err
 		}
 		w.Flush()
-
-		if cancel != nil {
-			cancel()
-		}
 
 		if streamErr != nil {
 			m.IncQueryErrors()
@@ -276,7 +283,7 @@ func executeArrowMsgPackQuery(
 			Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 			Msg("Arrow MsgPack query completed")
 		h.logSlowQuery(convertedSQL, start, rc, tokenName)
-	})
+	}))
 
 	return 0, true
 }

--- a/internal/api/stream_safety.go
+++ b/internal/api/stream_safety.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"bufio"
+
+	"github.com/basekick-labs/arc/internal/metrics"
+)
+
+// safeStream wraps a response body-stream writer so a panic inside it cannot
+// take the process down (#717).
+//
+// fasthttp runs these writers on a bare goroutine: SetBodyStreamWriter hands
+// the callback to NewStreamReader, which does `go func() { sw(bw); ... }()`
+// with no recovery of its own. Fiber's recover middleware does not help, since
+// the handler returned before the writer ever runs. An unrecovered panic there
+// is a process crash, not a failed request.
+//
+// onPanic runs only on the panic path, after the root cause has been logged,
+// and is for work the unwind skipped that a plain defer inside sw cannot do:
+// releasing resources whose release must not move relative to the rest of the
+// happy path, and disposing of a query-registry entry that would otherwise sit
+// in "running" forever. It runs inside its own recover, because it executes
+// while a panic is already in flight: a second panic here would either kill the
+// process or, being the most recent value, replace the root cause in the log.
+//
+// Resources that can simply be freed at the end of sw belong in an ordinary
+// defer inside sw instead, not here.
+//
+// Every SetBodyStreamWriter call in this package goes through this wrapper.
+func (h *QueryHandler) safeStream(stream string, onPanic func(), sw func(*bufio.Writer)) func(*bufio.Writer) {
+	return func(w *bufio.Writer) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				return
+			}
+			metrics.Get().IncQueryErrors()
+			h.logger.Error().Interface("panic", r).Str("stream", stream).
+				Msg("Response stream writer panicked; the client receives a truncated response")
+			if onPanic == nil {
+				return
+			}
+			defer func() {
+				if cr := recover(); cr != nil {
+					h.logger.Error().Interface("panic", cr).Str("stream", stream).
+						Msg("Stream panic cleanup panicked; resources may be leaked")
+				}
+			}()
+			onPanic()
+		}()
+		sw(w)
+	}
+}

--- a/internal/api/stream_safety_test.go
+++ b/internal/api/stream_safety_test.go
@@ -1,0 +1,200 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/pruning"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// Tests for #717. fasthttp runs body-stream writers on a bare goroutine with
+// no recovery, so a panic in one is a process crash rather than a failed
+// request. safeStream is what stands between the two.
+
+func TestSafeStreamRecoversAndRunsOnPanic(t *testing.T) {
+	metrics.Init(zerolog.Nop())
+	h := &QueryHandler{logger: zerolog.Nop()}
+
+	cleaned := false
+	wrapped := h.safeStream("test", func() { cleaned = true }, func(*bufio.Writer) {
+		panic("boom")
+	})
+
+	// The point of the wrapper: this call returns instead of killing the
+	// process. TestSafeStreamIsLoadBearing proves the negative direction.
+	wrapped(bufio.NewWriter(&bytes.Buffer{}))
+
+	if !cleaned {
+		t.Error("onPanic did not run, so resources and registry entries would leak")
+	}
+}
+
+func TestSafeStreamLeavesTheHappyPathAlone(t *testing.T) {
+	metrics.Init(zerolog.Nop())
+	h := &QueryHandler{logger: zerolog.Nop()}
+
+	ran := false
+	onPanicRan := false
+	var buf bytes.Buffer
+	wrapped := h.safeStream("test", func() { onPanicRan = true }, func(w *bufio.Writer) {
+		ran = true
+		w.WriteString("payload")
+		w.Flush()
+	})
+	wrapped(bufio.NewWriter(&buf))
+
+	if !ran {
+		t.Fatal("the wrapped writer never ran")
+	}
+	if onPanicRan {
+		t.Error("onPanic ran on the success path; it is for the panic path only")
+	}
+	if buf.String() != "payload" {
+		t.Errorf("body = %q, want %q", buf.String(), "payload")
+	}
+}
+
+func TestSafeStreamContainsAPanicFromOnPanic(t *testing.T) {
+	metrics.Init(zerolog.Nop())
+	h := &QueryHandler{logger: zerolog.Nop()}
+
+	// Cleanup runs while a panic is already in flight. If it panics too and
+	// that escapes, the process dies anyway and the wrapper is worthless.
+	wrapped := h.safeStream("test", func() { panic("cleanup exploded") }, func(*bufio.Writer) {
+		panic("original")
+	})
+	wrapped(bufio.NewWriter(&bytes.Buffer{}))
+}
+
+func TestSafeStreamNilOnPanicIsFine(t *testing.T) {
+	metrics.Init(zerolog.Nop())
+	h := &QueryHandler{logger: zerolog.Nop()}
+	h.safeStream("test", nil, func(*bufio.Writer) { panic("boom") })(bufio.NewWriter(&bytes.Buffer{}))
+}
+
+// TestSafeStreamIsLoadBearing proves the negative direction the positive tests
+// cannot: without the wrapper the panic is fatal. It has to run in a
+// subprocess, because an unrecovered panic on a stream-writer goroutine takes
+// the whole test binary down with it and reports no per-test failure.
+func TestSafeStreamIsLoadBearing(t *testing.T) {
+	if os.Getenv("ARC_STREAM_PANIC_CHILD") == "1" {
+		// Unwrapped, exactly as every one of these writers looked before
+		// this change.
+		func(sw func(*bufio.Writer)) { sw(bufio.NewWriter(&bytes.Buffer{})) }(func(*bufio.Writer) {
+			panic("unwrapped stream writer")
+		})
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestSafeStreamIsLoadBearing$", "-test.v")
+	cmd.Env = append(os.Environ(), "ARC_STREAM_PANIC_CHILD=1")
+	out, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Fatal("an unwrapped panicking stream writer exited cleanly; the premise of #717 no longer holds and this test needs revisiting")
+	}
+	if !strings.Contains(string(out), "unwrapped stream writer") {
+		t.Errorf("child died for the wrong reason:\n%s", out)
+	}
+}
+
+// TestExecuteQueryReturnsConnectionOnStreamPanic exercises a converted site
+// end to end. POST /api/v1/query held rows, an optional profiling connection
+// and cancel in straight-line code after the stream call, so a panic stranded
+// a pooled connection. Reverting that cleanup to straight-line fails this test.
+func TestExecuteQueryReturnsConnectionOnStreamPanic(t *testing.T) {
+	metrics.Init(zerolog.Nop())
+
+	tmpDir, err := os.MkdirTemp("", "arc-stream-safety-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+	backend, err := storage.NewLocalBackend(tmpDir, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duckdb, err := database.New(&database.Config{
+		MemoryLimit:      "256MB",
+		ThreadCount:      2,
+		MaxConnections:   2,
+		LocalStorageRoot: tmpDir,
+	}, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer duckdb.Close()
+
+	h := &QueryHandler{
+		db:         duckdb,
+		logger:     logger,
+		storage:    backend,
+		queryCache: database.NewQueryCache(database.QueryCacheTTL, database.DefaultQueryCacheMaxSize),
+		pruner:     pruning.NewPartitionPruner(zerolog.Nop()),
+	}
+
+	// streamed guards against a vacuous pass: if the request fails before the
+	// body writer runs, the pool is trivially idle and the test would report
+	// success while proving nothing.
+	// Force the database/sql fallback: with the duckdb_arrow build the Arrow
+	// path handles the query and the JSON stream writer never runs. handled
+	//=false is the driver-does-not-support-Arrow signal the handler already
+	// falls back on.
+	origArrow := arrowJSONQueryFunc
+	defer func() { arrowJSONQueryFunc = origArrow }()
+	arrowJSONQueryFunc = func(*QueryHandler, *fiber.Ctx, context.Context, context.CancelFunc, string, bool, int,
+		time.Time, string, func(int), func(string), func()) (int, bool) {
+		return 0, false
+	}
+
+	streamed := false
+	orig := streamTypedJSONFunc
+	defer func() { streamTypedJSONFunc = orig }()
+	streamTypedJSONFunc = func(context.Context, *bufio.Writer, []string, []colType, rowScanner, int,
+		*database.QueryProfile, time.Time, string) (int, error) {
+		streamed = true
+		panic("simulated failure inside the JSON stream")
+	}
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Post("/api/v1/query", h.executeQuery)
+
+	req := httptest.NewRequest("POST", "/api/v1/query", strings.NewReader(`{"sql":"SELECT 1 AS id"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, 10000)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if !streamed {
+		t.Fatalf("the body stream writer never ran, so this proves nothing: status=%d body=%s", resp.StatusCode, body)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if duckdb.Stats().InUse == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("connection never returned to the pool after the stream panicked: InUse=%d", duckdb.Stats().InUse)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Refs #717. Deliberately not "Fixes": three writers are out of scope, see the end.

## Why this is a crash and not a failed request

fasthttp runs body-stream writers on a bare goroutine: `SetBodyStreamWriter` (http.go:290) hands the callback to `NewStreamReader` (stream.go:29), which does `go func() { sw(bw); ... }()` with no recovery. Fiber's recover middleware is installed but wraps the handler chain, which returned long before the writer runs. So a panic in one of these writers stops the server.

Only the Arrow IPC writer recovered (from #716). The JSON, msgpack, parallel-partition and measurement writers did not.

## What changed

All six shipping writers now go through `QueryHandler.safeStream`, which recovers, counts the error, logs the panic value, and then runs an optional `onPanic` for work the unwind skipped. `onPanic` runs inside its own recover, because it executes while a panic is already in flight: a second panic there would either kill the process or, being the most recent value, replace the root cause in the only log line describing it. This generalises the shape #716 introduced, and `query_arrow.go` now uses the wrapper rather than its own bespoke recover.

**Cleanup.** Recovering is what makes the skipped cleanup matter, so each site's straight-line releases move into a single deferred block that preserves the original order. A block rather than separate defers: separate ones run LIFO and would have cancelled the timeout context before closing the rows and the pinned profiling connection. Deferring is safe at these sites because none of them writes a response trailer, which is the constraint that forced the different treatment in #716.

**A leak the issue did not mention.** Six sites disposed of their query-registry entry (`Complete`/`Fail`/`TimedOut`, or the `onComplete`/`onFail` closures) only on the normal path. Nothing reaps `active` entries, so a panicking query would sit in `GET /api/v1/queries/active` as `running` forever, holding its full SQL text, inflating the `active_queries` gauge, and making `DELETE /api/v1/queries/:id` report a successful cancel of a query that finished long ago. Those entries are now failed on the panic path. `Fail` is a no-op when the normal path already disposed of the entry, so the ordering is safe either way.

**A guard.** A CI step fails the build if a body-stream writer is added without the wrapper, so a tenth site cannot quietly reappear.

## Test plan

- [x] `TestSafeStreamIsLoadBearing` proves the negative direction in a subprocess: an unwrapped panicking writer kills the test binary, so this cannot be asserted in-process (it takes the whole package down with no per-test attribution).
- [x] Wrapper unit tests: recovery runs `onPanic`, the happy path is untouched and does not run it, a panic raised by `onPanic` itself is contained, and a nil `onPanic` is fine.
- [x] `TestExecuteQueryReturnsConnectionOnStreamPanic` drives the real handler against a real DuckDB, forces the stream writer to panic, and asserts the pooled connection returns. It carries a vacuity guard that fails the test if the writer never ran, which caught two earlier versions of this test that were proving nothing.
- [x] Mutation-verified: reverting that site's cleanup to straight-line fails the test with `InUse` stuck at 1.
- [x] Full `internal/api` suite green under `-race`; build, vet, gofmt clean.
- [x] Live server across every converted path: JSON, gzip-compressed JSON, msgpack, Arrow IPC and the measurement endpoint all return correct values, and 40 consecutive requests left the pool healthy.

## Out of scope, tracked separately

**The three writers in `arcx_hook.go` are not converted.** They build only under `arcx_engine`, a tag that appears in no CI, release or Docker build, so they ship in no binary and cannot be compile-checked here. Editing them blind would be unverifiable. The CI guard excludes that file with the reason inline. Follow-up issue to come.

**Silent truncation on the Arrow IPC shape.** Recovering converts a truncation the transport could detect into one it cannot: fasthttp still writes the terminating chunk, so the client sees HTTP 200 with a clean body. For JSON that is harmless (the body is unparseable) and for msgpack the length prefixes make it detectable, but an Arrow IPC stream truncated at a record-batch boundary decodes as a short, valid result with no error. That predates this PR on the `query_arrow.go` path and deserves its own fix (a truncation trailer, or closing the connection), not a rushed one here.