### PR TITLE
fix(query): mark truncated Arrow IPC streams so clients cannot read them as complete

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -214,6 +214,26 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### A truncated Arrow IPC response is no longer readable as a complete one ([#721](https://github.com/Basekick-Labs/arc/issues/721))
+
+When an Arrow IPC stream was cut short, the client could not tell. Arc flushes
+after every record batch, so a stream that stopped early stopped on a batch
+boundary, and an Arrow reader treats that as a clean end. The paths that still
+closed the writer went further and appended a valid end-of-stream marker. The
+result was HTTP 200, a well-formed Arrow stream, and silently fewer rows than
+the query matched. A query that exceeded `query.timeout` partway through
+delivering its results was the most likely way to hit it; a failure before the
+first batch produced a schema-only stream that read as a legitimate empty
+result, which a dashboard shows as no data rather than as an error.
+
+A failed stream is now marked so the client's decode fails instead. Complete
+responses are unchanged, and a client that has already disconnected is not
+written to, since there is nobody left to inform.
+
+Arc also now distinguishes a dropped connection from an encoder failure on this
+path. Both previously surfaced the same way, so a client hanging up mid-stream
+was logged as a server-side error and missed the client-disconnect metric.
+
 ### A panic while streaming a response no longer crashes the server ([#717](https://github.com/Basekick-Labs/arc/issues/717))
 
 Query responses are streamed from a callback that fasthttp runs on its own

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -5,6 +5,7 @@ package api
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"strconv"
@@ -40,6 +41,61 @@ const arrowExecutionTimeTrailer = "Arc-Execution-Time-Ms"
 // Smaller batches reduce peak memory usage and enable streaming.
 // 10K rows is a good balance between overhead and memory efficiency.
 const arrowBatchSize = 10000
+
+// arrowStreamTruncatedTrailer tells the client the Arrow IPC body it received
+// is short. It is a trailer because the status line and headers are long gone
+// by the time a stream fails.
+const arrowStreamTruncatedTrailer = "Arc-Stream-Truncated"
+
+// transportWriter distinguishes "the socket went away" from "the encoder
+// failed". Both surface as an error out of ipc.Writer.Write, and only the
+// former means nobody is listening. Wrapping the sink is the only way to tell:
+// a real Arrow batch is far larger than the 4KB bufio fasthttp hands the
+// stream callback, so writes go straight through and a hangup lands on Write
+// rather than on the later Flush that used to be the only place it was tagged.
+type transportWriter struct {
+	w   *bufio.Writer
+	err error
+}
+
+func (t *transportWriter) Write(p []byte) (int, error) {
+	n, err := t.w.Write(p)
+	if err != nil {
+		t.err = err
+	}
+	return n, err
+}
+
+// poisonArrowStream writes an Arrow IPC message header that can never be
+// satisfied, so a client decoding the stream fails instead of accepting a
+// short read as a complete result (#721).
+//
+// A truncated Arrow stream is otherwise indistinguishable from a complete one:
+// cut on a record-batch boundary it decodes with no error, and the paths that
+// still reach ipcWriter.Close() emit a valid end-of-stream marker on top. The
+// eight bytes here are the encapsulated-message format from the Arrow spec, a
+// 0xFFFFFFFF continuation token followed by a metadata length, so a reader hits
+// EOF partway through a message it was promised.
+//
+// The length must be non-zero, since zero after the continuation token is
+// itself the end-of-stream marker, and small, because readers allocate it
+// before reading.
+func poisonArrowStream(w *bufio.Writer, logger zerolog.Logger) {
+	if w == nil {
+		return
+	}
+	// The trailing byte matters: io.ReadFull returns a plain io.EOF when it
+	// reads nothing at all, and arrow-go treats that as a clean end of stream.
+	// One byte of the promised metadata makes the read genuinely short, which
+	// surfaces as an unexpected EOF the reader reports.
+	if _, err := w.Write([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0x00, 0x00}); err != nil {
+		logger.Debug().Err(err).Msg("Could not mark the Arrow IPC stream truncated; the client is already gone")
+		return
+	}
+	if err := w.Flush(); err != nil {
+		logger.Debug().Err(err).Msg("Could not flush the Arrow IPC truncation marker")
+	}
+}
 
 // releaseArrowStreamResources frees everything the Arrow IPC response owns:
 // the DuckDB-backed reader, the pooled connection behind it, and the query
