### PR TITLE
Reserve the write-staging suffix and stop manifests overflowing (#744)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -255,6 +255,54 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### A write could destroy an already-acknowledged write ([#744](https://github.com/Basekick-Labs/arc/issues/744))
+
+Local storage stages every streamed write at `{key}.part` and renames it into
+place on success. The staging file of key `x` was therefore the same file as the
+committed object `x.part`, and the two destroyed each other.
+
+Writing `x.parquet.part` returned success. The next write of `x.parquet` opened
+its staging file with truncate, wiped the committed object, and renamed it away,
+so the first key stopped existing. Three further orderings were worse: a
+committed `x.part` with no `x` present made size and range reads report the
+wrong object's bytes while existence checks said it was absent, which could make
+the cluster puller skip replicating a file that is not there; and an append
+could rename a committed object over an unrelated third key.
+
+The staging suffix is now reserved, so no key can name a staging file, and the
+callers that legitimately need a partial (edge-sync resume, backup cleanup)
+address it through an explicit interface rather than by spelling the suffix
+themselves. Staged partials are also hidden from listings, because a listing
+must never return a key the backend would refuse, and a new listing method
+exists so an abandoned partial can still be reclaimed rather than becoming
+invisible and permanent.
+
+This needed a key ending in `.part`, which Arc's own writers never produce, so
+it was reachable only by restoring a backup that contained an orphaned staging
+file.
+
+Two consequences worth knowing. Deleting a database now also reclaims any
+staged partial underneath it, which a failed upload could previously leave
+behind indefinitely, and which also kept the directory from being removed. And
+because the reservation applies to every backend so that a key stays portable,
+an object literally named `something.part` that already exists in an S3 bucket
+or Azure container is no longer readable or deletable through Arc. Arc cannot
+have written one, since only local storage stages; remove it with your provider's
+own tooling if you have one.
+
+### Compaction manifests no longer exceed the storage key limit ([#744](https://github.com/Basekick-Labs/arc/issues/744))
+
+A compaction manifest filename repeated the partition path that its job id
+already contained, and the database three times over. With a 30-character
+database and a 60-character measurement that produced a 270-byte filename, past
+the 255-byte limit a path component can have, so writing the manifest failed and
+compaction for that partition failed on every cycle. At the longest permitted
+names it reached 508 bytes.
+
+The filename is now the job id alone, which is already unique and already
+carries the partition. Nothing reads these names, so manifests written by an
+earlier version are still found and recovered, and no migration is needed.
+
 ### Every storage backend now enforces the same key contract ([#743](https://github.com/Basekick-Labs/arc/issues/743))
 
 The previous release made local storage refuse malformed keys

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -411,6 +411,13 @@ func (h *DatabasesHandler) handleDelete(c *fiber.Ctx) error {
 		}
 	}
 
+	// Reclaim staged partials under this prefix. They are invisible to List by
+	// design (#744), so nothing else would find them, and a leftover one also
+	// keeps the directory non-empty so RemoveDirectory below fails. The
+	// common source is an upload that failed after staging bytes, whose final
+	// key never existed, so the loop above never saw it.
+	deletedCount += reclaimStagedPartials(ctx, h.storage, name+"/", h.logger)
+
 	// Also delete the .arc-database marker file (not included in List due to hidden file filter)
 	markerPath := name + "/.arc-database"
 	if err := h.storage.Delete(ctx, markerPath); err == nil {
@@ -762,4 +769,34 @@ func (h *DatabasesHandler) dropIcebergCatalog(ctx context.Context, name string) 
 	} else {
 		h.logger.Info().Str("database", name).Msg("Iceberg catalog artifacts removed for dropped database")
 	}
