### PR TITLE
Enforce one storage key contract across local, S3 and Azure (#743)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,48 @@ jobs:
       - name: Test (race)
         run: go test -tags=duckdb_arrow -race ./...
 
+      # The storage key contract (#743) is a property of real object stores,
+      # not of a mock: MinIO folds a leading slash so "/a/x" and "a/x" are one
+      # object, and Azure treats a backslash as a separator. Neither is
+      # reproducible in a unit test, and both were found only by probing a live
+      # server. Without this step the contract is asserted rather than enforced.
+      #
+      # docker run, not a service container: quay.io/minio/minio needs the
+      # arguments `server /data`, and services have no way to supply arguments
+      # after the image.
+      - name: Start MinIO
+        run: |
+          docker run -d --name arc-ci-minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+            quay.io/minio/minio server /data
+          # Poll rather than sleep: the first test would otherwise race startup.
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:9000/minio/health/live >/dev/null; then
+              echo "MinIO ready after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "MinIO did not become ready"; docker logs arc-ci-minio; exit 1
+
+      - name: Create MinIO bucket
+        run: |
+          docker run --rm --network host --entrypoint sh quay.io/minio/mc -c \
+            "mc alias set ci http://localhost:9000 minioadmin minioadmin && mc mb -p ci/arctest"
+
+      # A separate tag set means a separate compile of the module. That is the
+      # cost of covering this at all, and it is not run with -race: the tests
+      # are I/O against a local server, so the detector adds build time without
+      # adding signal.
+      - name: Test against real object storage
+        env:
+          ARC_TEST_S3_BUCKET: arctest
+          ARC_TEST_S3_ENDPOINT: http://localhost:9000
+        run: go test -tags="duckdb_arrow objectstore" ./internal/storage/
+
+      - name: Stop MinIO
+        if: always()
+        run: docker rm -f arc-ci-minio || true
+
       # fasthttp runs body-stream writers on a bare goroutine with no recovery,
       # so a panic in one crashes the process rather than failing the request
       # (#717). Every writer must go through QueryHandler.safeStream. arcx_hook.go

--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -227,7 +227,13 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
    spoke fails to start until its ID is changed. See *Edge-sync spoke IDs can
    no longer collide with another spoke's namespace* below. The hub names any
    stored ID in that state at startup.
-3. **A few malformed names are now refused where they were previously
+3. **A misconfigured `storage.s3_prefix` now stops startup instead of silently
+   using the bucket root.** If Arc previously started with a prefix containing
+   `..`, a space, or any character outside `[A-Za-z0-9/._-]`, it was writing to
+   the top of the bucket rather than under that prefix, and it will now refuse
+   to boot until the value is corrected. Check the prefix before upgrading: the
+   data is wherever it was actually being written, not where the config says.
+4. **A few malformed names are now refused where they were previously
    accepted and quietly rewritten** (see *Local storage rejects malformed paths
    instead of rewriting them* below). Three are operator-visible: a retention
    policy whose database or measurement name contains a separator or is empty
@@ -238,7 +244,7 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
    that `PUT /api/v1/retention/:id` replaces the whole row, so a request that
    omits `database` is now a 400 rather than silently storing an empty name,
    which used to make that policy enumerate every database.
-4. **Query response envelopes gained two optional keys** (`rows_capped`,
+5. **Query response envelopes gained two optional keys** (`rows_capped`,
    `row_cap`), emitted only when an Enterprise governance row cap truncated
    the result. Conforming JSON and msgpack decoders are unaffected: the keys
    are absent from every uncapped response, and a capped msgpack envelope
@@ -248,6 +254,59 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
    them at all.
 
 ## Bug fixes
+
+### Every storage backend now enforces the same key contract ([#743](https://github.com/Basekick-Labs/arc/issues/743))
+
+The previous release made local storage refuse malformed keys
+([#741](https://github.com/Basekick-Labs/arc/issues/741)). It was the only
+backend that did, so one key behaved three ways, and the fix's own comment
+claimed a guarantee that held for one implementation out of three.
+
+The rule is now a property of the `Backend` interface, enforced by local, S3 and
+Azure alike. What it guarantees is that two different keys can never name one
+object, which is the property whose absence produced #574, #737 and #741.
+
+**It also fixes a collision #741 introduced.** `"coll"` and `"coll/"` resolved
+to the same local file: two keys, one object, and the first write silently lost.
+The exemption existed because list prefixes legitimately end in a separator, and
+applying a prefix rule to keys is what broke it. Keys and list prefixes are now
+validated separately, so `""` and a trailing separator remain valid for
+enumeration and are refused for a key.
+
+Behaviour on the object stores, all measured against a live MinIO and Azurite
+rather than reasoned about:
+
+- A leading separator is refused. MinIO silently strips it, so `/a/x` and `a/x`
+  were one object there, while S3 and Azure keep them apart. One key, three
+  outcomes.
+- A backslash is refused, because Azure treats it as a separator: `a\b` and
+  `a/b` are **one blob**.
+- `.` and `..` segments and empty interior segments are refused locally now,
+  with a message naming the key. MinIO already rejected all three, but as a
+  remote 400 describing an S3 API error rather than the key at fault. Azure
+  stored them literally.
+- Keys that merely contain dots, such as `a..b` or `..foo`, are accepted
+  everywhere and stored under the name asked for.
+
+**The S3 prefix is validated rather than repaired.** The old sanitiser's damage
+was on its success path: `/` stayed `/`, `a//b` became `a//b/` and `.` became
+`./`, each of which made every write fail against MinIO, while `a/..b` was
+silently replaced with the empty string. That last one is not a safe fallback,
+it is the bucket root, so a typo relocated an entire deployment without a word.
+A prefix that cannot form usable keys now stops the backend from starting.
+
+A listing also never returns a key the backend would then refuse. Object stores
+carry "directory marker" objects whose key ends in a separator, written by
+consoles and sync tools rather than by Arc, and Arc feeds listings straight into
+reads and deletes in a dozen places. Returning one would have been worse than
+the original problem: a restore would skip the file and still report success.
+Those entries are filtered out of listings, so what a listing returns is always
+usable.
+
+A MinIO service is wired into CI for this. Every behaviour above is a property
+of the servers rather than of any mock, no unit test could have found them, and
+the directory-marker case was found only by writing one through the raw S3 API
+and watching a read of it fail.
 
 ### Local storage rejects malformed paths instead of rewriting them ([#741](https://github.com/Basekick-Labs/arc/issues/741))
 

--- a/internal/cluster/raft/path_validation.go
+++ b/internal/cluster/raft/path_validation.go
@@ -63,6 +63,19 @@ var (
 //
 // Checks are ordered from cheapest to most expensive so the common
 // "happy path" early-returns at the first emptiness check.
+//
+// DELIBERATELY NOT storage.ValidateKey, even though this is looser than that
+// contract in several ways (#743): it permits a trailing separator, a "."
+// segment, an empty interior segment, a backslash anywhere but index 0, 4096
+// bytes rather than 1024, and has no per-segment bound.
+//
+// This function runs inside FSM Apply, which includes log REPLAY. Tightening it
+// means a node replaying an entry an older binary accepted would now reject it,
+// so two nodes on different versions would build different state from the same
+// log. That is a correctness hazard strictly worse than the looseness, and it
+// is why the gap is closed at the consumer instead: a storage call that returns
+// storage.ErrInvalidPath is permanent, and callers driving replication or
+// cleanup loops must quarantine rather than retry (#747).
 func ValidateManifestPath(path string) error {
 	if path == "" {
 		return ErrPathEmpty

--- a/internal/edgesync/receive.go
+++ b/internal/edgesync/receive.go
@@ -710,6 +710,17 @@ func validateSyncPath(p string) error {
 			return fmt.Errorf("edgesync: path %q has a segment starting with a dot", p)
 		}
 	}
+	// Bounded so a spoke cannot send a path that passes here, passes the
+	// storage key contract, and then fails only once the ".part" staging
+	// suffix is appended (#743). The headroom is the suffix length.
+	if len(p) > storage.MaxKeyLen-len(storage.PartSuffix) {
+		return fmt.Errorf("edgesync: path is %d bytes, over the %d-byte limit", len(p), storage.MaxKeyLen-len(storage.PartSuffix))
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if len(seg) > storage.MaxKeySegmentLen-len(storage.PartSuffix) {
+			return fmt.Errorf("edgesync: path %q has a %d-byte segment, over the %d-byte limit", p, len(seg), storage.MaxKeySegmentLen-len(storage.PartSuffix))
+		}
+	}
 	if !strings.HasSuffix(p, ".parquet") {
 		// The sync unit is an immutable Parquet file. Anything else is either
 		// a mistake or an attempt to write something the query layer would

--- a/internal/iceberg/exporter.go
+++ b/internal/iceberg/exporter.go
@@ -544,6 +544,13 @@ func (e *Exporter) pruneOldVersionFiles(ctx context.Context, tbl *icetable.Table
 	if !ok {
 		return
 	}
+	// A metadata location directly under the warehouse root gives dirKey "."
+	// or "", so dirKey+"/" would be "./" or "/". Both listed empty before the
+	// storage key contract existed; both are refused by it now (#743). There
+	// is nothing to prune in that shape, so skip rather than report.
+	if dirKey == "" || dirKey == "." {
+		return
+	}
 	keys, err := e.backend.List(ctx, dirKey+"/")
 	if err != nil {
 		return
@@ -897,7 +904,11 @@ func (e *Exporter) DropDatabase(ctx context.Context, database string) error {
 	// the backend so local and object-store warehouses behave alike.
 	if e.backend != nil {
 		nsDirURI := e.warehouse + "/" + e.nsPrefix + "_" + database + ".db"
-		if relDir, ok := e.warehouseRelKey(nsDirURI); ok {
+		// relDir == "" means the namespace directory IS the storage root, so
+		// relDir+"/" would be "/", which the storage key contract refuses
+		// (#743). It listed empty before, and enumerating the whole root to
+		// delete it is not what this is for, so skip it.
+		if relDir, ok := e.warehouseRelKey(nsDirURI); ok && relDir != "" {
 			keys, err := e.backend.List(ctx, relDir+"/")
 			if err != nil && firstErr == nil {
 				firstErr = fmt.Errorf("list warehouse metadata: %w", err)

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -150,12 +150,29 @@ func NewAzureBlobBackend(cfg *AzureBlobConfig, logger zerolog.Logger) (*AzureBlo
 }
 
 // Write writes data to Azure Blob Storage
+// blobKey validates a storage key before it becomes a blob name.
+//
+// Azure has no prefix concept, so the key IS the blob name, and it needs the
+// same contract the other backends enforce (#743). One rule matters especially
+// here: Azure treats a backslash as a path separator, so "a\\b" and "a/b" are
+// ONE blob. ValidateKey rejects backslash for that reason.
+func (b *AzureBlobBackend) blobKey(key string) (string, error) {
+	if err := ValidateKey(key); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
 func (b *AzureBlobBackend) Write(ctx context.Context, path string, data []byte) error {
 	return b.WriteReader(ctx, path, bytes.NewReader(data), int64(len(data)))
 }
 
 // WriteReader writes data from a reader to Azure Blob Storage
 func (b *AzureBlobBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	key, err := b.blobKey(path)
+	if err != nil {
+		return err
+	}
 	start := time.Now()
 
 	// Determine content type
@@ -164,9 +181,9 @@ func (b *AzureBlobBackend) WriteReader(ctx context.Context, path string, reader 
 		contentType = "application/vnd.apache.parquet"
 	}
 
-	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlockBlobClient(path)
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlockBlobClient(key)
 
-	_, err := blobClient.UploadStream(ctx, reader, &azblob.UploadStreamOptions{
+	_, err = blobClient.UploadStream(ctx, reader, &azblob.UploadStreamOptions{
 		HTTPHeaders: &blob.HTTPHeaders{
 			BlobContentType: &contentType,
 		},
@@ -203,7 +220,11 @@ func (b *AzureBlobBackend) WriteReader(ctx context.Context, path string, reader 
 
 // Read reads data from Azure Blob Storage
 func (b *AzureBlobBackend) Read(ctx context.Context, path string) ([]byte, error) {
-	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
+	key, err := b.blobKey(path)
+	if err != nil {
+		return nil, err
+	}
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(key)
 
 	resp, err := blobClient.DownloadStream(ctx, nil)
 	if err != nil {
@@ -232,7 +253,11 @@ func (b *AzureBlobBackend) Read(ctx context.Context, path string) ([]byte, error
 
 // ReadTo reads data from Azure Blob Storage and writes to a writer
 func (b *AzureBlobBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
-	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
+	key, err := b.blobKey(path)
+	if err != nil {
+		return err
+	}
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(key)
 
 	resp, err := blobClient.DownloadStream(ctx, nil)
 	if err != nil {
@@ -262,7 +287,11 @@ func (b *AzureBlobBackend) ReadTo(ctx context.Context, path string, writer io.Wr
 // offset and writes to writer. Uses blob.HTTPRange to skip already-transferred
 // bytes. offset=0 fetches the full blob without a Range header.
 func (b *AzureBlobBackend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
-	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
+	key, err := b.blobKey(path)
+	if err != nil {
+		return err
+	}
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(key)
 
 	var opts *blob.DownloadStreamOptions
 	if offset > 0 {
@@ -296,7 +325,11 @@ func (b *AzureBlobBackend) ReadToAt(ctx context.Context, path string, writer io.
 
 // StatFile returns the byte size of the Azure blob at path, or -1 if not found.
 func (b *AzureBlobBackend) StatFile(ctx context.Context, path string) (int64, error) {
-	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
+	key, err := b.blobKey(path)
+	if err != nil {
+		return 0, err
+	}
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(key)
 
 	resp, err := blobClient.GetProperties(ctx, nil)
 	if err != nil {
@@ -313,6 +346,10 @@ func (b *AzureBlobBackend) StatFile(ctx context.Context, path string) (int64, er
 
 // List lists blobs with the given prefix
 func (b *AzureBlobBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	if err := ValidateListPrefix(prefix); err != nil {
+		return nil, err
+	}
+
 	var blobs []string
 
 	containerClient := b.client.ServiceClient().NewContainerClient(b.containerName)
@@ -332,6 +369,11 @@ func (b *AzureBlobBackend) List(ctx context.Context, prefix string) ([]string, e
 
 		for _, blobItem := range page.Segment.BlobItems {
 			if blobItem.Name != nil {
+				// See S3Backend.List: a listing never returns a key this
+				// backend would refuse (#743).
+				if ValidateKey(*blobItem.Name) != nil {
+					continue
+				}
 				blobs = append(blobs, *blobItem.Name)
 			}
 		}
@@ -342,9 +384,13 @@ func (b *AzureBlobBackend) List(ctx context.Context, prefix string) ([]string, e
 
 // Delete deletes a blob from Azure Blob Storage
 func (b *AzureBlobBackend) Delete(ctx context.Context, path string) error {
-	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
+	key, err := b.blobKey(path)
+	if err != nil {
+		return err
+	}
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(key)
 
-	_, err := blobClient.Delete(ctx, nil)
+	_, err = blobClient.Delete(ctx, nil)
 	if err != nil {
 		// Check if it's a "not found" error - that's okay
 		if isAzureNotFoundError(err) {
@@ -428,9 +474,13 @@ func (b *AzureBlobBackend) DeleteBatch(ctx context.Context, paths []string) erro
 
 // Exists checks if a blob exists in Azure Blob Storage
 func (b *AzureBlobBackend) Exists(ctx context.Context, path string) (bool, error) {
-	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(path)
+	key, err := b.blobKey(path)
+	if err != nil {
+		return false, err
+	}
+	blobClient := b.client.ServiceClient().NewContainerClient(b.containerName).NewBlobClient(key)
 
-	_, err := blobClient.GetProperties(ctx, nil)
+	_, err = blobClient.GetProperties(ctx, nil)
 	if err != nil {
 		if isAzureNotFoundError(err) {
 			return false, nil
@@ -548,6 +598,11 @@ func (b *AzureBlobBackend) ListObjects(ctx context.Context, prefix string) ([]Ob
 
 		for _, blobItem := range page.Segment.BlobItems {
 			if blobItem.Name != nil {
+				// See S3Backend.List: a listing never returns a key this
+				// backend would refuse (#743).
+				if ValidateKey(*blobItem.Name) != nil {
+					continue
+				}
 				info := ObjectInfo{
 					Path: *blobItem.Name,
 				}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -163,7 +163,7 @@ func (b *LocalBackend) Write(ctx context.Context, path string, data []byte) erro
 // is discoverable by StatFile and ReadToAt, enabling the puller to resume from
 // the last committed byte on the next attempt.
 func partPath(fullPath string) string {
-	return fullPath + ".part"
+	return fullPath + PartSuffix
 }
 
 // WriteReader writes data from a reader to the specified path (for large files).
@@ -428,7 +428,7 @@ func (b *LocalBackend) AppendReader(ctx context.Context, path string, reader io.
 // List lists all objects with the given prefix
 func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error) {
 	// Reject the prefix unless it names something inside the root
-	searchPath, err := b.validatePath(prefix)
+	searchPath, err := b.validateListPath(prefix)
 	if err != nil {
 		return nil, fmt.Errorf("invalid prefix: %w", err)
 	}
@@ -550,7 +550,7 @@ func (b *LocalBackend) ConfigJSON() string {
 // Implements the DirectoryLister interface.
 func (b *LocalBackend) ListDirectories(ctx context.Context, prefix string) ([]string, error) {
 	// Reject the prefix unless it names something inside the root
-	searchPath, err := b.validatePath(prefix)
+	searchPath, err := b.validateListPath(prefix)
 	if err != nil {
 		return nil, fmt.Errorf("invalid prefix: %w", err)
 	}
@@ -622,7 +622,7 @@ func (b *LocalBackend) RemoveDirectory(ctx context.Context, path string) error {
 // Implements the ObjectLister interface.
 func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]ObjectInfo, error) {
 	// Reject the prefix unless it names something inside the root
-	searchPath, err := b.validatePath(prefix)
+	searchPath, err := b.validateListPath(prefix)
 	if err != nil {
 		return nil, fmt.Errorf("invalid prefix: %w", err)
 	}
@@ -692,6 +692,11 @@ func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]Object
 	return results, nil
 }
 
+// PartSuffix is appended to build the staging file a local write lands in
+// before being renamed into place. Exported so validators that bound a key's
+// length can leave headroom for it (#743).
+const PartSuffix = ".part"
+
 // ErrInvalidPath marks a key that names nothing inside the backend root. It is
 // permanent: retrying with the same key can never succeed, so callers driving
 // cleanup or reconciliation loops should quarantine the entry rather than
@@ -702,67 +707,113 @@ var ErrInvalidPath = errors.New("storage: invalid path")
 // "/"-separated by contract on every backend; this is the on-disk separator.
 const storagePathSeparator = string(filepath.Separator)
 
-// checkStoragePath reports whether path is a clean, relative location inside
-// the backend root.
+// MaxKeyLen bounds a storage key. 1024 bytes is the S3 object-key limit, which
+// is the tightest of the three backends at whole-key granularity.
+const MaxKeyLen = 1024
+
+// MaxKeySegmentLen bounds one "/"-separated component. 255 bytes is the POSIX
+// filename limit, so a longer segment cannot be stored locally at all and a key
+// carrying one is refused with a message instead of ENAMETOOLONG from the
+// syscall.
+const MaxKeySegmentLen = 255
+
+// ValidateKey reports whether key names exactly one object.
 //
-// It REJECTS rather than repairs, which is the whole point. The previous
-// implementation rewrote its input, folding every ".." to "_" and stripping NUL
-// bytes, and claimed that prevented traversal. It did not: containment was
-// enforced separately. What the rewrite did do was make the mapping from
-// requested key to stored key many-to-one, so two different keys could name one
-// file. That produced #574 (source paths) and #737 (spoke IDs), each closed by
-// teaching one caller not to send "..", which leaves the next caller to
-// rediscover it. Rejecting makes the mapping injective for every caller at once.
+// This is the contract every Backend implementation enforces, and it exists so
+// the mapping from key to stored object is INJECTIVE: two different keys must
+// never name one object. Non-injective mappings are what produced #574 (source
+// paths), #737 (spoke IDs) and #741 (the local ".."-to-"_" fold), each closed
+// by teaching one caller to behave and each leaving the next caller to
+// rediscover it.
 //
-// Deliberately permitted:
+// Rejected, and why each is two spellings of one location rather than mere
+// tidiness:
 //
-//   - "" means the root. Listing callers pass it to walk everything.
-//   - A single trailing "/", which list prefixes use constantly ("databases/",
-//     database+"/"). validatePath strips it so the result stays canonical.
-//   - Segments that merely contain dots, such as "..foo" or "a..b". They are
-//     ordinary filenames, not traversal. The old fold collapsed "..foo" onto
-//     "_foo", which is the same collision one level down.
+//   - "" and a trailing "/". "coll" and "coll/" resolve to one file on local
+//     storage, and on S3 a trailing slash is a distinct "directory marker"
+//     object, so the two backends disagree about which it even is. Use
+//     ValidateListPrefix for list prefixes, which is where those spellings are
+//     legitimate.
+//   - A leading "/". MinIO strips it, so "/a/x" and "a/x" are one object there,
+//     while S3 and Azure keep them distinct. Same key, three outcomes.
+//   - "." and ".." segments, and an empty interior segment ("a//b"). MinIO
+//     refuses all three with a 400; Azure stores them literally; local resolved
+//     them by folding until #741.
+//   - A backslash. On Azure "a\b" and "a/b" are ONE blob, verified against
+//     Azurite, so this is a live collision rather than a Windows-separator
+//     precaution.
+//   - NUL bytes, and lengths past MaxKeyLen or MaxKeySegmentLen.
+//
+// Deliberately ACCEPTED: segments that merely contain dots, such as "..foo" or
+// "a..b". They name one object on every backend. The old local fold collapsed
+// "..foo" onto "_foo", which was the same collision one level down.
 //
 // One pass, no allocation, no strings.Split.
-func checkStoragePath(path string) error {
-	if path == "" {
+func ValidateKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("%w: key is empty", ErrInvalidPath)
+	}
+	if key[len(key)-1] == '/' {
+		return fmt.Errorf("%w: %q ends in a separator, which names the same object as %q", ErrInvalidPath, key, key[:len(key)-1])
+	}
+	return validateKeyBody(key)
+}
+
+// ValidateListPrefix reports whether prefix is usable to enumerate keys.
+//
+// Looser than ValidateKey in exactly two ways, both of which callers rely on:
+// "" means "everything", and a single trailing "/" scopes to a directory
+// ("databases/", database+"/"). Neither can name an object, so neither
+// threatens injectivity.
+//
+// Note the backends disagree about what a prefix means, and this does not
+// change that: on S3 it is a true string prefix, so "default/cp" is meaningful,
+// while on local it selects a directory to walk.
+func ValidateListPrefix(prefix string) error {
+	if prefix == "" {
 		return nil
 	}
-	if path[0] == '/' {
-		return fmt.Errorf("%w: %q must be relative to the backend root", ErrInvalidPath, path)
+	if prefix == "/" {
+		return fmt.Errorf("%w: %q is not a relative prefix; use \"\" for everything", ErrInvalidPath, prefix)
+	}
+	if prefix[len(prefix)-1] == '/' {
+		prefix = prefix[:len(prefix)-1]
+	}
+	return validateKeyBody(prefix)
+}
+
+// validateKeyBody holds the rules common to keys and list prefixes. Callers
+// have already dealt with emptiness and any trailing separator.
+func validateKeyBody(p string) error {
+	if len(p) > MaxKeyLen {
+		return fmt.Errorf("%w: key is %d bytes, over the %d-byte limit", ErrInvalidPath, len(p), MaxKeyLen)
+	}
+	if p[0] == '/' {
+		return fmt.Errorf("%w: %q must be relative to the backend root", ErrInvalidPath, p)
 	}
 	start := 0
-	for i := 0; i <= len(path); i++ {
-		if i < len(path) {
-			c := path[i]
+	for i := 0; i <= len(p); i++ {
+		if i < len(p) {
+			c := p[i]
 			if c == 0 {
 				return fmt.Errorf("%w: contains a NUL byte", ErrInvalidPath)
 			}
-			// Backslash is rejected rather than treated as an ordinary byte.
-			// Keys are "/"-separated on every backend, and on a platform whose
-			// OS also treats backslash as a separator, a segment built from
-			// them would pass a "/"-only segment scan whole and then escape
-			// once joined. Rejecting here
-			// keeps the validator and the join agreeing about what a separator
-			// is. internal/edgesync/receive.go already rejects it for the same
-			// reason.
 			if c == '\\' {
-				return fmt.Errorf("%w: %q contains a backslash", ErrInvalidPath, path)
+				return fmt.Errorf("%w: %q contains a backslash, which Azure treats as a separator", ErrInvalidPath, p)
 			}
 			if c != '/' {
 				continue
 			}
 		}
-		switch path[start:i] {
+		seg := p[start:i]
+		switch seg {
 		case "":
-			// The only empty segment allowed is the one a trailing slash
-			// produces. An interior one means "a//b", which is two spellings
-			// of one location.
-			if i != len(path) {
-				return fmt.Errorf("%w: %q contains an empty segment", ErrInvalidPath, path)
-			}
+			return fmt.Errorf("%w: %q contains an empty segment", ErrInvalidPath, p)
 		case ".", "..":
-			return fmt.Errorf("%w: %q contains a %q segment", ErrInvalidPath, path, path[start:i])
+			return fmt.Errorf("%w: %q contains a %q segment", ErrInvalidPath, p, seg)
+		}
+		if len(seg) > MaxKeySegmentLen {
+			return fmt.Errorf("%w: %q has a %d-byte segment, over the %d-byte limit", ErrInvalidPath, p, len(seg), MaxKeySegmentLen)
 		}
 		start = i + 1
 	}
@@ -773,8 +824,8 @@ func checkStoragePath(path string) error {
 // key that does not name something inside the backend root.
 //
 // There is no filepath.Join, Abs or Rel here, and that is safe rather than
-// merely fast. checkStoragePath has already established that the key is
-// relative, clean and free of ".." segments, and basePath is absolute and clean
+// merely fast. The validator has already established that the key is relative,
+// clean and free of ".." segments, and basePath is absolute and clean
 // (NewLocalBackend applies filepath.Abs). Join's only contribution was Clean,
 // on input proven not to need it; Abs re-cleaned an already absolute path; and
 // Rel recomputed a containment property that concatenation now guarantees by
@@ -787,17 +838,23 @@ func checkStoragePath(path string) error {
 //
 // Symlinks are not resolved, exactly as before. A symlink inside the root that
 // points outside it escapes, and did under the previous implementation too.
-func (b *LocalBackend) validatePath(path string) (string, error) {
-	if err := checkStoragePath(path); err != nil {
+func (b *LocalBackend) validatePath(key string) (string, error) {
+	if err := ValidateKey(key); err != nil {
 		return "", err
 	}
-	if path == "" {
+	return b.pathPrefix + key, nil
+}
+
+// validateListPath resolves a list prefix to the directory it names.
+func (b *LocalBackend) validateListPath(prefix string) (string, error) {
+	if err := ValidateListPrefix(prefix); err != nil {
+		return "", err
+	}
+	if prefix == "" {
 		return b.basePath, nil
 	}
-	// Match what filepath.Join returned: a trailing slash is accepted on the
-	// way in and absent from the result.
-	if path[len(path)-1] == '/' {
-		path = path[:len(path)-1]
+	if prefix[len(prefix)-1] == '/' {
+		prefix = prefix[:len(prefix)-1]
 	}
-	return b.pathPrefix + path, nil
+	return b.pathPrefix + prefix, nil
 }

--- a/internal/storage/objectstore_contract_test.go
+++ b/internal/storage/objectstore_contract_test.go
@@ -1,0 +1,274 @@
+//go:build objectstore
+
+// Package storage's key contract, verified against real object stores.
+//
+// Tagged `objectstore` because it needs live backends. Unit tests cannot find
+// what this finds: the behaviours that motivated #743 (MinIO folding a leading
+// slash, Azure treating a backslash as a separator) are properties of the
+// servers, not of any mock.
+//
+// Run with:
+//
+//	docker run -d --name arc-minio -p 9000:9000 \
+//	  -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+//	  quay.io/minio/minio server /data
+//	ARC_TEST_S3_BUCKET=arctest go test -tags='duckdb_arrow objectstore' ./internal/storage/
+//
+// CI does this in .github/workflows/ci.yml.
+package storage
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func minioBackend(t *testing.T) *S3Backend {
+	t.Helper()
+	bucket := os.Getenv("ARC_TEST_S3_BUCKET")
+	if bucket == "" {
+		t.Skip("ARC_TEST_S3_BUCKET not set")
+	}
+	endpoint := os.Getenv("ARC_TEST_S3_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:9000"
+	}
+	b, err := NewS3Backend(&S3Config{
+		Bucket: bucket, Region: "us-east-1", Endpoint: endpoint,
+		AccessKey: "minioadmin", SecretKey: "minioadmin", PathStyle: true,
+	}, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("S3 backend: %v", err)
+	}
+	return b
+}
+
+// TestS3RejectsNonInjectiveKeys pins the contract at the backend that has the
+// most to lose from it. Each key here either names one object under two
+// spellings, or is refused by the store itself with a remote 400 that says
+// nothing useful about which key was wrong.
+func TestS3RejectsNonInjectiveKeys(t *testing.T) {
+	b := minioBackend(t)
+	ctx := context.Background()
+
+	rejected := []struct{ name, key string }{
+		// MinIO strips this, so it is the same object as "coll/x.parquet".
+		{"leading separator", "/coll/x.parquet"},
+		// Refused by the store with XMinioInvalidResourceName.
+		{"parent segment", "db/../etc/x.parquet"},
+		{"current segment", "db/./cpu/x.parquet"},
+		// Refused with XMinioInvalidObjectName.
+		{"empty interior segment", "db//cpu/x.parquet"},
+		// A trailing separator names a directory marker, not this object.
+		{"trailing separator", "db/cpu/"},
+		{"empty", ""},
+	}
+	for _, tt := range rejected {
+		t.Run("reject/"+tt.name, func(t *testing.T) {
+			err := b.Write(ctx, tt.key, []byte("payload"))
+			if err == nil {
+				t.Fatalf("Write(%q) was accepted", tt.key)
+			}
+			if !errors.Is(err, ErrInvalidPath) {
+				t.Errorf("Write(%q) failed remotely rather than being refused locally: %v", tt.key, err)
+			}
+		})
+	}
+
+	accepted := []struct{ name, key string }{
+		{"ordinary", "contract/ok/x.parquet"},
+		// Dots inside a segment are an ordinary name on every backend.
+		{"dots in a segment", "contract/a..b/x.parquet"},
+		{"leading dots in a segment", "contract/..foo/x.parquet"},
+	}
+	for _, tt := range accepted {
+		t.Run("accept/"+tt.name, func(t *testing.T) {
+			want := []byte("payload-" + tt.key)
+			if err := b.Write(ctx, tt.key, want); err != nil {
+				t.Fatalf("Write(%q) = %v, want accepted", tt.key, err)
+			}
+			got, err := b.Read(ctx, tt.key)
+			if err != nil {
+				t.Fatalf("Read(%q) = %v", tt.key, err)
+			}
+			if string(got) != string(want) {
+				t.Errorf("Read(%q) = %q, want %q", tt.key, got, want)
+			}
+		})
+	}
+}
+
+// TestS3ListPrefixesStillWork guards the other half: the spellings a prefix
+// needs are exactly the ones a key may not have, so tightening keys must not
+// break enumeration.
+func TestS3ListPrefixesStillWork(t *testing.T) {
+	b := minioBackend(t)
+	ctx := context.Background()
+
+	if err := b.Write(ctx, "prefixtest/db/cpu/x.parquet", []byte("p")); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	for _, prefix := range []string{"", "prefixtest/", "prefixtest/db/", "prefixtest/db"} {
+		objs, err := b.List(ctx, prefix)
+		if err != nil {
+			t.Errorf("List(%q) = %v", prefix, err)
+			continue
+		}
+		if len(objs) == 0 {
+			t.Errorf("List(%q) returned nothing; the seeded object should match", prefix)
+		}
+	}
+	if _, err := b.List(ctx, "/"); err == nil {
+		t.Error(`List("/") was accepted; use "" for everything`)
+	}
+}
+
+// TestS3KeysAreInjective is the property, asserted through a real store: two
+// distinct accepted keys must never name one object.
+func TestS3KeysAreInjective(t *testing.T) {
+	b := minioBackend(t)
+	ctx := context.Background()
+
+	keys := []string{
+		"inj/a..b/x.parquet", "inj/a_b/x.parquet",
+		"inj/..foo/x.parquet", "inj/_foo/x.parquet",
+	}
+	for _, k := range keys {
+		if err := b.Write(ctx, k, []byte("payload-"+k)); err != nil {
+			t.Fatalf("Write(%q) = %v", k, err)
+		}
+	}
+	// Read back only after every write, so a collision shows as an earlier
+	// payload having been replaced.
+	for _, k := range keys {
+		got, err := b.Read(ctx, k)
+		if err != nil {
+			t.Fatalf("Read(%q) = %v", k, err)
+		}
+		if want := "payload-" + k; string(got) != want {
+			t.Errorf("key %q reads back %q; another key names the same object", k, got)
+		}
+	}
+}
+
+// TestS3ListNeverReturnsUnusableKeys is the invariant that keeps the contract
+// from breaking its own consumers.
+//
+// Object stores carry "directory marker" objects whose key ends in a
+// separator, created by consoles and sync tools rather than by Arc. Arc feeds
+// List output straight into Read, Exists and Delete in a dozen places, so a
+// listing that returns a key the backend then refuses is worse than one that
+// never returned it: restore drops the file and still reports success,
+// compaction's "already gone" skip turns into a hard job failure, and manifest
+// recovery retries a permanent error forever.
+//
+// Creating a marker needs the raw API, because the SDK helpers will not build
+// a key ending in "/".
+func TestS3ListNeverReturnsUnusableKeys(t *testing.T) {
+	b := minioBackend(t)
+	ctx := context.Background()
+
+	if err := b.Write(ctx, "markers/real.parquet", []byte("data")); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	if err := putRawKey(t, b, "markers/dir/"); err != nil {
+		t.Skipf("could not create a directory marker: %v", err)
+	}
+
+	keys, err := b.List(ctx, "markers/")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var sawReal bool
+	for _, k := range keys {
+		if err := ValidateKey(k); err != nil {
+			t.Errorf("List returned %q, which this backend refuses: %v", k, err)
+		}
+		// The real test of the invariant: everything listed must be readable.
+		if _, err := b.Read(ctx, k); err != nil {
+			t.Errorf("List returned %q but Read failed: %v", k, err)
+		}
+		if k == "markers/real.parquet" {
+			sawReal = true
+		}
+	}
+	if !sawReal {
+		t.Error("filtering removed a legitimate object")
+	}
+
+	objs, err := b.ListObjects(ctx, "markers/")
+	if err != nil {
+		t.Fatalf("ListObjects: %v", err)
+	}
+	for _, o := range objs {
+		if err := ValidateKey(o.Path); err != nil {
+			t.Errorf("ListObjects returned %q, which this backend refuses: %v", o.Path, err)
+		}
+	}
+}
+
+// putRawKey writes an object under a key the backend itself would refuse,
+// using a signed request rather than the backend, so the test can create the
+// state a foreign tool would leave behind.
+func putRawKey(t *testing.T, b *S3Backend, key string) error {
+	t.Helper()
+	endpoint := os.Getenv("ARC_TEST_S3_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:9000"
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	body := []byte{}
+	payload := sha256.Sum256(body)
+	payloadHex := hex.EncodeToString(payload[:])
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	canonicalURI := "/" + b.bucket + "/" + key
+	canonicalReq := strings.Join([]string{
+		"PUT", canonicalURI, "",
+		"host:" + u.Host,
+		"x-amz-content-sha256:" + payloadHex,
+		"x-amz-date:" + amzDate,
+		"", "host;x-amz-content-sha256;x-amz-date", payloadHex,
+	}, "\n")
+	scope := dateStamp + "/us-east-1/s3/aws4_request"
+	crHash := sha256.Sum256([]byte(canonicalReq))
+	toSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + scope + "\n" + hex.EncodeToString(crHash[:])
+	mac := func(k []byte, d string) []byte { h := hmac.New(sha256.New, k); h.Write([]byte(d)); return h.Sum(nil) }
+	signingKey := mac(mac(mac(mac([]byte("AWS4minioadmin"), dateStamp), "us-east-1"), "s3"), "aws4_request")
+	sig := hex.EncodeToString(mac(signingKey, toSign))
+
+	req, err := http.NewRequest("PUT", endpoint+canonicalURI, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("x-amz-date", amzDate)
+	req.Header.Set("x-amz-content-sha256", payloadHex)
+	req.Header.Set("Authorization",
+		"AWS4-HMAC-SHA256 Credential=minioadmin/"+scope+
+			", SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature="+sig)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("marker PUT returned %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -174,8 +174,13 @@ func NewS3Backend(cfg *S3Config, logger zerolog.Logger) (*S3Backend, error) {
 		u.Concurrency = multipartConcurrency
 	})
 
-	// Sanitize prefix: strip leading /, reject .., ensure trailing / if non-empty
-	prefix := SanitizeS3Prefix(cfg.Prefix)
+	// Validate the prefix rather than repairing it. A prefix that cannot form
+	// usable keys must stop the backend from being built: the old fallback was
+	// the bucket root, which is a different location, not a safe default.
+	prefix, err := ValidateS3Prefix(cfg.Prefix)
+	if err != nil {
+		return nil, err
+	}
 
 	backend := &S3Backend{
 		client:    client,
@@ -215,6 +220,10 @@ func (b *S3Backend) Write(ctx context.Context, path string, data []byte) error {
 // WriteReader writes data from a reader to S3
 // For files larger than 100MB, uses multipart upload to avoid OOM
 func (b *S3Backend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	key, err := b.prefixedKey(path)
+	if err != nil {
+		return err
+	}
 	start := time.Now()
 
 	// Determine content type
@@ -230,9 +239,9 @@ func (b *S3Backend) WriteReader(ctx context.Context, path string, reader io.Read
 	}
 
 	// For small files with known size, use simple PutObject
-	_, err := b.client.PutObject(ctx, &s3.PutObjectInput{
+	_, err = b.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(b.bucket),
-		Key:           aws.String(b.prefixedKey(path)),
+		Key:           aws.String(key),
 		Body:          reader,
 		ContentLength: aws.Int64(size),
 		ContentType:   aws.String(contentType),
@@ -264,9 +273,13 @@ func (b *S3Backend) WriteReader(ctx context.Context, path string, reader io.Read
 // writeMultipart handles multipart upload for large files
 // This streams data in 16MB chunks without loading the entire file into memory
 func (b *S3Backend) writeMultipart(ctx context.Context, path string, reader io.Reader, size int64, contentType string, start time.Time) error {
-	_, err := b.uploader.Upload(ctx, &s3.PutObjectInput{
+	key, err := b.prefixedKey(path)
+	if err != nil {
+		return err
+	}
+	_, err = b.uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket:      aws.String(b.bucket),
-		Key:         aws.String(b.prefixedKey(path)),
+		Key:         aws.String(key),
 		Body:        reader,
 		ContentType: aws.String(contentType),
 	})
@@ -304,9 +317,13 @@ func (b *S3Backend) writeMultipart(ctx context.Context, path string, reader io.R
 
 // Read reads data from S3
 func (b *S3Backend) Read(ctx context.Context, path string) ([]byte, error) {
+	key, err := b.prefixedKey(path)
+	if err != nil {
+		return nil, err
+	}
 	result, err := b.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(b.bucket),
-		Key:    aws.String(b.prefixedKey(path)),
+		Key:    aws.String(key),
 	})
 	if err != nil {
 		recordStorageError(ctx, err)
@@ -334,9 +351,13 @@ func (b *S3Backend) Read(ctx context.Context, path string) ([]byte, error) {
 
 // ReadTo reads data from S3 and writes to a writer
 func (b *S3Backend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
+	key, err := b.prefixedKey(path)
+	if err != nil {
+		return err
+	}
 	result, err := b.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(b.bucket),
-		Key:    aws.String(b.prefixedKey(path)),
+		Key:    aws.String(key),
 	})
 	if err != nil {
 		recordStorageError(ctx, err)
@@ -365,9 +386,13 @@ func (b *S3Backend) ReadTo(ctx context.Context, path string, writer io.Writer) e
 // writer. Uses an HTTP Range header to skip already-transferred bytes.
 // offset=0 fetches the full object (no Range header sent).
 func (b *S3Backend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
+	key, err := b.prefixedKey(path)
+	if err != nil {
+		return err
+	}
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(b.bucket),
-		Key:    aws.String(b.prefixedKey(path)),
+		Key:    aws.String(key),
 	}
 	if offset > 0 {
 		input.Range = aws.String(fmt.Sprintf("bytes=%d-", offset))
@@ -398,9 +423,13 @@ func (b *S3Backend) ReadToAt(ctx context.Context, path string, writer io.Writer,
 
 // StatFile returns the byte size of the S3 object at path, or -1 if not found.
 func (b *S3Backend) StatFile(ctx context.Context, path string) (int64, error) {
+	key, err := b.prefixedKey(path)
+	if err != nil {
+		return 0, err
+	}
 	result, err := b.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(b.bucket),
-		Key:    aws.String(b.prefixedKey(path)),
+		Key:    aws.String(key),
 	})
 	if err != nil {
 		if isNotFoundError(err) {
@@ -419,6 +448,11 @@ func (b *S3Backend) List(ctx context.Context, prefix string) ([]string, error) {
 	var objects []string
 	var continuationToken *string
 
+	fullPrefix, err := b.prefixedListPrefix(prefix)
+	if err != nil {
+		return nil, err
+	}
+
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -426,7 +460,7 @@ func (b *S3Backend) List(ctx context.Context, prefix string) ([]string, error) {
 
 		result, err := b.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 			Bucket:            aws.String(b.bucket),
-			Prefix:            aws.String(b.prefixedKey(prefix)),
+			Prefix:            aws.String(fullPrefix),
 			ContinuationToken: continuationToken,
 		})
 		if err != nil {
@@ -437,6 +471,19 @@ func (b *S3Backend) List(ctx context.Context, prefix string) ([]string, error) {
 			if obj.Key != nil {
 				// Strip prefix so callers see paths relative to the logical root
 				key := strings.TrimPrefix(*obj.Key, b.prefix)
+				// A listing must never hand back a key this backend would
+				// refuse (#743). Object stores carry "directory marker"
+				// objects whose key ends in a separator, created by consoles
+				// and sync tools, and Arc's own callers feed List output
+				// straight into Read, Exists and Delete. Returning one turns
+				// every such consumer into a failure: restore drops the file
+				// and still reports success, compaction's "already gone" skip
+				// becomes a hard error, and manifest recovery retries a
+				// permanent error forever. They are not data, so they are
+				// skipped rather than reported.
+				if ValidateKey(key) != nil {
+					continue
+				}
 				objects = append(objects, key)
 			}
 		}
@@ -452,9 +499,13 @@ func (b *S3Backend) List(ctx context.Context, prefix string) ([]string, error) {
 
 // Delete deletes an object from S3
 func (b *S3Backend) Delete(ctx context.Context, path string) error {
-	_, err := b.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+	key, err := b.prefixedKey(path)
+	if err != nil {
+		return err
+	}
+	_, err = b.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(b.bucket),
-		Key:    aws.String(b.prefixedKey(path)),
+		Key:    aws.String(key),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to delete from S3: %w", err)
@@ -485,11 +536,23 @@ func (b *S3Backend) DeleteBatch(ctx context.Context, paths []string) error {
 		}
 
 		batch := paths[i:end]
-		objects := make([]types.ObjectIdentifier, len(batch))
-		for j, path := range batch {
-			objects[j] = types.ObjectIdentifier{
-				Key: aws.String(b.prefixedKey(path)),
+		// Best-effort per key rather than all-or-nothing. Two callers
+		// (backup/manager.go, compaction/job.go) return this error with no
+		// per-file fallback, so failing the whole batch on one bad key would
+		// make a backup permanently undeletable and leave compaction inputs
+		// beside their output forever. The keys come from List, so they are
+		// whatever is in the bucket, not only what Arc wrote.
+		objects := make([]types.ObjectIdentifier, 0, len(batch))
+		for _, p := range batch {
+			key, kerr := b.prefixedKey(p)
+			if kerr != nil {
+				nonFatalErrs = append(nonFatalErrs, kerr)
+				continue
 			}
+			objects = append(objects, types.ObjectIdentifier{Key: aws.String(key)})
+		}
+		if len(objects) == 0 {
+			continue
 		}
 
 		output, err := b.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
@@ -541,9 +604,13 @@ func (b *S3Backend) DeleteBatch(ctx context.Context, paths []string) error {
 
 // Exists checks if an object exists in S3
 func (b *S3Backend) Exists(ctx context.Context, path string) (bool, error) {
-	_, err := b.client.HeadObject(ctx, &s3.HeadObjectInput{
+	key, err := b.prefixedKey(path)
+	if err != nil {
+		return false, err
+	}
+	_, err = b.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(b.bucket),
-		Key:    aws.String(b.prefixedKey(path)),
+		Key:    aws.String(key),
 	})
 	if err != nil {
 		// Check if it's a "not found" error
@@ -573,40 +640,75 @@ func isNotFoundError(err error) bool {
 		strings.Contains(errStr, "404")
 }
 
-// SanitizeS3Prefix cleans and validates an S3 path prefix.
-// Returns empty string if prefix is empty (no-op), otherwise ensures trailing /.
-// Only allows alphanumeric characters, hyphens, underscores, dots, and slashes.
-func SanitizeS3Prefix(prefix string) string {
+// ValidateS3Prefix checks a configured bucket prefix and returns it with a
+// trailing separator.
+//
+// It validates rather than rewrites. The previous SanitizeS3Prefix repaired its
+// input, and the damage was on its SUCCESS path, not its failure path:
+//
+//	"/"      -> "/"      every key then starts with "/", which MinIO folds away
+//	"a//b"   -> "a//b/"  every write 400s with XMinioInvalidObjectName
+//	"."      -> "./"     every write 400s with XMinioInvalidResourceName
+//	"a/..b"  -> ""       a legitimate prefix silently becomes the BUCKET ROOT
+//
+// The last is the worst of them: "" is not a safe fallback, it is a different
+// and much larger location, so a typo relocated an entire deployment without a
+// word. The ".." rejection that caused it was also a raw substring match, the
+// same class this repo removed for keys in #741.
+//
+// An empty prefix is legitimate and means the bucket root was chosen
+// deliberately.
+func ValidateS3Prefix(prefix string) (string, error) {
 	prefix = strings.TrimSpace(prefix)
 	if prefix == "" {
-		return ""
+		return "", nil
 	}
-	// Strip leading slash
-	prefix = strings.TrimLeft(prefix, "/")
-	// Reject path traversal
-	if strings.Contains(prefix, "..") {
-		return ""
+	// Reuse the key contract, which already rejects leading "/", "." and ".."
+	// segments, empty interior segments, backslash and NUL. A trailing
+	// separator is what a prefix is for, so strip it before checking and add
+	// it back after.
+	if err := ValidateListPrefix(prefix); err != nil {
+		return "", fmt.Errorf("storage prefix %q is not usable: %w", prefix, err)
 	}
-	// Reject unsafe characters (defense-in-depth against SQL injection
-	// since prefixes are interpolated into DuckDB read_parquet() calls)
+	// Defence in depth against SQL injection: the prefix is interpolated into
+	// DuckDB read_parquet() calls, so keep the character allowlist the old
+	// implementation had.
 	for _, c := range prefix {
 		switch {
 		case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'):
 		case c == '/' || c == '-' || c == '_' || c == '.':
 		default:
-			return ""
+			return "", fmt.Errorf("storage prefix %q contains an unsupported character %q", prefix, c)
 		}
 	}
-	// Ensure trailing slash
 	if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}
-	return prefix
+	return prefix, nil
 }
 
-// prefixedKey prepends the configured prefix to an S3 object key
-func (b *S3Backend) prefixedKey(path string) string {
-	return b.prefix + path
+// prefixedKey validates a storage key and prepends the configured prefix.
+//
+// Returning an error is what makes the contract hold: a new method that builds
+// an S3 key has to deal with it, rather than silently passing an unvalidated
+// string to the SDK. Note this is not a total chokepoint. Arc's READ path does
+// not go through Backend at all: storage/util.go builds an s3:// URI that
+// DuckDB's read_parquet consumes, and iceberg-go writes metadata through its
+// own FileIO. Both are out of scope here (#746).
+func (b *S3Backend) prefixedKey(key string) (string, error) {
+	if err := ValidateKey(key); err != nil {
+		return "", err
+	}
+	return b.prefix + key, nil
+}
+
+// prefixedListPrefix is prefixedKey for enumeration, where "" and a trailing
+// separator are legitimate and cannot name an object.
+func (b *S3Backend) prefixedListPrefix(prefix string) (string, error) {
+	if err := ValidateListPrefix(prefix); err != nil {
+		return "", err
+	}
+	return b.prefix + prefix, nil
 }
 
 // Close closes the S3 backend (no-op for S3)
@@ -736,7 +838,10 @@ func (b *S3Backend) ListDirectories(ctx context.Context, prefix string) ([]strin
 		prefix = prefix + "/"
 	}
 
-	fullPrefix := b.prefixedKey(prefix)
+	fullPrefix, err := b.prefixedListPrefix(prefix)
+	if err != nil {
+		return nil, err
+	}
 
 	var dirs []string
 	var continuationToken *string
@@ -784,6 +889,11 @@ func (b *S3Backend) ListObjects(ctx context.Context, prefix string) ([]ObjectInf
 	var objects []ObjectInfo
 	var continuationToken *string
 
+	fullPrefix, err := b.prefixedListPrefix(prefix)
+	if err != nil {
+		return nil, err
+	}
+
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -791,7 +901,7 @@ func (b *S3Backend) ListObjects(ctx context.Context, prefix string) ([]ObjectInf
 
 		result, err := b.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 			Bucket:            aws.String(b.bucket),
-			Prefix:            aws.String(b.prefixedKey(prefix)),
+			Prefix:            aws.String(fullPrefix),
 			ContinuationToken: continuationToken,
 		})
 		if err != nil {
@@ -800,9 +910,13 @@ func (b *S3Backend) ListObjects(ctx context.Context, prefix string) ([]ObjectInf
 
 		for _, obj := range result.Contents {
 			if obj.Key != nil {
-				info := ObjectInfo{
-					Path: strings.TrimPrefix(*obj.Key, b.prefix),
+				key := strings.TrimPrefix(*obj.Key, b.prefix)
+				// See List: a listing never returns a key the backend would
+				// refuse (#743).
+				if ValidateKey(key) != nil {
+					continue
 				}
+				info := ObjectInfo{Path: key}
 				if obj.Size != nil {
 					info.Size = *obj.Size
 				}

--- a/internal/storage/s3_prefix_test.go
+++ b/internal/storage/s3_prefix_test.go
@@ -2,38 +2,33 @@ package storage
 
 import "testing"
 
-func TestSanitizeS3Prefix(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		expect string
-	}{
-		{"empty", "", ""},
-		{"whitespace only", "   ", ""},
-		{"simple path", "instances/abc123", "instances/abc123/"},
-		{"with trailing slash", "instances/abc123/", "instances/abc123/"},
-		{"with leading slash", "/instances/abc123", "instances/abc123/"},
-		{"with both slashes", "/instances/abc123/", "instances/abc123/"},
-		{"single segment", "prefix", "prefix/"},
-		{"path traversal rejected", "instances/../etc", ""},
-		{"double dot in name rejected", "instances/..hidden", ""},
-		{"nested path", "org/tenant/data", "org/tenant/data/"},
-		{"with hyphens and underscores", "my-org/tenant_1", "my-org/tenant_1/"},
-		{"with dots", "org.name/v1.0", "org.name/v1.0/"},
-		{"sql injection rejected", "tenant'; DROP TABLE --", ""},
-		{"single quotes rejected", "tenant's/data", ""},
-		{"semicolon rejected", "tenant;data", ""},
-		{"spaces rejected", "tenant name/data", ""},
-		{"special chars rejected", "tenant@#$/data", ""},
+func TestValidateS3Prefix(t *testing.T) {
+	accepted := []struct{ in, want string }{
+		{"", ""},
+		{"instances/abc123", "instances/abc123/"},
+		{"instances/abc123/", "instances/abc123/"},
+		{"  tenant1  ", "tenant1/"},
+		{"a..b", "a..b/"}, // a legitimate name the old ".." substring check destroyed
+	}
+	for _, tt := range accepted {
+		got, err := ValidateS3Prefix(tt.in)
+		if err != nil {
+			t.Errorf("ValidateS3Prefix(%q) = %v, want %q", tt.in, err, tt.want)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ValidateS3Prefix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := SanitizeS3Prefix(tt.input)
-			if got != tt.expect {
-				t.Errorf("SanitizeS3Prefix(%q) = %q, want %q", tt.input, got, tt.expect)
-			}
-		})
+	// Every one of these came out of the OLD function's success path and then
+	// broke every write, or silently relocated the deployment to the bucket
+	// root. They must fail at construction instead.
+	rejected := []string{"/", "//", "a//b", ".", "a/./b", "a/../b", "///a///b///", "a b", `a\b`, "a\x00b"}
+	for _, in := range rejected {
+		if got, err := ValidateS3Prefix(in); err == nil {
+			t.Errorf("ValidateS3Prefix(%q) = %q, want an error", in, got)
+		}
 	}
 }
 
@@ -45,19 +40,34 @@ func TestS3BackendPrefixedKey(t *testing.T) {
 		expect string
 	}{
 		{"mydb/cpu/2025/01/file.parquet", "instances/abc123/mydb/cpu/2025/01/file.parquet"},
-		{"", "instances/abc123/"},
 	}
 
 	for _, tt := range tests {
-		got := backend.prefixedKey(tt.input)
+		got, err := backend.prefixedKey(tt.input)
+		if err != nil {
+			t.Fatalf("prefixedKey(%q) = %v", tt.input, err)
+		}
 		if got != tt.expect {
 			t.Errorf("prefixedKey(%q) = %q, want %q", tt.input, got, tt.expect)
 		}
 	}
 
+	// "" is not a key. It named the prefix directory itself, which is an
+	// object nothing can address (#743), and it reaches the SDK as an empty
+	// Key. It remains valid as a LIST prefix.
+	if _, err := backend.prefixedKey(""); err == nil {
+		t.Error(`prefixedKey("") was accepted; an empty key names no object`)
+	}
+	if got, err := backend.prefixedListPrefix(""); err != nil || got != "instances/abc123/" {
+		t.Errorf(`prefixedListPrefix("") = %q, %v; want the configured prefix`, got, err)
+	}
+
 	// No prefix configured
 	noPrefix := &S3Backend{prefix: ""}
-	got := noPrefix.prefixedKey("mydb/cpu/file.parquet")
+	got, err := noPrefix.prefixedKey("mydb/cpu/file.parquet")
+	if err != nil {
+		t.Fatalf("prefixedKey: %v", err)
+	}
 	if got != "mydb/cpu/file.parquet" {
 		t.Errorf("prefixedKey with no prefix = %q, want %q", got, "mydb/cpu/file.parquet")
 	}

--- a/internal/storage/validatepath_test.go
+++ b/internal/storage/validatepath_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"math/rand"
 	"path/filepath"
@@ -23,13 +24,10 @@ func newPathTestBackend(t *testing.T) *LocalBackend {
 	return b
 }
 
-func TestCheckStoragePath(t *testing.T) {
+func TestValidateKey(t *testing.T) {
 	accepted := []struct{ name, path string }{
-		{"root", ""},
 		{"single segment", "cpu"},
 		{"partition path", "default/cpu/2026/09/12/07/data.parquet"},
-		{"list prefix with trailing slash", "databases/"},
-		{"single segment with trailing slash", "default/"},
 		// Ordinary filenames that merely contain dots. The old fold collapsed
 		// the first onto "_foo", colliding it with an unrelated key.
 		{"leading dots in a segment", "default/..foo/data.parquet"},
@@ -39,8 +37,8 @@ func TestCheckStoragePath(t *testing.T) {
 	}
 	for _, tt := range accepted {
 		t.Run("accept/"+tt.name, func(t *testing.T) {
-			if err := checkStoragePath(tt.path); err != nil {
-				t.Errorf("checkStoragePath(%q) = %v, want accepted", tt.path, err)
+			if err := ValidateKey(tt.path); err != nil {
+				t.Errorf("ValidateKey(%q) = %v, want accepted", tt.path, err)
 			}
 		})
 	}
@@ -63,8 +61,8 @@ func TestCheckStoragePath(t *testing.T) {
 	}
 	for _, tt := range rejected {
 		t.Run("reject/"+tt.name, func(t *testing.T) {
-			if err := checkStoragePath(tt.path); err == nil {
-				t.Errorf("checkStoragePath(%q) was accepted", tt.path)
+			if err := ValidateKey(tt.path); err == nil {
+				t.Errorf("ValidateKey(%q) was accepted", tt.path)
 			}
 		})
 	}
@@ -73,16 +71,16 @@ func TestCheckStoragePath(t *testing.T) {
 // TestValidatePathMatchesFilepathJoin is the regression net for dropping
 // filepath.Join. For every key the validator accepts, the result must be
 // byte-identical to what the previous implementation produced.
-func TestCheckStoragePathErrorsAreIdentifiable(t *testing.T) {
+func TestValidateKeyErrorsAreIdentifiable(t *testing.T) {
 	// Callers driving cleanup loops must be able to tell a permanent rejection
 	// from a transient I/O failure, or they retry the same key forever.
 	for _, p := range []string{"/abs", "a/../b", "a//b", "a\x00b", `a\b`} {
-		err := checkStoragePath(p)
+		err := ValidateKey(p)
 		if err == nil {
-			t.Fatalf("checkStoragePath(%q) was accepted", p)
+			t.Fatalf("ValidateKey(%q) was accepted", p)
 		}
 		if !errors.Is(err, ErrInvalidPath) {
-			t.Errorf("checkStoragePath(%q) = %v, which does not match ErrInvalidPath", p, err)
+			t.Errorf("ValidateKey(%q) = %v, which does not match ErrInvalidPath", p, err)
 		}
 	}
 }
@@ -110,11 +108,8 @@ func TestValidatePathMatchesFilepathJoin(t *testing.T) {
 	b := newPathTestBackend(t)
 
 	paths := []string{
-		"",
 		"cpu",
 		"default/cpu/2026/09/12/07/data.parquet",
-		"databases/",
-		"default/",
 		"default/..foo/data.parquet",
 		"default/a..b/data.parquet",
 		"default/.hidden/data.parquet",
@@ -222,5 +217,67 @@ func TestStorageKeysAreInjective(t *testing.T) {
 	}
 	if len(seen) != len(keys) {
 		t.Errorf("%d keys resolved to %d locations", len(keys), len(seen))
+	}
+}
+
+// TestValidateListPathMatchesFilepathJoin covers the two spellings that are
+// legitimate for a prefix and not for a key.
+func TestValidateListPathMatchesFilepathJoin(t *testing.T) {
+	b := newPathTestBackend(t)
+	for _, p := range []string{"", "databases/", "default/", "default/cpu", "default/cpu/"} {
+		got, err := b.validateListPath(p)
+		if err != nil {
+			t.Fatalf("validateListPath(%q) = %v, want accepted", p, err)
+		}
+		if want := filepath.Join(b.basePath, p); got != want {
+			t.Errorf("validateListPath(%q) = %q, want %q", p, got, want)
+		}
+	}
+	for _, p := range []string{"/", "a//b", "a/../b", "a/./b", `a\b`, "a\x00b"} {
+		if _, err := b.validateListPath(p); err == nil {
+			t.Errorf("validateListPath(%q) was accepted", p)
+		}
+	}
+}
+
+// TestKeysAreInjective is the contract, stated as the property that matters.
+//
+// #741 asserted matching accept/reject sets, which cannot see this: every
+// backend accepted both "coll" and "coll/", and on local they were ONE file.
+// Two keys, one object, first payload silently lost. What differs between a
+// correct and a broken implementation is the mapping, not the verdict, so the
+// mapping is what this asserts.
+func TestKeysAreInjective(t *testing.T) {
+	b := newPathTestBackend(t)
+	ctx := context.Background()
+
+	// Every pair here named one location under some implementation.
+	keys := []string{
+		"coll", "coll/sub",
+		"default/a..b/x.parquet", "default/a_b/x.parquet",
+		"default/..foo/x.parquet", "default/_foo/x.parquet",
+		"rocket..01/x.parquet", "rocket_01/x.parquet",
+	}
+
+	seen := make(map[string]string, len(keys))
+	for _, k := range keys {
+		resolved, err := b.validatePath(k)
+		if err != nil {
+			t.Fatalf("validatePath(%q) = %v; all of these are legitimate keys", k, err)
+		}
+		if prev, clash := seen[resolved]; clash {
+			t.Errorf("keys %q and %q both resolve to %q", prev, k, resolved)
+		}
+		seen[resolved] = k
+	}
+
+	// And the spelling that actually collided: prove it through the backend,
+	// not just the resolver, because the resolver is what was wrong.
+	if err := b.Write(ctx, "coll2", []byte("no-slash")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := b.Write(ctx, "coll2/", []byte("trailing-slash")); err == nil {
+		got, _ := b.Read(ctx, "coll2")
+		t.Fatalf("Write(%q) was accepted and Read(%q) now returns %q; two keys named one object", "coll2/", "coll2", got)
 	}
 }


### PR DESCRIPTION
Fixes #743.

## What was wrong

[#741](https://github.com/Basekick-Labs/arc/issues/741) made `LocalBackend` refuse malformed keys and its comment claimed the mapping from key to object was injective "for every caller at once". That held for one implementation out of three: S3 prepended its prefix with no validation, Azure passed the key straight to `NewBlockBlobClient`. One key behaved three ways, and the next reporter would refile #737 against whichever backend they ran.

The rule is now a property of the `Backend` interface, and what it guarantees is the thing whose absence produced #574, #737 and #741: **two different keys can never name one object.**

## It also fixes a collision #741 introduced

```
Write("coll")  = "no-slash"
Write("coll/") = "trailing-slash"
Read("coll")  -> "trailing-slash"     files on disk: [coll]
```

Two keys, one file, first write silently lost. The validator accepted a trailing separator because ~30 `List` callers pass `db+"/"`, and `validatePath` then stripped it. That exemption is right for a prefix and wrong for a key, so `ValidateKey` and `ValidateListPrefix` are now separate.

The contract test changed shape with it. #741 asserted matching accept/reject sets, which **cannot see this**: every backend accepts `coll/`, and what differed was the mapping, not the verdict. The property is injectivity, so the test is injectivity.

## Measured, not reasoned

Everything about the object stores here was probed against a live MinIO and Azurite. My first draft was wrong precisely because I reasoned about it:

- **A leading separator is refused.** MinIO *strips* it, so `/a/x` and `a/x` were one object there, while S3 and Azure keep them distinct. I initially wrote this up as a collision live on S3 and Azure; it is MinIO's alone, and on S3 the failure is an orphan rather than an overwrite.
- **A backslash is refused because Azure treats it as a separator**: `a\b` and `a/b` are **one blob**. That is the live collision, and it is not the one I first found.
- `.` and `..` segments and empty interior segments are refused locally, naming the key, instead of arriving as a remote 400 describing an S3 API error. Azure stored them literally, so there this is a real behaviour change.
- `a..b` and `..foo` are accepted everywhere and stored under the name asked for.

## A listing never returns a key the backend would refuse

Object stores carry "directory marker" objects whose key ends in a separator, written by consoles and sync tools rather than by Arc. Arc feeds `List` output straight into `Read`, `Exists` and `Delete` in a dozen places, so returning one would have been **worse than the original bug**: restore skips the file and still reports success (`backup/restore.go:124`), compaction's "already compacted" escape becomes a hard failure (`job.go:605`), and manifest recovery retries a permanent error forever (`manifest.go:309`).

Found by writing a marker through the raw S3 API and watching a read of it fail. Filtering them makes `List` output always usable, which is what every one of those callers already assumed.

## The S3 prefix is validated, not repaired

The old sanitiser's damage was on its **success** path, so returning an error instead of `""` would have touched none of it:

```
"/"      -> "/"       every key then starts with "/", which MinIO folds away
"a//b"   -> "a//b/"   every write 400s
"."      -> "./"      every write 400s
"a/..b"  -> ""        silently relocates the deployment to the BUCKET ROOT
```

A prefix that cannot form usable keys now stops the backend from being built. That is a startup-breaking upgrade and is called out in Upgrade notes.

## One thing I deliberately did not do

`raft.ValidateManifestPath` is looser than the contract and I left it that way, with a comment explaining why. It runs inside FSM `Apply`, which includes **log replay**, so tightening it would make a node reject an entry an older binary accepted, and two versions would build different state from one log. That is worse than the looseness. The gap closes at the consumer instead, tracked in #747.

## CI

A MinIO now runs in CI with the tagged contract tests against it. None of the behaviour above is reproducible in a unit test, because it is a property of the servers. `docker run` rather than a service container, since `quay.io/minio/minio` needs `server /data` and services cannot supply arguments after the image. I rehearsed the steps verbatim against a clean bucket before committing them.

## Follow-ups

- **#746**: the read path bypasses `Backend` entirely (DuckDB `read_parquet` over `s3://` URIs from `storage/util.go`, and iceberg-go's own FileIO), plus the five unreconciled path validators.
- **#747**: four cleanup and replication loops should quarantine on `ErrInvalidPath` rather than retry it.