### PR TITLE
fix(query): register the measurement endpoint with the query registry

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -222,6 +222,32 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### The measurement endpoint now appears in query management ([#731](https://github.com/Basekick-Labs/arc/issues/731))
+
+`GET /api/v1/query/:measurement` never registered with the query registry, so
+it was missing from `GET /api/v1/queries/active` and `/history` and could not be
+stopped through `DELETE /api/v1/queries/:id`. An operator watching queries could
+not see it, and an expensive one could not be stopped.
+
+It now registers like `POST /api/v1/query`: the response carries
+`X-Arc-Query-ID`, the query shows up while running and lands in history with the
+right disposition, including `timed_out` rather than a generic failure, and a
+capped result carries `row_cap` as it does elsewhere.
+
+**These queries are now cancellable**, which they were not before. Cancelling
+stops the stream at the next chunk boundary; a single long-running sort or
+aggregate is not interrupted mid-chunk, so a cancel can take until that chunk
+materialises. A cancelled stream is marked truncated by the same signalling as
+any other interrupted response, so a client never reads a cancelled result as
+complete.
+
+`HEAD` on this route is deliberately not registered. Fiber routes `HEAD` to the
+same handler while the response body is discarded, so registering would leave a
+history entry whose only outcome is a spurious connection failure.
+
+`POST /api/v1/query/arrow` is unchanged and still creates no history entry;
+#731 stays open for it.
+
 ### Arrow IPC responses no longer write trailers from the wrong goroutine ([#729](https://github.com/Basekick-Labs/arc/issues/729))
 
 `POST /api/v1/query/arrow` set its HTTP trailers from inside the body-stream
@@ -273,10 +299,10 @@ incomplete. It does not prove rows were dropped: a query whose own `LIMIT`
 equals the cap reaches it on every run with nothing lost. The entry's SQL sits
 alongside, which is what tells the two apart.
 
-Note that `/api/v1/query/arrow` and `/api/v1/query/:measurement` do not create
-history entries at all, so a capped result on those endpoints is still absent
-from history rather than misreported
+Note that `/api/v1/query/arrow` does not create history entries at all, so a
+capped result there is still absent from history rather than misreported
 ([#731](https://github.com/Basekick-Labs/arc/issues/731)).
+`/api/v1/query/:measurement` is covered, see below.
 
 ### A governance row cap no longer looks like a complete result ([#724](https://github.com/Basekick-Labs/arc/issues/724))
 

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -4667,7 +4667,50 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	if governanceTimeout > 0 {
 		effectiveTimeout = governanceTimeout
 	}
-	ctx := c.UserContext()
+
+	// Register with the query registry so this endpoint appears in
+	// /api/v1/queries and can be cancelled (#731). The registered statement is
+	// the one built above, not the transformed SQL below: the transform
+	// resolves storage globs, and /active truncates SQL for display, so the
+	// converted form would show as unreadable noise.
+	//
+	// HEAD is excluded. Fiber routes HEAD to the same GET handler, and
+	// fasthttp discards the body while still running the stream writer, so a
+	// HEAD would otherwise leave a history entry whose only outcome is a
+	// spurious "connection closed" failure.
+	baseCtx := c.UserContext()
+	var queryID string
+	if h.queryRegistry != nil && c.Method() != fiber.MethodHead {
+		var queryCtx context.Context
+		queryID, queryCtx = h.queryRegistry.Register(
+			baseCtx, sql, getTokenID(c), getTokenName(c), c.IP(), false, 0,
+		)
+		baseCtx = queryCtx
+		c.Set("X-Arc-Query-ID", queryID)
+	}
+
+	// A panic in the handler itself unwinds past every disposition below.
+	// Fiber's recover middleware keeps the process alive, so without this the
+	// entry would sit in "running" forever with nothing to reap it. Dispose
+	// and re-panic so the middleware still sees it.
+	//
+	// streamStarted guards the one case where disposing would be wrong: once
+	// an asynchronous writer owns the response, it owns the disposition too,
+	// and marking the entry here would overwrite the outcome of a query that
+	// is still streaming.
+	streamStarted := false
+	if queryID != "" {
+		defer func() {
+			if r := recover(); r != nil {
+				if !streamStarted {
+					h.queryRegistry.Fail(queryID, "handler panicked")
+				}
+				panic(r)
+			}
+		}()
+	}
+
+	ctx := baseCtx
 	var cancel context.CancelFunc
 	if effectiveTimeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, effectiveTimeout)
@@ -4676,10 +4719,28 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 		// asynchronously after this function returns.
 	}
 