+}
+
+// reclaimStagedPartials deletes write-staging partials under prefix and returns
+// how many were removed.
+//
+// Staged partials do not appear in List: a listing must never return a key the
+// backend would refuse (#743), and the staging suffix is reserved (#744). That
+// makes them unreachable through the ordinary delete loop, so a prefix-wide
+// delete has to ask for them explicitly or they survive the database that owned
+// them. Backends that do not stage have none, which is why a failed type
+// assertion is simply zero.
+func reclaimStagedPartials(ctx context.Context, backend storage.Backend, prefix string, logger zerolog.Logger) int {
+	si, ok := backend.(storage.StagingInspector)
+	if !ok {
+		return 0
+	}
+	staged, err := si.ListStaged(ctx, prefix)
+	if err != nil {
+		logger.Warn().Err(err).Str("prefix", prefix).Msg("Could not list staged partials to reclaim")
+		return 0
+	}
+	var removed int
+	for _, obj := range staged {
+		if err := si.DeleteStaged(ctx, obj.Path); err != nil {
+			logger.Warn().Err(err).Str("key", obj.Path).Msg("Failed to reclaim staged partial")
+			continue
+		}
+		removed++
+	}
+	return removed
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -402,10 +402,6 @@ func (m *Manager) streamBackupFile(ctx context.Context, srcPath, destPath string
 	return size, nil
 }
 
-// partSuffix mirrors the staging suffix LocalBackend.WriteReader uses for
-// in-progress writes. Kept in sync with internal/storage/local.go#partPath.
-const partSuffix = ".part"
-
 // cleanupPartialWrite removes the staging file a failed WriteReader leaves behind.
 //
 // LocalBackend.WriteReader deliberately preserves "<path>.part" on failure so the
@@ -419,10 +415,17 @@ const partSuffix = ".part"
 // fails too (unwritable volume, storage unreachable). A cleanup failure must not
 // mask the real error, so it is logged at debug and discarded.
 func (m *Manager) cleanupPartialWrite(ctx context.Context, destPath string) {
-	stagingPath := destPath + partSuffix
-	if err := m.backupStorage.Delete(ctx, stagingPath); err != nil {
+	// Addressed through the staging API rather than by appending the suffix to
+	// the key. That suffix is reserved now, because the staging file of key
+	// "x" used to BE the committed object "x.part" (#744). A backend that does
+	// not stage never leaves a partial, so there is nothing to clean up.
+	si, ok := m.backupStorage.(storage.StagingInspector)
+	if !ok {
+		return
+	}
+	if err := si.DeleteStaged(ctx, destPath); err != nil {
 		m.logger.Debug().
-			Str("path", stagingPath).
+			Str("path", destPath).
 			Err(err).
 			Msg("Could not remove partial backup staging file")
 	}

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -510,8 +510,12 @@ func TestCopyDataFiles_ProgressUsesActualBytes(t *testing.T) {
 // through, reproducing what LocalBackend does on a transport error: it consumes
 // some of the reader, leaves a "<path>.part" staging file behind, and returns an
 // error. Delete is delegated so cleanup can be observed.
+// Embeds the CONCRETE backend, not the storage.Backend interface. Embedding the
+// interface would drop the optional StagingInspector methods, so the staging
+// cleanup under test would silently no-op and the test would pass while doing
+// nothing (#744).
 type partialWriteBackend struct {
-	storage.Backend
+	*storage.LocalBackend
 	dir           string
 	deleteCalls   []string
 	failWriteWith error
@@ -519,7 +523,7 @@ type partialWriteBackend struct {
 
 func (b *partialWriteBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
 	if b.failWriteWith == nil {
-		return b.Backend.WriteReader(ctx, path, reader, size)
+		return b.LocalBackend.WriteReader(ctx, path, reader, size)
 	}
 	// Mimic LocalBackend: stage partial bytes to "<path>.part", then fail and
 	// deliberately leave the staging file in place.
@@ -538,7 +542,7 @@ func (b *partialWriteBackend) WriteReader(ctx context.Context, path string, read
 
 func (b *partialWriteBackend) Delete(ctx context.Context, path string) error {
 	b.deleteCalls = append(b.deleteCalls, path)
-	return b.Backend.Delete(ctx, path)
+	return b.LocalBackend.Delete(ctx, path)
 }
 
 // A failed backup write must not leave an orphaned ".part" staging file in
@@ -556,7 +560,7 @@ func TestStreamBackupFile_CleansUpPartFileOnWriteFailure(t *testing.T) {
 
 	backupDir := t.TempDir()
 	backupBackend := &partialWriteBackend{
-		Backend:       mustLocalBackend(t, backupDir, logger),
+		LocalBackend:  mustLocalBackend(t, backupDir, logger),
 		dir:           backupDir,
 		failWriteWith: fmt.Errorf("simulated transport failure"),
 	}
@@ -578,9 +582,14 @@ func TestStreamBackupFile_CleansUpPartFileOnWriteFailure(t *testing.T) {
 		t.Errorf("orphaned .part file left in backup storage: %s (stat err: %v)", staging, statErr)
 	}
 
-	// And cleanup must have targeted exactly the staging path.
-	if len(backupBackend.deleteCalls) != 1 || backupBackend.deleteCalls[0] != destPath+".part" {
-		t.Errorf("expected cleanup of %q, got delete calls %v", destPath+".part", backupBackend.deleteCalls)
+	// And the backend must agree there is no staged partial left. Asserted
+	// through the staging API rather than by counting Delete calls on a
+	// hand-built ".part" key: that key is reserved now (#744), so a Delete of
+	// it would be refused rather than performed.
+	if n, err := backupBackend.StagedSize(ctx, destPath); err != nil {
+		t.Errorf("StagedSize(%q): %v", destPath, err)
+	} else if n >= 0 {
+		t.Errorf("staged partial for %q survived cleanup (%d bytes)", destPath, n)
 	}
 }
 
@@ -597,7 +606,7 @@ func TestStreamBackupFile_CleanupFailureDoesNotMaskWriteError(t *testing.T) {
 
 	backupDir := t.TempDir()
 	backupBackend := &deleteFailingBackend{
-		Backend:       mustLocalBackend(t, backupDir, logger),
+		LocalBackend:  mustLocalBackend(t, backupDir, logger),
 		failWriteWith: fmt.Errorf("simulated transport failure"),
 	}
 	m := &Manager{dataStorage: dataStorage, backupStorage: backupBackend, logger: logger}
@@ -620,8 +629,10 @@ func TestStreamBackupFile_CleanupFailureDoesNotMaskWriteError(t *testing.T) {
 	}
 }
 
+// Concrete embed, same reason as partialWriteBackend: the interface would drop
+// StagingInspector and the cleanup under test would no-op.
 type deleteFailingBackend struct {
-	storage.Backend
+	*storage.LocalBackend
 	failWriteWith error
 }
 
@@ -633,7 +644,12 @@ func (b *deleteFailingBackend) Delete(ctx context.Context, path string) error {
 	return fmt.Errorf("simulated cleanup failure")
 }
 
-func mustLocalBackend(t *testing.T, dir string, logger zerolog.Logger) storage.Backend {
+// DeleteStaged fails too, so the test still exercises "cleanup failed".
+func (b *deleteFailingBackend) DeleteStaged(ctx context.Context, key string) error {
+	return fmt.Errorf("simulated cleanup failure")
+}
+
+func mustLocalBackend(t *testing.T, dir string, logger zerolog.Logger) *storage.LocalBackend {
 	t.Helper()
 	b, err := storage.NewLocalBackend(dir, logger)
 	if err != nil {

--- a/internal/compaction/manifest.go
+++ b/internal/compaction/manifest.go
@@ -2,6 +2,8 @@ package compaction
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -75,11 +77,41 @@ func NewManifestManager(backend storage.Backend, logger zerolog.Logger) *Manifes
 	}
 }
 
-// GenerateManifestPath generates a unique manifest path for a compaction job
+// GenerateManifestPath generates a unique manifest path for a compaction job.
+//
+// Path format: _compaction_state/{tier}/{database}/{jobID}.json
+//
+// The partition path is NOT repeated in the filename. jobID already embeds the
+// sanitized database and the folded partition path (manager.go), and the
+// database is a path segment here besides, so the old
+// "{folded_partition}_{jobID}.json" carried the partition twice and the
+// database three times. That pushed ordinary names past the 255-byte segment
+// limit: a 30-character database with a 60-character measurement produced a
+// 270-byte filename, which the storage key contract refuses, so WriteManifest
+// failed and compaction for that partition failed on every cycle (#744).
+//
+// Nothing parses this name. ListManifests filters on the ".json" suffix and
+// recoverManifest drives every decision off the unmarshalled body, so the
+// format is free to change and old manifests stay discoverable.
+//
+// The hash fallback covers the remaining tail: at the maximum permitted
+// database (64) and measurement (128) lengths even the jobID alone exceeds the
+// segment limit. It is deterministic, so a retry of the same job addresses the
+// same manifest.
 func (m *ManifestManager) GenerateManifestPath(tier, database, partitionPath, jobID string) string {
-	// Path format: _compaction_state/{tier}/{database}/{partition_path_sanitized}_{jobID}.json
-	sanitizedPartition := strings.ReplaceAll(partitionPath, "/", "_")
-	return filepath.Join(ManifestBasePath, tier, database, fmt.Sprintf("%s_%s.json", sanitizedPartition, jobID))
+	// An empty jobID would give ".json", which LocalBackend's hidden-file
+	// filter drops from List, so the manifest would be written and then never
+	// discovered or deleted. The old format always had a partition prefix in
+	// front; this one does not, so the guard is explicit.
+	if jobID == "" {
+		jobID = "unidentified-job"
+	}
+	name := jobID + ".json"
+	if len(name) > storage.MaxKeySegmentLen {
+		sum := sha256.Sum256([]byte(jobID))
+		name = hex.EncodeToString(sum[:16]) + ".json"
+	}
+	return filepath.Join(ManifestBasePath, tier, database, name)
 }
 
 // WriteManifest writes a manifest to storage

--- a/internal/compaction/manifest_path_test.go
+++ b/internal/compaction/manifest_path_test.go
@@ -1,0 +1,117 @@
+package compaction
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/storage"
+)
+
+// Tests for #744. The manifest filename used to repeat the folded partition
+// path, which jobID already contains, so the name grew with the database and
+// measurement lengths and blew past the storage key segment limit.
+
+func jobIDFor(database, partitionPath string) string {
+	// Mirrors manager.go's construction.
+	return fmt.Sprintf("%s_%s_%d_b%d",
+		sanitizeDBForName(database),
+		strings.ReplaceAll(partitionPath, "/", "_"),
+		time.Now().UnixNano(),
+		0,
+	)
+}
+
+// TestManifestPathFitsTheKeyContract is the regression. At db=30/meas=60 the
+// old format produced a 270-byte filename; the storage contract caps a segment
+// at 255, so WriteManifest failed and that partition never compacted again.
+func TestManifestPathFitsTheKeyContract(t *testing.T) {
+	m := &ManifestManager{}
+
+	for _, tt := range []struct {
+		name    string
+		dbLen   int
+		measLen int
+	}{
+		{"short", 4, 3},
+		{"moderate", 20, 40},
+		{"over the old limit", 30, 60},
+		{"maximum permitted", 64, 128},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			db := strings.Repeat("d", tt.dbLen)
+			meas := strings.Repeat("m", tt.measLen)
+			partition := filepath.Join(db, meas, "2026", "09", "12", "14")
+			path := m.GenerateManifestPath("hourly", db, partition, jobIDFor(db, partition))
+
+			if err := storage.ValidateKey(path); err != nil {
+				t.Fatalf("manifest path is not a usable storage key: %v", err)
+			}
+			for _, seg := range strings.Split(path, "/") {
+				if len(seg) > storage.MaxKeySegmentLen {
+					t.Errorf("segment %q is %d bytes, over the %d-byte limit", seg, len(seg), storage.MaxKeySegmentLen)
+				}
+			}
+			if !strings.HasSuffix(path, ".json") {
+				t.Errorf("manifest path %q must end in .json; ListManifests filters on it", path)
+			}
+			if !strings.HasPrefix(path, ManifestBasePath+"/") {
+				t.Errorf("manifest path %q must live under %q", path, ManifestBasePath)
+			}
+		})
+	}
+}
+
+// TestManifestPathsAreDistinct pins where the distinctness actually comes from,
+// which is NOT the filename.
+//
+// Worth being precise, because an earlier version of this comment was wrong:
+// the adversarial pair below produces an IDENTICAL filename under both the old
+// and the new format, because jobID itself folds them together
+// (a + a_a_cpu and a_a + cpu give one jobID). What keeps the two manifests
+// apart is the {database} path segment, and that was true before this change
+// too. The filename contributes uniqueness per job, not per partition.
+func TestManifestPathsAreDistinct(t *testing.T) {
+	m := &ManifestManager{}
+
+	// The pair that folds identically: database and measurement can both
+	// contain "_", and the partition path already starts with the database.
+	type tuple struct{ db, meas string }
+	tuples := []tuple{
+		{"a", "a_a_cpu"},
+		{"a_a", "cpu"},
+		{"a", "b_c"},
+		{"a_b", "c"},
+		{"prod", "cpu"},
+	}
+
+	seen := make(map[string]tuple, len(tuples))
+	for _, tu := range tuples {
+		partition := filepath.Join(tu.db, tu.meas, "2026", "09", "12", "14")
+		// jobID held CONSTANT across tuples: a nanosecond timestamp would make
+		// any encoding look injective.
+		jobID := fmt.Sprintf("%s_%s_%d_b%d", sanitizeDBForName(tu.db),
+			strings.ReplaceAll(partition, "/", "_"), 1757000000000000000, 0)
+		path := m.GenerateManifestPath("hourly", tu.db, partition, jobID)
+		if prev, clash := seen[path]; clash {
+			t.Errorf("tuples %+v and %+v both produce %q", prev, tu, path)
+		}
+		seen[path] = tu
+		// And the guarantee the filename itself owes: it must be one path
+		// segment, so the database segment above can do its job.
+		if strings.Contains(filepath.Base(path), "/") {
+			t.Errorf("manifest filename %q spans more than one segment", filepath.Base(path))
+		}
+	}
+}
+
+// TestManifestPathRejectsAnEmptyJobID pins the hidden-filename guard.
+func TestManifestPathRejectsAnEmptyJobID(t *testing.T) {
+	m := &ManifestManager{}
+	path := m.GenerateManifestPath("hourly", "db", "db/cpu/2026/09/12/14", "")
+	if base := filepath.Base(path); strings.HasPrefix(base, ".") {
+		t.Errorf("manifest filename %q starts with a dot; List hides it, so the manifest would never be recovered", base)
+	}
+}

--- a/internal/edgesync/receive.go
+++ b/internal/edgesync/receive.go
@@ -296,12 +296,23 @@ func (r *Receiver) Receive(ctx context.Context, spokeID, sourcePath, declaredSHA
 			// rejects, so the spoke would hard-error on the hub's own reply.
 			if staged >= declaredSize {
 				_ = r.backend.Delete(ctx, stagingPath)
-				_ = r.backend.Delete(ctx, partSuffix(stagingPath))
+				if si := r.staging(); si != nil {
+					_ = si.DeleteStaged(ctx, stagingPath)
+				}
 				return &PutResult{Outcome: OutcomePartial, BytesAccepted: 0}, nil
 			}
 			return &PutResult{Outcome: OutcomePartial, BytesAccepted: staged}, nil
 		}
-		if err := r.backend.ReadTo(ctx, partSuffix(stagingPath), hasherWriter{hasher}); err != nil {
+		// Unreachable in practice, and deliberately kept: reaching here means
+		// the backend implements AppendingBackend (SupportsResume short-
+		// circuits otherwise), and LocalBackend is the only one that does and
+		// it also stages. A future appending backend that does not stage would
+		// land here rather than silently resuming from nothing.
+		si := r.staging()
+		if si == nil {
+			return nil, fmt.Errorf("%w: backend supports resume but exposes no staged partial, so %q cannot be rehashed", ErrReceiveInternal, stagingPath)
+		}
+		if err := si.ReadStaged(ctx, stagingPath, hasherWriter{hasher}); err != nil {
 			return nil, fmt.Errorf("%w: rehash staged prefix %q: %w", ErrReceiveInternal, stagingPath, err)
 		}
 	}
@@ -488,18 +499,31 @@ func (r *Receiver) stage(ctx context.Context, stagingPath string, body io.Reader
 // stagedSize reports how many bytes of a staged file the hub holds, whether it
 // sits in the backend's partial (".part") state or was fully written.
 func (r *Receiver) stagedSize(ctx context.Context, stagingPath string) (int64, error) {
-	if n, err := r.backend.StatFile(ctx, partSuffix(stagingPath)); err != nil {
-		return -1, err
-	} else if n >= 0 {
-		return n, nil
+	if si := r.staging(); si != nil {
+		if n, err := si.StagedSize(ctx, stagingPath); err != nil {
+			return -1, err
+		} else if n >= 0 {
+			return n, nil
+		}
 	}
 	return r.backend.StatFile(ctx, stagingPath)
 }
 
-// partSuffix names the backend's in-progress staging file. LocalBackend writes
-// through "{path}.part" and renames on completion; sizing that file is how the
-// hub learns where a dropped transfer stopped.
-func partSuffix(p string) string { return p + ".part" }
+// staging returns the backend's staging inspector, or nil when the backend
+// does not stage writes.
+//
+// The hub used to reach for a partial by appending ".part" to the key itself.
+// That spelling put the staging file in the same namespace as committed
+// objects, so the staging file of key "x" WAS the object "x.part" and the two
+// destroyed each other (#744). The suffix is reserved now and the partial is
+// addressed through the interface. A backend that does not stage (S3, Azure)
+// simply never has one, which is what a nil inspector means here.
+func (r *Receiver) staging() storage.StagingInspector {
+	if si, ok := r.backend.(storage.StagingInspector); ok {
+		return si
+	}
+	return nil
+}
 
 // errShortBody signals that the spoke sent fewer bytes than it declared. It is
 // returned from the reader so the backend abandons its write with the partial
@@ -547,8 +571,10 @@ func (r *Receiver) promote(ctx context.Context, stagingPath, finalPath string, s
 	// rename leaves "{finalPath}.part" behind; left in place it makes
 	// StatFile report the final file as present (see the note in Receive) and
 	// would defeat the Exists() guard for any code that still uses StatFile.
-	if err := r.backend.Delete(ctx, partSuffix(finalPath)); err != nil {
-		r.logger.Debug().Err(err).Str("path", finalPath).Msg("No stale promote staging file to clear")
+	if si := r.staging(); si != nil {
+		if err := si.DeleteStaged(ctx, finalPath); err != nil {
+			r.logger.Debug().Err(err).Str("path", finalPath).Msg("No stale promote staging file to clear")
+		}
 	}
 
 	pr, pw := io.Pipe()
@@ -793,19 +819,47 @@ func (r *Receiver) SweepStaging(ctx context.Context, maxAge time.Duration, now t
 		return 0, fmt.Errorf("%w: list staging: %w", ErrReceiveInternal, err)
 	}
 
+	// Staged partials are invisible to ListObjects by design (#744), so they
+	// are collected separately. Without this an abandoned partial would be
+	// unreachable AND unreclaimable, which is the disk-exhaustion this sweep
+	// exists to prevent.
+	type staleEntry struct {
+		path    string
+		staged  bool
+		modTime time.Time
+	}
+	entries := make([]staleEntry, 0, len(objects)*2)
+	for _, obj := range objects {
+		entries = append(entries, staleEntry{path: obj.Path, modTime: obj.LastModified})
+	}
+	if si := r.staging(); si != nil {
+		staged, err := si.ListStaged(ctx, StagingPrefix+"/")
+		if err != nil {
+			return 0, fmt.Errorf("%w: list staged partials: %w", ErrReceiveInternal, err)
+		}
+		for _, obj := range staged {
+			entries = append(entries, staleEntry{path: obj.Path, staged: true, modTime: obj.LastModified})
+		}
+	}
+
 	cutoff := now.Add(-maxAge)
 	var removed int
-	for _, obj := range objects {
+	for _, obj := range entries {
 		if err := ctx.Err(); err != nil {
 			return removed, err
 		}
-		if !obj.LastModified.Before(cutoff) {
+		if !obj.modTime.Before(cutoff) {
 			continue
 		}
-		if err := r.backend.Delete(ctx, obj.Path); err != nil {
+		del := func() error { return r.backend.Delete(ctx, obj.path) }
+		if obj.staged {
+			si := r.staging()
+			del = func() error { return si.DeleteStaged(ctx, obj.path) }
+		}
+		if err := del(); err != nil {
 			// Keep going: one undeletable orphan must not stop the sweep from
 			// reclaiming the rest.
-			r.logger.Warn().Err(err).Str("path", obj.Path).Msg("Failed to delete abandoned sync staging file")
+			r.logger.Warn().Err(err).Str("path", obj.path).Msg("Failed to delete abandoned sync staging file")
 			continue
 		}
 		removed++

--- a/internal/edgesync/receive_test.go
+++ b/internal/edgesync/receive_test.go
@@ -763,8 +763,18 @@ func TestReceiver_SweepStagingReclaimsAbandonedPartials(t *testing.T) {
 		if exists, _ := backend.Exists(ctx, staging); exists {
 			t.Errorf("abandoned staging file %d survived the sweep", i)
 		}
-		if exists, _ := backend.Exists(ctx, partSuffix(staging)); exists {
-			t.Errorf("abandoned .part file %d survived the sweep", i)
+		// Asserted through the staging API, not Exists on a hand-built
+		// ".part" key: that key is reserved now, so Exists would return
+		// (false, error) and read as "gone" whether or not the partial
+		// survived (#744).
+		si, ok := backend.(storage.StagingInspector)
+		if !ok {
+			t.Fatal("test backend does not stage; the sweep cannot be exercised")
+		}
+		if n, err := si.StagedSize(ctx, staging); err != nil {
+			t.Errorf("StagedSize(%q): %v", staging, err)
+		} else if n >= 0 {
+			t.Errorf("abandoned staged partial %d survived the sweep (%d bytes)", i, n)
 		}
 	}
 }

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -74,6 +74,44 @@ type AppendingBackend interface {
 	AppendReader(ctx context.Context, path string, reader io.Reader, appendSize int64) error
 }
 
+// StagingInspector exposes a backend's in-progress write staging area.
+//
+// Backends that stage a write before committing it (only LocalBackend does)
+// leave a partial file behind when a transfer is interrupted, which is what
+// lets the cluster puller and the edge-sync receiver resume from the last
+// committed byte instead of refetching. Those callers need to size, hash and
+// discard that partial.
+//
+// They used to do it by appending ".part" to the key and calling StatFile,
+// ReadTo and Delete, which reached around the abstraction and, worse, put the
+// staging file in the same namespace as committed objects: the staging file of
+// key "x" WAS the committed object "x.part", so writing one destroyed the
+// other (#744). These methods name the staging area explicitly so the key
+// namespace can reserve it.
+//
+// A backend that does not stage does not implement this. Callers type-assert
+// and treat a failed assertion as "there is never a partial", which is exactly
+// true for S3 and Azure.
+type StagingInspector interface {
+	Backend
+
+	// StagedSize returns the byte size of the staged partial for key, or -1
+	// (with a nil error) when there is none.
+	StagedSize(ctx context.Context, key string) (int64, error)
+
+	// ReadStaged writes the staged partial for key to writer.
+	ReadStaged(ctx context.Context, key string, writer io.Writer) error
+
+	// DeleteStaged removes the staged partial for key. Removing one that does
+	// not exist is not an error.
+	DeleteStaged(ctx context.Context, key string) error
+
+	// ListStaged returns metadata for staged partials whose key has the given
+	// prefix, so a caller can reclaim abandoned ones. Staged partials are
+	// invisible to List by design, so this is the only way to find them.
+	ListStaged(ctx context.Context, prefix string) ([]ObjectInfo, error)
+}
+
 // DirectoryLister lists immediate subdirectories at a prefix.
 // This is useful for SHOW DATABASES/TABLES commands.
 type DirectoryLister interface {

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -468,6 +468,16 @@ func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error
 			return err
 		}
 
+		relPath = filepath.ToSlash(relPath)
+		// A listing never returns a key this backend would refuse (#743), and
+		// since #744 that includes write-staging partials: they are not
+		// objects, and returning one gave every List-then-Read caller a key
+		// that fails. StagingInspector.ListStaged is how an abandoned partial
+		// is found.
+		if ValidateKey(relPath) != nil {
+			return nil
+		}
+
 		results = append(results, relPath)
 		return nil
 	})
@@ -490,6 +500,12 @@ func (b *LocalBackend) Delete(ctx context.Context, path string) error {
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
 	}
+
+	// Remove the key's staged partial alongside it. Deleting an object should
+	// not leave its half-written staging file behind, and since #744 that file
+	// is invisible to List, so nothing else would ever find it. Best-effort:
+	// the object is what the caller asked about.
+	_ = os.Remove(partPath(fullPath))
 
 	if err := os.Remove(fullPath); err != nil {
 		if os.IsNotExist(err) {
@@ -568,6 +584,11 @@ func (b *LocalBackend) ListDirectories(ctx context.Context, prefix string) ([]st
 		if entry.IsDir() {
 			// Skip hidden directories
 			if strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			// Callers join this name into a key, so a name the contract would
+			// refuse produces an unusable key. Same rule as List (#743).
+			if ValidateKey(entry.Name()) != nil {
 				continue
 			}
 			dirs = append(dirs, entry.Name())
@@ -661,6 +682,12 @@ func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]Object
 		relPath, err := filepath.Rel(b.basePath, path)
 		if err != nil {
 			return err
+		}
+		relPath = filepath.ToSlash(relPath)
+		// See List: a listing never returns a key this backend would refuse,
+		// which since #744 includes write-staging partials.
+		if ValidateKey(relPath) != nil {
+			return nil
 		}
 
 		// Metadata (size, mod-time) is not on DirEntry — stat the kept file.
@@ -756,6 +783,20 @@ func ValidateKey(key string) error {
 	if key[len(key)-1] == '/' {
 		return fmt.Errorf("%w: %q ends in a separator, which names the same object as %q", ErrInvalidPath, key, key[:len(key)-1])
 	}
+	// PartSuffix is reserved because LocalBackend stages every write at
+	// key+PartSuffix. Without this the staging file of key "x" IS the
+	// committed object "x.part", and the two destroy each other: opening
+	// staging with O_TRUNC wipes a committed object whose write already
+	// returned success, and AppendReader's promote renames it over a third
+	// key (#744). Callers that legitimately need the staged partial use
+	// StagingInspector rather than spelling the suffix themselves.
+	//
+	// Reserved in the shared contract rather than only in LocalBackend so a
+	// key remains portable between backends, which is the property #743
+	// established.
+	if strings.HasSuffix(key, PartSuffix) {
+		return fmt.Errorf("%w: %q ends in %q, which is reserved for write staging", ErrInvalidPath, key, PartSuffix)
+	}
 	return validateKeyBody(key)
 }
 
@@ -785,8 +826,12 @@ func ValidateListPrefix(prefix string) error {
 // validateKeyBody holds the rules common to keys and list prefixes. Callers
 // have already dealt with emptiness and any trailing separator.
 func validateKeyBody(p string) error {
-	if len(p) > MaxKeyLen {
-		return fmt.Errorf("%w: key is %d bytes, over the %d-byte limit", ErrInvalidPath, len(p), MaxKeyLen)
+	// The bounds subtract PartSuffix because LocalBackend appends it to build
+	// the staging file. A key at exactly the limit passes the contract and
+	// then fails the write with ENAMETOOLONG, which is the same
+	// blessed-but-unstorable shape the manifest half of #744 fixes.
+	if len(p) > MaxKeyLen-len(PartSuffix) {
+		return fmt.Errorf("%w: key is %d bytes, over the %d-byte limit", ErrInvalidPath, len(p), MaxKeyLen-len(PartSuffix))
 	}
 	if p[0] == '/' {
 		return fmt.Errorf("%w: %q must be relative to the backend root", ErrInvalidPath, p)
@@ -812,12 +857,137 @@ func validateKeyBody(p string) error {
 		case ".", "..":
 			return fmt.Errorf("%w: %q contains a %q segment", ErrInvalidPath, p, seg)
 		}
-		if len(seg) > MaxKeySegmentLen {
-			return fmt.Errorf("%w: %q has a %d-byte segment, over the %d-byte limit", ErrInvalidPath, p, len(seg), MaxKeySegmentLen)
+		if len(seg) > MaxKeySegmentLen-len(PartSuffix) {
+			return fmt.Errorf("%w: %q has a %d-byte segment, over the %d-byte limit", ErrInvalidPath, p, len(seg), MaxKeySegmentLen-len(PartSuffix))
 		}
 		start = i + 1
 	}
 	return nil
+}
+
+// stagedPath resolves the staging location for a key. Separate from
+// validatePath because the staging suffix is reserved, so the staging path is
+// deliberately not a valid key and cannot be reached through the normal
+// methods.
+func (b *LocalBackend) stagedPath(key string) (string, error) {
+	// Validated WITHOUT the reserved-suffix rule. A partial left by an older
+	// version can belong to a key that the contract now refuses, such as the
+	// staging file of the once-legal key "x.part". Refusing to address it
+	// would leave it hidden from List and unreclaimable forever, which is the
+	// opposite of the point (#744).
+	if key == "" {
+		return "", fmt.Errorf("%w: key is empty", ErrInvalidPath)
+	}
+	if key[len(key)-1] == '/' {
+		return "", fmt.Errorf("%w: %q ends in a separator", ErrInvalidPath, key)
+	}
+	if err := validateKeyBody(key); err != nil {
+		return "", err
+	}
+	return partPath(b.pathPrefix + key), nil
+}
+
+// StagedSize implements StagingInspector.
+func (b *LocalBackend) StagedSize(ctx context.Context, key string) (int64, error) {
+	staged, err := b.stagedPath(key)
+	if err != nil {
+		return 0, err
+	}
+	info, err := os.Stat(staged)
+	if os.IsNotExist(err) {
+		return -1, nil
+	}
+	if err != nil {
+		metrics.Get().IncStorageErrors()
+		return 0, fmt.Errorf("failed to stat staged file: %w", err)
+	}
+	return info.Size(), nil
+}
+
+// ReadStaged implements StagingInspector.
+func (b *LocalBackend) ReadStaged(ctx context.Context, key string, writer io.Writer) error {
+	staged, err := b.stagedPath(key)
+	if err != nil {
+		return err
+	}
+	file, err := os.Open(staged)
+	if err != nil {
+		metrics.Get().IncStorageErrors()
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file not found: %s", key)
+		}
+		return fmt.Errorf("failed to open staged file: %w", err)
+	}
+	defer file.Close()
+	if _, err := io.Copy(writer, file); err != nil {
+		metrics.Get().IncStorageErrors()
+		return fmt.Errorf("failed to read staged file: %w", err)
+	}
+	metrics.Get().IncStorageReads()
+	return nil
+}
+
+// DeleteStaged implements StagingInspector.
+func (b *LocalBackend) DeleteStaged(ctx context.Context, key string) error {
+	staged, err := b.stagedPath(key)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(staged); err != nil && !os.IsNotExist(err) {
+		metrics.Get().IncStorageErrors()
+		return fmt.Errorf("failed to delete staged file: %w", err)
+	}
+	return nil
+}
+
+// ListStaged implements StagingInspector.
+//
+// Staged partials are filtered out of List and ListObjects, so this is the only
+// way to find an abandoned one. Without it a spoke that keeps abandoning
+// transfers would fill the disk with files nothing could see.
+func (b *LocalBackend) ListStaged(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	searchPath, err := b.validateListPath(prefix)
+	if err != nil {
+		return nil, err
+	}
+	var results []ObjectInfo
+	err = filepath.WalkDir(searchPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		// Checked per entry, as List does: with an empty prefix this walks the
+		// whole data root, and the sweep's shutdown hook cancels its context
+		// expecting the walk to stop.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), PartSuffix) {
+			return nil
+		}
+		rel, relErr := filepath.Rel(b.basePath, path)
+		if relErr != nil {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		results = append(results, ObjectInfo{
+			// Reported WITHOUT the suffix: the caller addresses a partial by
+			// the key it belongs to, never by the staging spelling.
+			Path:         strings.TrimSuffix(filepath.ToSlash(rel), PartSuffix),
+			Size:         info.Size(),
+			LastModified: info.ModTime(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list staged files: %w", err)
+	}
+	return results, nil
 }
 
 // validatePath resolves a storage key to its absolute location, rejecting any

--- a/internal/storage/objectstore_contract_test.go
+++ b/internal/storage/objectstore_contract_test.go
@@ -74,6 +74,11 @@ func TestS3RejectsNonInjectiveKeys(t *testing.T) {
 		// A trailing separator names a directory marker, not this object.
 		{"trailing separator", "db/cpu/"},
 		{"empty", ""},
+		// Reserved for local write staging (#744). Refused on every backend so
+		// a key stays portable, which does mean a pre-existing ".part" object
+		// on S3 or Azure is no longer addressable through Arc. Those backends
+		// never stage, so Arc cannot have written one.
+		{"reserved staging suffix", "contract/x.parquet.part"},
 	}
 	for _, tt := range rejected {
 		t.Run("reject/"+tt.name, func(t *testing.T) {

--- a/internal/storage/staging_test.go
+++ b/internal/storage/staging_test.go
@@ -1,0 +1,190 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// Tests for #744. LocalBackend stages every write at key+PartSuffix, so the
+// staging file of key "x" WAS the committed object "x.part". The two destroyed
+// each other in four different orderings, all of which are closed by reserving
+// the suffix and addressing the partial through StagingInspector.
+
+func TestReservedStagingSuffixIsNotAKey(t *testing.T) {
+	for _, k := range []string{"x.parquet.part", "db/cpu/a.part", ".part"} {
+		err := ValidateKey(k)
+		if err == nil {
+			t.Errorf("ValidateKey(%q) was accepted; it names the staging file of another key", k)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidPath) {
+			t.Errorf("ValidateKey(%q) = %v, want ErrInvalidPath", k, err)
+		}
+	}
+	// The suffix is only reserved at the end.
+	for _, k := range []string{"x.part.parquet", "db/.partial/a.parquet", "a.parts"} {
+		if err := ValidateKey(k); err != nil {
+			t.Errorf("ValidateKey(%q) = %v, want accepted", k, err)
+		}
+	}
+}
+
+// TestCommittedWriteSurvivesAConcurrentStagedWrite is the regression proper.
+// Before the fix, Write("x.parquet.part") returned success and was then wiped
+// by the next WriteReader("x.parquet") opening its staging file with O_TRUNC.
+func TestCommittedWriteSurvivesAConcurrentStagedWrite(t *testing.T) {
+	b, _ := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	ctx := context.Background()
+
+	if err := b.Write(ctx, "x.parquet.part", []byte("PAYLOAD-TWO")); err == nil {
+		t.Fatal(`Write("x.parquet.part") was accepted; it is the staging file of "x.parquet"`)
+	}
+	if err := b.Write(ctx, "x.parquet", []byte("PAYLOAD-ONE")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := b.Read(ctx, "x.parquet")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "PAYLOAD-ONE" {
+		t.Errorf("Read = %q, want PAYLOAD-ONE", got)
+	}
+}
+
+// TestStagedPartialIsInvisibleToListButReclaimable pins both halves. A partial
+// must not appear in List, because every List-then-Read caller would then get a
+// key the backend refuses; and it must still be findable, or an abandoned one
+// could never be reclaimed and would fill the disk.
+func TestStagedPartialIsInvisibleToListButReclaimable(t *testing.T) {
+	b, _ := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	ctx := context.Background()
+
+	// A failed WriteReader leaves a staged partial behind by design.
+	err := b.WriteReader(ctx, "db/cpu/x.parquet", io.MultiReader(
+		bytes.NewReader([]byte("PART")),
+		errReader{errors.New("transport failed")},
+	), 64)
+	if err == nil {
+		t.Fatal("expected the staged write to fail")
+	}
+
+	keys, err := b.List(ctx, "db/")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, k := range keys {
+		if ValidateKey(k) != nil {
+			t.Errorf("List returned %q, which this backend refuses", k)
+		}
+	}
+
+	n, err := b.StagedSize(ctx, "db/cpu/x.parquet")
+	if err != nil {
+		t.Fatalf("StagedSize: %v", err)
+	}
+	if n != int64(len("PART")) {
+		t.Fatalf("StagedSize = %d, want %d; an abandoned partial must stay findable", n, len("PART"))
+	}
+
+	staged, err := b.ListStaged(ctx, "db/")
+	if err != nil {
+		t.Fatalf("ListStaged: %v", err)
+	}
+	if len(staged) != 1 || staged[0].Path != "db/cpu/x.parquet" {
+		t.Fatalf("ListStaged = %+v, want one entry keyed by the owning key", staged)
+	}
+
+	if err := b.DeleteStaged(ctx, "db/cpu/x.parquet"); err != nil {
+		t.Fatalf("DeleteStaged: %v", err)
+	}
+	if n, _ := b.StagedSize(ctx, "db/cpu/x.parquet"); n != -1 {
+		t.Errorf("StagedSize after delete = %d, want -1", n)
+	}
+	// Deleting one that is not there is not an error.
+	if err := b.DeleteStaged(ctx, "db/cpu/x.parquet"); err != nil {
+		t.Errorf("DeleteStaged on a missing partial = %v, want nil", err)
+	}
+}
+
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+// TestDeleteReclaimsTheKeysPartial pins that removing an object removes its
+// half-written staging file too. Without this the partial is invisible to List
+// and nothing else would ever find it.
+func TestDeleteReclaimsTheKeysPartial(t *testing.T) {
+	b, _ := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	ctx := context.Background()
+
+	if err := b.Write(ctx, "db/cpu/x.parquet", []byte("committed")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = b.WriteReader(ctx, "db/cpu/x.parquet", io.MultiReader(
+		bytes.NewReader([]byte("PART")), errReader{errors.New("boom")}), 64)
+	if n, _ := b.StagedSize(ctx, "db/cpu/x.parquet"); n < 0 {
+		t.Fatal("precondition: expected a staged partial")
+	}
+
+	if err := b.Delete(ctx, "db/cpu/x.parquet"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if n, _ := b.StagedSize(ctx, "db/cpu/x.parquet"); n >= 0 {
+		t.Errorf("staged partial survived Delete (%d bytes); nothing else can see it", n)
+	}
+}
+
+// TestStagedPartialOfANowReservedKeyIsReclaimable covers the pre-upgrade
+// orphan. A partial can belong to a key that was legal before the suffix was
+// reserved, and refusing to address it would leave it hidden from List and
+// unreclaimable forever.
+func TestStagedPartialOfANowReservedKeyIsReclaimable(t *testing.T) {
+	dir := t.TempDir()
+	b, _ := NewLocalBackend(dir, zerolog.Nop())
+	ctx := context.Background()
+
+	// Written behind the backend's back, as an older version would have left it.
+	if err := os.MkdirAll(filepath.Join(dir, "db"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "db", "x.part"+PartSuffix), []byte("LEGACY"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	staged, err := b.ListStaged(ctx, "db/")
+	if err != nil {
+		t.Fatalf("ListStaged: %v", err)
+	}
+	if len(staged) != 1 || staged[0].Path != "db/x.part" {
+		t.Fatalf("ListStaged = %+v, want one entry for db/x.part", staged)
+	}
+	// The owning key is itself reserved now, so this is exactly the case that
+	// must not be refused.
+	if err := b.DeleteStaged(ctx, staged[0].Path); err != nil {
+		t.Fatalf("DeleteStaged(%q) = %v; the orphan would be permanently unreclaimable", staged[0].Path, err)
+	}
+}
+
+// TestKeyLengthLeavesRoomForTheStagingSuffix pins that a key the contract
+// accepts can actually be written. At exactly the segment limit the staging
+// file overflowed the filesystem's own limit and the write failed.
+func TestKeyLengthLeavesRoomForTheStagingSuffix(t *testing.T) {
+	b, _ := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	ctx := context.Background()
+
+	key := "db/" + strings.Repeat("k", MaxKeySegmentLen-len(PartSuffix))
+	if err := ValidateKey(key); err != nil {
+		t.Fatalf("ValidateKey rejected a key at the documented limit: %v", err)
+	}
+	if err := b.WriteReader(ctx, key, bytes.NewReader([]byte("x")), 1); err != nil {
+		t.Errorf("the contract accepted a key the write path cannot store: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #744. Two of its three items; the third, `SanitizeS3Prefix`, was already fixed by #743.

## A write could destroy an already-acknowledged write

Local storage stages every streamed write at `{key}.part`, so the staging file of key `x` *was* the committed object `x.part`. Four orderings, all reproduced:

- **A.** `Write("x.parquet.part")` returns success. The next `WriteReader("x.parquet")` opens its staging file with `O_TRUNC`, wipes the committed object and renames it away. The acknowledged key stops existing.
- **B.** A committed `x.part` with no `x` makes `StatFile` report the wrong object's size and `ReadToAt` return its bytes, while `Read` and `Exists` agree the key is absent. In the cluster puller that can mark a file replicated that isn't there, or hash an unrelated object as a resume prefix and then delete the wrong key on mismatch.
- **C.** `AppendReader` appends to a committed object in place.
- **D.** `AppendReader`'s promote renames a committed object over a third key, destroying two objects in one call.

Only ordering A was in the issue. The suffix is now reserved, so no key can name a staging file.

## Reserving alone would have broken six call sites

This is the part I got wrong first, and the plan review caught it. Edge-sync resume sizes, hashes and clears a partial through `StatFile`/`ReadTo`/`Delete` on a hand-built `.part` key, and backup cleanup deletes one. Reserving without replacing them kills edge-sync resume and leaks every abandoned partial, which is the disk exhaustion `SweepStaging` exists to prevent.

So the capability is explicit: `StagingInspector` with `StagedSize`, `ReadStaged`, `DeleteStaged` and `ListStaged`, implemented by `LocalBackend` only. S3 and Azure never stage, so a failed type assertion means "there is never a partial", which is exactly true there.

## And the first version of the fix regressed reclamation

The implementation review caught this one. Hiding partials from `List` (required by #743's rule that a listing never returns a key the backend refuses) removed the only thing that ever reclaimed them. A failed upload in the ordinary data tree leaked permanently and, on local, kept `DROP DATABASE` from removing the directory. Compaction was worst: its output key carries a nanosecond timestamp, so a retry never reuses the failed key.

Two fixes: `Delete` reclaims its key's partial, and a prefix-wide delete asks for the ones whose final key never existed.

`DeleteStaged` deliberately does **not** apply the reserved-suffix rule to its argument, because a partial can belong to a key that was legal before this change. Refusing it would leave exactly the orphan this PR is about hidden and unreclaimable.

The key length bounds now subtract the suffix too. A key at exactly the segment limit passed the contract and then failed the write with `ENAMETOOLONG`, which is the same blessed-but-unstorable shape the manifest half fixes. Edge-sync already made that subtraction; the contract did not.

## Manifests could exceed the key segment limit

`GenerateManifestPath` prepended the folded partition path to a `jobID` that already embeds the sanitized database *and* that same folded partition, so the filename carried the partition twice and the database three times. At database 30 / measurement 60 that is **270 bytes** against a 255-byte limit, so `WriteManifest` failed and that partition never compacted again. At the maximum permitted names, **508 bytes**.

The filename is the `jobID` alone now, with a deterministic hash fallback and a guard against an empty `jobID` (which would give `.json` and be hidden by the same listing filter).

**I had planned not to change this**, on the grounds that a new format would orphan existing manifests. That premise was false: nothing parses these names, `ListManifests` filters on the suffix and `recoverManifest` drives off the unmarshalled body. My three stated reasons for believing the old fold was injective were also wrong, including citing a validator that isn't on that code path.

The distinctness test now says plainly what it pins, after a first version claimed too much: the adversarial pair folds to one `jobID` under *both* formats, and what separates the manifests is the `{database}` path segment, which was true before this change too.

## Known cost

Because the reservation is shared so a key stays portable, an object literally named `something.part` already in an S3 bucket or Azure container is no longer readable or deletable through Arc. Only local storage stages, so Arc cannot have written one. Called out in the release notes with the remedy, and pinned by the object-store contract test so it is a decision rather than an accident.

## Filed rather than folded in

- **#749**, which outranks everything here and is live: compaction temp-dir cleanup prefix-matches a folded name and then `os.RemoveAll`s it. Two ordinary database and measurement names collide (`a`/`a_a_cpu` vs `a_a`/`cpu`), and partitions run concurrently, so one job deletes a running job's working directory.
- **#750**: six more lossy encodings that become paths, keys or authorization decisions, including daily compaction flattening source keys into one temp dir by basename, and an RBAC dedup key that case-folds while the permission check does not.

## Testing

`go build`, `go vet`, `go test -tags=duckdb_arrow ./...` clean, plus the object-store contract tests against a live MinIO. New tests cover the collision, the reserved suffix, listing invisibility with reclaimability, `Delete` reclaiming its partial, the pre-upgrade orphan whose owning key is now reserved, length headroom, and both manifest properties. The manifest length test fails against the pre-change code at exactly the predicted 270 and 508 bytes.