### PR TITLE
fix(query): mark truncated JSON responses instead of reporting success

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -214,6 +214,32 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### JSON query responses now say when the result was cut short ([#723](https://github.com/Basekick-Labs/arc/issues/723))
+
+A JSON response opens with `{"success":true,...,"data":[` before the first row
+is known, and both streaming writers closed the document whether or not the
+stream had failed. A client that was still connected therefore received HTTP
+200, valid JSON, `success: true`, and silently fewer rows than its query
+matched, with `row_count` reporting the rows delivered rather than the rows
+found. A query that exceeded `query.timeout` partway through delivering a large
+result was the likeliest way to hit it.
+
+A failed stream now adds `"truncated": true` and a `truncation_reason` to the
+closing envelope. **Clients that need to distinguish a complete result from a
+partial one should check `truncated`.** The document still parses, and the rows
+already delivered are still there, so a client that ignores the field behaves
+exactly as before.
+
+`success` is deliberately left as-is. It is written before the first row and, on
+any result large enough to have flushed, has already reached the client and
+cannot be revised. Emitting a different shape for small results would make the
+response depend on whether the result happened to fit in a buffer.
+
+This is the JSON counterpart to the Arrow IPC fix in the same release. Failures
+that happen before streaming begins are unaffected: those still return a real
+error status, as they always have. MessagePack responses were never affected,
+because they commit their counts up front and a cut is a hard decode error.
+
 ### A truncated Arrow IPC response is no longer readable as a complete one ([#721](https://github.com/Basekick-Labs/arc/issues/721))
 
 When an Arrow IPC stream was cut short, the client could not tell. Arc flushes

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -364,6 +364,25 @@ done:
 		}
 	}
 
+	// A stream that failed part way still emits a valid JSON document, but it
+	// must not look complete (#723). success was written before the first row
+	// and, once the buffer has flushed, cannot be revised; even while it is
+	// still buffered, revising it would make the response shape depend on
+	// whether the result happened to exceed the buffer, so the marker is
+	// emitted uniformly instead.
+	//
+	// The reason is a separate field rather than "error": that key means
+	// "the request failed and there is no data" everywhere else in the API,
+	// and clients key off it. Here there IS data, just not all of it.
+	//
+	// writeJSONString, not WriteString: the sanitizer masks the contents of
+	// quoted spans but leaves the quote characters in place, so concatenating
+	// it raw would emit a document that does not parse.
+	if streamErr != nil {
+		w.WriteString(`,"truncated":true,"truncation_reason":`)
+		writeJSONString(w, scratch, sqlutil.SanitizeErrText(streamErr.Error()))
+	}
+
 	w.WriteByte('}')
 
 	return rowCount, streamErr

