### PR TITLE
security(query): harden the read-SQL validator (GHSA-w6w2-x8xv-q8x2)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -63,6 +63,17 @@ This rides on the existing telemetry channel and the existing switch: `telemetry
 
 ## Security fixes
 
+### Read-SQL validator hardening ([GHSA-w6w2-x8xv-q8x2](https://github.com/Basekick-Labs/arc/security/advisories/GHSA-w6w2-x8xv-q8x2))
+
+Closes a read-path validator bypass on RBAC-enabled multi-tenant deployments, in
+the same family as the earlier quoted-name and replacement-scan hardening. The
+sandbox storage-root allowlist bounded impact throughout, and single-tenant and
+OSS deployments were not exposed to a new risk.
+
+Full technical detail will accompany the corresponding security advisory once it
+is published. Responsibly reported by **[@rexpository](https://github.com/rexpository)**.
+
+
 ### Dependency bump: Apache Thrift 0.23.0 → 0.24.0 ([GHSA-8wv5-x4w7-5gww](https://github.com/advisories/GHSA-8wv5-x4w7-5gww))
 
 `github.com/apache/thrift` is bumped to 0.24.0, which patches a high-severity

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -2319,6 +2319,13 @@ func ValidateSQLRequest(sql string) error {
 		return &SQLValidationError{Message: "File I/O function not allowed in user SQL: " + m[1] + "()"}
 	}
 
+	// Dynamic-SQL table functions execute a nested SQL string that neither the
+	// I/O denylist above nor RBAC table extraction can see (GHSA-w6w2-x8xv-q8x2),
+	// checked on the same normalised form.
+	if m := dynamicSQLFunctionPattern.FindStringSubmatch(ioCheckNormalised); m != nil {
+		return &SQLValidationError{Message: "Dynamic SQL function not allowed in user SQL: " + m[1] + "()"}
+	}
+
 	// SECURITY: reject a bare single-quoted string in table position — a
 	// DuckDB replacement scan (GHSA-w8x2-cccw-25f7, incomplete-fix residual of
 	// GHSA-93cm-2v4m-c56c).
@@ -2621,6 +2628,33 @@ var ioTableFunctionPattern = regexp.MustCompile(`(?i)\b(` + strings.Join([]strin
 	"iceberg_snapshots",
 	"arc_partition_agg",
 }, "|") + `)\s*\(`)
+
+// dynamicSQLFunctionPattern matches DuckDB table functions that evaluate a
+// string as SQL (or resolve a string to a relation). They are the I/O
+// denylist's blind spot: the dangerous inner SQL rides as a string argument,
+// so literal masking hides it and neither ioTableFunctionPattern nor RBAC's
+// extractTableReferences (which skips `name(` as a table-valued function) ever
+// sees the read_parquet, replacement scan, or cross-tenant reference inside it.
+// A read token scoped to one database could call
+// `query('SELECT * FROM read_parquet(”/other-tenant/…”)')` and read across
+// the tenant boundary inside the storage root — confirmed live returning
+// another database's rows on /api/v1/query and /api/v1/query/estimate
+// (GHSA-w6w2-x8xv-q8x2). Same class as the quoted-name (GHSA-93cm-2v4m-c56c)
+// and replacement-scan (GHSA-w8x2-cccw-25f7) evasions of the I/O denylist.
+//
+// Arc's read API has no user-facing need for dynamic SQL, so these are rejected
+// outright rather than recursively validated (a far larger, riskier surface).
+// Matched against the quote-stripped, literal-masked, comment-stripped form
+// (ioDenylistNormalise) so `"query"(…)`, comment/spacing/case variants, and
+// schema-qualified `main.query(…)` cannot evade it.
+//
+// Maintenance: this set was enumerated from duckdb_functions() against the
+// pinned DuckDB release (see duckdb-go/v2 in go.mod) plus the extensions Arc
+// autoloads (json). json_execute_serialized_sql is the json-extension member
+// and is the reason this is not just {query, query_table}. When DuckDB or a
+// loaded extension adds another string-executing table function, add it here;
+// TestDynamicSQLFunctionPattern_Family pins the set.
+var dynamicSQLFunctionPattern = regexp.MustCompile(`(?i)\b(query|query_table|json_execute_serialized_sql)\s*\(`)
 
 // getTransformedSQL returns the transformed SQL with caching.
 // If headerDB is non-empty, uses the optimized path with that database for all tables.

--- a/internal/api/query_dynamic_sql_test.go
+++ b/internal/api/query_dynamic_sql_test.go
@@ -1,0 +1,69 @@
+//go:build duckdb_arrow
+
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for GHSA-w6w2-x8xv-q8x2: DuckDB dynamic-SQL table functions let an
+// authenticated read token smuggle a nested read_parquet or replacement scan
+// past the I/O denylist and RBAC, reading across the tenant boundary. The
+// validator must reject them before any DB call.
+
+func TestDynamicSQLFunctionPattern_Family(t *testing.T) {
+	// The complete set of string-executing table functions in the pinned
+	// DuckDB build plus autoloaded extensions, enumerated from
+	// duckdb_functions(). json_execute_serialized_sql is the json-extension
+	// member and the reason this is not just {query, query_table}; a plan that
+	// stopped at the first two would have shipped a working cross-tenant read.
+	mustBlock := []string{"query", "query_table", "json_execute_serialized_sql"}
+
+	for _, fn := range mustBlock {
+		for _, sql := range []string{
+			"SELECT * FROM " + fn + "('SELECT 1')",
+			"SELECT * FROM cpu, " + fn + "('SELECT 1')",
+			"SELECT * FROM " + strings.ToUpper(fn) + "  ('SELECT 1')", // case + spacing
+			"SELECT * FROM \"" + fn + "\"('SELECT 1')",                // quoted name
+			"SELECT * FROM main." + fn + "('SELECT 1')",               // schema-qualified
+			"SELECT * FROM " + fn + "/**/('SELECT 1')",                // comment before paren
+		} {
+			if err := ValidateSQLRequest(sql); err == nil {
+				t.Errorf("ValidateSQLRequest(%q): expected rejection for dynamic-SQL function %q, got nil", sql, fn)
+			}
+		}
+	}
+}
+
+func TestDynamicSQLFunction_ExploitVariantsBlocked(t *testing.T) {
+	// These are the shapes that actually exfiltrated cross-tenant rows live.
+	exploits := []string{
+		`SELECT * FROM query('SELECT * FROM read_parquet(''/data/tenant_b/x.parquet'')')`,
+		`SELECT count(*) FROM query('SELECT * FROM read_parquet(''/data/*/secrets/**/*.parquet'')')`,
+		`SELECT * FROM query_table(['/data/tenant_b/x.parquet'])`,
+		`SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM read_parquet(''/data/tenant_b/x.parquet'')'))`,
+		`SELECT * FROM query('SELECT * FROM query(''SELECT 1'')')`, // nested
+	}
+	for _, sql := range exploits {
+		if err := ValidateSQLRequest(sql); err == nil {
+			t.Errorf("ValidateSQLRequest(%q): exploit not blocked", sql)
+		}
+	}
+}
+
+func TestDynamicSQLFunction_NoFalsePositives(t *testing.T) {
+	// Identifiers named like the functions, with no call form, must pass.
+	ok := []string{
+		"SELECT query FROM cpu",
+		"SELECT * FROM cpu AS query",
+		"SELECT count(*) AS query FROM cpu",
+		"SELECT query_table FROM cpu",
+		"SELECT * FROM cpu WHERE query_table > 5",
+	}
+	for _, sql := range ok {
+		if err := ValidateSQLRequest(sql); err != nil {
+			t.Errorf("ValidateSQLRequest(%q): false positive, got %v", sql, err)
+		}
+	}
+}


### PR DESCRIPTION
Addresses [GHSA-w6w2-x8xv-q8x2](https://github.com/Basekick-Labs/arc/security/advisories/GHSA-w6w2-x8xv-q8x2) (private). Reported by @rexpository.

Full technical detail is held in the advisory and will accompany it when it publishes with the 26.09.2 release. Deliberately terse here so the public PR is not a pre-release roadmap.

## Summary

Hardens `ValidateSQLRequest` against a class of read-path validator bypass in the same family as GHSA-93cm-2v4m-c56c and GHSA-w8x2-cccw-25f7. Confirmed exploitable on an RBAC-enabled multi-tenant deployment; single-tenant and OSS deployments are not exposed to a new risk. The sandbox storage-root allowlist continued to bound impact throughout.

## Change

An additional denylist class in `ValidateSQLRequest`, checked on the same normalised form the existing I/O denylist uses, so quoted, commented, spaced, case, and schema-qualified spellings are all covered. All five user-SQL entry points funnel through this validator, so it is a single locus. Rejected outright rather than recursively validated; nothing in Arc's own generated SQL uses the rejected form, and benign identifiers are unaffected.

## Verification

- New validator test family covering the blocked forms, their evasion spellings, and no-false-positive identifiers; full `internal/api` suite green under `-race`; build, vet, gofmt clean.
- Verified end to end on a seeded multi-tenant server: every attack variant is now refused, ordinary queries and estimate still work. The live replay caught a regex-corruption bug that the unit tests alone passed through.

## Notes for the maintainer

- The adversarial plan review found one more affected function than the first draft covered; the set is now enumerated against the pinned DuckDB build with a maintenance note and a family test. Detail in the advisory.
- One low-risk defense-in-depth item deliberately left out of this targeted fix, filed as #739.
- Merge/publish timing is yours: hold until the 26.09.2 release.