@@ -105,6 +161,9 @@ func streamArrowIPC(
 	// re-sends the full dictionary when it grows. Deliberately NOT
 	// WithDictionaryDeltas — polars cannot read delta batches (verified
 	// against polars 1.43; pyarrow reads both).
+	// Everything the encoder writes goes through tw, so a socket failure can
+	// be told apart from an encoder failure when classifying the error below.
+	tw := &transportWriter{w: w}
 	newIPCWriter := func(outSchema *arrow.Schema) *ipc.Writer {
 		opts := []ipc.Option{ipc.WithSchema(outSchema)}
 		switch ipcCompression {
@@ -113,7 +172,7 @@ func streamArrowIPC(
 		case "lz4":
 			opts = append(opts, ipc.WithLZ4())
 		}
-		return ipc.NewWriter(w, opts...)
+		return ipc.NewWriter(tw, opts...)
 	}
 
 	var totalRows int64
@@ -218,7 +277,15 @@ streamLoop:
 			}
 
 			if err := ipcWriter.Write(writeBatch); err != nil {
-				streamErr = fmt.Errorf("failed to write arrow batch at row %d: %w", totalRows, err)
+				// A hangup surfaces here, not at the Flush below, because a
+				// batch overflows the 4KB bufio and writes straight through.
+				// Tag it so the caller treats it as a client disconnect
+				// rather than a server-side failure worth alerting on.
+				if tw.err != nil {
+					streamErr = fmt.Errorf("stream write failed at row %d: %w: %w", totalRows, errClientDisconnected, err)
+				} else {
+					streamErr = fmt.Errorf("failed to write arrow batch at row %d: %w", totalRows, err)
+				}
 				return true
 			}
 			// Capture Flush error: fasthttp's RequestCtx.Done() only fires
@@ -255,6 +322,22 @@ streamLoop:
 	}
 	if dictXform != nil {
 		defer dictXform.release()
+	}
+
+	// A failed stream must not be closed cleanly (#721). ipc.Writer.Close
+	// emits the end-of-stream marker, which would make a short result read as
+	// a complete one: an Arrow stream cut on a batch boundary decodes without
+	// error, and this path is always on a boundary because every batch is
+	// flushed. Mark the body unsatisfiable instead, so the client's decode
+	// fails rather than quietly returning fewer rows than the query matched.
+	// This covers the zero-batch case too, where the schema-only stream would
+	// otherwise read as a legitimate empty result.
+	//
+	// A client that has already gone is skipped: there is nobody to tell, and
+	// writing to a dead socket only produces noise.
+	if streamErr != nil && !errors.Is(streamErr, errClientDisconnected) {
+		poisonArrowStream(w, logger)
+		return totalRows, streamErr
 	}
 
 	if err := ipcWriter.Close(); err != nil {
@@ -497,6 +580,12 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 	// trailers degrade gracefully to wall-clock timing. The Warn is
 	// sync.Once-gated against per-request log spam if a future fasthttp
 	// release ever rejects the trailer name.
+	if err := respHeader.AddTrailer(arrowStreamTruncatedTrailer); err != nil {
+		arrowTrailerWarnOnce.Do(func() {
+			h.logger.Warn().Err(err).Str("trailer", arrowStreamTruncatedTrailer).
+				Msg("Failed to register Arrow truncation trailer; clients will not see the reason a stream was cut")
+		})
+	}
 	if err := respHeader.AddTrailer(arrowExecutionTimeTrailer); err != nil {
 		arrowTrailerWarnOnce.Do(func() {
 			h.logger.Warn().Err(err).Str("trailer", arrowExecutionTimeTrailer).
@@ -509,9 +598,26 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 	// defer inside the writer: on the success path the release must stay
 	// ahead of the trailer set below, because the stream-writer goroutine
 	// and the connection goroutine both touch the response header (#716).
+	// streamW lets the panic path reach the same writer the body used, so it
+	// can mark the stream truncated. safeStream's onPanic takes no arguments,
+	// and widening it would churn five other call sites that have no writer to
+	// mark.
+	var streamW *bufio.Writer
 	fctx.SetBodyStreamWriter(h.safeStream("query_arrow_ipc", func() {
+		// A recovered panic leaves a stream the client would otherwise read as
+		// complete: fasthttp still writes the terminating chunk, and a cut on
+		// a batch boundary decodes without error (#721).
+		//
+		// Only the body is marked here, not the trailer. By this point
+		// fasthttp's connection goroutine may already be serialising the
+		// response header, and writing a trailer from this goroutine races
+		// with it (caught by the race detector). The marker in the body is
+		// what every client detects anyway; the trailer only ever carried the
+		// reason, and the panic is logged with far more detail than it could.
+		poisonArrowStream(streamW, h.logger)
 		releaseArrowStreamResources(reader, conn, cancel, h.logger)
 	}, func(w *bufio.Writer) {
+		streamW = w
 		totalRows, streamErr := streamArrowIPCFunc(
 			streamCtx, w, reader, schema, castInfo, dictEnabled, ipcCompression, governanceMaxRows, h.logger,
 		)
@@ -535,6 +641,17 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 			// — server-side stream failures stay in IncQueryErrors only.
 			if isClientError(streamErr) {
 				m.IncQueryClientDisconnect(metrics.DisconnectPathArrowIPC)
+			}
+			// Tell the client its Arrow stream is short (#721). Skipped only
+			// when the socket is already gone: a server-side timeout is a
+			// client-side error class here but the caller is still waiting,
+			// so it must be told, which is why this keys off the disconnect
+			// sentinel rather than isClientError.
+			// streamArrowIPC has already marked the body itself; the
+			// marker has to precede the end-of-stream bytes, so it cannot
+			// be written from out here.
+			if !errors.Is(streamErr, errClientDisconnected) {
+				respHeader.Set(arrowStreamTruncatedTrailer, sqlutil.SanitizeErrText(streamErr.Error()))
 			}
 			// Warn for client-disconnect / timeout (expected ops noise);
 			// Error for everything else (real server-side problem worth

--- a/internal/api/query_arrow_truncation_test.go
+++ b/internal/api/query_arrow_truncation_test.go
@@ -1,0 +1,141 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/rs/zerolog"
+)
+
+// Tests for #721. A truncated Arrow IPC stream used to be indistinguishable
+// from a complete one: cut on a record-batch boundary it decodes with no
+// error, and the failure paths that still closed the writer emitted a valid
+// end-of-stream marker on top of the short result. A client saw HTTP 200,
+// a valid stream, and silently fewer rows than its query matched.
+
+// failingRecordReader yields n good batches, then reports an error, which is
+// the shape of a mid-stream server-side failure.
+type failingRecordReader struct {
+	*simpleRecordReader
+	err error
+}
+
+func (r *failingRecordReader) Err() error { return r.err }
+
+func decodeStream(t *testing.T, b []byte) (int64, error) {
+	t.Helper()
+	r, err := ipc.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return 0, err
+	}
+	defer r.Release()
+	var rows int64
+	for r.Next() {
+		rows += r.Record().NumRows()
+	}
+	return rows, r.Err()
+}
+
+func TestStreamArrowIPCMarksTruncatedStreams(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer alloc.AssertSize(t, 0)
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+
+	newReader := func(batches int) *failingRecordReader {
+		recs := make([]arrow.Record, batches)
+		for i := range recs {
+			rows := make([][]interface{}, 10)
+			for j := range rows {
+				rows[j] = []interface{}{int64(i*10 + j)}
+			}
+			recs[i] = buildArrowBatch(alloc, schema, rows)
+		}
+		return &failingRecordReader{simpleRecordReader: newSimpleRecordReader(schema, recs)}
+	}
+
+	t.Run("a complete stream still decodes cleanly", func(t *testing.T) {
+		reader := newReader(3)
+		var out bytes.Buffer
+		rows, err := streamArrowIPC(context.Background(), bufio.NewWriter(&out), reader,
+			schema, nil, false, "", 0, zerolog.Nop())
+		reader.Release()
+		if err != nil {
+			t.Fatalf("streamArrowIPC: %v", err)
+		}
+		if rows != 30 {
+			t.Fatalf("streamed %d rows, want 30", rows)
+		}
+		decoded, derr := decodeStream(t, out.Bytes())
+		if derr != nil {
+			t.Fatalf("a complete stream must decode without error, got %v", derr)
+		}
+		if decoded != 30 {
+			t.Errorf("decoded %d rows, want 30", decoded)
+		}
+	})
+
+	t.Run("a failed stream does not decode as complete", func(t *testing.T) {
+		reader := newReader(2)
+		reader.err = errors.New("simulated mid-stream failure")
+		var out bytes.Buffer
+		rows, err := streamArrowIPC(context.Background(), bufio.NewWriter(&out), reader,
+			schema, nil, false, "", 0, zerolog.Nop())
+		reader.Release()
+		if err == nil {
+			t.Fatal("expected the reader error to surface")
+		}
+		if rows != 20 {
+			t.Fatalf("streamed %d rows, want 20 before the failure", rows)
+		}
+		// The whole point: the client must not read this as a valid result.
+		decoded, derr := decodeStream(t, out.Bytes())
+		if derr == nil {
+			t.Fatalf("a truncated stream decoded cleanly as %d rows; the client cannot tell it lost data", decoded)
+		}
+	})
+
+	t.Run("a zero-batch failure does not decode as an empty result", func(t *testing.T) {
+		reader := &failingRecordReader{
+			simpleRecordReader: newSimpleRecordReader(schema, nil),
+			err:                errors.New("failed before the first batch"),
+		}
+		var out bytes.Buffer
+		_, err := streamArrowIPC(context.Background(), bufio.NewWriter(&out), reader,
+			schema, nil, false, "", 0, zerolog.Nop())
+		reader.Release()
+		if err == nil {
+			t.Fatal("expected the reader error to surface")
+		}
+		// Without the marker this is a schema-only stream that reads as a
+		// legitimate "no rows", which a dashboard shows as no data rather
+		// than as a failure.
+		if _, derr := decodeStream(t, out.Bytes()); derr == nil {
+			t.Fatal("a zero-batch failure decoded as a valid empty result")
+		}
+	})
+
+	t.Run("a client that already hung up is not written to", func(t *testing.T) {
+		reader := newReader(1)
+		reader.err = errClientDisconnected
+		var out bytes.Buffer
+		_, err := streamArrowIPC(context.Background(), bufio.NewWriter(&out), reader,
+			schema, nil, false, "", 0, zerolog.Nop())
+		reader.Release()
+		if err == nil {
+			t.Fatal("expected the disconnect to surface")
+		}
+		// Nobody is listening; the stream is closed normally rather than
+		// marked, so this stays out of the truncation signal.
+		if _, derr := decodeStream(t, out.Bytes()); derr != nil {
+			t.Errorf("a disconnect should not poison the body, got %v", derr)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #721.

## The problem is wider than the issue says

I filed #721 as a consequence of recovering panics (#717). It is not limited to that. The `streamErr != nil` path returns the same way, so an ordinary mid-stream timeout also hands the client a short, clean, valid Arrow stream. Its own log line already reads "client received partial result" while the client is told nothing. Timeouts are routine and panics are rare, so that is the likelier trigger.

Three facts combine: Arc flushes after every record batch, so a stream that stops early stops on a boundary; arrow readers treat a boundary EOF as a clean end; and the error path still called `ipcWriter.Close()`, appending a valid end-of-stream marker on top of the short result. A failure before the first batch was worst of all, producing a schema-only stream that reads as a legitimate empty result, which a dashboard renders as no data rather than as a failure.

## What changed

A failed stream now ends with an Arrow message header that cannot be satisfied, so the client's decode fails instead of quietly returning fewer rows. Those bytes are the encapsulated-message format from the Arrow spec, not an implementation detail.

Two subtleties, both found by testing rather than reasoning:

- The marker has to precede the end-of-stream bytes. A reader stops at the first EOS and ignores everything after it, so marking from the handler after `streamArrowIPC` returned did nothing.
- The promised metadata must be partly present. `io.ReadFull` returns a plain `io.EOF` when it reads *nothing*, which readers treat as a clean end; one byte makes the read genuinely short and surfaces as an unexpected EOF. My first version wrote a bare 8-byte header and the truncation test still decoded 20 rows cleanly.

Transport failures are now told apart from encoder failures. A real batch overflows the 4KB buffer fasthttp supplies, so a hangup surfaces at `Write`, not at the `Flush` that was the only place tagging it with the disconnect sentinel. That means a client hanging up was being logged as a server-side error and missed by the client-disconnect metric. Streams whose client is already gone are left alone.

## What I rejected, and why

**Aborting the connection**, which was my original recommendation in the issue. `RequestCtx.Conn()` is only safe on the connection goroutine: fasthttp recycles the ctx as soon as the response write fails, so a stream writer reading it races with `reset` and can be handed **another client's live connection**. Measured 5 times out of 5 under load. Closing it would kill an unrelated in-flight request. It also usually destroys the status line rather than truncating the body, so the client gets nothing at all instead of partial rows, and behind a proxy it becomes a 502.

**Setting the truncation trailer on the panic path.** I implemented it, and the race detector caught it writing the response header while the connection goroutine serialises it. The body marker is what every client detects anyway; the trailer only carried a reason, and the panic is logged with far more detail.

## Test plan

- [x] Four subtests: a complete stream still decodes cleanly, a mid-stream failure does not decode as complete, a zero-batch failure does not decode as an empty result, and a disconnected client is not written to.
- [x] Mutation-verified: removing the marker makes the truncation test pass silently again.
- [x] Full `internal/api` suite green under `-race`; build, vet, gofmt clean.
- [x] Live server with `query.timeout = 2`: a normal Arrow query decodes cleanly at 50 rows, and a query that exceeds the timeout mid-stream now surfaces as `could not read message metadata: unexpected EOF` instead of a short success. Dictionary and zstd variants unaffected, 25 consecutive queries clean, JSON and msgpack unchanged.

## Follow-ups filed separately

The JSON path has the same bug with a wider blast radius, and the governance row cap is a deliberate silent truncation. Both are their own decisions about response contracts rather than something to bolt on here.