--- a/internal/api/query_json_truncation_test.go
+++ b/internal/api/query_json_truncation_test.go
@@ -1,0 +1,127 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// Tests for #723. A JSON query response opened with {"success":true,...} and
+// closed the envelope whether or not the stream failed, so a client that was
+// still connected received HTTP 200, valid JSON, success:true, and silently
+// fewer rows than its query matched.
+
+// truncatingScanner yields n rows and then reports a deferred error, the shape
+// of a mid-stream failure (a timeout, or a row-fetch failure from *sql.Rows).
+type truncatingScanner struct {
+	rows int
+	at   int
+	err  error
+}
+
+func (s *truncatingScanner) Next() bool { return s.at < s.rows }
+func (s *truncatingScanner) Scan(dest ...interface{}) error {
+	s.at++
+	if p, ok := dest[0].(*interface{}); ok {
+		*p = int64(s.at)
+	}
+	return nil
+}
+func (s *truncatingScanner) Err() error { return s.err }
+
+func streamJSONForTest(t *testing.T, sc *truncatingScanner) map[string]interface{} {
+	t.Helper()
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	_, _ = streamTypedJSON(context.Background(), w, []string{"id"}, []colType{colInt64},
+		sc, 0, nil, time.Now(), "2026-09-11T00:00:00Z")
+	w.Flush()
+
+	var doc map[string]interface{}
+	// Unmarshal, not a substring match: the whole promise of this shape is
+	// that the document still parses.
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, buf.String())
+	}
+	return doc
+}
+
+func TestStreamTypedJSONMarksTruncation(t *testing.T) {
+	t.Run("a complete stream carries no marker", func(t *testing.T) {
+		doc := streamJSONForTest(t, &truncatingScanner{rows: 3})
+		if _, ok := doc["truncated"]; ok {
+			t.Error("a successful response must not carry the truncation marker")
+		}
+		if doc["success"] != true {
+			t.Errorf("success = %v, want true", doc["success"])
+		}
+		if doc["row_count"].(float64) != 3 {
+			t.Errorf("row_count = %v, want 3", doc["row_count"])
+		}
+	})
+
+	t.Run("a failed stream is marked and still parses", func(t *testing.T) {
+		doc := streamJSONForTest(t, &truncatingScanner{rows: 2, err: errors.New("simulated mid-stream failure")})
+		if doc["truncated"] != true {
+			t.Fatalf("truncated = %v, want true; the client cannot tell it lost data", doc["truncated"])
+		}
+		if reason, _ := doc["truncation_reason"].(string); reason == "" {
+			t.Error("truncation_reason is empty; the client is told it lost data but not why")
+		}
+		// row_count stays the rows actually delivered; truncated is what says
+		// the set is short.
+		if doc["row_count"].(float64) != 2 {
+			t.Errorf("row_count = %v, want 2", doc["row_count"])
+		}
+	})
+
+	t.Run("a failure before the first row is marked", func(t *testing.T) {
+		// The most damaging case: an empty result reads as a legitimate
+		// "no data" rather than as a failure.
+		doc := streamJSONForTest(t, &truncatingScanner{rows: 0, err: errors.New("failed before the first row")})
+		if doc["truncated"] != true {
+			t.Fatal("an empty truncated result is indistinguishable from an empty successful one")
+		}
+		if doc["row_count"].(float64) != 0 {
+			t.Errorf("row_count = %v, want 0", doc["row_count"])
+		}
+	})
+
+	t.Run("a reason containing JSON metacharacters keeps the document valid", func(t *testing.T) {
+		// The sanitiser masks the CONTENTS of quoted spans but leaves the
+		// quotes themselves, so a raw concatenation would emit a document
+		// that does not parse. Backslashes, newlines and control bytes are
+		// the same class of hazard.
+		nasty := "Could not read \"s3://b/k.parquet\": back\\slash\nnewline\x01ctrl"
+		doc := streamJSONForTest(t, &truncatingScanner{rows: 1, err: errors.New(nasty)})
+		if doc["truncated"] != true {
+			t.Fatal("expected the truncation marker")
+		}
+		if _, ok := doc["truncation_reason"].(string); !ok {
+			t.Errorf("truncation_reason is not a string: %#v", doc["truncation_reason"])
+		}
+	})
+
+	t.Run("a governance cap is not a truncation", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := bufio.NewWriter(&buf)
+		_, _ = streamTypedJSON(context.Background(), w, []string{"id"}, []colType{colInt64},
+			&truncatingScanner{rows: 10}, 4, nil, time.Now(), "2026-09-11T00:00:00Z")
+		w.Flush()
+		var doc map[string]interface{}
+		if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+			t.Fatalf("not valid JSON: %v", err)
+		}
+		// A capped result is deliberate and complete as far as policy is
+		// concerned; marking it truncated would cry wolf. Tracked as #724.
+		if _, ok := doc["truncated"]; ok {
+			t.Error("a governance-capped result must not be marked truncated")
+		}
+	})
+}

--- a/internal/api/query_json_writer.go
+++ b/internal/api/query_json_writer.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	sqlutil "github.com/basekick-labs/arc/internal/sql"
 	"math"
 	"strconv"
 	"strings"
