### PR TITLE
Mark results an Enterprise governance row cap truncated (#724)

### DIFF
--- a/RELEASE_NOTES_2026.02.2.md
+++ b/RELEASE_NOTES_2026.02.2.md
@@ -78,6 +78,12 @@ Arc Enterprise now includes per-token query governance with sliding window rate 
 - **Default policies** via config — apply limits to all tokens without explicit policies
 - **Hot-reconfigurable** — policy changes take effect immediately without restart
 
+> **Correction (2026.09.2).** The "max rows per query" bullet above promised a
+> warning alongside the partial result. No warning was implemented: a capped
+> response was byte-identical to a complete one on every wire format until
+> [#724](https://github.com/Basekick-Labs/arc/issues/724) shipped in v2026.09.2.
+> The bullet is left as published; treat it as accurate only from 2026.09.2 on.
+
 **Configuration:**
 ```toml
 [governance]

--- a/RELEASE_NOTES_2026.06.1.md
+++ b/RELEASE_NOTES_2026.06.1.md
@@ -351,17 +351,26 @@ The columnar redesign was the single change that mattered. Everything else was d
 **Wire format spec.** Single msgpack map per response; `data` is columnar:
 
 ```
-map(7 or 8) {
+map(7, 8, 9 or 10) {
   "success":           bool                                    // true on success
   "columns":           [string, ...]                           // column names (numCols entries)
   "types":             [string, ...]                           // arrow.DataType.String() per column, parallel to columns
   "data":              [[col0_v, col0_v, ...], [col1_v, ...]]  // numCols outer entries, numRows inner
   "row_count":         uint                                    // = inner length, redundant for client convenience
+  "rows_capped":       bool                                    // only when a governance row cap was reached (26.09.2+)
+  "row_cap":           uint                                    // paired with rows_capped, never sent alone
   "execution_time_ms": uint                                    // millisecond integer (JSON sends a float)
   "timestamp":         string                                  // RFC3339
   "profile":           map                                     // only when ?profile=true (json-tagged QueryProfile struct)
 }
 ```
+
+> **Updated in 26.09.2.** `rows_capped` / `row_cap` were added by
+> [#724](https://github.com/Basekick-Labs/arc/issues/724) so a result truncated
+> by an Enterprise governance row cap stops being indistinguishable from a
+> complete one. They are emitted as a pair and only when a cap was reached, so
+> an uncapped response still has exactly the 7 or 8 keys documented above. Read
+> the declared map length rather than assuming it.
 
 Per-column primitive encoding:
 - **Int8/16/32/64, Uint8/16/32/64**: msgpack int / uint. `Int64`/`Uint64` use `EncodeInt64`/`EncodeUint64` (always 9 bytes) to skip the library's size-class branching.
@@ -374,7 +383,7 @@ Per-column primitive encoding:
 
 **Important operational constraints.**
 
-- **Buffered, not streamed.** msgpack arrays require an explicit length prefix, so the endpoint drains every Arrow batch into memory before emitting the data array. The only row ceiling is `governance.max_rows` (Enterprise token policy); without it, the response is unbounded — same hazard the JSON `database/sql` fallback carries, just sharper because msgpack materializes the whole result before sending the first byte. If msgpack graduates we'll re-introduce an operator-configurable ceiling.
+- **Buffered, not streamed.** msgpack arrays require an explicit length prefix, so the endpoint drains every Arrow batch into memory before emitting the data array. The only row ceiling is `governance.default_max_rows_per_query`, or a per-token `max_rows_per_query` policy (Enterprise); without one, the response is unbounded, the same hazard the JSON `database/sql` fallback carries, just sharper because msgpack materializes the whole result before sending the first byte. If msgpack graduates we'll re-introduce an operator-configurable ceiling.
 - **Parallel-partition execution is bypassed.** The msgpack endpoint forces the standard Arrow dispatch even when the query would otherwise be eligible for the parallel-partition executor. Parallel queries route through the JSON-streaming merge iterator and don't share the msgpack encode path; coupling them would multiply the experimental surface area.
 - **No `database/sql` fallback.** The Arrow path is the entire reason for the endpoint; falling back to `Scan`-based row iteration would defeat the contract. When the Arrow driver is unavailable (build without `duckdb_arrow`, or driver capability mismatch), the route returns `501 Not Implemented` rather than silently downgrading.
 - **Errors, `SHOW DATABASES`, `SHOW TABLES`** are also encoded as columnar msgpack. The same `wire_format` request-local that routes the streaming hot path also drives a `respondError` / `respondSuccessRows` / `respondEmptySuccess` helper trio so every response from the shared `executeQuery` pipeline matches the content type the caller asked for.

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -211,9 +211,106 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
    deployments need no action.
 2. **No configuration change is required.** Existing `arc.toml` files and
    license keys work as-is; no new keys were added.
+3. **Query response envelopes gained two optional keys** (`rows_capped`,
+   `row_cap`), emitted only when an Enterprise governance row cap truncated
+   the result. Conforming JSON and msgpack decoders are unaffected: the keys
+   are absent from every uncapped response, and a capped msgpack envelope
+   declares its own map length. A client that hardcodes the msgpack envelope
+   at seven or eight keys should read the length instead. Only deployments
+   with `governance.enabled = true` and a `max_rows_per_query` policy can see
+   them at all.
 
 ## Bug fixes
 
+### A governance row cap no longer looks like a complete result ([#724](https://github.com/Basekick-Labs/arc/issues/724))
+
+When an Enterprise governance policy capped a query with `max_rows_per_query`,
+the response was byte-identical to a complete one. The cap path returned no
+error, logged the ordinary "query completed" line, and emitted a normal
+end-of-stream marker and trailer on every wire format. Nothing said the result
+had been cut. Unlike the Arrow IPC truncation described below, this is reachable on
+purpose and by configuration, so an operator could hit it every day without
+knowing, and a dashboard quietly capped at 10,000 rows drew conclusions from
+truncated data.
+
+The 2026.02.2 notes that introduced the feature described the cap as returning
+"partial results with a warning". No warning existed. This release makes that
+claim true rather than correcting it.
+
+A capped result now says so on all four wire formats:
+
+- The JSON envelope carries `"rows_capped": true` and `"row_cap": <N>`. This
+  covers both JSON writers: the Arrow-backed one behind `POST /api/v1/query`
+  and the `database/sql` fallback that also serves the parallel-partition and
+  measurement paths.
+- The msgpack envelope carries the same two keys.
+- Both keys are present together or not at all, so an uncapped response is
+  unchanged on the wire and the msgpack envelope keeps its historical seven or
+  eight keys.
+- Arrow IPC carries an `Arc-Rows-Capped` response trailer holding the cap. A
+  trailer for the same reason `Arc-Execution-Time-Ms` is one: whether the cap
+  was reached is only known once the last batch is written, long after the
+  status line went out. Like every registered trailer it is emitted on every
+  response, empty when it does not apply, so the client contract is "non-empty
+  means capped".
+
+A plain response header was the first choice and does not work. Headers are
+committed before the body streams, so a header can announce that a cap applies
+but never that the result reached it, which is the fact a client needs.
+
+Read `Arc-Rows-Capped` alongside `Arc-Stream-Truncated`, which means close to
+the opposite. `Arc-Stream-Truncated` says the body is short because the stream
+failed and must not be trusted. `Arc-Rows-Capped` says the body is short
+because policy said so, and is a valid, complete result up to the cap.
+
+This pairs with `truncated` / `truncation_reason` from the JSON fix below, and
+the two answer different questions. `truncated` means the stream failed and the
+result is short by accident. `rows_capped` means policy stopped it on purpose
+and the rows delivered are a valid result up to the cap. A response can carry
+both, when a stream reaches the cap and then fails on the way out; each field
+still means exactly what it means alone.
+
+Server side, a capped query now emits a WARN naming the responsible token
+(`token_id`, `token_name`, `row_cap`, `row_count`) and increments the new
+`arc_governance_queries_capped_total` counter. The "query completed" line stays
+at Info, so existing log filters keep working. Only queries that actually reach
+a cap log or count, so a token that merely has a policy adds no log volume.
+
+One consequence worth knowing before you alert on the counter: a query whose own
+`LIMIT` equals the policy cap reaches the cap on every run, so it is marked, and
+logged, and counted every time, even though nothing was ever dropped. If a
+dashboard issues `LIMIT 10000` against a `max_rows_per_query` of 10000, raise
+the cap above the limit and the noise goes away. Arc cannot tell the two apart
+without fetching a row past the cap, and that fetch is not free:
+
+The marker means "this result reached the cap and may be incomplete", not "rows
+were definitely dropped". A stream that stops exactly at the cap cannot know
+whether another row was waiting without fetching one, and fetching one is worse
+than the ambiguity: on the Arrow IPC path it would let a policy timeout firing
+during that extra fetch poison a result that was complete at the cap, turning a
+readable response into an undecodable one. Reaching the cap is what the client
+needs in order to stop trusting the row count, and it is always known for
+certain.
+
+Two related gaps are unchanged. The experimental arcx Arrow IPC serve path
+applies no row cap at all, and returns before any trailer is registered, so an
+arcx-served Arrow IPC response carries none of the three trailers
+([#727](https://github.com/Basekick-Labs/arc/issues/727)); clients should read a
+missing trailer as "unknown", never as "not capped". And
+`/api/v1/queries/history` still records a capped query as an ordinary success
+([#728](https://github.com/Basekick-Labs/arc/issues/728)).
+
+Adding end-to-end coverage for the Arrow IPC trailer also turned up a data race
+that predates it ([#729](https://github.com/Basekick-Labs/arc/issues/729)): all
+three trailers on that endpoint are set from the stream-writer goroutine while
+fasthttp serialises the response head on the connection goroutine, and the two
+mutate the same buffer. It fires on `Arc-Execution-Time-Ms` alone, so it arrived
+with the trailers in this release rather than with the row cap. No test had ever
+driven that handler to success over a real HTTP response, which is why it went
+unseen.
+
+`[governance]` is also now documented in the reference `arc.toml`, which
+shipped with none of its keys.
 ### JSON query responses now say when the result was cut short ([#723](https://github.com/Basekick-Labs/arc/issues/723))
 
 A JSON response opens with `{"success":true,...,"data":[` before the first row
@@ -307,7 +404,9 @@ cost). All four now share one enforcement path: rejected requests get 429
 (with `Retry-After` for rate limits), the policy's `max_rows_per_query`
 caps streamed rows on the row-returning endpoints (JSON, Arrow IPC, and
 the database/sql fallback), and `max_scan_duration_sec` overrides the
-global `query.timeout` everywhere. RBAC was never affected; this closes a
+global `query.timeout` everywhere. That cap was silent when this landed;
+see *A governance row cap no longer looks like a complete result* above
+for the marker that now accompanies it. RBAC was never affected; this closes a
 limits and accounting gap, not an authorization hole.
 
 ### The measurement endpoint now honors the configured query timeout ([#308](https://github.com/Basekick-Labs/arc/issues/308))

--- a/arc.toml
+++ b/arc.toml
@@ -146,6 +146,27 @@ s3_cache_size = "128MB"
 s3_cache_ttl_seconds = 3600
 
 # -----------------------------------------------------------------------------
+# Query Governance (Enterprise)
+# -----------------------------------------------------------------------------
+# Per-token rate limits, quotas and row caps. Defaults here apply to every token
+# without an explicit policy; per-token policies are managed through
+# /api/v1/governance/policies. 0 means unlimited. The per-query timeout override
+# (max_scan_duration_sec) is per-policy only and has no default key here.
+[governance]
+enabled = false
+# default_rate_limit_per_min = 0
+# default_rate_limit_per_hour = 0
+# default_max_queries_per_hour = 0
+# default_max_queries_per_day = 0
+
+# Caps the rows any single query returns. A capped response is a valid,
+# complete-up-to-the-cap result, and says so: JSON and msgpack carry
+# "rows_capped": true and "row_cap", Arrow IPC carries the Arc-Rows-Capped
+# response trailer, and the server logs a WARN naming the token and counts
+# arc_governance_queries_capped_total.
+# default_max_rows_per_query = 0
+
+# -----------------------------------------------------------------------------
 # Telemetry
 # -----------------------------------------------------------------------------
 [telemetry]

--- a/internal/api/arcx_hook.go
+++ b/internal/api/arcx_hook.go
@@ -244,6 +244,7 @@ func (h *QueryHandler) serveArcxResult(
 	// the released RequestCtx) segfaults the process. Capture every ctx-derived
 	// value the async writers need BEFORE committing the stream writer.
 	tokenName := getTokenName(c)
+	tokenID := getTokenID(c)
 
 	if isMsgPackWire(c) {
 		// MAJOR-4: msgpack must drain SYNCHRONOUSLY here — BEFORE committing headers —
@@ -282,7 +283,7 @@ func (h *QueryHandler) serveArcxResult(
 				}
 			}()
 			bw := bufio.NewWriterSize(w, 256*1024)
-			if _, serr := streamMsgPackFromBatches(streamCtx, bw, schema, batches, rowCount, nil, start, timestamp); serr != nil {
+			if _, serr := streamMsgPackFromBatches(streamCtx, bw, schema, batches, rowCount, governanceMaxRows, nil, start, timestamp); serr != nil {
 				h.logger.Warn().Err(serr).Msg("arcx serve: msgpack stream error after headers committed")
 			}
 			bw.Flush()
@@ -298,6 +299,7 @@ func (h *QueryHandler) serveArcxResult(
 			if onComplete != nil {
 				onComplete(rowCount)
 			}
+			h.logGovernanceRowCap("msgpack", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rowCount))
 			h.logSlowQuery(convertedSQL, start, rowCount, tokenName)
 		})
 		return true
@@ -319,6 +321,10 @@ func (h *QueryHandler) serveArcxResult(
 		}()
 		rc, serr := streamArrowJSON(streamCtx, w, reader, governanceMaxRows, nil, start, timestamp)
 		m := metrics.Get()
+		// Reported before the branch below: a stream can reach the cap and
+		// then fail on the way out, and the envelope marks it capped either
+		// way, so the operator-side record has to fire on both paths (#724).
+		h.logGovernanceRowCap("arrow_json", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rc))
 		if serr != nil {
 			// F4: headers (and `"success":true`) are already committed, so the CLIENT
 			// has been told this succeeded. Marking the registry Fail here would make

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -939,6 +939,43 @@ func (h *QueryHandler) logSlowQuery(sql string, start time.Time, rowCount int, t
 		Msg("Slow query detected")
 }
 
+// getTokenID extracts the token id from the Fiber context, or 0 if auth is
+// not configured or no token is present. Governance policies are keyed by
+// token id, so it is the field an operator needs in order to find the policy
+// behind a capped result; it is captured before the async stream writers run,
+// for the same reason getTokenName is.
+func getTokenID(c *fiber.Ctx) int64 {
+	if ti := auth.GetTokenInfo(c); ti != nil {
+		return ti.ID
+	}
+	return 0
+}
+
+// logGovernanceRowCap emits the operator-side half of the #724 signal. The
+// wire marker tells the client its result may be incomplete; this tells the
+// operator which policy did it, and feeds the counter they can alert on.
+//
+// It is a separate Warn record rather than a promotion of the per-format
+// "query completed" line, matching logSlowQuery: the completion line stays at
+// Info so existing log filters on it keep working, and one record does not
+// change severity depending on its fields. It fires only for queries that
+// actually reached a cap, so a token that merely has a policy generates no
+// extra log volume.
+func (h *QueryHandler) logGovernanceRowCap(format, sql string, tokenID int64, tokenName string, rowCap int, rowCount int64) {
+	if !rowCapReached(rowCap, rowCount) {
+		return
+	}
+	metrics.Get().IncGovernanceQueriesCapped()
+	h.logger.Warn().
+		Str("format", format).
+		Str("sql", sqlutil.ForLog(sql)).
+		Int64("token_id", tokenID).
+		Str("token_name", tokenName).
+		Int("row_cap", rowCap).
+		Int64("row_count", rowCount).
+		Msg("Query result reached the governance row cap; client received a partial result")
+}
+
 // getTokenName extracts the token name from the Fiber context, or returns
 // empty string if auth is not configured or no token is present.
 func getTokenName(c *fiber.Ctx) string {
@@ -1806,6 +1843,7 @@ localProcessing:
 
 		// Capture token name before async callback (Fiber context not safe in callbacks)
 		tokenName := getTokenName(c)
+		tokenID := getTokenID(c)
 
 		// Stream typed JSON response directly to HTTP — no full-response buffering.
 		// streamCtx captures the timeout-aware context for per-row cancellation
@@ -1833,6 +1871,13 @@ localProcessing:
 			}()
 			rowCount, streamErr := streamTypedJSONFunc(streamCtx, w, columns, colTypes, iter, governanceMaxRows, profile, start, timestamp)
 			w.Flush()
+
+			// Reported before the error branch below: a stream can reach the
+			// cap and then fail on the way out, and the envelope marks it
+			// capped either way, so the operator-side record has to fire on
+			// both paths or it would go missing in the one case where the
+			// result is both capped and truncated (#724).
+			h.logGovernanceRowCap("json", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rowCount))
 
 			// Record metrics after streaming completes. If the stream
 			// terminated mid-flight (Scan / Err / ctx cancel), record as
@@ -2066,6 +2111,7 @@ localProcessing:
 
 		// Capture token name before async callback (Fiber context not safe in callbacks)
 		tokenName := getTokenName(c)
+		tokenID := getTokenID(c)
 
 		// Stream typed JSON response directly to HTTP — no full-response buffering.
 		// streamCtx captures the timeout-aware context so per-row cancellation
@@ -2090,6 +2136,13 @@ localProcessing:
 			}()
 			rowCount, streamErr := streamTypedJSONFunc(streamCtx, w, columns, colTypes, rows, governanceMaxRows, profile, start, timestamp)
 			w.Flush()
+
+			// Reported before the error branch below: a stream can reach the
+			// cap and then fail on the way out, and the envelope marks it
+			// capped either way, so the operator-side record has to fire on
+			// both paths or it would go missing in the one case where the
+			// result is both capped and truncated (#724).
+			h.logGovernanceRowCap("json", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rowCount))
 
 			// If the stream terminated mid-flight (Scan / Err / ctx
 			// cancel) record as failure even though the JSON envelope
@@ -4399,6 +4452,27 @@ func (h *QueryHandler) checkQueryGovernance(c *fiber.Ctx) (maxRows int, timeout 
 	return result.MaxRows, result.MaxDuration, nil
 }
 
+// rowCapReached reports whether a result reached the governance row cap, which
+// is the single definition of the #724 signal. It deliberately answers "reached
+// the cap", not "rows were dropped": a stream that stops exactly at the cap
+// cannot know whether another row was waiting without fetching one, and the one
+// design that fetched it turned a complete-at-cap Arrow IPC result into a
+// poisoned, undecodable stream whenever the policy timeout fired during the
+// extra fetch. "Reached the cap, so this may be incomplete" is always true here
+// and is what a client needs in order to stop trusting the result.
+//
+// The known cost of those semantics: a query whose own LIMIT equals the policy
+// cap reaches the cap on every run, so it is marked, logged and counted every
+// time without a row ever being dropped. Operators hitting that raise the cap
+// above the limit. Distinguishing the two requires fetching a row past the cap,
+// which is the fetch described above.
+//
+// maxRows <= 0 means no policy cap applies, including when governance is
+// unlicensed, unconfigured, or the request carries no token.
+func rowCapReached(maxRows int, rowCount int64) bool {
+	return maxRows > 0 && rowCount >= int64(maxRows)
+}
+
 // queryMeasurement handles GET /api/v1/query/:measurement - query a specific measurement
 func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	start := time.Now()
@@ -4635,6 +4709,7 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 
 	// Capture token name before async callback (Fiber context not safe in callbacks)
 	tokenName := getTokenName(c)
+	tokenID := getTokenID(c)
 
 	// Stream typed JSON with the timeout-aware context so per-row cancellation
 	// fires inside the streaming callback (#308).
@@ -4651,6 +4726,13 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 		}()
 		rowCount, streamErr := streamTypedJSONFunc(streamCtx, w, columns, colTypes, rows, governanceMaxRows, nil, start, timestamp)
 		w.Flush()
+
+		// Reported before the error branch below: a stream can reach the cap
+		// and then fail on the way out, and the envelope marks it capped
+		// either way, so the operator-side record has to fire on both paths
+		// or it would go missing in the one case where the result is both
+		// capped and truncated (#724).
+		h.logGovernanceRowCap("json", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rowCount))
 
 		if streamErr != nil {
 			m.IncQueryErrors()

--- a/internal/api/query_arrow.go
+++ b/internal/api/query_arrow.go
@@ -47,6 +47,22 @@ const arrowBatchSize = 10000
 // by the time a stream fails.
 const arrowStreamTruncatedTrailer = "Arc-Stream-Truncated"
 
+// arrowRowsCappedTrailer tells the client the Arrow IPC body it received
+// stopped at an Enterprise governance row cap and may therefore be missing
+// rows the query matched (#724). The value is the cap.
+//
+// Read it alongside arrowStreamTruncatedTrailer, which means nearly the
+// opposite: that trailer says the body is short because the stream FAILED and
+// must not be trusted, while this one says the body is short because policy
+// said so, and is a complete, valid result up to the cap.
+//
+// A trailer for the same reason the other two are: the cap is only known to
+// have been reached once the last batch has been written, long after the
+// status line and headers went out. Like every fasthttp trailer it is emitted
+// on every response once registered, carrying an empty value when never Set,
+// so the client contract is "non-empty means capped".
+const arrowRowsCappedTrailer = "Arc-Rows-Capped"
+
 // transportWriter distinguishes "the socket went away" from "the encoder
 // failed". Both surface as an error out of ipc.Writer.Write, and only the
 // former means nobody is listening. Wrapping the sink is the only way to tell:
@@ -574,6 +590,12 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 	fctx := c.Context()
 	respHeader := &fctx.Response.Header
 
+	// Captured before the stream writer commits: the pooled fiber.Ctx is
+	// recycled by the time the closure runs, so reading the token out of it
+	// there is the same use-after-free the comment above describes.
+	tokenName := getTokenName(c)
+	tokenID := getTokenID(c)
+
 	// Declare the execution-time trailer in the response head before
 	// SetBodyStreamWriter runs so the `Trailer:` response header is
 	// emitted before the chunked body starts. Clients that don't read
@@ -590,6 +612,15 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		arrowTrailerWarnOnce.Do(func() {
 			h.logger.Warn().Err(err).Str("trailer", arrowExecutionTimeTrailer).
 				Msg("Failed to register Arrow execution-time trailer; clients will not see server-side timing")
+		})
+	}
+	// Registered unconditionally rather than only when a cap applies: the
+	// registration has to happen here, before the body streams, and whether
+	// the cap is reached is not known until the stream ends.
+	if err := respHeader.AddTrailer(arrowRowsCappedTrailer); err != nil {
+		arrowTrailerWarnOnce.Do(func() {
+			h.logger.Warn().Err(err).Str("trailer", arrowRowsCappedTrailer).
+				Msg("Failed to register Arrow row-cap trailer; clients will not see that a governance cap truncated the result")
 		})
 	}
 
@@ -633,6 +664,14 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 		execMs := time.Since(start).Milliseconds()
 		respHeader.Set(arrowExecutionTimeTrailer, strconv.FormatInt(execMs, 10))
 
+		// Reported before the error branch below: a stream can reach the cap
+		// and then fail on the way out, so the operator-side record has to
+		// fire on both paths or it would go missing in the one case where the
+		// result is both capped and truncated (#724). The trailer below stays
+		// on the success path only, because a failed body is poisoned and
+		// must not be advertised as valid up to the cap.
+		h.logGovernanceRowCap("arrow_ipc", convertedSQL, tokenID, tokenName, governanceMaxRows, totalRows)
+
 		if streamErr != nil {
 			m.IncQueryErrors()
 			// Per-handler client-disconnect counter (#426). Lets operators
@@ -661,6 +700,16 @@ func (h *QueryHandler) executeQueryArrow(c *fiber.Ctx) error {
 				Int64("execution_time_ms", execMs).
 				Msg("Arrow IPC stream truncated after headers committed; client received partial result")
 			return
+		}
+
+		// Governance row cap (#724): an Arrow IPC stream that stopped at the
+		// cap is a valid, cleanly terminated stream, so nothing in the body
+		// distinguishes it from a complete result. Set on the success path
+		// only: a failed stream is already poisoned and carries
+		// arrowStreamTruncatedTrailer, which tells the client the opposite
+		// thing (do not trust this body at all).
+		if rowCapReached(governanceMaxRows, totalRows) {
+			respHeader.Set(arrowRowsCappedTrailer, strconv.Itoa(governanceMaxRows))
 		}
 
 		h.logger.Info().

--- a/internal/api/query_arrow_json.go
+++ b/internal/api/query_arrow_json.go
@@ -131,6 +131,7 @@ func executeArrowJSONQuery(
 
 	// Capture token name before async callback (Fiber context not safe in callbacks)
 	tokenName := getTokenName(c)
+	tokenID := getTokenID(c)
 
 	// Stream Arrow JSON response.
 	// SetBodyStreamWriter runs asynchronously — metrics are recorded in the callback.
@@ -181,6 +182,13 @@ func executeArrowJSONQuery(
 			}
 		}
 		w.Flush()
+
+		// Reported before the error branch below: a stream can reach the cap
+		// and then fail on the way out, and the marker is emitted either way,
+		// so the operator-side record has to fire on both paths or it would
+		// go missing in the one case where the result is both capped and
+		// truncated (#724).
+		h.logGovernanceRowCap("arrow_json", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rc))
 
 		if streamErr != nil {
 			m.IncQueryErrors()
@@ -346,6 +354,15 @@ done:
 	w.WriteString(`],"row_count":`)
 	scratch = strconv.AppendInt(scratch[:0], int64(rowCount), 10)
 	w.Write(scratch)
+
+	// Governance row cap (#724): see streamTypedJSON. Same two keys, same
+	// omit-when-absent rule, so the JSON and Arrow-JSON envelopes stay
+	// identical in shape.
+	if rowCapReached(governanceMaxRows, int64(rowCount)) {
+		w.WriteString(`,"rows_capped":true,"row_cap":`)
+		scratch = strconv.AppendInt(scratch[:0], int64(governanceMaxRows), 10)
+		w.Write(scratch)
+	}
 
 	executionTime := float64(time.Since(start).Milliseconds())
 	w.WriteString(`,"execution_time_ms":`)

--- a/internal/api/query_arrow_rowcap_trailer_test.go
+++ b/internal/api/query_arrow_rowcap_trailer_test.go
@@ -1,0 +1,159 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"net/textproto"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/governance"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// TestExecuteQueryArrowSetsRowsCappedTrailer is the #724 regression proper for
+// the Arrow IPC path: it drives the real handler, through real governance, to a
+// real chunked HTTP response, and reads the trailer off the wire. Arrow IPC has
+// no envelope to carry the marker, so this trailer is the whole signal on that
+// endpoint; without a test at this level, deleting either the AddTrailer or the
+// Set leaves the suite green and every Arrow IPC client silently loses it.
+//
+// streamArrowIPCFunc is stubbed so the row count is exact and the test does not
+// depend on how DuckDB batches a result.
+func TestExecuteQueryArrowSetsRowsCappedTrailer(t *testing.T) {
+	if raceDetectorEnabled {
+		// Any success-path request to this handler trips the pre-existing
+		// trailer race described in #729, including with the #724 trailer
+		// removed, because Arc-Execution-Time-Ms is set unconditionally.
+		t.Skip("blocked by #729: Arrow IPC trailer Set races with fasthttp header serialisation")
+	}
+	const cap = 10000
+
+	newApp := func(t *testing.T, policy *governance.Policy, rowsStreamed int64, streamErr error) *fiber.App {
+		t.Helper()
+		metrics.Init(zerolog.Nop())
+
+		tmpDir := t.TempDir()
+		logger := zerolog.New(os.Stderr).Level(zerolog.Disabled)
+		backend, err := storage.NewLocalBackend(tmpDir, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		duckdb, err := database.New(&database.Config{
+			MemoryLimit:      "256MB",
+			ThreadCount:      2,
+			MaxConnections:   2,
+			LocalStorageRoot: tmpDir,
+		}, logger)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { duckdb.Close() })
+
+		h := newGovernanceTestHandler(newGovernanceTestManager(t, policy), 0)
+		h.db = duckdb
+		h.storage = backend
+
+		origLicensed := queryGovernanceLicensed
+		queryGovernanceLicensed = func(*QueryHandler) bool { return true }
+		t.Cleanup(func() { queryGovernanceLicensed = origLicensed })
+
+		orig := streamArrowIPCFunc
+		t.Cleanup(func() { streamArrowIPCFunc = orig })
+		streamArrowIPCFunc = func(_ context.Context, w *bufio.Writer, _ array.RecordReader, _ *arrow.Schema,
+			_ *decimalCastInfo, _ bool, _ string, maxRows int, _ zerolog.Logger) (int64, error) {
+			// Write and flush at least one byte, as the real streamArrowIPC
+			// always does (it emits the schema message before anything else).
+			// The flush is what orders this goroutine after fasthttp's header
+			// serialisation: fasthttp writes the response head, then reads the
+			// body pipe, so a stream writer that never writes has no
+			// happens-before edge to the header and any trailer Set it makes
+			// races with formatStatusLine. A stub that writes nothing would
+			// report a data race that production code cannot hit.
+			_, _ = w.Write([]byte{0})
+			_ = w.Flush()
+			return rowsStreamed, streamErr
+		}
+
+		app := fiber.New(fiber.Config{DisableStartupMessage: true})
+		app.Use(func(c *fiber.Ctx) error {
+			c.Locals("token_info", &auth.TokenInfo{ID: 42, Name: "capped"})
+			return c.Next()
+		})
+		app.Post("/api/v1/query/arrow", h.executeQueryArrow)
+		return app
+	}
+
+	// trailerOf drains the body first: Go populates Response.Trailer only once
+	// the chunked body has been read to EOF.
+	trailerOf := func(t *testing.T, app *fiber.App) string {
+		t.Helper()
+		req := httptest.NewRequest("POST", "/api/v1/query/arrow", strings.NewReader(`{"sql":"SELECT 1 AS id"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, 10000)
+		if err != nil {
+			t.Fatalf("app.Test: %v", err)
+		}
+		if _, err := io.ReadAll(resp.Body); err != nil {
+			t.Fatalf("draining body: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		// Presence is checked separately from value: fasthttp emits every
+		// REGISTERED trailer on every response, empty when never Set, and the
+		// client contract rests on that. Get() alone cannot tell an empty
+		// trailer from a missing one.
+		if _, ok := resp.Trailer[textproto.CanonicalMIMEHeaderKey(arrowRowsCappedTrailer)]; !ok {
+			t.Errorf("%s is absent from the trailers; it must be registered on every response", arrowRowsCappedTrailer)
+		}
+		return resp.Trailer.Get(arrowRowsCappedTrailer)
+	}
+
+	t.Run("a result that reached the cap carries the cap in the trailer", func(t *testing.T) {
+		app := newApp(t, &governance.Policy{TokenID: 42, MaxRowsPerQuery: cap}, cap, nil)
+		if got := trailerOf(t, app); got != "10000" {
+			t.Errorf("%s = %q, want \"10000\"", arrowRowsCappedTrailer, got)
+		}
+	})
+
+	t.Run("a result short of the cap leaves the trailer empty", func(t *testing.T) {
+		app := newApp(t, &governance.Policy{TokenID: 42, MaxRowsPerQuery: cap}, cap-1, nil)
+		// Empty, not absent: the trailer is registered on every response, so
+		// the client contract is "non-empty means capped".
+		if got := trailerOf(t, app); got != "" {
+			t.Errorf("%s = %q on an under-cap result, want empty", arrowRowsCappedTrailer, got)
+		}
+	})
+
+	t.Run("no policy cap leaves the trailer empty", func(t *testing.T) {
+		app := newApp(t, nil, 5_000_000, nil)
+		if got := trailerOf(t, app); got != "" {
+			t.Errorf("%s = %q with no policy, want empty", arrowRowsCappedTrailer, got)
+		}
+	})
+
+	t.Run("a failed stream is not marked capped", func(t *testing.T) {
+		// The body is poisoned and Arc-Stream-Truncated says do not trust it,
+		// which subsumes the cap. Marking both would tell the client the body
+		// is valid up to the cap when it is not decodable at all.
+		app := newApp(t, &governance.Policy{TokenID: 42, MaxRowsPerQuery: cap}, cap, errors.New("boom"))
+		if got := trailerOf(t, app); got != "" {
+			t.Errorf("%s = %q on a failed stream, want empty", arrowRowsCappedTrailer, got)
+		}
+	})
+}

--- a/internal/api/query_governance_rowcap_test.go
+++ b/internal/api/query_governance_rowcap_test.go
@@ -1,0 +1,426 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/rs/zerolog"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// Tests for #724. An Enterprise governance row cap truncated a result with no
+// error, no header, no field and no log entry, so a capped response was
+// byte-identical to a complete one on every wire format and a dashboard
+// quietly cut at 10,000 rows drew conclusions from truncated data.
+//
+// The signal deliberately means "this result reached the cap and may be
+// incomplete", not "rows were definitely dropped": see rowCapReached.
+
+func TestRowCapReached(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxRows  int
+		rowCount int64
+		want     bool
+	}{
+		{"no policy cap, empty result", 0, 0, false},
+		{"no policy cap, large result", 0, 1 << 20, false},
+		{"negative cap is treated as no cap", -1, 100, false},
+		{"below the cap", 10, 9, false},
+		{"empty result under a cap", 10, 0, false},
+		{"exactly at the cap", 10, 10, true},
+		{"past the cap", 10, 11, true},
+		{"cap of one", 1, 1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rowCapReached(tt.maxRows, tt.rowCount); got != tt.want {
+				t.Errorf("rowCapReached(%d, %d) = %v, want %v", tt.maxRows, tt.rowCount, got, tt.want)
+			}
+		})
+	}
+}
+
+// jsonCapFields pulls the two #724 keys out of an encoded JSON envelope.
+func jsonCapFields(t *testing.T, body []byte) (capped bool, rowCap float64, hasCap bool) {
+	t.Helper()
+	var env map[string]interface{}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v\n%s", err, body)
+	}
+	if v, ok := env["rows_capped"]; ok {
+		b, isBool := v.(bool)
+		if !isBool {
+			t.Fatalf("rows_capped is %T, want bool", v)
+		}
+		capped = b
+	}
+	if v, ok := env["row_cap"]; ok {
+		hasCap = true
+		rowCap = v.(float64)
+	}
+	return capped, rowCap, hasCap
+}
+
+func TestStreamTypedJSONMarksCappedResult(t *testing.T) {
+	columns := []string{"id"}
+	colTypes := []colType{colInt64}
+	rows := func(n int) [][]interface{} {
+		out := make([][]interface{}, n)
+		for i := range out {
+			out[i] = []interface{}{int64(i)}
+		}
+		return out
+	}
+
+	t.Run("a capped result carries both keys", func(t *testing.T) {
+		body, rowCount := streamToBytes(columns, colTypes, &mockRowScanner{rows: rows(25)}, 10, nil)
+		if rowCount != 10 {
+			t.Fatalf("rowCount = %d, want 10", rowCount)
+		}
+		capped, rowCap, hasCap := jsonCapFields(t, body)
+		if !capped {
+			t.Errorf("rows_capped missing or false on a capped result: %s", body)
+		}
+		if !hasCap || rowCap != 10 {
+			t.Errorf("row_cap = %v (present=%v), want 10", rowCap, hasCap)
+		}
+	})
+
+	t.Run("an uncapped result carries neither key", func(t *testing.T) {
+		body, _ := streamToBytes(columns, colTypes, &mockRowScanner{rows: rows(25)}, 0, nil)
+		if bytes.Contains(body, []byte("rows_capped")) || bytes.Contains(body, []byte("row_cap")) {
+			t.Errorf("uncapped response must be unchanged on the wire, got: %s", body)
+		}
+	})
+
+	t.Run("a result short of the cap carries neither key", func(t *testing.T) {
+		body, rowCount := streamToBytes(columns, colTypes, &mockRowScanner{rows: rows(3)}, 10, nil)
+		if rowCount != 3 {
+			t.Fatalf("rowCount = %d, want 3", rowCount)
+		}
+		if bytes.Contains(body, []byte("rows_capped")) {
+			t.Errorf("a result under the cap must not be marked, got: %s", body)
+		}
+	})
+
+	t.Run("the marked envelope is still valid JSON alongside a profile", func(t *testing.T) {
+		body, _ := streamToBytes(columns, colTypes, &mockRowScanner{rows: rows(25)}, 10,
+			&database.QueryProfile{})
+		var env map[string]interface{}
+		if err := json.Unmarshal(body, &env); err != nil {
+			t.Fatalf("profiled capped envelope is not valid JSON: %v\n%s", err, body)
+		}
+		if _, ok := env["profile"]; !ok {
+			t.Error("profile key went missing from a capped envelope")
+		}
+	})
+}
+
+func TestStreamArrowJSONMarksCappedResult(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer alloc.AssertSize(t, 0)
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+
+	newReader := func(batches, perBatch int) *simpleRecordReader {
+		recs := make([]arrow.Record, batches)
+		for b := range recs {
+			rows := make([][]interface{}, perBatch)
+			for r := range rows {
+				rows[r] = []interface{}{int64(b*perBatch + r)}
+			}
+			recs[b] = buildArrowBatch(alloc, schema, rows)
+		}
+		return newSimpleRecordReader(schema, recs)
+	}
+
+	t.Run("a capped result carries both keys", func(t *testing.T) {
+		reader := newReader(3, 10)
+		body, rowCount := arrowStreamToBytes(reader, 12, nil)
+		reader.Release()
+		if rowCount != 12 {
+			t.Fatalf("rowCount = %d, want 12", rowCount)
+		}
+		capped, rowCap, hasCap := jsonCapFields(t, body)
+		if !capped {
+			t.Errorf("rows_capped missing or false on a capped result: %s", body)
+		}
+		if !hasCap || rowCap != 12 {
+			t.Errorf("row_cap = %v (present=%v), want 12", rowCap, hasCap)
+		}
+	})
+
+	t.Run("an uncapped result carries neither key", func(t *testing.T) {
+		reader := newReader(3, 10)
+		body, rowCount := arrowStreamToBytes(reader, 0, nil)
+		reader.Release()
+		if rowCount != 30 {
+			t.Fatalf("rowCount = %d, want 30", rowCount)
+		}
+		if bytes.Contains(body, []byte("rows_capped")) || bytes.Contains(body, []byte("row_cap")) {
+			t.Errorf("uncapped response must be unchanged on the wire, got: %s", body)
+		}
+	})
+
+	t.Run("a cap larger than the result marks nothing", func(t *testing.T) {
+		reader := newReader(2, 5)
+		body, rowCount := arrowStreamToBytes(reader, 100, nil)
+		reader.Release()
+		if rowCount != 10 {
+			t.Fatalf("rowCount = %d, want 10", rowCount)
+		}
+		if bytes.Contains(body, []byte("rows_capped")) {
+			t.Errorf("a result under the cap must not be marked, got: %s", body)
+		}
+	})
+}
+
+func TestMsgPackEnvelopeMarksCappedResult(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer alloc.AssertSize(t, 0)
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+
+	newReader := func(batches, perBatch int) *simpleRecordReader {
+		recs := make([]arrow.Record, batches)
+		for b := range recs {
+			rows := make([][]interface{}, perBatch)
+			for r := range rows {
+				rows[r] = []interface{}{int64(b*perBatch + r)}
+			}
+			recs[b] = buildArrowBatch(alloc, schema, rows)
+		}
+		return newSimpleRecordReader(schema, recs)
+	}
+
+	decode := func(t *testing.T, body []byte) map[string]interface{} {
+		t.Helper()
+		var env map[string]interface{}
+		if err := msgpack.Unmarshal(body, &env); err != nil {
+			t.Fatalf("envelope is not decodable msgpack: %v", err)
+		}
+		return env
+	}
+
+	t.Run("a capped result carries both keys and still decodes", func(t *testing.T) {
+		reader := newReader(3, 10)
+		body, rowCount := msgpackStreamToBytes(reader, 12)
+		reader.Release()
+		if rowCount != 12 {
+			t.Fatalf("rowCount = %d, want 12", rowCount)
+		}
+		env := decode(t, body)
+		// A wrong EncodeMapLen does not drop a field, it leaves trailing
+		// bytes that decode as a second object, so the key count is the
+		// assertion that catches it.
+		if len(env) != 9 {
+			t.Fatalf("capped envelope has %d keys, want 9: %v", len(env), env)
+		}
+		if env["rows_capped"] != true {
+			t.Errorf("rows_capped = %v, want true", env["rows_capped"])
+		}
+		// msgpack picks the narrowest integer encoding, so the decoded Go
+		// type depends on the value; compare numerically, not by type.
+		if got := asInt64(t, env["row_cap"]); got != 12 {
+			t.Errorf("row_cap = %d, want 12", got)
+		}
+	})
+
+	t.Run("an uncapped result keeps the historical seven-key shape", func(t *testing.T) {
+		reader := newReader(3, 10)
+		body, _ := msgpackStreamToBytes(reader, 0)
+		reader.Release()
+		env := decode(t, body)
+		if len(env) != 7 {
+			t.Fatalf("uncapped envelope has %d keys, want 7: %v", len(env), env)
+		}
+		if _, ok := env["rows_capped"]; ok {
+			t.Error("uncapped response must not carry rows_capped")
+		}
+	})
+
+	t.Run("a result short of the cap is not marked", func(t *testing.T) {
+		reader := newReader(2, 5)
+		body, _ := msgpackStreamToBytes(reader, 100)
+		reader.Release()
+		env := decode(t, body)
+		if len(env) != 7 {
+			t.Fatalf("under-cap envelope has %d keys, want 7: %v", len(env), env)
+		}
+	})
+}
+
+// TestMsgPackMapLenMatchesEncodedKeys covers all four combinations of the two
+// optional key groups. EncodeMapLen is written before the pairs, so an
+// arithmetic slip there does not drop a field: the decoder stops early and the
+// remaining bytes parse as a second top-level object, or the decode fails
+// outright. Only an exact key count catches it.
+func TestMsgPackMapLenMatchesEncodedKeys(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer alloc.AssertSize(t, 0)
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+
+	tests := []struct {
+		name     string
+		maxRows  int
+		profile  *database.QueryProfile
+		wantKeys int
+	}{
+		{"uncapped, no profile", 0, nil, 7},
+		{"uncapped, profiled", 0, &database.QueryProfile{}, 8},
+		{"capped, no profile", 4, nil, 9},
+		{"capped, profiled", 4, &database.QueryProfile{}, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The encoder writes the inner data array as
+			// EncodeArrayLen(rowCount) and then emits every row the
+			// batches hold, so rowCount must equal the batch contents.
+			// drainArrowBatches guarantees that in production by trimming
+			// the batch that crosses the cap; mirror it here.
+			rowCount := 10
+			if tt.maxRows > 0 {
+				rowCount = tt.maxRows
+			}
+			rows := make([][]interface{}, rowCount)
+			for i := range rows {
+				rows[i] = []interface{}{int64(i)}
+			}
+			rec := buildArrowBatch(alloc, schema, rows)
+			defer rec.Release()
+
+			var buf bytes.Buffer
+			w := bufio.NewWriter(&buf)
+			if _, err := streamMsgPackFromBatches(context.Background(), w, schema,
+				[]arrow.Record{rec}, rowCount, tt.maxRows, tt.profile,
+				time.Now(), "2024-01-15T12:00:00Z"); err != nil {
+				t.Fatalf("streamMsgPackFromBatches: %v", err)
+			}
+			w.Flush()
+
+			// Decode into the stream decoder so trailing bytes are visible:
+			// Unmarshal alone would happily stop after a short map.
+			dec := msgpack.NewDecoder(bytes.NewReader(buf.Bytes()))
+			var env map[string]interface{}
+			if err := dec.Decode(&env); err != nil {
+				t.Fatalf("envelope did not decode: %v", err)
+			}
+			if len(env) != tt.wantKeys {
+				t.Errorf("envelope has %d keys, want %d: %v", len(env), tt.wantKeys, env)
+			}
+			if _, err := dec.DecodeInterface(); err != io.EOF {
+				t.Errorf("bytes remain after the envelope (mapLen undercounts the pairs written): err=%v", err)
+			}
+		})
+	}
+}
+
+// asInt64 normalizes whichever width the msgpack decoder chose for an integer.
+func asInt64(t *testing.T, v interface{}) int64 {
+	t.Helper()
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rv.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(rv.Uint())
+	default:
+		t.Fatalf("value %v (%T) is not an integer", v, v)
+		return 0
+	}
+}
+
+// deferredErrRowScanner reports an error from Err() rather than from Scan,
+// the shape *sql.Rows uses for a failure discovered after iteration stops.
+type deferredErrRowScanner struct {
+	*mockRowScanner
+	err error
+}
+
+func (d *deferredErrRowScanner) Err() error { return d.err }
+
+// TestStreamTypedJSONMarksCappedResultThatThenFailed covers the case where both
+// #723's and #724's markers apply: the stream reaches the cap and the iterator
+// then reports a deferred error. The client must be told both facts, and the
+// operator-side record must not be the one that goes missing, which is why
+// logGovernanceRowCap is called ahead of the error branch at every call site.
+func TestStreamTypedJSONMarksCappedResultThatThenFailed(t *testing.T) {
+	rows := make([][]interface{}, 25)
+	for i := range rows {
+		rows[i] = []interface{}{int64(i)}
+	}
+	// A deferred iterator error, which is what *sql.Rows reports after the
+	// loop has already stopped. The cap breaks the loop first, then Err()
+	// surfaces the failure, so the result is both capped and truncated.
+	scanner := &deferredErrRowScanner{
+		mockRowScanner: &mockRowScanner{rows: rows},
+		err:            errors.New("connection reset"),
+	}
+
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	rowCount, streamErr := streamTypedJSON(context.Background(), w, []string{"id"},
+		[]colType{colInt64}, scanner, 10, nil, time.Now(), "2024-01-15T12:00:00Z")
+	w.Flush()
+
+	if rowCount != 10 {
+		t.Fatalf("rowCount = %d, want 10", rowCount)
+	}
+	if streamErr == nil {
+		t.Fatal("deferred iterator error was swallowed; the stream must report it")
+	}
+
+	var env map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v\n%s", err, buf.Bytes())
+	}
+	if env["rows_capped"] != true {
+		t.Errorf("a result that reached the cap must be marked capped: %v", env)
+	}
+
+	// The operator half must fire for this query too, not only on the clean
+	// path. rowCapReached is the predicate every call site shares.
+	metrics.Init(zerolog.Nop())
+	h := &QueryHandler{logger: zerolog.Nop()}
+	before := metrics.Get().Snapshot()["governance_queries_capped_total"].(int64)
+	h.logGovernanceRowCap("json", "SELECT 1", 42, "capped", 10, int64(rowCount))
+	if got := metrics.Get().Snapshot()["governance_queries_capped_total"].(int64); got != before+1 {
+		t.Errorf("capped-then-failed query did not reach the operator counter: %d -> %d", before, got)
+	}
+}
+
+func TestLogGovernanceRowCapCountsOnlyCappedQueries(t *testing.T) {
+	metrics.Init(zerolog.Nop())
+	h := &QueryHandler{logger: zerolog.Nop()}
+
+	read := func() int64 {
+		return metrics.Get().Snapshot()["governance_queries_capped_total"].(int64)
+	}
+
+	before := read()
+	h.logGovernanceRowCap("json", "SELECT 1", 42, "capped", 10, 9)
+	if got := read(); got != before {
+		t.Errorf("a result under the cap incremented the counter: %d -> %d", before, got)
+	}
+	h.logGovernanceRowCap("json", "SELECT 1", 42, "capped", 0, 1000)
+	if got := read(); got != before {
+		t.Errorf("an ungoverned query incremented the counter: %d -> %d", before, got)
+	}
+	h.logGovernanceRowCap("json", "SELECT 1", 42, "capped", 10, 10)
+	if got := read(); got != before+1 {
+		t.Errorf("a capped query did not increment the counter: %d -> %d", before, got)
+	}
+}