+	// Dispositions for the Arrow JSON path, which owns the response once it
+	// reports handled=true and streams asynchronously. Passing these rather
+	// than nil is what keeps an entry from sitting in "running" forever; the
+	// writer fires exactly one of them on every outcome it distinguishes,
+	// including its panic path.
+	var onComplete func(int)
+	var onFail func(string)
+	var onTimeout func()
+	if queryID != "" {
+		onComplete = func(rc int) {
+			h.queryRegistry.RecordRowCap(queryID, reachedRowCap(governanceMaxRows, int64(rc)))
+			h.queryRegistry.Complete(queryID, rc)
+		}
+		onFail = func(msg string) { h.queryRegistry.Fail(queryID, msg) }
+		onTimeout = func() { h.queryRegistry.TimedOut(queryID) }
+	}
+
 	// Arrow-native path: bypasses database/sql row scanning entirely.
 	if arrowJSONQueryFunc != nil {
-		_, handled := arrowJSONQueryFunc(h, c, ctx, cancel, convertedSQL, false, governanceMaxRows, start, timestamp, nil, nil, nil)
+		_, handled := arrowJSONQueryFunc(h, c, ctx, cancel, convertedSQL, false, governanceMaxRows, start, timestamp, onComplete, onFail, onTimeout)
 		if handled {
+			streamStarted = true
 			// Metrics are recorded inside the async stream callback — not here.
 			// cancel is owned by executeArrowJSONQuery when handled=true.
 			return nil
@@ -4695,6 +4756,9 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 		m.IncQueryErrors()
 		if effectiveTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
 			m.IncQueryTimeouts()
+			if onTimeout != nil {
+				onTimeout()
+			}
 			h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(sql)).Dur("timeout", effectiveTimeout).Msg("Measurement query timed out")
 			return c.Status(fiber.StatusGatewayTimeout).JSON(QueryResponse{
 				Success:         false,
@@ -4702,6 +4766,9 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 				ExecutionTimeMs: float64(time.Since(start).Milliseconds()),
 				Timestamp:       timestamp,
 			})
+		}
+		if onFail != nil {
+			onFail(sqlutil.SanitizeErrText(err.Error()))
 		}
 		h.logger.Error().Err(err).Str("sql", sqlutil.ForLog(sql)).Msg("Measurement query failed")
 		return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
@@ -4720,6 +4787,9 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 			cancel()
 		}
 		m.IncQueryErrors()
