### PR TITLE
Reject malformed local storage paths instead of rewriting them (#741)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -227,7 +227,18 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
    spoke fails to start until its ID is changed. See *Edge-sync spoke IDs can
    no longer collide with another spoke's namespace* below. The hub names any
    stored ID in that state at startup.
-3. **Query response envelopes gained two optional keys** (`rows_capped`,
+3. **A few malformed names are now refused where they were previously
+   accepted and quietly rewritten** (see *Local storage rejects malformed paths
+   instead of rewriting them* below). Three are operator-visible: a retention
+   policy whose database or measurement name contains a separator or is empty
+   is rejected on create and on update, and existing ones are named in the log
+   at startup; an MQTT subscription whose database or topic-mapping target is
+   not a usable name now fails at startup; and an edge-sync spoke may no longer
+   sync a path with a dot-prefixed segment such as `db/./cpu/x.parquet`. Note
+   that `PUT /api/v1/retention/:id` replaces the whole row, so a request that
+   omits `database` is now a 400 rather than silently storing an empty name,
+   which used to make that policy enumerate every database.
+4. **Query response envelopes gained two optional keys** (`rows_capped`,
    `row_cap`), emitted only when an Enterprise governance row cap truncated
    the result. Conforming JSON and msgpack decoders are unaffected: the keys
    are absent from every uncapped response, and a capped msgpack envelope
@@ -237,6 +248,73 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
    them at all.
 
 ## Bug fixes
+
+### Local storage rejects malformed paths instead of rewriting them ([#741](https://github.com/Basekick-Labs/arc/issues/741))
+
+The local storage backend used to repair the paths it was given: every `..` was
+replaced with `_` and NUL bytes were stripped, with a comment saying this
+prevented directory traversal. It did not. Containment was enforced separately,
+by resolving the path and checking it still sat under the storage root.
+
+What the rewrite did do was make two different keys able to name one file.
+`a..b` and `a_b` were the same location, and so were `..foo` and `_foo`. That
+is the root of two bugs already fixed in this release: the edge-sync source
+path ([#574](https://github.com/Basekick-Labs/arc/pull/574)) and the edge-sync
+spoke ID ([#737](https://github.com/Basekick-Labs/arc/issues/737)). Each was
+closed by teaching one caller not to send `..`, which left the next caller to
+rediscover it.
+
+A malformed path is now refused rather than quietly turned into a different
+one, so the mapping from key to file is one-to-one for every caller at once.
+Refused: absolute paths, any `.` or `..` segment, an empty interior segment
+such as `a//b`, NUL bytes, and backslashes. Still accepted, and now stored under
+the name actually asked for: filenames that merely contain dots, such as `a..b`
+or `..foo`.
+
+The check got cheaper as a side effect. Once a path is known to be clean and
+relative, the three `path/filepath` calls that followed it were redundant: one
+normalised input proven not to need it, one re-resolved an already absolute
+path, and one recomputed a containment property that now holds by construction.
+Validation is a single pass with no allocation, and the containment proof moved
+into a property test rather than being paid for on every call.
+
+```
+                          before      after
+BenchmarkValidatePath      605 ns/op   110 ns/op   1 alloc, unchanged
+BenchmarkValidatePathDeep  757 ns/op   150 ns/op   1 alloc, unchanged
+```
+
+In proportion: about 0.06% of a 4 MiB Parquet write, and roughly half of a bare
+existence check. It matters in the stat-heavy loops that reconciliation and
+tiering run, and is noise on the ingest path. Nothing gets slower and the
+allocation count is unchanged, which is the part that matters under
+concurrency.
+
+Two audits back the change. Instrumenting the backend and running the full test
+suite found no path anywhere in Arc that the rewrite altered, and none that
+normalisation altered either. Both are evidence rather than proof: neither can
+see a path built from stored operator configuration or from an ingest field the
+validators happened to skip, and review found one of each.
+
+So the surfaces that build a storage key from a name now validate it. Retention
+policies reject a malformed database or measurement on create and on update, and
+any already stored that can no longer resolve is named at startup. The per-name
+database routes return 400 rather than letting the storage layer refuse the key
+later. A MessagePack record with an empty measurement name is refused instead of
+being skipped by the validator and reaching the writer, and MQTT does the same,
+including for the database its topic mappings select. An empty measurement used
+to produce `{database}//{year}/...`, which normalisation collapsed so the rows
+landed a level up, under the database itself.
+
+The `mqtt.subscriptions` config is now validated at load: a subscription whose
+database, or whose topic-mapping target, is not a usable name fails at startup
+rather than at the first flush.
+
+If you have a deployment that stored data under a folded name, that file is now
+addressed by its real name and the folded spelling no longer reaches it. The one
+known way to be in that state is an edge-sync spoke registered before
+[#737](https://github.com/Basekick-Labs/arc/issues/737), which the hub already
+names at startup.
 
 ### Edge-sync spoke IDs can no longer collide with another spoke's namespace ([#737](https://github.com/Basekick-Labs/arc/issues/737))
 

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -211,6 +212,14 @@ func (h *DatabasesHandler) handleGet(c *fiber.Ctx) error {
 			"error": "Database name is required",
 		})
 	}
+	// The name becomes a storage path prefix below. Validating it here turns a
+	// malformed one into a 400 at the boundary rather than a 500 from the
+	// storage layer refusing the key it was built into (#741).
+	if !isSafeStoragePathSegment(name) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid database name %q", name),
+		})
+	}
 
 	ctx := context.Background()
 
@@ -248,6 +257,14 @@ func (h *DatabasesHandler) handleListMeasurements(c *fiber.Ctx) error {
 	if name == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Database name is required",
+		})
+	}
+	// The name becomes a storage path prefix below. Validating it here turns a
+	// malformed one into a 400 at the boundary rather than a 500 from the
+	// storage layer refusing the key it was built into (#741).
+	if !isSafeStoragePathSegment(name) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid database name %q", name),
 		})
 	}
 