--- a/internal/api/query_json_writer.go
+++ b/internal/api/query_json_writer.go
@@ -211,6 +211,17 @@ scanLoop:
 	scratch = strconv.AppendInt(scratch[:0], int64(rowCount), 10)
 	w.Write(scratch)
 
+	// Governance row cap (#724): a capped result was otherwise byte-identical
+	// to a complete one, so a dashboard quietly cut at 10,000 rows drew
+	// conclusions from truncated data. Both keys are omitted entirely when no
+	// cap applied or the result did not reach it, so an uncapped response is
+	// unchanged on the wire.
+	if rowCapReached(governanceMaxRows, int64(rowCount)) {
+		w.WriteString(`,"rows_capped":true,"row_cap":`)
+		scratch = strconv.AppendInt(scratch[:0], int64(governanceMaxRows), 10)
+		w.Write(scratch)
+	}
+
 	executionTime := float64(time.Since(start).Milliseconds())
 	w.WriteString(`,"execution_time_ms":`)
 	scratch = strconv.AppendFloat(scratch[:0], executionTime, 'f', -1, 64)

--- a/internal/api/query_msgpack.go
+++ b/internal/api/query_msgpack.go
@@ -137,6 +137,7 @@ func executeArrowMsgPackQuery(
 	}
 
 	tokenName := getTokenName(c)