@@ -226,6 +227,25 @@ scanLoop:
 		} else {
 			w.WriteString("null")
 		}
+	}
+
+	// A stream that failed part way still emits a valid JSON document, but it
+	// must not look complete (#723). success was written before the first row
+	// and, once the buffer has flushed, cannot be revised; even while it is
+	// still buffered, revising it would make the response shape depend on
+	// whether the result happened to exceed the buffer, so the marker is
+	// emitted uniformly instead.
+	//
+	// The reason is a separate field rather than "error": that key means
+	// "the request failed and there is no data" everywhere else in the API,
+	// and clients key off it. Here there IS data, just not all of it.
+	//
+	// writeJSONString, not WriteString: the sanitizer masks the contents of
+	// quoted spans but leaves the quote characters in place, so concatenating
+	// it raw would emit a document that does not parse.
+	if streamErr != nil {
+		w.WriteString(`,"truncated":true,"truncation_reason":`)
+		writeJSONString(w, scratch, sqlutil.SanitizeErrText(streamErr.Error()))
 	}
 
 	w.WriteByte('}')


### PR DESCRIPTION
Fixes #723. JSON counterpart to the Arrow IPC fix (#722) in the same release, on the endpoint most clients actually use.

## What changed

A failed stream now appends `"truncated": true` and a `truncation_reason` to the closing envelope. The document still parses and the delivered rows are still there, so a client that ignores the field behaves exactly as before.

## Three decisions worth reviewing

**The reason is its own field, not `error`.** Everywhere else in the API `error` means the request failed and carries no data, and clients key off that: the Grafana datasource's msgpack decoder already treats an `error` key on a 200 as a hard failure. Here there *is* data, just not all of it, so overloading `error` would turn a partial success into a total failure for those clients.

**The reason is written with `writeJSONString`, not concatenated.** `SanitizeErrText` masks the *contents* of quoted spans but leaves the quote characters in place, so the obvious implementation emits a document that does not parse. The escaping test fails without this, which is worth noting given the whole premise of the fix is "valid JSON".

**`success` is left as `true`.** My own issue text listed flipping it as an option and I initially argued it was impossible. That was wrong, and the correction is worth stating: the envelope sits in a 4KB buffer (64KB when compression is negotiated), so on a *small* result it has not reached the client and could be revised. I still chose not to, because revising it only when the result happens to fit in a buffer would make the response shape depend on result size, which is worse than a consistent marker. Failures before streaming begins are unaffected and still return a real error status.

## Test plan

- [x] Five subtests: a complete stream carries no marker, a failed stream is marked and still parses, a failure before the first row is marked (the empty-result case that otherwise reads as legitimate "no data"), a reason containing quotes, backslashes, newlines and control bytes keeps the document valid, and a governance cap is *not* marked.
- [x] Mutation-verified: replacing `writeJSONString` with raw concatenation fails the escaping test with `invalid character '.' after object key:value pair`.
- [x] Full `internal/api` suite green under `-race`; build, vet, gofmt clean.
- [x] Live server, `query.timeout = 2`, 20M-row query: **HTTP 200, valid JSON, 874,496 rows, `truncated: true`**, reason `arrow reader error after 874496 rows: context deadline exceeded`. Before this change that was indistinguishable from a complete answer. Repeated with `Accept-Encoding: gzip` (the 64KB buffer path): 1,390,592 rows, marked. Small queries carry no marker; msgpack unchanged.

## Known limitation, and the follow-up that matters

**No first-party client reads this field yet.** The Grafana datasource decodes into a map and uses only `columns` and `data`; the documented Python SDK `QueryResult` exposes `columns`, `data`, `row_count`. So this change makes the condition *detectable* but nothing surfaces it yet. The server-side contract has to exist first, but the client work and the docs response-field table are what make it visible to a user. Filing that separately.

Also unmarked, deliberately: a panic mid-stream leaves the body unterminated with no marker at all. That is a different shape (the document does not parse, so it is not silent) and belongs with the panic-path work rather than here.