### PR TITLE
Reject edge-sync spoke IDs containing a parent-directory sequence (#737)

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,3 +461,4 @@ Thanks to everyone who has contributed code to Arc:
 And a thank-you to community members whose bug reports drove fixes:
 
 - [@bjarneksat](https://github.com/bjarneksat) — reported the line-protocol null-field handling bug fixed in 26.03.1
+- [@rexpository](https://github.com/rexpository) — reported the edge-sync spoke-ID namespace collision fixed in 26.09.2 (#737), and ongoing security research across the cluster, auth and edge-sync boundaries

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -220,8 +220,13 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
    additionally cannot establish WAL replication with a writer and will fall
    behind until both ends are upgraded. Single-node, non-clustered and OSS
    deployments need no action.
-2. **No configuration change is required.** Existing `arc.toml` files and
-   license keys work as-is; no new keys were added.
+2. **No configuration change is required, with one edge-sync exception.**
+   Existing `arc.toml` files and license keys work as-is and no new keys were
+   added. The exception: a spoke whose `spoke_id` contains `..`, is longer than
+   128 bytes, or has leading or trailing whitespace is now refused, so such a
+   spoke fails to start until its ID is changed. See *Edge-sync spoke IDs can
+   no longer collide with another spoke's namespace* below. The hub names any
+   stored ID in that state at startup.
 3. **Query response envelopes gained two optional keys** (`rows_capped`,
    `row_cap`), emitted only when an Enterprise governance row cap truncated
    the result. Conforming JSON and msgpack decoders are unaffected: the keys
@@ -232,6 +237,41 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
    them at all.
 
 ## Bug fixes
+
+### Edge-sync spoke IDs can no longer collide with another spoke's namespace ([#737](https://github.com/Basekick-Labs/arc/issues/737))
+
+A spoke identifier containing an embedded `..`, such as `rocket..01`, passed
+validation. The local storage backend then folded every `..` to `_` while
+resolving the path, so that identifier and the legitimate `rocket_01` landed in
+one directory, and a spoke authenticated as one could write into the other's
+namespace. The HMAC proves which spoke is asking; the namespace mapping is what
+decides where it may write, and that mapping was not injective.
+
+`validateSpokeID` now rejects the sequence anywhere in the identifier, closing
+both the receive path and registration. This is the same rule
+[#574](https://github.com/Basekick-Labs/arc/pull/574) applied to the source
+path, which left the identity that prefixes it open. The validator also gained
+the bounds it was missing next to a field it shares a table with: a 128-byte
+cap, no control characters, and no leading or trailing whitespace. An over-long
+ID used to register successfully and then fail every write with
+`ENAMETOOLONG`, wedging the spoke with nothing said at registration.
+
+Reaching the collision required an administrator to create a spoke ID
+containing `..` in the first place: registration is admin-only, secrets are
+generated server-side, and there is no self-registration, so no advisory was
+issued. It affects the local filesystem backend only, since S3 and Azure
+preserve key spelling, and edge sync is opt-in.
+
+**If you already run a spoke whose ID is now refused**, the hub says so at
+startup, naming each stored ID and why, so you do not have to wait for an edge
+box to fail. Re-registering is not simply a rename: for an ID like
+`rocket..01`, the data it already synced is on disk under `rocket_01/`, which
+is the other spoke's namespace, and the hub's file index is keyed on the spoke
+ID, so a spoke re-pointed at a fresh ID finds no index rows and re-uploads its
+whole backlog into the new namespace. Plan the move deliberately, deciding what
+happens to the files already written under the folded name.
+
+Reported by **[@rexpository](https://github.com/rexpository)**.
 
 ### Arrow IPC cleanup no longer runs twice on the panic path ([#733](https://github.com/Basekick-Labs/arc/issues/733))
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2466,6 +2466,22 @@ func main() {
 		if countErr != nil {
 			log.Fatal().Err(countErr).Msg("Edge sync spoke registry is unusable; refusing to start")
 		}
+		// Spoke IDs registered before the validator tightened are still in the
+		// table and still enabled, and the only signal an operator would
+		// otherwise get is an edge box failing at the far end (#737).
+		idCtx, cancelIDs := context.WithTimeout(context.Background(), 10*time.Second)
+		badIDs, idErr := spokeRegistry.InvalidStoredIDs(idCtx)
+		cancelIDs()
+		if idErr != nil {
+			syncLogger.Warn().Err(idErr).Msg("Could not check registered spoke IDs against the current rules")
+		}
+		for id, reason := range badIDs {
+			syncLogger.Warn().
+				Str("spoke_id", id).
+				Err(reason).
+				Msg("Registered spoke ID is no longer accepted; this spoke can no longer sync and must be re-registered under a valid ID")
+		}
+
 		if spokeCount == 0 {
 			syncLogger.Warn().
 				Str("hub_id", cfg.EdgeSync.HubID).

--- a/internal/edgesync/receive.go
+++ b/internal/edgesync/receive.go
@@ -607,6 +607,10 @@ func stagingPathFor(spokeID, sourcePath string) string {
 	return path.Join(StagingPrefix, spokeID, sourcePath)
 }
 
+// MaxSpokeIDLen bounds a spoke identifier. It becomes a filesystem path
+// component, and 128 matches the cap the registry applies to the spoke name.
+const MaxSpokeIDLen = 128
+
 // validateSpokeID rejects identifiers that could escape their namespace.
 //
 // The spoke ID becomes the first path segment of everything that spoke writes,
@@ -624,8 +628,40 @@ func validateSpokeID(spokeID string) error {
 	if spokeID == "." || spokeID == ".." || strings.HasPrefix(spokeID, ".") {
 		return fmt.Errorf("edgesync: spoke ID %q may not start with a dot", spokeID)
 	}
+	// Reject ".." ANYWHERE, for the same reason validateSyncPath does: the
+	// local backend sanitizes by replacing every ".." substring with "_"
+	// (storage/local.go), which is many-to-one. The spoke ID is the first
+	// path segment of everything a spoke writes, so "rocket..01" and
+	// "rocket_01" resolve to one directory and either spoke can write into
+	// the other's namespace. #574 closed this for the source path and left
+	// the identity that prefixes it open (#737).
+	if strings.Contains(spokeID, "..") {
+		return fmt.Errorf("edgesync: spoke ID %q contains a parent-directory sequence", spokeID)
+	}
 	if strings.ContainsRune(spokeID, 0) {
 		return fmt.Errorf("edgesync: spoke ID contains a NUL byte")
+	}
+	// The ID is a filesystem path component, so an over-long one registers
+	// fine and then fails every write with ENAMETOOLONG (255 bytes per
+	// component on ext4), wedging the spoke with no signal at registration.
+	// 128 matches the cap the registry already applies to the spoke name,
+	// which is the field with no security role.
+	if len(spokeID) > MaxSpokeIDLen {
+		return fmt.Errorf("edgesync: spoke ID is %d bytes; the maximum is %d", len(spokeID), MaxSpokeIDLen)
+	}
+	// Leading or trailing whitespace is invisible in a config file and in
+	// every listing, so two IDs that differ only by it are indistinguishable
+	// to an operator. Windows strips trailing dots and spaces outright, which
+	// would collide them for real.
+	if strings.TrimSpace(spokeID) != spokeID {
+		return fmt.Errorf("edgesync: spoke ID %q has leading or trailing whitespace", spokeID)
+	}
+	// Echoed into logs and API responses, so an embedded newline forges log
+	// lines against whatever reads them.
+	for _, r := range spokeID {
+		if r < 0x20 || r == 0x7f {
+			return errors.New("edgesync: spoke ID contains a control character")
+		}
 	}
 	return nil
 }

--- a/internal/edgesync/receive_test.go
+++ b/internal/edgesync/receive_test.go
@@ -331,6 +331,15 @@ func TestReceiver_RejectsMaliciousSpokeIDs(t *testing.T) {
 		{"backslash", "rocket\\other"},
 		{"dot prefix", ".sync-staging"},
 		{"NUL byte", "rocket\x00-01"},
+		// #737: accepted by every other check, but the local backend folds
+		// ".." to "_", so this lands in rocket_01's namespace.
+		{"embedded traversal", "rocket..01"},
+		{"embedded traversal, trailing", "rocket01.."},
+		{"embedded traversal, only dots", "a..b"},
+		{"over-long", strings.Repeat("r", MaxSpokeIDLen+1)},
+		{"trailing space", "rocket_01 "},
+		{"leading space", " rocket_01"},
+		{"control character", "rocket\n01"},
 	}
 
 	for _, tt := range ids {
@@ -985,5 +994,66 @@ func TestReceiver_CompactedReceiptAnswersAlreadyPresent(t *testing.T) {
 	}
 	if res.Outcome != OutcomeConflict || res.TheirSHA256 != digest {
 		t.Fatalf("outcome = %v/%q, want conflict with the delivered digest", res.Outcome, res.TheirSHA256)
+	}
+}
+
+// TestSpokeNamespacesAreInjective is the invariant #737 actually violated, and
+// the one worth keeping: every spoke ID validateSpokeID accepts must resolve to
+// a namespace no other accepted ID can reach.
+//
+// It asserts through the real local backend rather than by reasoning about
+// validateSpokeID's rules, because the collision came from the gap between what
+// the validator allows and what the backend does to a path afterwards
+// (storage/local.go folds every ".." to "_"). Checking the validator alone
+// would have missed it exactly as the original review did.
+//
+// Every candidate is written FIRST and read back only afterwards. Reading each
+// one straight after its own write proves nothing: the read is sanitized by the
+// same rule as the write, so a colliding pair still returns the bytes it just
+// stored. The collision only shows up as an earlier spoke's payload having been
+// replaced.
+func TestSpokeNamespacesAreInjective(t *testing.T) {
+	ctx := context.Background()
+	_, backend := newTestReceiver(t)
+
+	// Candidates that differ as strings but are plausible collisions under a
+	// sanitizer that rewrites rather than rejects. Whatever validateSpokeID
+	// accepts here must stay distinct on disk.
+	// Deliberately all-lowercase. "ROCKET_01" and "rocket_01" are both
+	// accepted and collide on a case-insensitive filesystem, which is the same
+	// bug on a different fold, but it is not the one this change closes and
+	// rejecting uppercase would break existing deployments. Including it here
+	// would make this test pass on Linux CI and fail on a macOS dev machine.
+	// Tracked separately (#740).
+	candidates := []string{
+		"rocket_01", "rocket..01", "rocket-01", "rocket01..", "a..b", "a_b",
+		"rocket.01", "rocket__01",
+	}
+
+	const sourcePath = "default/cpu/2026/09/02/00/collision.parquet"
+	accepted := make([]string, 0, len(candidates))
+
+	for _, id := range candidates {
+		if err := validateSpokeID(id); err != nil {
+			continue // rejected, so it can never reach storage
+		}
+		accepted = append(accepted, id)
+		if err := backend.Write(ctx, NamespacedPath(id, sourcePath), []byte("payload-from-"+id)); err != nil {
+			t.Fatalf("writing as %q: %v", id, err)
+		}
+	}
+
+	if len(accepted) < 2 {
+		t.Fatalf("only %d spoke IDs were accepted; the test asserts nothing", len(accepted))
+	}
+
+	for _, id := range accepted {
+		got, err := backend.Read(ctx, NamespacedPath(id, sourcePath))
+		if err != nil {
+			t.Fatalf("reading back as %q: %v", id, err)
+		}
+		if want := "payload-from-" + id; string(got) != want {
+			t.Errorf("spoke %q reads back %q, so another accepted spoke ID resolves to its namespace", id, got)
+		}
 	}
 }

--- a/internal/edgesync/registry.go
+++ b/internal/edgesync/registry.go
@@ -379,6 +379,30 @@ func (r *Registry) Count(ctx context.Context) (int64, error) {
 	return n, nil
 }
 
+// InvalidStoredIDs returns the registered spoke IDs that today's validator
+// rejects, so an upgrade that tightens the rules can say so at startup instead
+// of letting an edge box fail later with no explanation on the hub (#737).
+//
+// It reports rather than deletes: the rows still hold a live secret and the
+// data those spokes already synced is still on disk, so removing them is an
+// operator decision.
+func (r *Registry) InvalidStoredIDs(ctx context.Context) (map[string]error, error) {
+	spokes, err := r.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var bad map[string]error
+	for _, s := range spokes {
+		if err := validateSpokeID(s.SpokeID); err != nil {
+			if bad == nil {
+				bad = make(map[string]error, 1)
+			}
+			bad[s.SpokeID] = err
+		}
+	}
+	return bad, nil
+}
+
 // VerifyStoredSecrets checks that the configured key can still decrypt what is
 // already stored, and reports how many spokes are registered.
 //

--- a/internal/edgesync/registry_test.go
+++ b/internal/edgesync/registry_test.go
@@ -669,3 +669,55 @@ func TestRegistry_VerifyStoredSecretsChecksDisabledSpokesToo(t *testing.T) {
 		t.Error("a corrupt secret on a disabled spoke was not detected")
 	}
 }
+
+// TestRegistry_RejectsCollidingSpokeIDs closes the other half of #737. The
+// receive path validating the ID is not enough on its own: if a colliding ID
+// can be registered, an operator hands out a credential that resolves into
+// somebody else's namespace, and the receive-side rejection only surfaces it
+// later as an unexplained refusal.
+func TestRegistry_RejectsCollidingSpokeIDs(t *testing.T) {
+	ctx := context.Background()
+	reg, _ := newTestRegistry(t)
+
+	if _, err := reg.Register(ctx, "rocket_01", "Rocket 01"); err != nil {
+		t.Fatalf("registering the legitimate spoke: %v", err)
+	}
+
+	// Accepted by every other rule, and folds onto rocket_01 in local storage.
+	if _, err := reg.Register(ctx, "rocket..01", "Impostor"); err == nil {
+		t.Error("a spoke ID containing \"..\" was registered; it collides with rocket_01 on the local backend")
+	}
+}
+
+// TestRegistry_InvalidStoredIDs covers the migration half of #737. Tightening
+// the validator does nothing for rows registered under the old rules, and the
+// only signal an operator would otherwise get is an edge box failing at the far
+// end with no matching entry in the hub's log.
+func TestRegistry_InvalidStoredIDs(t *testing.T) {
+	ctx := context.Background()
+	reg, db := newTestRegistry(t)
+
+	if _, err := reg.Register(ctx, "rocket-01", "Rocket 01"); err != nil {
+		t.Fatalf("registering a valid spoke: %v", err)
+	}
+
+	// Register refuses this now, so a legacy row goes in behind its back. That
+	// is exactly the state an upgraded hub is in.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO sync_spokes (spoke_id, name, secret_encrypted, enabled, registered_at)
+		 VALUES (?, ?, ?, 1, CURRENT_TIMESTAMP)`,
+		"rocket..01", "Legacy", "x"); err != nil {
+		t.Fatalf("inserting the legacy row: %v", err)
+	}
+
+	bad, err := reg.InvalidStoredIDs(ctx)
+	if err != nil {
+		t.Fatalf("InvalidStoredIDs: %v", err)
+	}
+	if _, found := bad["rocket..01"]; !found {
+		t.Errorf("the legacy colliding ID was not reported: %v", bad)
+	}
+	if _, found := bad["rocket-01"]; found {
+		t.Errorf("a valid spoke ID was reported as invalid: %v", bad)
+	}
+}


### PR DESCRIPTION
Fixes #737. Reported privately by **[@rexpository](https://github.com/rexpository)** in GHSA-jxr7-m365-vvg7, moved to a public issue and handled as hardening rather than an advisory.

## The bug

`validateSpokeID` rejected separators, NUL, the exact values `.` and `..`, and any leading dot, but allowed `..` anywhere inside an identifier. `LocalBackend.sanitizePath` then folds every `..` to `_`, so `rocket..01` and `rocket_01` named one directory. The spoke ID is the first path segment of everything a spoke writes, so a spoke authenticated as one could write into the other's namespace.

The HMAC proves which spoke is asking. The namespace mapping decides where it may write, and that mapping was not injective.

`validateSyncPath` already rejects `..` anywhere and carries a comment recording this exact many-to-one reasoning, added by [#574](https://github.com/Basekick-Labs/arc/pull/574) for the source path. The identity that prefixes it was left open. Same rule, same file, covering all seven callers at once.

## Why no advisory

Every path to it runs through an administrator creating the colliding ID: registration is admin-only (`auth.RequireAdmin`), secrets are generated server-side and shown once, and there is no self-registration. It is local-backend only, since S3 and Azure preserve key spelling, and edge sync is opt-in. The reporter's own PoC creates a file at an absent path and does not demonstrate overwriting.

## Also in this change

**The bounds the validator was missing.** A 128-byte cap, no control characters, no leading or trailing whitespace: the same rules the registry already applies to the spoke *name*, which unlike the ID never becomes a path component. An over-long ID registered successfully and then failed every write with `ENAMETOOLONG`, which is precisely the "issue a credential that only surfaces later as an unexplained refusal" shape this change exists to close.

**Migration detection.** Tightening a validator does nothing for rows already stored, so `Registry.InvalidStoredIDs` re-checks them and the hub names each offender at startup. Without it the only signal is an edge box failing at the far end with no matching hub log line.

## Testing

Four tests, all verified to fail with the check reverted:

- The rejection table gains the traversal spellings plus the new bounds.
- `Registry.Register` is covered, since a receive-side rejection alone still lets an operator issue a credential that resolves into somebody else's namespace.
- `InvalidStoredIDs` is covered against a legacy row inserted behind `Register`'s back, which is the state an upgraded hub is actually in.
- `TestSpokeNamespacesAreInjective` asserts the invariant that was violated, through the real local backend rather than by reasoning about the validator, since the collision lived in the gap between them.

That last one is worth flagging: **its first draft was vacuous and passed with the fix reverted**, because reading each ID back straight after its own write goes through the same sanitizer as the write and returns the bytes it just stored. Writing every candidate before reading any of them makes the collision visible as an earlier spoke's payload having been replaced. It now fails without the fix on two pairs, including `a..b` against `a_b`, which none of my hand-written cases listed.

## Migration guidance is not a simple rename

The release note says what actually has to happen. For an ID like `rocket..01` the already-synced data sits on disk under `rocket_01/`, which is the *other* spoke's namespace, and the hub's file index is keyed on spoke ID, so a spoke re-pointed at a fresh ID finds no index rows and re-uploads its whole backlog into the new namespace. Upgrade note 2 no longer claims no configuration change is required, because for such a spoke there is one.

## Credits

Release notes and the README bug-reporter list both credit the reporter, matching how `@bjarneksat` is credited there.

## Follow-ups filed rather than folded in

- **#740**: the same collision survives through case folding and Unicode normalization on macOS and Windows volumes. `TestSpokeNamespacesAreInjective` deliberately excludes `ROCKET_01` with a comment pointing there, because including it would pass on Linux CI and fail on a macOS dev machine, and we ship a `darwin-arm64` binary. Rejecting mixed case would refuse identifiers that are legitimate today, so it needs a deprecation path rather than a validator line.
- **#741**: `sanitizePath` rewrites rather than rejects, which is the root of this whole collision class (#574 and #737 are both instances). It backs every `LocalBackend` operation in Arc, so it needs its own audit. The issue records two traps found while looking at it, including that the containment check uses the raw-prefix pattern this repo already names as the #534 bug class.