### PR TITLE
fix(query): record a governance row cap in the query registry

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -222,6 +222,31 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### Query history records when a governance row cap truncated a result ([#728](https://github.com/Basekick-Labs/arc/issues/728))
+
+An Enterprise governance row cap was visible to the client and in the operator
+log, but `GET /api/v1/queries/history` still showed a capped query as an
+ordinary success carrying the truncated count. Someone reviewing history to
+work out why a report came back short found no answer on the surface built for
+that question.
+
+History entries now carry `row_cap` when the query reached a cap, alongside the
+existing `row_count`. The status stays `completed`, because the query did
+finish and every other status value means it did not; the cap is a property of
+the result, not a different outcome. The field is recorded before the query is
+dispositioned, so a result that reached the cap and then failed on the way out
+keeps the cap and appears in history as both capped and failed.
+
+As on the wire, the field means the result reached the cap and may therefore be
+incomplete. It does not prove rows were dropped: a query whose own `LIMIT`
+equals the cap reaches it on every run with nothing lost. The entry's SQL sits
+alongside, which is what tells the two apart.
+
+Note that `/api/v1/query/arrow` and `/api/v1/query/:measurement` do not create
+history entries at all, so a capped result on those endpoints is still absent
+from history rather than misreported
+([#731](https://github.com/Basekick-Labs/arc/issues/731)).
+
 ### A governance row cap no longer looks like a complete result ([#724](https://github.com/Basekick-Labs/arc/issues/724))
 
 When an Enterprise governance policy capped a query with `max_rows_per_query`,
@@ -292,13 +317,11 @@ readable response into an undecodable one. Reaching the cap is what the client
 needs in order to stop trusting the row count, and it is always known for
 certain.
 
-Two related gaps are unchanged. The experimental arcx Arrow IPC serve path
+One related gap is unchanged. The experimental arcx Arrow IPC serve path
 applies no row cap at all, and returns before any trailer is registered, so an
 arcx-served Arrow IPC response carries none of the three trailers
 ([#727](https://github.com/Basekick-Labs/arc/issues/727)); clients should read a
-missing trailer as "unknown", never as "not capped". And
-`/api/v1/queries/history` still records a capped query as an ordinary success
-([#728](https://github.com/Basekick-Labs/arc/issues/728)).
+missing trailer as "unknown", never as "not capped".
 
 Adding end-to-end coverage for the Arrow IPC trailer also turned up a data race
 that predates it ([#729](https://github.com/Basekick-Labs/arc/issues/729)): all

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -1878,6 +1878,13 @@ localProcessing:
 			// both paths or it would go missing in the one case where the
 			// result is both capped and truncated (#724).
 			h.logGovernanceRowCap("json", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rowCount))
+			// Same reasoning for the history entry (#728): recorded here,
+			// before the disposition below, so a result that reached the cap
+			// and then failed keeps the cap instead of losing it on the
+			// Fail/TimedOut path.
+			if h.queryRegistry != nil && queryID != "" {
+				h.queryRegistry.RecordRowCap(queryID, reachedRowCap(governanceMaxRows, int64(rowCount)))
+			}
 
 			// Record metrics after streaming completes. If the stream
 			// terminated mid-flight (Scan / Err / ctx cancel), record as
@@ -1948,7 +1955,10 @@ localProcessing:
 		var arcxOnComplete func(int)
 		var arcxOnFail func(string)
 		if h.queryRegistry != nil && queryID != "" {
-			arcxOnComplete = func(rc int) { h.queryRegistry.Complete(queryID, rc) }
+			arcxOnComplete = func(rc int) {
+				h.queryRegistry.RecordRowCap(queryID, reachedRowCap(governanceMaxRows, int64(rc)))
+				h.queryRegistry.Complete(queryID, rc)
+			}
 			arcxOnFail = func(msg string) { h.queryRegistry.Fail(queryID, msg) }
 		}
 		if h.tryArcxRouter(c, ctx, cancel, start, req.SQL, headerDB, convertedSQL,
@@ -1991,7 +2001,10 @@ localProcessing:
 			var onFail func(string)
 			var onTimeout func()
 			if h.queryRegistry != nil && queryID != "" {
-				onComplete = func(rc int) { h.queryRegistry.Complete(queryID, rc) }
+				onComplete = func(rc int) {
+					h.queryRegistry.RecordRowCap(queryID, reachedRowCap(governanceMaxRows, int64(rc)))
+					h.queryRegistry.Complete(queryID, rc)
+				}
 				onFail = func(msg string) { h.queryRegistry.Fail(queryID, msg) }
 				onTimeout = func() { h.queryRegistry.TimedOut(queryID) }
 			}
@@ -2143,6 +2156,13 @@ localProcessing:
 			// both paths or it would go missing in the one case where the
 			// result is both capped and truncated (#724).
 			h.logGovernanceRowCap("json", convertedSQL, tokenID, tokenName, governanceMaxRows, int64(rowCount))
+			// Same reasoning for the history entry (#728): recorded here,
+			// before the disposition below, so a result that reached the cap
+			// and then failed keeps the cap instead of losing it on the
+			// Fail/TimedOut path.
+			if h.queryRegistry != nil && queryID != "" {
+				h.queryRegistry.RecordRowCap(queryID, reachedRowCap(governanceMaxRows, int64(rowCount)))
+			}
 
 			// If the stream terminated mid-flight (Scan / Err / ctx
 			// cancel) record as failure even though the JSON envelope
@@ -4450,6 +4470,17 @@ func (h *QueryHandler) checkQueryGovernance(c *fiber.Ctx) (maxRows int, timeout 
 		return 0, 0, &governanceRejection{reason: result.Reason}
 	}
 	return result.MaxRows, result.MaxDuration, nil
+}
+
+// reachedRowCap returns the governance cap when a result reached it, and 0
+// otherwise, so callers can hand it straight to Registry.RecordRowCap without
+// branching. It wraps rowCapReached rather than re-deriving the condition, so
+// the wire markers, the operator log and the history entry cannot drift apart.
+func reachedRowCap(rowCap int, rowCount int64) int {
+	if rowCapReached(rowCap, rowCount) {
+		return rowCap
+	}
+	return 0
 }
 
 // rowCapReached reports whether a result reached the governance row cap, which

--- a/internal/api/query_registry_rowcap_test.go
+++ b/internal/api/query_registry_rowcap_test.go
@@ -1,0 +1,126 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/governance"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/queryregistry"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+// Tests for #728. #724 made a governance row cap visible on the wire and in
+// operator logs but left the query registry alone, so GET /api/v1/queries/history
+// showed a capped query as an ordinary success carrying the truncated count.
+//
+// These drive the real handler rather than the registry directly: the failure
+// mode is a wrong or missing cap at the call site, which a registry unit test
+// cannot see (the argument is positional, so omitting it would not compile).
+
+func newRowCapRegistryHandler(t *testing.T, policy *governance.Policy) (*QueryHandler, *queryregistry.Registry) {
+	t.Helper()
+	m := newGovernanceTestManager(t, policy)
+	h := newGovernanceTestHandler(m, 0)
+	reg := queryregistry.NewRegistry(&queryregistry.RegistryConfig{HistorySize: 50}, zerolog.Nop())
+	h.queryRegistry = reg
+	return h, reg
+}
+
+// runQueryReturningRows drives POST /api/v1/query with the Arrow JSON dispatch
+// stubbed to report rowsReturned rows, which is how a real capped stream
+// reports itself to the registry.
+func runQueryReturningRows(t *testing.T, h *QueryHandler, rowsReturned int) {
+	t.Helper()
+	metrics.Init(zerolog.Nop())
+
+	origLicensed := queryGovernanceLicensed
+	queryGovernanceLicensed = func(*QueryHandler) bool { return true }
+	t.Cleanup(func() { queryGovernanceLicensed = origLicensed })
+
+	origArrow := arrowJSONQueryFunc
+	arrowJSONQueryFunc = func(h *QueryHandler, c *fiber.Ctx, ctx context.Context, cancel context.CancelFunc,
+		convertedSQL string, profileMode bool, governanceMaxRows int, start time.Time, timestamp string,
+		onComplete func(int), onFail func(string), onTimeout func()) (int, bool) {
+		if cancel != nil {
+			cancel()
+		}
+		if onComplete != nil {
+			onComplete(rowsReturned)
+		}
+		return rowsReturned, true
+	}
+	t.Cleanup(func() { arrowJSONQueryFunc = origArrow })
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("token_info", &auth.TokenInfo{ID: 42, Name: "capped-token"})
+		return c.Next()
+	})
+	app.Post("/api/v1/query", h.executeQuery)
+
+	req := httptest.NewRequest("POST", "/api/v1/query", strings.NewReader(`{"sql":"SELECT 1 AS id"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, 10000)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	resp.Body.Close()
+}
+
+func TestQueryHistoryRecordsGovernanceRowCap(t *testing.T) {
+	t.Run("a capped query carries the cap in history", func(t *testing.T) {
+		h, reg := newRowCapRegistryHandler(t, &governance.Policy{TokenID: 42, MaxRowsPerQuery: 7})
+		runQueryReturningRows(t, h, 7) // reached the cap exactly
+
+		hist := reg.GetHistory(10)
+		if len(hist) != 1 {
+			t.Fatalf("history has %d entries, want 1", len(hist))
+		}
+		e := hist[0]
+		if e.RowCap != 7 {
+			t.Errorf("RowCap = %d, want 7; history still shows a capped query as an ordinary success", e.RowCap)
+		}
+		if e.RowCount != 7 {
+			t.Errorf("RowCount = %d, want 7", e.RowCount)
+		}
+		// The cap is a property of the result, not a different outcome: the
+		// query did finish, and every other status value means it did not.
+		if e.Status != queryregistry.StatusCompleted {
+			t.Errorf("Status = %q, want completed", e.Status)
+		}
+	})
+
+	t.Run("an uncapped query records no cap", func(t *testing.T) {
+		h, reg := newRowCapRegistryHandler(t, &governance.Policy{TokenID: 42, MaxRowsPerQuery: 7})
+		runQueryReturningRows(t, h, 3) // well under the cap
+
+		hist := reg.GetHistory(10)
+		if len(hist) != 1 {
+			t.Fatalf("history has %d entries, want 1", len(hist))
+		}
+		if hist[0].RowCap != 0 {
+			t.Errorf("RowCap = %d, want 0 for a result that never reached the cap", hist[0].RowCap)
+		}
+	})
+
+	t.Run("no policy means no cap recorded", func(t *testing.T) {
+		h, reg := newRowCapRegistryHandler(t, nil)
+		runQueryReturningRows(t, h, 5)
+
+		hist := reg.GetHistory(10)
+		if len(hist) != 1 {
+			t.Fatalf("history has %d entries, want 1", len(hist))
+		}
+		if hist[0].RowCap != 0 {
+			t.Errorf("RowCap = %d, want 0 when no governance policy applies", hist[0].RowCap)
+		}
+	})
+}

--- a/internal/queryregistry/registry.go
+++ b/internal/queryregistry/registry.go
@@ -22,19 +22,25 @@ const (
 
 // TrackedQuery holds all metadata about a tracked query.
 type TrackedQuery struct {
-	ID             string      `json:"id"`
-	SQL            string      `json:"sql"`
-	TokenID        int64       `json:"token_id,omitempty"`
-	TokenName      string      `json:"token_name,omitempty"`
-	RemoteAddr     string      `json:"remote_addr,omitempty"`
-	Status         QueryStatus `json:"status"`
-	StartTime      time.Time   `json:"start_time"`
-	EndTime        *time.Time  `json:"end_time,omitempty"`
-	DurationMs     float64     `json:"duration_ms,omitempty"`
-	RowCount       int         `json:"row_count,omitempty"`
-	Error          string      `json:"error,omitempty"`
-	IsParallel     bool        `json:"is_parallel"`
-	PartitionCount int         `json:"partition_count,omitempty"`
+	ID         string      `json:"id"`
+	SQL        string      `json:"sql"`
+	TokenID    int64       `json:"token_id,omitempty"`
+	TokenName  string      `json:"token_name,omitempty"`
+	RemoteAddr string      `json:"remote_addr,omitempty"`
+	Status     QueryStatus `json:"status"`
+	StartTime  time.Time   `json:"start_time"`
+	EndTime    *time.Time  `json:"end_time,omitempty"`
+	DurationMs float64     `json:"duration_ms,omitempty"`
+	RowCount   int         `json:"row_count,omitempty"`
+	// RowCap is the Enterprise governance row cap this query reached, or 0.
+	// Its presence means the result reached the cap and may therefore be
+	// incomplete; it does not prove rows were dropped, since a query whose
+	// own LIMIT equals the cap reaches it with nothing lost. The entry's SQL
+	// is alongside, which is what distinguishes the two when reading history.
+	RowCap         int    `json:"row_cap,omitempty"`
+	Error          string `json:"error,omitempty"`
+	IsParallel     bool   `json:"is_parallel"`
+	PartitionCount int    `json:"partition_count,omitempty"`
 }
 
 // activeEntry stores the tracked query plus its cancel func.
@@ -102,6 +108,29 @@ func (r *Registry) Register(parentCtx context.Context, sql string, tokenID int64
 		Msg("Query registered")
 
 	return queryID, ctx
+}
+
+// RecordRowCap notes that a query reached an Enterprise governance row cap.
+//
+// It is separate from the terminal dispositions on purpose. A stream can reach
+// the cap and then fail on the way out, which ends at Fail or TimedOut rather
+// than Complete, and that is precisely the case worth seeing in history: the
+// result is both capped and truncated. Recording the cap independently means
+// it survives whichever disposition follows, instead of being carried by
+// Complete alone and lost on every failure path.
+//
+// Call it before the disposition: afterwards the entry has moved to history and
+// this is a no-op. A rowCap of 0 (no cap, or a cap not reached) is ignored, so
+// callers can pass the result of a predicate without branching.
+func (r *Registry) RecordRowCap(queryID string, rowCap int) {
+	if rowCap <= 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if entry, ok := r.active[queryID]; ok {
+		entry.query.RowCap = rowCap
+	}
 }
 
 // Complete marks a query as completed and moves it to history.


### PR DESCRIPTION
Fixes #728. Extends #724's row-cap signal to the operator-facing surface.

## What changed

`TrackedQuery` gains `RowCap`, so a capped query in `GET /api/v1/queries/history` carries the cap alongside the truncated `row_count`.

## The design decision worth reviewing

The issue suggested carrying the cap on `Complete`. **That would have reproduced, inside the registry, the exact hole #724 went out of its way to close in the log.** A stream can reach the cap and then fail on the way out, which ends at `Fail` or `TimedOut`, never `Complete` — and #724 deliberately calls `logGovernanceRowCap` *before* the error branch in all four writers, with a comment saying why, plus a dedicated test. Carrying the cap on `Complete` alone would lose it in precisely the case where the result is both capped and truncated.

So the cap is recorded through a separate `Registry.RecordRowCap`, called before the disposition. It survives whichever terminal state follows, and it keeps the change away from the sixteen `Fail`/`TimedOut` call sites that run before any row is streamed and therefore can never be capped.

## Other decisions

- **`reachedRowCap` wraps #724's `rowCapReached`** rather than re-deriving the condition, so the wire marker, the operator log and the history entry cannot drift apart.
- **The false positive is inherited and documented.** `rowCapReached` answers "reached the cap", not "rows were dropped", so a query whose own `LIMIT` equals the cap is marked every run. That is weaker in history, read later by someone who does not know the query, than on the wire. The field is documented as "reached the cap and may be incomplete", and the entry's SQL sits alongside to distinguish the two.
- **Status stays `completed`.** The query did finish; every other status value means it did not. Concretely, `cancelQuery` interpolates the status into user-facing text, where "Query already capped" would read as nonsense.
- **The 26.09.2 notes listed this gap as unchanged.** That paragraph is amended in the same commit, rather than shipping notes that claim the gap both remains and is fixed.

## Test plan

- [x] Three handler-level tests driving the real `executeQuery` with a registry and a governance policy: a capped query carries the cap and stays `completed`, an uncapped query records none, and no policy records none. Registry-level tests could not catch this class, since a positional argument omitted at a call site is a compile error, not a test failure.
- [x] Mutation-verified both real failure modes: passing the cap unconditionally instead of through the predicate, and dropping the recorder from the closure. Each fails a test.
- [x] `internal/api` and `internal/queryregistry` green under `-race`; build, vet, gofmt clean.
- [x] Live Enterprise-licensed server with `max_rows_per_query: 10` against 50 rows: history shows `row_count=10 row_cap=10` for the capped query, and no `row_cap` key at all for uncapped ones.

## Known limitation, filed as #731

`POST /api/v1/query/arrow` and `GET /api/v1/query/:measurement` never call `Register`, so they produce no history entries at all. A capped result there is absent rather than misreported, which this change cannot address. The release-notes entry says so rather than implying full coverage.