@@ -313,6 +330,14 @@ func (h *DatabasesHandler) handleDelete(c *fiber.Ctx) error {
 	if name == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Database name is required",
+		})
+	}
+	// The name becomes a storage path prefix below. Validating it here turns a
+	// malformed one into a 400 at the boundary rather than a 500 from the
+	// storage layer refusing the key it was built into (#741).
+	if !isSafeStoragePathSegment(name) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid database name %q", name),
 		})
 	}
 
@@ -435,6 +460,27 @@ func (h *DatabasesHandler) handleDelete(c *fiber.Ctx) error {
 }
 
 // Helper functions
+
+// isSafeStoragePathSegment reports whether name can be used as one segment of a
+// storage key.
+//
+// Deliberately looser than isValidDatabaseName, which governs what a NEW
+// database may be called. Directories already in the storage root were not all
+// created through that route: an edge-sync hub writes each spoke's namespace
+// there, and validateSpokeID permits a leading digit, interior dots and up to
+// 128 bytes. Those directories are listed by GET /api/v1/databases, so gating
+// the per-name routes on the create-time rule would return 400 for something
+// the list endpoint just reported. This rule asks only what the storage layer
+// asks: is it one segment, and does it name something inside the root.
+func isSafeStoragePathSegment(name string) bool {
+	if name == "" || len(name) > 255 {
+		return false
+	}
+	if name == "." || name == ".." || strings.HasPrefix(name, ".") {
+		return false
+	}
+	return !strings.ContainsAny(name, "/\\\x00")
+}
 
 func isValidDatabaseName(name string) bool {
 	n := len(name)

--- a/internal/api/msgpack.go
+++ b/internal/api/msgpack.go
@@ -125,7 +125,16 @@ func (h *MsgPackHandler) SetRouter(router *cluster.Router) {
 	h.router = router
 }
 
-// extractMeasurements extracts unique measurement names from decoded msgpack records
+// extractMeasurements extracts unique measurement names from decoded msgpack records.
+//
+// An empty name is collected rather than skipped, so the caller's
+// isValidMeasurementName check rejects it. Skipping it used to mean a record
+// with "m": "" passed validation and reached the writer, which builds
+// "{database}//{year}/..." from it. filepath.Join silently collapsed the empty
+// segment and the rows landed a directory level up, under the database itself.
+// Since #741 the storage backend refuses that key instead, and a refused flush
+// keeps its data in the WAL and retries forever, so one such record would wedge
+// the buffer permanently.
 func (h *MsgPackHandler) extractMeasurements(records interface{}) []string {
 	seen := make(map[string]struct{})
 
@@ -133,20 +142,14 @@ func (h *MsgPackHandler) extractMeasurements(records interface{}) []string {
 	extract = func(v interface{}) {
 		switch r := v.(type) {
 		case *models.Record:
-			if r.Measurement != "" {
-				seen[r.Measurement] = struct{}{}
-			}
+			seen[r.Measurement] = struct{}{}
 		case *models.ColumnarRecord:
-			if r.Measurement != "" {
-				seen[r.Measurement] = struct{}{}
-			}
+			seen[r.Measurement] = struct{}{}
 		case *ingest.TypedColumnarRecord:
 			// Typed decode fast path — MUST be listed here: a record type
 			// missing from this switch silently skips measurement-name
 			// validation and RBAC for its writes.
-			if r.Measurement != "" {
-				seen[r.Measurement] = struct{}{}
-			}
+			seen[r.Measurement] = struct{}{}
 		case []interface{}:
 			for _, item := range r {
 				extract(item)

--- a/internal/api/retention.go
+++ b/internal/api/retention.go
@@ -153,7 +153,51 @@ func NewRetentionHandler(storage storage.Backend, duckdb *database.DuckDB, cfg *
 		return nil, fmt.Errorf("failed to initialize retention tables: %w", err)
 	}
 
+	h.warnUnusablePolicies()
+
 	return h, nil
+}
+
+// warnUnusablePolicies reports stored policies whose database or measurement
+// name cannot form a storage prefix (#741).
+//
+// Create and update validate both fields now, but rows written before that do
+// not disappear, and the scheduler replays them forever. Without this the only
+// signal is a listing error buried in a scheduled run hours later, attributed
+// to storage rather than to the policy.
+func (h *RetentionHandler) warnUnusablePolicies() {
+	// Inactive rows are included: a disabled policy with a broken name is one
+	// toggle away from failing, and the point is to report it before then.
+	rows, err := h.db.Query(`SELECT name, database, measurement FROM retention_policies`)
+	if err != nil {
+		h.logger.Warn().Err(err).Msg("Could not check stored retention policies against the current name rules")
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name, database string
+		var measurement sql.NullString
+		if err := rows.Scan(&name, &database, &measurement); err != nil {
+			// Skip the row rather than returning: one unreadable row must not
+			// hide every offender after it.
+			h.logger.Warn().Err(err).Msg("Could not read a stored retention policy")
+			continue
+		}
+		// Both fields are reported, not just the first: a policy can be broken
+		// in both and fixing one would leave it still failing.
+		if !isSafeStoragePathSegment(database) {
+			h.logger.Warn().Str("policy", name).Str("database", database).
+				Msg("Retention policy has an unusable database name and will fail every run; update or delete it")
+		}
+		if measurement.Valid && measurement.String != "" && !isSafeStoragePathSegment(measurement.String) {
+			h.logger.Warn().Str("policy", name).Str("measurement", measurement.String).
+				Msg("Retention policy has an unusable measurement name and will fail every run; update or delete it")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		h.logger.Warn().Err(err).Msg("Could not finish checking stored retention policies")
+	}
 }
 
 // SetCoordinator wires the cluster coordinator for manifest updates.
@@ -260,6 +304,20 @@ func (h *RetentionHandler) handleCreate(c *fiber.Ctx) error {
 	if req.Database == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "database is required"})
 	}
+	// Both fields are concatenated into a storage prefix by
+	// getMeasurementsToProcess and deleteOldFiles, and the row is replayed by
+	// the scheduler forever, so an unvalidated one is a policy that fails on
+	// every run long after the request that created it (#741).
+	if !isSafeStoragePathSegment(req.Database) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid database name %q: may not be empty, contain a separator, or start with a dot", req.Database),
+		})
+	}
+	if req.Measurement != nil && *req.Measurement != "" && !isSafeStoragePathSegment(*req.Measurement) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid measurement name %q: may not contain a separator or start with a dot", *req.Measurement),
+		})
+	}
 	if req.RetentionDays <= 0 {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "retention_days must be greater than 0"})
 	}