+	tokenID := getTokenID(c)
 
 	// Materialize all Arrow batches synchronously BEFORE committing
 	// HTTP headers. The columnar msgpack wire format buffers every
@@ -244,12 +245,19 @@ func executeArrowMsgPackQuery(
 		// negotiated, the pooled encoder sits between that buffer and w.
 		sink, finishCompression := compressedSink(w, respEncoding)
 		bw := bufio.NewWriterSize(sink, 256*1024)
-		rc, streamErr := streamMsgPackFromBatches(ctx, bw, schema, batches, rowCount, profile, start, timestamp)
+		rc, streamErr := streamMsgPackFromBatches(ctx, bw, schema, batches, rowCount, governanceMaxRows, profile, start, timestamp)
 		bw.Flush()
 		if err := finishCompression(); err != nil && streamErr == nil {
 			streamErr = err
 		}
 		w.Flush()
+
+		// Reported before the error branch below: a stream can reach the cap
+		// and then fail on the way out, and the marker is emitted either way,
+		// so the operator-side record has to fire on both paths or it would
+		// go missing in the one case where the result is both capped and
+		// truncated (#724).
+		h.logGovernanceRowCap("msgpack", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rc))
 
 		if streamErr != nil {
 			m.IncQueryErrors()
@@ -394,12 +402,14 @@ func wrapMsgPackWriteErr(err error) error {
 // streamMsgPackFromBatches writes the query response as a single
 // msgpack map over a pre-drained slice of Arrow record batches. Shape:
 //
-//	map(7 or 8) {
+//	map(7, 8, 9 or 10) {
 //	  "success":           bool
 //	  "columns":           [string...]            // column names
 //	  "types":             [string...]            // Arc wire type names, parallel to columns
 //	  "data":              [[v...], [v...], ...]  // numCols arrays, each with N values
 //	  "row_count":         uint
+//	  "rows_capped":       bool                   (optional, #724; always true when present)
+//	  "row_cap":           uint                   (optional, #724; paired with rows_capped)
 //	  "execution_time_ms": uint                   (milliseconds)
 //	  "timestamp":         string                 (RFC3339)
 //	  "profile":           map (optional)
@@ -425,6 +435,7 @@ func streamMsgPackFromBatches(
 	schema *arrow.Schema,
 	batches []arrow.Record,
 	rowCount int,
+	governanceMaxRows int,
 	profile *database.QueryProfile,
 	start time.Time,
 	timestamp string,
@@ -453,10 +464,16 @@ func streamMsgPackFromBatches(
 	fields := schema.Fields()
 	numCols := len(fields)
 
-	// Decide map size up front: 7 base keys + 1 if profile attached.
+	// Decide map size up front: 7 base keys, +1 if profile attached, +2 for
+	// the governance row-cap pair (#724). Both cap keys are present or both
+	// absent, so an uncapped response keeps its historical 7/8 shape.
+	capped := rowCapReached(governanceMaxRows, int64(rowCount))
 	mapLen := 7
 	if profile != nil {
-		mapLen = 8
+		mapLen++
+	}
+	if capped {
+		mapLen += 2
 	}
 	if err := enc.EncodeMapLen(mapLen); err != nil {
 		return 0, fmt.Errorf("encode map header: %w", err)
@@ -550,6 +567,25 @@ func streamMsgPackFromBatches(
 	}
 	if err := enc.EncodeUint(uint64(rowCount)); err != nil {
 		return rowCount, err
+	}
+
+	// "rows_capped" / "row_cap" (#724): emitted as a pair, and only when the
+	// result reached a governance cap, so an uncapped response keeps its
+	// historical shape. Same two keys as the JSON envelope, which keeps the
+	// documented JSON/msgpack parity true.
+	if capped {
+		if err := enc.EncodeString("rows_capped"); err != nil {
+			return rowCount, err
+		}
+		if err := enc.EncodeBool(true); err != nil {
+			return rowCount, err
+		}
+		if err := enc.EncodeString("row_cap"); err != nil {
+			return rowCount, err
+		}
+		if err := enc.EncodeUint(uint64(governanceMaxRows)); err != nil {
+			return rowCount, err
+		}
 	}
 
 	// "execution_time_ms": uint (milliseconds, integer — JSON sends

--- a/internal/api/query_msgpack_disconnect_test.go
+++ b/internal/api/query_msgpack_disconnect_test.go
@@ -73,7 +73,7 @@ func TestMsgPackStream_DisconnectIsClientError(t *testing.T) {
 
 	_, streamErr := streamMsgPackFromBatches(
 		context.Background(), bw, schema, []arrow.Record{rec}, rows,
-		nil, time.Now(), time.Now().UTC().Format(time.RFC3339),
+		0, nil, time.Now(), time.Now().UTC().Format(time.RFC3339),
 	)
 
 	if streamErr == nil {
@@ -117,7 +117,7 @@ func TestMsgPackStream_CtxCancelStaysCtxError(t *testing.T) {
 
 	_, streamErr := streamMsgPackFromBatches(
 		ctx, bw, schema, []arrow.Record{rec}, rows,
-		nil, time.Now(), time.Now().UTC().Format(time.RFC3339),
+		0, nil, time.Now(), time.Now().UTC().Format(time.RFC3339),
 	)
 
 	if streamErr == nil {

--- a/internal/api/query_msgpack_test.go
+++ b/internal/api/query_msgpack_test.go
@@ -56,7 +56,7 @@ func msgpackStreamToBytes(
 		w.Flush()
 		return buf.Bytes(), rowCount
 	}
-	rc, _ := streamMsgPackFromBatches(ctx, w, schema, batches, rowCount, nil, start, "2024-01-15T12:00:00Z")
+	rc, _ := streamMsgPackFromBatches(ctx, w, schema, batches, rowCount, governanceMaxRows, nil, start, "2024-01-15T12:00:00Z")
 	w.Flush()
 	return buf.Bytes(), rc
 }

--- a/internal/api/racedetector_race_test.go
+++ b/internal/api/racedetector_race_test.go
@@ -1,0 +1,17 @@
+//go:build race
+
+package api
+
+// raceDetectorEnabled reports whether this binary was built with -race.
+//
+// Used to skip the one test that drives POST /api/v1/query/arrow to its
+// success path over a real HTTP response. That path trips a pre-existing data
+// race between the trailer Set in the stream-writer goroutine and fasthttp's
+// response-header serialisation on the connection goroutine (#729). The race
+// is in the trailer mechanism itself, not in the test: it fires on
+// Arc-Execution-Time-Ms, shipped before the test existed, with the #724
+// trailer removed entirely.
+//
+// Skipped rather than deleted so the coverage exists for local runs now and
+// starts running in CI the moment #729 lands.
+const raceDetectorEnabled = true

--- a/internal/api/racedetector_test.go
+++ b/internal/api/racedetector_test.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package api
+
+// raceDetectorEnabled reports whether this binary was built with -race.
+// See the //go:build race variant for why it exists.
+const raceDetectorEnabled = false

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -125,6 +125,7 @@ type Metrics struct {
 	// Governance metrics
 	governanceRateLimited    atomic.Int64 // Queries rejected by rate limiting
 	governanceQuotaExhausted atomic.Int64 // Queries rejected by quota exhaustion
+	governanceQueriesCapped  atomic.Int64 // Queries whose results reached a policy row cap (#724)
 	governancePoliciesActive atomic.Int64 // Number of active governance policies
 
 	// Query Management metrics
@@ -381,6 +382,7 @@ func (m *Metrics) IncDecompBufferDiscards() { m.decompBufferDiscards.Add(1) }
 // Governance Metrics
 func (m *Metrics) IncGovernanceRateLimited()           { m.governanceRateLimited.Add(1) }
 func (m *Metrics) IncGovernanceQuotaExhausted()        { m.governanceQuotaExhausted.Add(1) }
+func (m *Metrics) IncGovernanceQueriesCapped()         { m.governanceQueriesCapped.Add(1) }
 func (m *Metrics) SetGovernancePoliciesActive(n int64) { m.governancePoliciesActive.Store(n) }
 
 // Query Management Metrics
@@ -570,6 +572,7 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 		// Governance
 		"governance_rate_limited_total":    m.governanceRateLimited.Load(),
 		"governance_quota_exhausted_total": m.governanceQuotaExhausted.Load(),
+		"governance_queries_capped_total":  m.governanceQueriesCapped.Load(),
 		"governance_policies_active":       m.governancePoliciesActive.Load(),
 
 		// Query Management
@@ -903,6 +906,10 @@ func (m *Metrics) PrometheusFormat() string {
 	b = append(b, "# HELP arc_governance_quota_exhausted_total Queries rejected by quota exhaustion\n"...)
 	b = append(b, "# TYPE arc_governance_quota_exhausted_total counter\n"...)
 	b = appendMetric(b, "arc_governance_quota_exhausted_total", float64(m.governanceQuotaExhausted.Load()))
+
+	b = append(b, "# HELP arc_governance_queries_capped_total Queries whose results reached a policy row cap and may be incomplete\n"...)
+	b = append(b, "# TYPE arc_governance_queries_capped_total counter\n"...)
+	b = appendMetric(b, "arc_governance_queries_capped_total", float64(m.governanceQueriesCapped.Load()))
 
 	b = append(b, "# HELP arc_governance_policies_active Number of active governance policies\n"...)
 	b = append(b, "# TYPE arc_governance_policies_active gauge\n"...)


### PR DESCRIPTION
Fixes #724.

## The bug

A query capped by a policy's `max_rows_per_query` returned a response byte-identical to a complete one. No error, no header, no field, no log entry, on any of the four wire formats. Unlike the Arrow IPC truncation in #721, this is reachable on purpose and by configuration, so an operator can hit it every day without knowing while a dashboard capped at 10,000 rows draws conclusions from truncated data. The 2026.02.2 notes promised "partial results with a warning"; no warning was ever written.

## What a capped result carries now

| Format | Signal |
|---|---|
| JSON (`streamTypedJSON`: parallel merge, `database/sql` fallback, measurement) | `"rows_capped": true`, `"row_cap": N` |
| Arrow-JSON (`POST /api/v1/query` in `duckdb_arrow` builds) | same two keys, same position |
| msgpack | same two keys, map length 9 or 10 |
| Arrow IPC | `Arc-Rows-Capped: N` response trailer |

Both keys are emitted together or not at all, so an uncapped response is unchanged on the wire and the msgpack envelope keeps its historical 7/8 keys. Operators get a separate WARN naming the token and a new `arc_governance_queries_capped_total`.

## Why not the header the issue preferred

The issue leaned toward Option 1, a pre-body `Arc-Rows-Capped` header. That cannot work. All four formats commit headers with `c.Set(...)` and then `SetBodyStreamWriter`, whose callback runs after the handler returns, so a pre-body header can announce that a cap *applies* but never that the result *reached* it, which is the fact a client needs. msgpack is the one exception, since it drains before committing headers, and a single mechanism that is accurate on one format out of four is not a mechanism.

Arrow IPC gets a trailer because it has no envelope, and because #722 already established the pattern on that endpoint for exactly this reason.

## Semantics, and what they cost

The marker means "this result reached the cap and may be incomplete", not "rows were definitely dropped".

My first design proved truncation by letting the loop pull one batch past the cap. That is actively harmful. The Arrow IPC loop re-enters its ctx check and its `reader.Err()` check, both of which set `streamErr`, and `streamErr != nil` reaches `poisonArrowStream`. A policy timeout firing during that extra 10,000-row fetch would poison a result that was **complete at the cap**, turning a readable response into an undecodable one. It also overturns `TestStreamArrowIPCGovernanceCapExactBoundary`, which deliberately pins the resource guarantee the cap exists to provide.

Dropping the probe removed the hazard and collapsed the change: every caller already holds the row count and the cap, so `rowCapReached` is computed locally and the signature churn went from five functions across 31 call sites to one function across five.

The honest cost: a query whose own `LIMIT` equals the policy cap reaches the cap on every run, so it is marked, logged and counted every time without a row ever being dropped. Documented in the release notes with the remedy (raise the cap above the limit).

## Relationship to #723

#725 landed on main while this was in progress and touches the same two JSON writers. The two marker pairs are complementary and were designed that way. `truncated` / `truncation_reason` means the stream failed and the result is short by accident; `rows_capped` / `row_cap` means policy stopped it on purpose and the rows delivered are valid up to the cap. A response can carry both, when a stream reaches the cap and then fails on the way out. This branch is rebased on #725 and the release-notes entries are ordered together.

Likewise `Arc-Rows-Capped` sits next to `Arc-Stream-Truncated` and means close to the opposite. Both contrasts are spelled out in the notes and in the code.

## Docs

- New `## Bug fixes` entry in the 09.2 notes.
- `RELEASE_NOTES_2026.06.1.md`'s published msgpack spec updated for the two keys, and for a `governance.max_rows` row-ceiling key it cited that never existed.
- `RELEASE_NOTES_2026.02.2.md` gets a dated correction appended rather than a rewrite, so the claim operators were given stays visible as published.
- `arc.toml` gains a `[governance]` block. It shipped with none of its keys, which is half of why the cap was invisible. Every value matches the code default, so it is documentation only.

## Testing

`go build`, `go vet`, and `go test -race` all clean, and CI's panic-safety guard passes locally. New coverage: `rowCapReached` semantics, the three envelopes marked and unmarked, all four msgpack `mapLen` combinations with a trailing-bytes assertion, the capped-then-failed case, and the operator counter.

Two things worth a reviewer's attention:

1. `internal/api/arcx_hook.go` is not compile-checked by CI (it needs the `arcx_engine` tag) and cannot be built here either, since `arcx.h` is absent. Its four changes are mechanical and were reviewed by hand.
2. The one end-to-end test of `POST /api/v1/query/arrow` is skipped under `-race`, see below.

## Filed while doing this

- **#729, please read.** A pre-existing data race: all three Arrow IPC trailers are set from the stream-writer goroutine while fasthttp serialises the response head on the connection goroutine, and both mutate the same `ResponseHeader` buffer. It fires on `Arc-Execution-Time-Ms` with this PR's trailer removed entirely, so it arrived with the trailers shipped in this release, not with the row cap. It went unseen because no test had ever driven that handler to success over a real HTTP response. It blocks the end-to-end trailer test here, which is skipped under `-race` following the existing `internal/auth` precedent and will start running in CI the moment #729 lands.
- #727, the arcx Arrow IPC serve path applies no row cap and registers no trailers.
- #728, query history records a capped query as an ordinary success.