+		if onFail != nil {
+			onFail(sqlutil.SanitizeErrText(err.Error()))
+		}
 		h.logger.Error().Err(err).Msg("Failed to get column names in measurement query")
 		return c.Status(fiber.StatusInternalServerError).JSON(QueryResponse{
 			Success:         false,
@@ -4746,9 +4816,15 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 	// fires inside the streaming callback (#308).
 	streamCtx := ctx
 	c.Set("Content-Type", "application/json")
-	c.Context().SetBodyStreamWriter(h.safeStream("query_measurement", nil, func(w *bufio.Writer) {
-		// The measurement endpoint never registers with the query registry,
-		// so there is nothing to dispose of on the panic path.
+	streamStarted = true
+	c.Context().SetBodyStreamWriter(h.safeStream("query_measurement", func() {
+		// A recovered panic skips the dispositions below, which would leave
+		// the entry listed as running forever with nothing to reap it (#731,
+		// the shape #717 found elsewhere).
+		if onFail != nil {
+			onFail("stream writer panicked")
+		}
+	}, func(w *bufio.Writer) {
 		defer func() {
 			rows.Close()
 			if cancel != nil {
@@ -4780,6 +4856,15 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 				Str("measurement", measurement).
 				Int("rows_sent", rowCount).
 				Msg("queryMeasurement stream truncated after headers committed")
+			// Split timeout from failure so this endpoint reports the same
+			// disposition POST /api/v1/query does for the same event.
+			if errors.Is(streamErr, context.DeadlineExceeded) {
+				if onTimeout != nil {
+					onTimeout()
+				}
+			} else if onFail != nil {
+				onFail(sqlutil.SanitizeErrText(streamErr.Error()))
+			}
 			return
 		}
 
@@ -4794,6 +4879,9 @@ func (h *QueryHandler) queryMeasurement(c *fiber.Ctx) error {
 			Float64("execution_time_ms", float64(time.Since(start).Milliseconds())).
 			Msg("Measurement query completed")
 		h.logSlowQuery(convertedSQL, start, rowCount, tokenName)
+		if onComplete != nil {
+			onComplete(rowCount)
+		}
 	}))
 	return nil
 }

--- a/internal/api/query_measurement_registry_test.go
+++ b/internal/api/query_measurement_registry_test.go
@@ -1,0 +1,211 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/auth"
+	"github.com/basekick-labs/arc/internal/database"
+	"github.com/basekick-labs/arc/internal/governance"
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/queryregistry"
+	"github.com/gofiber/fiber/v2"
+	recovermw "github.com/gofiber/fiber/v2/middleware/recover"
+	"github.com/rs/zerolog"
+)
+
+// Tests for #731. GET /api/v1/query/:measurement never registered with the
+// query registry, so it was invisible to /api/v1/queries and could not be
+// cancelled. Registering creates the obligation these tests guard: every exit
+// must dispose, or the entry sits in "running" forever holding its SQL and
+// inflating the active gauge, which is the shape #717 found elsewhere.
+
+// measurementRegistryApp wires the real handler with a registry and stubs the
+// Arrow JSON dispatch, which is the path that serves this endpoint in a
+// duckdb_arrow build.
+func measurementRegistryApp(t *testing.T, policy *governance.Policy,
+	arrow func(*QueryHandler, *fiber.Ctx, context.Context, context.CancelFunc, string, bool, int,
+		time.Time, string, func(int), func(string), func()) (int, bool),
+) (*fiber.App, *queryregistry.Registry) {
+	t.Helper()
+	metrics.Init(zerolog.Nop())
+
+	m := newGovernanceTestManager(t, policy)
+	h := newGovernanceTestHandler(m, 0)
+	reg := queryregistry.NewRegistry(&queryregistry.RegistryConfig{HistorySize: 50}, zerolog.Nop())
+	h.queryRegistry = reg
+
+	origLicensed := queryGovernanceLicensed
+	queryGovernanceLicensed = func(*QueryHandler) bool { return true }
+	t.Cleanup(func() { queryGovernanceLicensed = origLicensed })
+
+	origArrow := arrowJSONQueryFunc
+	arrowJSONQueryFunc = arrow
+	t.Cleanup(func() { arrowJSONQueryFunc = origArrow })
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	// The real server installs recover middleware, so a handler panic is
+	// contained there rather than reaching the caller.
+	app.Use(recovermw.New())
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("token_info", &auth.TokenInfo{ID: 42, Name: "t"})
+		return c.Next()
+	})
+	app.Get("/api/v1/query/:measurement", h.queryMeasurement)
+	return app, reg
+}
+
+func doMeasurement(t *testing.T, app *fiber.App, method string) {
+	t.Helper()
+	resp, err := app.Test(httptest.NewRequest(method, "/api/v1/query/cpu?database=default", nil), 10000)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	resp.Body.Close()
+}
+
+func TestQueryMeasurementRegistersWithTheRegistry(t *testing.T) {
+	t.Run("a successful query completes in history", func(t *testing.T) {
+		app, reg := measurementRegistryApp(t, nil, func(h *QueryHandler, c *fiber.Ctx, ctx context.Context,
+			cancel context.CancelFunc, sql string, pm bool, maxRows int, start time.Time, ts string,
+			onComplete func(int), onFail func(string), onTimeout func()) (int, bool) {
+			if cancel != nil {
+				cancel()
+			}
+			onComplete(5)
+			return 5, true
+		})
+		doMeasurement(t, app, "GET")
+
+		if n := reg.ActiveCount(); n != 0 {
+			t.Errorf("%d entries still listed as running; the query finished", n)
+		}
+		hist := reg.GetHistory(10)
+		if len(hist) != 1 {
+			t.Fatalf("history has %d entries, want 1", len(hist))
+		}
+		if hist[0].Status != queryregistry.StatusCompleted || hist[0].RowCount != 5 {
+			t.Errorf("entry = %s/%d rows, want completed/5", hist[0].Status, hist[0].RowCount)
+		}
+		// The registered statement must be the readable one, not the
+		// transformed SQL full of resolved storage globs.
+		if hist[0].SQL == "" || len(hist[0].SQL) > 200 {
+			t.Errorf("unexpected registered SQL: %q", hist[0].SQL)
+		}
+	})
+
+	t.Run("a failed query does not sit in running forever", func(t *testing.T) {
+		app, reg := measurementRegistryApp(t, nil, func(h *QueryHandler, c *fiber.Ctx, ctx context.Context,
+			cancel context.CancelFunc, sql string, pm bool, maxRows int, start time.Time, ts string,
+			onComplete func(int), onFail func(string), onTimeout func()) (int, bool) {
+			if cancel != nil {
+				cancel()
+			}
+			onFail("boom")
+			return 0, true
+		})
+		doMeasurement(t, app, "GET")
+
+		if n := reg.ActiveCount(); n != 0 {
+			t.Fatalf("%d phantom entries left running after a failure", n)
+		}
+		hist := reg.GetHistory(10)
+		if len(hist) != 1 || hist[0].Status != queryregistry.StatusFailed {
+			t.Fatalf("history = %+v, want one failed entry", hist)
+		}
+	})
+
+	t.Run("a timeout is recorded as timed_out, matching POST /api/v1/query", func(t *testing.T) {
+		app, reg := measurementRegistryApp(t, nil, func(h *QueryHandler, c *fiber.Ctx, ctx context.Context,
+			cancel context.CancelFunc, sql string, pm bool, maxRows int, start time.Time, ts string,
+			onComplete func(int), onFail func(string), onTimeout func()) (int, bool) {
+			if cancel != nil {
+				cancel()
+			}
+			onTimeout()
+			return 0, true
+		})
+		doMeasurement(t, app, "GET")
+
+		hist := reg.GetHistory(10)
+		if len(hist) != 1 || hist[0].Status != queryregistry.StatusTimedOut {
+			t.Fatalf("history = %+v, want one timed_out entry", hist)
+		}
+	})
+
+	t.Run("a handler panic disposes the entry instead of stranding it", func(t *testing.T) {
+		app, reg := measurementRegistryApp(t, nil, func(h *QueryHandler, c *fiber.Ctx, ctx context.Context,
+			cancel context.CancelFunc, sql string, pm bool, maxRows int, start time.Time, ts string,
+			onComplete func(int), onFail func(string), onTimeout func()) (int, bool) {
+			if cancel != nil {
+				cancel()
+			}
+			// The dispatch panics before firing any disposition, the shape
+			// safeStream recovers from.
+			panic(errors.New("simulated writer panic"))
+		})
+		doMeasurement(t, app, "GET")
+
+		if n := reg.ActiveCount(); n != 0 {
+			t.Fatalf("%d entries left running after a panic; fiber's recover keeps the process alive but the entry would leak forever", n)
+		}
+		hist := reg.GetHistory(10)
+		if len(hist) != 1 || hist[0].Status != queryregistry.StatusFailed {
+			t.Fatalf("history = %+v, want one failed entry", hist)
+		}
+	})
+
+	t.Run("HEAD creates no entry", func(t *testing.T) {
+		// Fiber routes HEAD to the GET handler and fasthttp discards the
+		// body, so registering would leave an entry whose only outcome is a
+		// spurious connection failure.
+		app, reg := measurementRegistryApp(t, nil, func(h *QueryHandler, c *fiber.Ctx, ctx context.Context,
+			cancel context.CancelFunc, sql string, pm bool, maxRows int, start time.Time, ts string,
+			onComplete func(int), onFail func(string), onTimeout func()) (int, bool) {
+			if cancel != nil {
+				cancel()
+			}
+			if onComplete != nil {
+				onComplete(1)
+			}
+			return 1, true
+		})
+		doMeasurement(t, app, "HEAD")
+
+		if n := len(reg.GetHistory(10)); n != 0 {
+			t.Errorf("HEAD produced %d history entries, want 0", n)
+		}
+		if n := reg.ActiveCount(); n != 0 {
+			t.Errorf("HEAD left %d entries running", n)
+		}
+	})
+
+	t.Run("a capped result records the cap", func(t *testing.T) {
+		app, reg := measurementRegistryApp(t, &governance.Policy{TokenID: 42, MaxRowsPerQuery: 4},
+			func(h *QueryHandler, c *fiber.Ctx, ctx context.Context, cancel context.CancelFunc, sql string,
+				pm bool, maxRows int, start time.Time, ts string,
+				onComplete func(int), onFail func(string), onTimeout func()) (int, bool) {
+				if cancel != nil {
+					cancel()
+				}
+				onComplete(maxRows) // stream stopped at the cap
+				return maxRows, true
+			})
+		doMeasurement(t, app, "GET")
+
+		hist := reg.GetHistory(10)
+		if len(hist) != 1 {
+			t.Fatalf("history has %d entries, want 1", len(hist))
+		}
+		if hist[0].RowCap != 4 {
+			t.Errorf("RowCap = %d, want 4 (#728 parity for this endpoint)", hist[0].RowCap)
+		}
+	})
+}
+
+var _ = database.QueryCacheTTL


### PR DESCRIPTION
Refs #731. Half of it: the measurement endpoint. `POST /api/v1/query/arrow` stays with the issue, see the end.

## What changed

`GET /api/v1/query/:measurement` now registers like `POST /api/v1/query`: the response carries `X-Arc-Query-ID`, the query is visible in `/api/v1/queries/active` while running, lands in `/history` with the right disposition, and can be cancelled.

The disposition work is the substance. The Arrow JSON dispatch was being passed `nil, nil, nil` for its `onComplete`/`onFail`/`onTimeout` callbacks; it now gets real ones, which is what covers every asynchronous outcome including that writer's own panic path. The database/sql fallback disposes at its query error, column error and stream outcomes, and a timeout is recorded as `timed_out` rather than a generic failure, matching what `POST /api/v1/query` reports for the same event.

## Two things the plan got wrong, both caught before implementation

**My hand-off flag would have disposed live streams.** I proposed flipping a flag immediately before `SetBodyStreamWriter`. Both handlers hand off *earlier* than that — this one through `arrowJSONQueryFunc`, which installs the writer internally and returns `handled=true`. The flag would have been false at that return, so the defer would have marked a still-streaming query abandoned and removed it from `active`, making it uncancellable. The fix was already in the tree: `executeQuery` passes real callbacks for exactly this reason.

**My risk justification was wrong.** I claimed 16 exit paths after registration. There are 5, all enumerated and covered. The flag was solving a problem that did not exist while creating one that did.

A guard is still needed for one case I initially dropped and a test then caught: a synchronous handler panic unwinds past every disposition, and fiber's recover keeps the process alive, so the entry would sit in `running` forever. That guard is skipped once an async writer owns the response.

## Details worth reviewing

- **`HEAD` is excluded.** Fiber routes `HEAD` to the same handler while fasthttp discards the body but still runs the writer, so registering would leave an entry whose only outcome is a spurious connection failure. (Separately: `HEAD` on this route runs a full measurement query today. Pre-existing, not addressed here.)
- **The registered statement is the synthesized SQL**, not the transformed one. The transform resolves storage globs, `/active` truncates SQL for display, and #728's `row_cap` relies on the entry's SQL being readable enough to distinguish a real cap from a `LIMIT` equal to the cap.
- **Cancellation is a behaviour change**, called out in the release notes: it stops the stream at the next chunk boundary, so a single long sort or aggregate is not interrupted mid-chunk. A cancelled stream is marked truncated by the #721/#723 signalling, so it never reads as complete.

## Test plan

- [x] Six handler-level tests: success completes with the right count and readable SQL, a failure does not sit in `running`, a timeout records `timed_out`, a handler panic disposes rather than stranding, `HEAD` creates no entry, and a capped result records `row_cap`.
- [x] Mutation-verified three ways: removing the panic guard, restoring the `nil, nil, nil` callbacks (the original bug), and registering on `HEAD` each fail a test.
- [x] `internal/api` and `internal/queryregistry` green under `-race`; build, vet, gofmt clean.
- [x] Live Enterprise-licensed server: the query appears in history with the readable SQL and `X-Arc-Query-Id` on the response, `HEAD` creates no entry, a capped result shows `row_cap=10`, and a slow query was cancelled through `DELETE /api/v1/queries/:id` and recorded as `cancelled`.

## Why Arrow IPC is not here

It needs a signature change on `tryArcxRouterArrow` and its build-tagged stub, a decision on the missing `isNoFilesFoundError` branch (without which the same query reports `failed` on Arrow IPC and `completed` on `/api/v1/query`), and it collides with #733, which is smaller and should land first. Splitting keeps this reviewable and unblocked. #731 stays open, and the #728 release-note caveat is amended rather than removed.