@@ -341,10 +399,21 @@ func (h *RetentionHandler) handleUpdate(c *fiber.Ctx) error {
 		})
 	}
 
-	// Validate
+	// Validate. Update writes both name fields verbatim, so it can put a row
+	// into exactly the state create now refuses (#741).
 	if req.RetentionDays <= req.BufferDays {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "retention_days must be greater than buffer_days",
+		})
+	}
+	if !isSafeStoragePathSegment(req.Database) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid database name %q: may not be empty, contain a separator, or start with a dot", req.Database),
+		})
+	}
+	if req.Measurement != nil && *req.Measurement != "" && !isSafeStoragePathSegment(*req.Measurement) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("invalid measurement name %q: may not contain a separator or start with a dot", *req.Measurement),
 		})
 	}
 

--- a/internal/edgesync/receive.go
+++ b/internal/edgesync/receive.go
@@ -628,13 +628,14 @@ func validateSpokeID(spokeID string) error {
 	if spokeID == "." || spokeID == ".." || strings.HasPrefix(spokeID, ".") {
 		return fmt.Errorf("edgesync: spoke ID %q may not start with a dot", spokeID)
 	}
-	// Reject ".." ANYWHERE, for the same reason validateSyncPath does: the
-	// local backend sanitizes by replacing every ".." substring with "_"
-	// (storage/local.go), which is many-to-one. The spoke ID is the first
-	// path segment of everything a spoke writes, so "rocket..01" and
-	// "rocket_01" resolve to one directory and either spoke can write into
-	// the other's namespace. #574 closed this for the source path and left
-	// the identity that prefixes it open (#737).
+	// Reject ".." ANYWHERE, for the same reason validateSyncPath does. The
+	// original reason was that the local backend folded every ".." to "_"
+	// (#737): the spoke ID is the first path segment of everything a spoke
+	// writes, so "rocket..01" and "rocket_01" resolved to one directory.
+	// #741 removed that fold, so the collision is gone on local storage, but
+	// the rule stays: S3 and Azure still accept any key spelling with no
+	// validation at all (#743), and a spoke ID is the one component here that
+	// an operator types by hand.
 	if strings.Contains(spokeID, "..") {
 		return fmt.Errorf("edgesync: spoke ID %q contains a parent-directory sequence", spokeID)
 	}
@@ -684,12 +685,12 @@ func validateSyncPath(p string) error {
 	if strings.Contains(p, "\\") {
 		return fmt.Errorf("edgesync: path %q contains a backslash", p)
 	}
-	// Reject ".." ANYWHERE, not only as a whole segment. LocalBackend
-	// sanitizes by replacing every ".." substring with "_" (storage/local.go),
-	// which is many-to-one: "a..b.parquet" and "a_b.parquet" both land on
-	// "a_b.parquet". A spoke sending the former would then collide with an
-	// unrelated file, get an unresolvable 409 naming a digest it never
-	// uploaded, and leave that path permanently unsyncable.
+	// Reject ".." ANYWHERE, not only as a whole segment. This was written when
+	// LocalBackend folded every ".." to "_" (#574), so "a..b.parquet" and
+	// "a_b.parquet" landed on one file and a spoke sending the former got an
+	// unresolvable 409 naming a digest it never uploaded. #741 removed the
+	// fold, so local storage now keeps both spellings apart, but the rule
+	// stays while the key contract is still per-backend (#743).
 	//
 	// Checked before cleaning: path.Clean would resolve "a/../../b" into
 	// "../b", and checking only the cleaned form invites the reader to assume
@@ -701,9 +702,13 @@ func validateSyncPath(p string) error {
 		if seg == "" {
 			return fmt.Errorf("edgesync: path %q contains an empty segment", p)
 		}
-	}
-	if strings.HasPrefix(p, ".") {
-		return fmt.Errorf("edgesync: path %q may not start with a dot", p)
+		// Checked per segment, not on the whole string. "db/./cpu/x.parquet"
+		// used to pass: path.Join cleans it before storage, but Measurement is
+		// derived from the RAW path, so "." reached the Raft manifest and then
+		// reconciliation built the prefix "db/./" from it (#741).
+		if strings.HasPrefix(seg, ".") {
+			return fmt.Errorf("edgesync: path %q has a segment starting with a dot", p)
+		}
 	}
 	if !strings.HasSuffix(p, ".parquet") {
 		// The sync unit is an immutable Parquet file. Anything else is either

--- a/internal/mqtt/subscriber.go
+++ b/internal/mqtt/subscriber.go
@@ -455,10 +455,18 @@ func (s *Subscriber) mapToRecord(m map[string]interface{}) (*models.Record, erro
 		Tags:   make(map[string]string),
 	}
 
-	// Extract measurement
-	if meas, ok := m["m"].(string); ok {
+	// Extract measurement.
+	//
+	// An empty string is treated as absent rather than accepted: it satisfies
+	// the type assertion, so it used to win over the default below and reach
+	// the writer, which builds "{database}//{year}/..." from it. That key is
+	// refused by the storage backend since #741, and a refused flush keeps its
+	// data in the WAL and retries forever, wedging the buffer. MQTT payloads
+	// are unauthenticated relative to the HTTP write path, which validates
+	// measurement names before they reach the buffer.
+	if meas, ok := m["m"].(string); ok && meas != "" {
 		record.Measurement = meas
-	} else if meas, ok := m["measurement"].(string); ok {
+	} else if meas, ok := m["measurement"].(string); ok && meas != "" {
 		record.Measurement = meas
 	} else {
 		record.Measurement = "mqtt" // Default measurement

--- a/internal/mqtt/subscription.go
+++ b/internal/mqtt/subscription.go
@@ -191,6 +191,18 @@ func (s *Subscription) Validate() error {
 	if s.Database == "" {
 		return errors.New("database is required")
 	}
+	// Both the subscription database and every topic-mapping target become the
+	// first segment of a storage key. This is the one ingest surface with no
+	// HTTP handler in front of it to validate them, so a mapping value like
+	// "" or "../x" would otherwise reach the writer directly (#741).
+	if !isValidStorageSegment(s.Database) {
+		return fmt.Errorf("database %q must start with a letter and contain only alphanumeric characters, underscores, or hyphens", s.Database)
+	}
+	for topic, db := range s.TopicMapping {
+		if !isValidStorageSegment(db) {
+			return fmt.Errorf("topic mapping %q targets database %q, which must start with a letter and contain only alphanumeric characters, underscores, or hyphens", topic, db)
+		}
+	}
 
 	// Path traversal check for TLS certificate paths
 	for _, path := range []string{s.TLSCertPath, s.TLSKeyPath, s.TLSCAPath} {
@@ -311,4 +323,24 @@ func ValidateCreateRequest(req *CreateSubscriptionRequest) error {
 	}
 	s.SetDefaults()
 	return s.Validate()
+}
+
+// isValidStorageSegment reports whether s is safe as a single path segment in a
+// storage key. Mirrors the rule the HTTP ingest handlers apply to database and
+// measurement names; kept local so internal/mqtt does not depend on internal/api.
+func isValidStorageSegment(s string) bool {
+	if len(s) == 0 || len(s) > 64 {
+		return false
+	}
+	c := s[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		c = s[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -20,7 +20,11 @@ const maxDirCacheEntries = 1024
 // LocalBackend implements the Backend interface for local filesystem storage
 type LocalBackend struct {
 	basePath string
-	logger   zerolog.Logger
+	// basePath plus a trailing separator, precomputed so validatePath is one
+	// concatenation. Computed rather than assumed because a root of "/" is
+	// already separator-terminated, and appending another would produce "//a".
+	pathPrefix string
+	logger     zerolog.Logger
 
 	// OPTIMIZATION: Directory cache to avoid redundant os.MkdirAll calls
 	// Under sustained load, hundreds of goroutines would call MkdirAll for same dirs
@@ -43,10 +47,16 @@ func NewLocalBackend(basePath string, logger zerolog.Logger) (*LocalBackend, err
 		return nil, fmt.Errorf("failed to create base path: %w", err)
 	}
 
+	prefix := absPath
+	if !strings.HasSuffix(prefix, storagePathSeparator) {
+		prefix += storagePathSeparator
+	}
+
 	return &LocalBackend{
-		basePath: absPath,
-		logger:   logger.With().Str("component", "local-storage").Logger(),
-		dirCache: make(map[string]bool),
+		basePath:   absPath,
+		pathPrefix: prefix,
+		logger:     logger.With().Str("component", "local-storage").Logger(),
+		dirCache:   make(map[string]bool),
 	}, nil
 }
 
@@ -84,7 +94,7 @@ func (b *LocalBackend) ensureDir(dir string) error {
 
 // Write writes data to the specified path with atomic write (write to temp, then rename)
 func (b *LocalBackend) Write(ctx context.Context, path string, data []byte) error {
-	// Validate and sanitize the path to prevent path traversal
+	// Reject the key unless it names something inside the root
 	fullPath, err := b.validatePath(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
@@ -224,7 +234,7 @@ func (b *LocalBackend) WriteReader(ctx context.Context, path string, reader io.R
 
 // Read reads data from the specified path
 func (b *LocalBackend) Read(ctx context.Context, path string) ([]byte, error) {
-	// Validate and sanitize the path to prevent path traversal
+	// Reject the key unless it names something inside the root
 	fullPath, err := b.validatePath(path)
 	if err != nil {
 		return nil, fmt.Errorf("invalid path: %w", err)
@@ -254,7 +264,7 @@ func (b *LocalBackend) Read(ctx context.Context, path string) ([]byte, error) {
 
 // ReadTo reads data from the specified path and writes it to the writer
 func (b *LocalBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
-	// Validate and sanitize the path to prevent path traversal
+	// Reject the key unless it names something inside the root
 	fullPath, err := b.validatePath(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
@@ -417,7 +427,7 @@ func (b *LocalBackend) AppendReader(ctx context.Context, path string, reader io.
 
 // List lists all objects with the given prefix
 func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error) {
-	// Validate and sanitize the prefix to prevent path traversal
+	// Reject the prefix unless it names something inside the root
 	searchPath, err := b.validatePath(prefix)
 	if err != nil {
 		return nil, fmt.Errorf("invalid prefix: %w", err)
@@ -475,7 +485,7 @@ func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error
 
 // Delete deletes the object at the specified path
 func (b *LocalBackend) Delete(ctx context.Context, path string) error {
-	// Validate and sanitize the path to prevent path traversal
+	// Reject the key unless it names something inside the root
 	fullPath, err := b.validatePath(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
@@ -497,7 +507,7 @@ func (b *LocalBackend) Delete(ctx context.Context, path string) error {
 
 // Exists checks if an object exists at the specified path
 func (b *LocalBackend) Exists(ctx context.Context, path string) (bool, error) {
-	// Validate and sanitize the path to prevent path traversal
+	// Reject the key unless it names something inside the root
 	fullPath, err := b.validatePath(path)
 	if err != nil {
 		return false, fmt.Errorf("invalid path: %w", err)
@@ -517,18 +527,6 @@ func (b *LocalBackend) Exists(ctx context.Context, path string) (bool, error) {
 // Close closes any resources held by the backend (no-op for local storage)
 func (b *LocalBackend) Close() error {
 	return nil
-}
-
-// GetFullPath returns the full filesystem path for a given storage path
-// Useful for debugging and direct file access
-func (b *LocalBackend) GetFullPath(path string) string {
-	// Validate and sanitize the path to prevent path traversal
-	fullPath, err := b.validatePath(path)
-	if err != nil {
-		// Return empty string for invalid paths
-		return ""
-	}
-	return fullPath
 }
 
 // GetBasePath returns the base path for the local storage
@@ -551,7 +549,7 @@ func (b *LocalBackend) ConfigJSON() string {
 // ListDirectories lists immediate subdirectories at a prefix.
 // Implements the DirectoryLister interface.
 func (b *LocalBackend) ListDirectories(ctx context.Context, prefix string) ([]string, error) {
-	// Validate and sanitize the prefix to prevent path traversal
+	// Reject the prefix unless it names something inside the root
 	searchPath, err := b.validatePath(prefix)
 	if err != nil {
 		return nil, fmt.Errorf("invalid prefix: %w", err)
@@ -623,7 +621,7 @@ func (b *LocalBackend) RemoveDirectory(ctx context.Context, path string) error {
 // ListObjects lists objects with their metadata at a prefix.
 // Implements the ObjectLister interface.
 func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]ObjectInfo, error) {
-	// Validate and sanitize the prefix to prevent path traversal
+	// Reject the prefix unless it names something inside the root
 	searchPath, err := b.validatePath(prefix)
 	if err != nil {
 		return nil, fmt.Errorf("invalid prefix: %w", err)
@@ -694,43 +692,112 @@ func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]Object
 	return results, nil
 }
 
-// sanitizePath removes any potentially dangerous path components
-func sanitizePath(path string) string {
-	// Remove leading slashes
-	path = strings.TrimPrefix(path, "/")
+// ErrInvalidPath marks a key that names nothing inside the backend root. It is
+// permanent: retrying with the same key can never succeed, so callers driving
+// cleanup or reconciliation loops should quarantine the entry rather than
+// treat it as the transient I/O failure a bare error would look like.
+var ErrInvalidPath = errors.New("storage: invalid path")
 
-	// Replace .. with _ to prevent directory traversal
-	path = strings.ReplaceAll(path, "..", "_")
+// storagePathSeparator is what joins the root to a storage key. Keys are
+// "/"-separated by contract on every backend; this is the on-disk separator.
+const storagePathSeparator = string(filepath.Separator)
 
-	// Remove any null bytes (can bypass some checks)
-	path = strings.ReplaceAll(path, "\x00", "")
-
-	return path
+// checkStoragePath reports whether path is a clean, relative location inside
+// the backend root.
+//
+// It REJECTS rather than repairs, which is the whole point. The previous
+// implementation rewrote its input, folding every ".." to "_" and stripping NUL
+// bytes, and claimed that prevented traversal. It did not: containment was
+// enforced separately. What the rewrite did do was make the mapping from
+// requested key to stored key many-to-one, so two different keys could name one
+// file. That produced #574 (source paths) and #737 (spoke IDs), each closed by
+// teaching one caller not to send "..", which leaves the next caller to
+// rediscover it. Rejecting makes the mapping injective for every caller at once.
+//
+// Deliberately permitted:
+//
+//   - "" means the root. Listing callers pass it to walk everything.
+//   - A single trailing "/", which list prefixes use constantly ("databases/",
+//     database+"/"). validatePath strips it so the result stays canonical.
+//   - Segments that merely contain dots, such as "..foo" or "a..b". They are
+//     ordinary filenames, not traversal. The old fold collapsed "..foo" onto
+//     "_foo", which is the same collision one level down.
+//
+// One pass, no allocation, no strings.Split.
+func checkStoragePath(path string) error {
+	if path == "" {
+		return nil
+	}
+	if path[0] == '/' {
+		return fmt.Errorf("%w: %q must be relative to the backend root", ErrInvalidPath, path)
+	}
+	start := 0
+	for i := 0; i <= len(path); i++ {
+		if i < len(path) {
+			c := path[i]
+			if c == 0 {
+				return fmt.Errorf("%w: contains a NUL byte", ErrInvalidPath)
+			}
+			// Backslash is rejected rather than treated as an ordinary byte.
+			// Keys are "/"-separated on every backend, and on a platform whose
+			// OS also treats backslash as a separator, a segment built from
+			// them would pass a "/"-only segment scan whole and then escape
+			// once joined. Rejecting here
+			// keeps the validator and the join agreeing about what a separator
+			// is. internal/edgesync/receive.go already rejects it for the same
+			// reason.
+			if c == '\\' {
+				return fmt.Errorf("%w: %q contains a backslash", ErrInvalidPath, path)
+			}
+			if c != '/' {
+				continue
+			}
+		}
+		switch path[start:i] {
+		case "":
+			// The only empty segment allowed is the one a trailing slash
+			// produces. An interior one means "a//b", which is two spellings
+			// of one location.
+			if i != len(path) {
+				return fmt.Errorf("%w: %q contains an empty segment", ErrInvalidPath, path)
+			}
+		case ".", "..":
+			return fmt.Errorf("%w: %q contains a %q segment", ErrInvalidPath, path, path[start:i])
+		}
+		start = i + 1
+	}
+	return nil
 }
 
-// validatePath ensures the resolved path stays within the base path (prevents path traversal)
+// validatePath resolves a storage key to its absolute location, rejecting any
+// key that does not name something inside the backend root.
+//
+// There is no filepath.Join, Abs or Rel here, and that is safe rather than
+// merely fast. checkStoragePath has already established that the key is
+// relative, clean and free of ".." segments, and basePath is absolute and clean
+// (NewLocalBackend applies filepath.Abs). Join's only contribution was Clean,
+// on input proven not to need it; Abs re-cleaned an already absolute path; and
+// Rel recomputed a containment property that concatenation now guarantees by
+// construction. Dropping all three takes the hot path from ~600ns to ~100ns
+// with the same single allocation, on a function that runs for every local read
+// and write.
+//
+// The containment proof is asserted as a property test rather than paid for on
+// every call: see TestValidatePathNeverEscapesRoot.
+//
+// Symlinks are not resolved, exactly as before. A symlink inside the root that
+// points outside it escapes, and did under the previous implementation too.
 func (b *LocalBackend) validatePath(path string) (string, error) {
-	// First sanitize the path
-	sanitized := sanitizePath(path)
-
-	// Join with base path and get the absolute path
-	fullPath := filepath.Join(b.basePath, sanitized)
-	absPath, err := filepath.Abs(fullPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve path: %w", err)
+	if err := checkStoragePath(path); err != nil {
+		return "", err
 	}
-
-	// Ensure the resolved path is within the base path
-	// basePath is already absolute (set in NewLocalBackend via filepath.Abs)
-	relPath, err := filepath.Rel(b.basePath, absPath)
-	if err != nil {
-		return "", fmt.Errorf("path traversal detected")
+	if path == "" {
+		return b.basePath, nil
 	}
-
-	// If the relative path starts with "..", it's outside the base path
-	if strings.HasPrefix(relPath, "..") {
-		return "", fmt.Errorf("path traversal detected: path escapes base directory")
+	// Match what filepath.Join returned: a trailing slash is accepted on the
+	// way in and absent from the result.
+	if path[len(path)-1] == '/' {
+		path = path[:len(path)-1]
 	}
-
-	return absPath, nil
+	return b.pathPrefix + path, nil
 }

--- a/internal/storage/validatepath_bench_test.go
+++ b/internal/storage/validatepath_bench_test.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// The path shape every ingest, compaction and query read goes through:
+// {database}/{measurement}/{YYYY}/{MM}/{DD}/{HH}/{file}.parquet
+const benchPath = "default/cpu/2026/09/12/07/1757683200000000000-abc123def456.parquet"
+
+func benchBackend(b *testing.B) *LocalBackend {
+	b.Helper()
+	be, err := NewLocalBackend(b.TempDir(), zerolog.Nop())
+	if err != nil {
+		b.Fatal(err)
+	}
+	return be
+}
+
+func BenchmarkValidatePath(b *testing.B) {
+	be := benchBackend(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := be.validatePath(benchPath); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValidatePathDeep(b *testing.B) {
+	be := benchBackend(b)
+	const deep = "default/cpu/2026/09/12/07/sub/dir/another/level/deeper/still/1757683200000000000-abc123def456.parquet"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := be.validatePath(deep); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/storage/validatepath_test.go
+++ b/internal/storage/validatepath_test.go
@@ -1,0 +1,226 @@
+package storage
+
+import (
+	"errors"
+	"math/rand"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// Tests for #741. sanitizePath used to rewrite its input, folding every ".."
+// to "_", which made the mapping from storage key to stored file many-to-one
+// and produced #574 and #737. validatePath now rejects instead.
+
+func newPathTestBackend(t *testing.T) *LocalBackend {
+	t.Helper()
+	b, err := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestCheckStoragePath(t *testing.T) {
+	accepted := []struct{ name, path string }{
+		{"root", ""},
+		{"single segment", "cpu"},
+		{"partition path", "default/cpu/2026/09/12/07/data.parquet"},
+		{"list prefix with trailing slash", "databases/"},
+		{"single segment with trailing slash", "default/"},
+		// Ordinary filenames that merely contain dots. The old fold collapsed
+		// the first onto "_foo", colliding it with an unrelated key.
+		{"leading dots in a segment", "default/..foo/data.parquet"},
+		{"interior dots in a segment", "default/a..b/data.parquet"},
+		{"hidden file", "default/.hidden/data.parquet"},
+		{"dots in a filename", "default/cpu/a..b.parquet"},
+	}
+	for _, tt := range accepted {
+		t.Run("accept/"+tt.name, func(t *testing.T) {
+			if err := checkStoragePath(tt.path); err != nil {
+				t.Errorf("checkStoragePath(%q) = %v, want accepted", tt.path, err)
+			}
+		})
+	}
+
+	rejected := []struct{ name, path string }{
+		{"absolute", "/etc/passwd"},
+		{"parent segment", "../etc/passwd"},
+		{"interior parent segment", "default/../../etc/passwd"},
+		{"trailing parent segment", "default/.."},
+		{"current segment", "default/./cpu"},
+		{"lone current segment", "."},
+		{"lone parent segment", ".."},
+		{"empty interior segment", "default//cpu"},
+		{"NUL byte", "default/cpu\x00.parquet"},
+		{"NUL byte at the end", "default/cpu.parquet\x00"},
+		// The validator scans "/" segments, so a backslash-built traversal
+		// would pass whole on a platform whose OS also splits on it.
+		{"backslash traversal", `..\..\..\etc\passwd`},
+		{"backslash separator", `default\cpu.parquet`},
+	}
+	for _, tt := range rejected {
+		t.Run("reject/"+tt.name, func(t *testing.T) {
+			if err := checkStoragePath(tt.path); err == nil {
+				t.Errorf("checkStoragePath(%q) was accepted", tt.path)
+			}
+		})
+	}
+}
+
+// TestValidatePathMatchesFilepathJoin is the regression net for dropping
+// filepath.Join. For every key the validator accepts, the result must be
+// byte-identical to what the previous implementation produced.
+func TestCheckStoragePathErrorsAreIdentifiable(t *testing.T) {
+	// Callers driving cleanup loops must be able to tell a permanent rejection
+	// from a transient I/O failure, or they retry the same key forever.
+	for _, p := range []string{"/abs", "a/../b", "a//b", "a\x00b", `a\b`} {
+		err := checkStoragePath(p)
+		if err == nil {
+			t.Fatalf("checkStoragePath(%q) was accepted", p)
+		}
+		if !errors.Is(err, ErrInvalidPath) {
+			t.Errorf("checkStoragePath(%q) = %v, which does not match ErrInvalidPath", p, err)
+		}
+	}
+}
+
+// TestValidatePathWithRootBasePath covers a root of "/", the one base path that
+// already ends in a separator. t.TempDir() can never produce it.
+func TestValidatePathWithRootBasePath(t *testing.T) {
+	// Through NewLocalBackend, so it exercises how pathPrefix is derived. A
+	// hand-built struct would pass even if the constructor appended a second
+	// separator to a root that already ends in one.
+	b, err := NewLocalBackend("/", zerolog.Nop())
+	if err != nil {
+		t.Skipf("cannot use / as a storage root here: %v", err)
+	}
+	got, err := b.validatePath("a/b")
+	if err != nil {
+		t.Fatalf("validatePath: %v", err)
+	}
+	if want := filepath.Join("/", "a/b"); got != want {
+		t.Errorf("validatePath(\"a/b\") with root base = %q, want %q", got, want)
+	}
+}
+
+func TestValidatePathMatchesFilepathJoin(t *testing.T) {
+	b := newPathTestBackend(t)
+
+	paths := []string{
+		"",
+		"cpu",
+		"default/cpu/2026/09/12/07/data.parquet",
+		"databases/",
+		"default/",
+		"default/..foo/data.parquet",
+		"default/a..b/data.parquet",
+		"default/.hidden/data.parquet",
+		".sync-staging/rocket-01/default/cpu/f.parquet",
+		strings.Repeat("deep/", 40) + "leaf.parquet",
+	}
+	for _, p := range paths {
+		t.Run(p, func(t *testing.T) {
+			got, err := b.validatePath(p)
+			if err != nil {
+				t.Fatalf("validatePath(%q) = %v, want accepted", p, err)
+			}
+			// filepath.Join is the reference: it is what resolution should
+			// produce. Note this is NOT equivalence with the previous
+			// implementation, which folded the dotted names in this list onto
+			// different locations. That divergence is the fix.
+			if want := filepath.Join(b.basePath, p); got != want {
+				t.Errorf("validatePath(%q) = %q, previous implementation gave %q", p, got, want)
+			}
+		})
+	}
+}
+
+// TestValidatePathNeverEscapesRoot pays for the containment proof here instead
+// of on every call. validatePath dropped its filepath.Rel check because a
+// clean, relative, ".."-free key cannot escape by concatenation; this asserts
+// that property over generated input rather than trusting the argument.
+func TestValidatePathNeverEscapesRoot(t *testing.T) {
+	b := newPathTestBackend(t)
+
+	// Weighted so most generated keys are ACCEPTED, and so the accepted ones
+	// are adversarial rather than trivially safe. A generator that mostly
+	// produces rejects asserts almost nothing, because every reject is skipped.
+	safe := []string{"a", "cpu", "..foo", "a..b", "...", "....", "foo..", "data.parquet", "_x", "x-y"}
+	nasty := []string{"..", ".", "", "/", "x\x00y", "a/", "/a", "//", "a//b", `a\b`}
+	rng := rand.New(rand.NewSource(1))
+
+	accepted := 0
+	distinct := make(map[string]struct{})
+
+	for i := 0; i < 20000; i++ {
+		n := 1 + rng.Intn(5)
+		parts := make([]string, n)
+		for j := range parts {
+			// 85% safe segments, so the accepted population is large, with the
+			// rest seeded from the traversal alphabet.
+			if rng.Intn(100) < 85 {
+				parts[j] = safe[rng.Intn(len(safe))]
+			} else {
+				parts[j] = nasty[rng.Intn(len(nasty))]
+			}
+		}
+		key := strings.Join(parts, "/")
+
+		got, err := b.validatePath(key)
+		if err != nil {
+			continue // rejected, so it never reaches the filesystem
+		}
+		accepted++
+		distinct[key] = struct{}{}
+		rel, relErr := filepath.Rel(b.basePath, got)
+		if relErr != nil {
+			t.Fatalf("accepted key %q resolved to %q, which is not relative to the root: %v", key, got, relErr)
+		}
+		// Compare on a separator boundary, not with a raw prefix: a directory
+		// named "..foo" is inside the root and must not be read as an escape.
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Fatalf("accepted key %q escaped the root: resolved %q, relative %q", key, got, rel)
+		}
+		// The containment assertion is only worth as much as the equivalence
+		// it rests on, so check both on every accepted key.
+		if want := filepath.Join(b.basePath, key); got != want {
+			t.Fatalf("accepted key %q resolved to %q, filepath.Join gives %q", key, got, want)
+		}
+	}
+
+	// Guard against the generator drifting into rejecting almost everything,
+	// which would leave this test asserting nothing while still passing.
+	if accepted < 10000 || len(distinct) < 2000 {
+		t.Fatalf("generator produced only %d accepted keys (%d distinct); the property is barely exercised", accepted, len(distinct))
+	}
+}
+
+// TestStorageKeysAreInjective is #737's invariant at the layer that caused it.
+func TestStorageKeysAreInjective(t *testing.T) {
+	b := newPathTestBackend(t)
+
+	// Pairs that the old fold collapsed onto one location.
+	keys := []string{
+		"default/a..b/x.parquet", "default/a_b/x.parquet",
+		"default/..foo/x.parquet", "default/_foo/x.parquet",
+		"rocket..01/x.parquet", "rocket_01/x.parquet",
+	}
+
+	seen := make(map[string]string, len(keys))
+	for _, k := range keys {
+		resolved, err := b.validatePath(k)
+		if err != nil {
+			t.Fatalf("validatePath(%q) = %v; all of these are legitimate keys", k, err)
+		}
+		if prev, clash := seen[resolved]; clash {
+			t.Errorf("keys %q and %q both resolve to %q", prev, k, resolved)
+		}
+		seen[resolved] = k
+	}
+	if len(seen) != len(keys) {
+		t.Errorf("%d keys resolved to %d locations", len(keys), len(seen))
+	}
+}


### PR DESCRIPTION
Fixes #741.

## The bug

`sanitizePath` repaired its input: every `..` became `_`, NUL bytes were stripped, with a comment saying this prevented directory traversal. It did not. Containment was enforced separately by `validatePath`.

What the rewrite did do was make the mapping from key to file many-to-one. `a..b` and `a_b` were one location, as were `..foo` and `_foo`. That is the root of two bugs already fixed in this release, [#574](https://github.com/Basekick-Labs/arc/pull/574) on the edge-sync source path and [#737](https://github.com/Basekick-Labs/arc/issues/737) on the spoke ID. Each was closed by teaching one caller not to send `..`, which left the next caller to rediscover it.

`TestStorageKeysAreInjective` fails on the old code with **six keys resolving to three locations**.

## Two audits, and the two things they could not see

Instrumenting the backend and running the full suite found no path that the rewrite altered, and none that `filepath.Clean` altered. Both are evidence, not proof. Review found one of each kind they are blind to, and I'd have shipped the first.

**Ingest wedge.** The writer builds `{database}/{measurement}/{year}/...` by interpolation, so an empty measurement yields `db//2026/...`. `filepath.Join` used to collapse that, landing rows a level up under the database itself; this change refuses the key instead. A refused flush **keeps its data in the WAL and retries forever**, so one such record would poison that buffer key permanently. Two producers could reach it: `extractMeasurements` *skipped* empty names so the `isValidMeasurementName` loop right after it never saw them, and MQTT took `"m": ""` as present because it satisfies the type assertion, so the `"mqtt"` default never fired. Both now reject, and MQTT subscriptions validate their database and every topic-mapping target at config load, which was the one ingest surface with no handler in front of it.

**Stored operator config.** Retention builds a prefix from `policy.Database` and `policy.Measurement`, and neither was validated: create checked only non-empty, update checked nothing, and the scheduler replays the row forever. Both validate now, and rows already stored are named at startup. Worth noting the old behaviour was worse than a rejection: an empty database folded to the storage root, so retention enumerated every database as a measurement and **deleted aged files instance-wide**.

## A stricter check would have been its own bug

Those API checks use a storage-segment rule, not `isValidDatabaseName`. The create-time rule is far stricter than the storage contract, and the root legitimately holds directories that never went through it: an edge-sync hub writes each spoke namespace there, and `validateSpokeID` permits a leading digit, interior dots and 128 bytes. Gating the per-name routes on the create rule would have returned 400 for directories `GET /api/v1/databases` had just listed, and would have hidden the `_internal` 403 behind a 400.

## Latent hole the first draft would have shipped

The validator scans `/` segments while the join used `filepath.Separator`, so on a platform whose OS also splits on backslash, a segment built from backslashes passes the scan whole and then escapes. Arc builds linux and darwin only, so it was never live. Backslash is rejected now, as `edgesync` already did.

## Performance

`validatePath` runs on every local read and write. Once the path is known clean and relative, the three `path/filepath` calls after it were redundant, so the check is a single pass with no allocation.

```
                          before      after
BenchmarkValidatePath      605 ns/op   110 ns/op   1 alloc, unchanged
BenchmarkValidatePathDeep  757 ns/op   150 ns/op   1 alloc, unchanged
```

In proportion that is about **0.06% of a 4 MiB Parquet write** and roughly half of a bare existence check, so it is real in the stat-heavy reconciliation and tiering loops and noise on ingest. An earlier draft of mine cited 1565 ns/op as the baseline; that measurement was noisy and 605 is correct. **The change is carried on correctness, not on the speedup.**

Containment is now guaranteed by construction rather than recomputed, so the proof moved into a property test. Its generator is weighted to produce mostly *accepted* keys and asserts it reached 10,000 of them across 2,000 distinct values, because a generator that mostly rejects skips nearly every iteration and asserts nothing. Every accepted key is also checked against `filepath.Join`.

## Also

`ErrInvalidPath` marks rejections, because a permanent error delivered into loops written for transient ones is how a compaction manifest gets retried forever. `validateSyncPath` checked its leading dot on the whole string rather than per segment, so `db/./cpu/x.parquet` was accepted and wrote `Measurement = "."` into the Raft manifest. `GetFullPath` is deleted: no callers, and it swallowed the validation error. The eight surviving copies of "validate and sanitize the path to prevent path traversal" are corrected, since that comment is the lie this change is about.

## Follow-ups

- **#743**: the key contract is now local-only while S3 and Azure validate nothing, so the invariant belongs in the `Backend` interface rather than one implementation.
- **#744**: three further many-to-one mappings found while auditing, including the same `ReplaceAll` fold in compaction manifest names.

## Review note

Three operator-visible refusals are in Upgrade notes: retention policies with a malformed name, MQTT subscriptions with an unusable database or mapping target, and edge-sync paths with a dot-prefixed segment. Also flagged there: `PUT /api/v1/retention/:id` replaces the whole row, so a request omitting `database` is now a 400 rather than silently storing an empty name.