### PR TITLE
Quarantine permanently unusable storage keys instead of retrying them (#747)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -255,6 +255,104 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### Cleanup and replication loops no longer retry an unusable storage key forever ([#747](https://github.com/Basekick-Labs/arc/issues/747))
+
+[#743](https://github.com/Basekick-Labs/arc/issues/743) made a refused storage
+key report a permanent, identifiable error, and documented that a loop meeting
+one should quarantine the entry rather than retry it. Nothing acted on that yet,
+and the loops the note was written about kept treating it as a passing I/O
+failure.
+
+A key gets into this state by being stored, not by being typed. The cluster
+manifest's own validator is looser than the storage contract on purpose: it runs
+inside Raft `Apply`, which includes log replay, so tightening it would make a
+node refuse an entry an older binary accepted and two versions would build
+different state from one log. The gap that leaves is exactly six spellings, and
+compaction manifests and edge-sync ledger rows are persisted state that can
+carry one written by an earlier version.
+
+What each loop did with such an entry, and does now:
+
+- **Peer file replication** fetched the whole file body from a peer and only
+  then failed writing it, once per candidate peer, once per attempt, on every
+  catch-up walk and every reconciliation pass. The entry is now recognised at
+  the first backend call and no peer is contacted. Its test suite runs in 3
+  seconds where it took 108 before, which is the retry storm made visible.
+
+  The reader's query gate stays **closed** for that entry, deliberately. The
+  file really is absent, the read path is a glob so a query over that partition
+  would just return fewer rows, and `query.gate_on_catchup` exists to turn that
+  silence into a 503. An entry no peer holds is equally unsatisfiable and holds
+  the gate today; this one gets no exemption. Puller stats and the 503 body
+  gained an `invalid_path` key so the reason is legible.
+
+- **Compaction manifest recovery** could not delete the manifest and could not
+  confirm the output, so it reprocessed it every cycle and its input files were
+  held out of compaction indefinitely. The manifest is now parked alongside
+  itself with a `.quarantined` suffix, which takes it out of the recovery work
+  set and releases its inputs while keeping the record of what it described.
+  It is parked rather than deleted because the inputs may already be gone: the
+  only binary that could have written such a manifest is one whose upload and
+  source deletion both succeeded.
+
+- **A compaction job** failed outright when one of its inputs had an unusable
+  key, every cycle, because the "already compacted, skip it" escape hatch is
+  gated on an existence check that fails the same way. That input is now
+  skipped and the rest of the partition is compacted. The skipped file is not
+  deleted and its manifest entry is not dropped.
+
+- **Reconciliation** counted these as transient in a bucket whose log line
+  promises "next run retries". Both sweeps now separate the two, and a run
+  report carries `skipped_transient` and `skipped_invalid_path` as separate
+  numbers, because waiting helps with one and never helps with the other. The
+  entries are reported, not deleted: these sweeps issue the irreversible
+  operations, and on an object store an object can sit under the literal key
+  where the listing filter hides it, so absence is unobservable here rather
+  than established.
+
+- **Air-gap bundle export** kept the entry on an existence-check error, by a
+  rule written for transient failures, and the copy then aborted the entire
+  export rather than one file. Nothing on that path caps attempts, so a single
+  unusable file stopped all telemetry leaving the site permanently, on the
+  deployment least able to receive a visit. It is now marked skipped.
+
+- Serving a peer fetch for such a path answered `backend`, which reads as a
+  transient fault on the peer; it now answers `invalid_path`, which is the code
+  that already meant this. Peer-fallback behaviour is unchanged.
+
+- The Phase 4 local delete worker never retried, so nothing was stuck there, but
+  it logged a permanent condition at the same level as a backend hiccup. It now
+  says plainly that the local copy can never be removed by Arc.
+
+A new counter, `arc_storage_invalid_path_quarantined_total`, aggregates every
+one of these. It matters more than most: after this change there is no retry
+storm, no growing error log and no stuck queue to notice, so the counter and the
+per-site Error lines are the whole signal. It should sit at zero.
+
+**Azure batch deletes were also unsafe** and are fixed here, because the test
+that pins the contract is what exposed it. `DeleteBatch` was the one key-taking
+method on any backend that never validated its input, and on Azure a backslash
+is a path separator, so a batch carrying `a\b.parquet` deleted the unrelated
+blob `a/b.parquet`. Bad keys are now collected and reported the way S3 already
+did, without failing the rest of the batch.
+
+**A five-byte window in this release's own manifest fix is closed here too.**
+The manifest filename fix above generates a hashed name once the filename passes
+255 bytes, but the key validator subtracts the write-staging suffix and refuses
+anything over 250, so a job id of 246 to 250 characters produced a filename the
+generator considered fine and every write refused: the manifest write failed and
+that partition's compaction failed on every cycle, which is exactly the failure
+that fix removed. The limits the validator actually enforces are now exported,
+so a caller that builds a key bounds it by the same number the backend checks.
+Neither the window nor the fix ever appeared in a release.
+
+One asymmetry is left in place and tracked separately: local listings do not
+filter unusable keys the way S3 and Azure have since #743. Filtering them there
+would be consistent, but on local these are real data files rather than the
+object stores' directory markers, and silently omitting them from a backup is
+worse than the listing being inconsistent. That trade-off deserves its own
+decision rather than a drive-by.
+
 ### A write could destroy an already-acknowledged write ([#744](https://github.com/Basekick-Labs/arc/issues/744))
 
 Local storage stages every streamed write at `{key}.part` and renames it into
@@ -302,6 +400,7 @@ names it reached 508 bytes.
 The filename is now the job id alone, which is already unique and already
 carries the partition. Nothing reads these names, so manifests written by an
 earlier version are still found and recovered, and no migration is needed.
+
 
 ### Every storage backend now enforces the same key contract ([#743](https://github.com/Basekick-Labs/arc/issues/743))
 

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/basekick-labs/arc/internal/config"
 	"github.com/basekick-labs/arc/internal/ingest"
 	"github.com/basekick-labs/arc/internal/license"
+	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/basekick-labs/arc/internal/wal"
 	"github.com/rs/zerolog"
@@ -105,6 +106,12 @@ type Coordinator struct {
 	// large compaction cycles.
 	deleteQueue chan deleteRequest
 	deleteWg    sync.WaitGroup
+
+	// fetchInvalidPathCount counts inbound fetch requests refused because the
+	// path is permanently unusable (#747). Its only job is to rate-limit the
+	// log line; the alertable number is the storage_invalid_path_quarantined
+	// metric.
+	fetchInvalidPathCount atomic.Int64
 
 	// nonceCache tracks recently seen nonces for replay protection on
 	// HMAC-authenticated messages: the join/heartbeat/leave handshake,
@@ -738,7 +745,22 @@ func (c *Coordinator) runDeleteWorker() {
 			// Delete all items in the batch.
 			for _, item := range batch {
 				delCtx, cancel := context.WithTimeout(c.ctx, 10*time.Second)
-				if err := c.storage.Delete(delCtx, item.path); err != nil {
+				if err := c.storage.Delete(delCtx, item.path); errors.Is(err, storage.ErrInvalidPath) {
+					// Permanent (#747). This queue is fire-and-forget, so the
+					// item is already out of the work set and nothing retries
+					// it; what changes is the diagnosis. A Warn here is
+					// indistinguishable from a backend hiccup, and an operator
+					// reading it would wait for a convergence that cannot
+					// happen: the local copy stays on disk forever, and no
+					// sweep can remove it either, because every path to it
+					// addresses the same unusable key.
+					metrics.Get().IncStorageInvalidPathQuarantined()
+					c.logger.Error().
+						Err(err).
+						Str("path", item.path).
+						Str("reason", item.reason).
+						Msg("Phase 4 local delete worker: the key is permanently unusable, so this local copy can never be removed by Arc and needs operator action")
+				} else if err != nil {
 					c.logger.Warn().
 						Err(err).
 						Str("path", item.path).
@@ -1757,6 +1779,35 @@ func (c *Coordinator) handleFetchFile(conn net.Conn, req *protocol.FetchFileRequ
 	exists, existsErr := backend.Exists(existsCtx, sanitized)
 	existsCancel()
 	if existsErr != nil {
+		if errors.Is(existsErr, storage.ErrInvalidPath) {
+			// Permanent (#747): this key names nothing this backend can
+			// address, and it will name nothing on the next request either.
+			// AckCodeBackend reads as a transient peer-side fault, which is the
+			// wrong thing to tell a puller about a condition no retry changes.
+			// AckCodeInvalidPath already carries exactly this meaning — it is
+			// what sanitizeFetchPath returns above — so the two rejections that
+			// mean "this path is not addressable" answer alike.
+			//
+			// Peer-fallback behaviour is unchanged: isFileNotOnPeerAck treats
+			// AckCodeBackend and AckCodeInvalidPath identically. Only the
+			// diagnosis the operator reads changes.
+			metrics.Get().IncStorageInvalidPathQuarantined()
+			// Rate-limited on powers of two, the same shape the puller uses for
+			// queue-full drops. This is the one site driven by an inbound
+			// request rather than by our own work set, so a peer still running
+			// a pre-#747 binary retries the same entry forever and would
+			// otherwise write one Error line per request here.
+			if n := c.fetchInvalidPathCount.Add(1); n&(n-1) == 0 {
+				c.logger.Error().
+					Err(existsErr).
+					Str("peer", remoteAddr).
+					Str("path", sanitized).
+					Int64("total_invalid_path_fetches", n).
+					Msg("FetchFile: refusing a manifest path the storage backend cannot address; answering invalid_path rather than a retryable backend error. A peer repeating this is running a binary that does not yet quarantine the entry")
+			}
+			c.sendFetchError(conn, protocol.AckCodeInvalidPath, "path is not addressable by this backend")
+			return
+		}
 		c.logger.Warn().
 			Err(existsErr).
 			Str("path", sanitized).

--- a/internal/cluster/delete_worker_test.go
+++ b/internal/cluster/delete_worker_test.go
@@ -1,0 +1,119 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// recordingBackend notes every Delete it is asked for and can fail one key
+// transiently, so the worker's three outcomes can be told apart.
+type recordingBackend struct {
+	*memBackend
+	mu       sync.Mutex
+	deleted  []string
+	flakyKey string
+}
+
+func (b *recordingBackend) Delete(ctx context.Context, path string) error {
+	b.mu.Lock()
+	b.deleted = append(b.deleted, path)
+	flaky := b.flakyKey == path
+	b.mu.Unlock()
+	if flaky {
+		return errors.New("RequestTimeout: connection reset by peer")
+	}
+	return b.memBackend.Delete(ctx, path)
+}
+
+func (b *recordingBackend) deleteCalls() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.deleted))
+	copy(out, b.deleted)
+	return out
+}
+
+// runDeleteWorkerOnce drives the real worker over one batch and returns when it
+// has drained. The worker waits 500ms for its grace period before deleting
+// anything, so the poll deadline allows for that.
+func runDeleteWorkerOnce(t *testing.T, backend storage.Backend, reqs ...deleteRequest) *Coordinator {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	c := &Coordinator{
+		storage:     backend,
+		logger:      zerolog.Nop(),
+		ctx:         ctx,
+		deleteQueue: make(chan deleteRequest, len(reqs)+1),
+	}
+	for _, r := range reqs {
+		c.deleteQueue <- r
+	}
+	c.deleteWg.Add(1)
+	go c.runDeleteWorker()
+	t.Cleanup(func() {
+		close(c.deleteQueue)
+		c.deleteWg.Wait()
+	})
+	return c
+}
+
+// TestDeleteWorkerClassifiesAnUnusableKey covers the Phase 4 local delete
+// worker. It is fire-and-forget, so the entry was already out of the work set
+// and nothing retried it; what was wrong is that a permanent condition was
+// logged as an ordinary delete failure, indistinguishable from a backend
+// hiccup an operator should wait out. Nothing here can ever remove that local
+// copy.
+//
+// The three outcomes are driven together because the branch was rewritten from
+// a plain `if err != nil` into a three-way classification, which is the shape
+// where the nil case is easiest to break.
+func TestDeleteWorkerClassifiesAnUnusableKey(t *testing.T) {
+	const good = "testdb/cpu/2026/04/11/14/good.parquet"
+	const flaky = "testdb/cpu/2026/04/11/14/flaky.parquet"
+	const unusable = `testdb\cpu/2026/04/11/14/bad.parquet`
+
+	mem := newMemBackend()
+	ctx := context.Background()
+	for _, k := range []string{good, flaky} {
+		if err := mem.Write(ctx, k, []byte("bytes")); err != nil {
+			t.Fatalf("seed %s: %v", k, err)
+		}
+	}
+	backend := &recordingBackend{memBackend: mem, flakyKey: flaky}
+
+	before := metrics.Get().Snapshot()["storage_invalid_path_quarantined_total"].(int64)
+
+	runDeleteWorkerOnce(t, backend,
+		deleteRequest{path: good, reason: "test"},
+		deleteRequest{path: unusable, reason: "test"},
+		deleteRequest{path: flaky, reason: "test"},
+	)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(backend.deleteCalls()) == 3 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	calls := backend.deleteCalls()
+	if len(calls) != 3 {
+		t.Fatalf("worker issued %d deletes, want 3: %v. One bad item must not stop the batch", len(calls), calls)
+	}
+	if ok, _ := mem.Exists(ctx, good); ok {
+		t.Error("the deletable local copy survived")
+	}
+	if got := metrics.Get().Snapshot()["storage_invalid_path_quarantined_total"].(int64) - before; got != 1 {
+		t.Errorf("quarantine counter moved by %d, want exactly 1 (the unusable key only)", got)
+	}
+}

--- a/internal/cluster/fetch_invalid_path_test.go
+++ b/internal/cluster/fetch_invalid_path_test.go
@@ -1,0 +1,127 @@
+package cluster
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/protocol"
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/cluster/security"
+	"github.com/rs/zerolog"
+)
+
+// fetchAck drives one real MsgFetchFile request through the real
+// handleFetchFile over a real TCP connection and returns the ack header.
+func fetchAck(t *testing.T, origin *originServer, sharedSecret, clusterName, nodeID, path string) *protocol.FetchFileAckHeader {
+	t.Helper()
+	nonce, err := security.GenerateNonce()
+	if err != nil {
+		t.Fatalf("nonce: %v", err)
+	}
+	ts := time.Now().Unix()
+	mac := security.ComputeFetchHMAC(sharedSecret, nonce, nodeID, clusterName, path, ts)
+
+	conn, err := net.DialTimeout("tcp", origin.addr(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := protocol.SendMessage(conn, &protocol.Message{
+		Type: protocol.MsgFetchFile,
+		Payload: &protocol.FetchFileRequest{
+			Path:      path,
+			NodeID:    nodeID,
+			Nonce:     nonce,
+			Timestamp: ts,
+			HMAC:      mac,
+		},
+	}, 2*time.Second); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	ackMsg, err := protocol.ReceiveMessage(conn, 2*time.Second)
+	if err != nil {
+		t.Fatalf("receive ack: %v", err)
+	}
+	ack, ok := ackMsg.Payload.(*protocol.FetchFileAckHeader)
+	if !ok {
+		t.Fatalf("ack payload wrong type: %T", ackMsg.Payload)
+	}
+	return ack
+}
+
+// TestFetchReportsUnusableKeyAsInvalidPath covers the serve side of #747. The
+// manifest entry passes sanitizeFetchPath and the FSM lookup, so the request
+// reaches the backend Exists call, which fails permanently. That used to be
+// answered as AckCodeBackend, which reads as a transient fault on the peer and
+// invites the requester to come back.
+//
+// The key here is a backslash on purpose, and that is the whole point of the
+// test: it is the only reachable spelling that survives sanitizeFetchPath, so
+// it is the only one that can reach the Exists call at all. A test written
+// with, say, "db//x.parquet" would be green before and after the fix, because
+// the sanitizer rejects that one several steps earlier.
+func TestFetchReportsUnusableKeyAsInvalidPath(t *testing.T) {
+	const (
+		sharedSecret = "auth"
+		clusterName  = "test-cluster"
+		originID     = "writer-1"
+		pullerID     = "reader-1"
+	)
+	// Accepted by raft.ValidateManifestPath, refused by storage.ValidateKey.
+	const unusable = `testdb\cpu/2026/04/11/14/file.parquet`
+
+	fsm := raft.NewClusterFSM(zerolog.Nop())
+	seedFileInFSM(t, fsm, raft.FileEntry{
+		Path:         unusable,
+		SizeBytes:    32,
+		Database:     "testdb",
+		Measurement:  "cpu",
+		OriginNodeID: originID,
+		SHA256:       "deadbeef",
+		CreatedAt:    time.Now().UTC(),
+	})
+
+	origin := startOriginServer(t, newMemBackend(), fsm, sharedSecret, clusterName, originID)
+	defer origin.stop()
+
+	ack := fetchAck(t, origin, sharedSecret, clusterName, pullerID, unusable)
+	if ack.Status != "error" {
+		t.Fatalf("ack status = %q, want error", ack.Status)
+	}
+	if ack.Code != protocol.AckCodeInvalidPath {
+		t.Fatalf("ack code = %q, want %q: a permanently unusable key must not be reported as a retryable backend fault", ack.Code, protocol.AckCodeInvalidPath)
+	}
+}
+
+// TestFetchSanitizerBoundary documents which spellings never reach the backend
+// at all. It is cheap, and it is what stops someone later "simplifying" the
+// backslash key in the test above into one of these, which would silently turn
+// that test into a test of sanitizeFetchPath.
+func TestFetchSanitizerBoundary(t *testing.T) {
+	const (
+		sharedSecret = "auth"
+		clusterName  = "test-cluster"
+		originID     = "writer-1"
+		pullerID     = "reader-1"
+	)
+	fsm := raft.NewClusterFSM(zerolog.Nop())
+	origin := startOriginServer(t, newMemBackend(), fsm, sharedSecret, clusterName, originID)
+	defer origin.stop()
+
+	// Rejected by sanitizeFetchPath before the manifest lookup or any backend
+	// call, so they answer invalid_path without the new branch being involved.
+	for _, path := range []string{
+		"testdb/cpu/2026/04/11/14/",
+		"testdb/./cpu/2026/04/11/14/f.parquet",
+		"testdb//cpu/2026/04/11/14/f.parquet",
+		"/testdb/cpu/2026/04/11/14/f.parquet",
+	} {
+		ack := fetchAck(t, origin, sharedSecret, clusterName, pullerID, path)
+		if ack.Code != protocol.AckCodeInvalidPath {
+			t.Errorf("path %q: ack code = %q, want %q", path, ack.Code, protocol.AckCodeInvalidPath)
+		}
+	}
+}

--- a/internal/cluster/filereplication/puller.go
+++ b/internal/cluster/filereplication/puller.go
@@ -21,11 +21,18 @@ import (
 	"time"
 
 	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/rs/zerolog"
 )
 
 const defaultReconciliationInterval = 5 * time.Minute
+
+// maxQuarantineLogPaths bounds the set of paths remembered for log
+// deduplication of permanently unusable keys (#747). A healthy cluster keeps
+// this set empty; the cap exists so a manifest full of bad entries costs a
+// bounded amount of memory rather than one map entry per distinct path.
+const maxQuarantineLogPaths = 1024
 
 // Fetcher is the contract the puller uses to download a single file from a
 // peer. It's an interface rather than a concrete type so the puller can be
@@ -208,6 +215,7 @@ type Puller struct {
 	totalPeerLookupFailure atomic.Int64 // no candidate peers available
 	totalBadOffsetServer   atomic.Int64 // server rejected resume offset (AckCodeBadOffset)
 	totalBadOffsetBackend  atomic.Int64 // backend can't append (ErrResumeNotSupported)
+	totalInvalidPath       atomic.Int64 // entry path is permanently unusable (storage.ErrInvalidPath)
 
 	// Catch-up metrics (Phase 3). Populated by RunCatchUp and read via Stats.
 	catchupStartedAt     atomic.Int64 // unix seconds; 0 if never started
@@ -242,6 +250,18 @@ type Puller struct {
 	catchupFailedPaths  map[string]struct{}
 	catchupDroppedPaths map[string]struct{}
 	catchupInflight     atomic.Int64
+
+	// quarantinedPaths holds paths already logged as permanently unusable, so
+	// the Error line is emitted once per path per process rather than once per
+	// arrival (#747). The same path is re-offered by three independent sources
+	// — the reactive FSM callback, the startup catch-up walker and the periodic
+	// reconciler — and none of them can know another already reported it.
+	//
+	// Bounded by maxQuarantineLogPaths. Past the cap the set stops growing and
+	// every arrival logs again: noisier, but a log flood is recoverable and an
+	// unbounded map on a path an adversary with Raft write access could feed is
+	// not. Shares inflightMu with the sets above.
+	quarantinedPaths map[string]struct{}
 
 	// catchupFailed / catchupDropped count failures and drops scoped to the
 	// catch-up batch only. FullyCaughtUp uses these (not the cumulative
@@ -314,6 +334,7 @@ func New(cfg Config) (*Puller, error) {
 		catchupPaths:        make(map[string]struct{}),
 		catchupFailedPaths:  make(map[string]struct{}),
 		catchupDroppedPaths: make(map[string]struct{}),
+		quarantinedPaths:    make(map[string]struct{}),
 		catchupFinished:     make(chan struct{}),
 		logger:              cfg.Logger.With().Str("component", "file-puller").Logger(),
 	}, nil
@@ -385,6 +406,26 @@ func (p *Puller) finishEntry(path string, source enqueueSource, failed, succeede
 		p.removeCatchUpTagLocked(path)
 	}
 	p.removeInflightOnlyLocked(path)
+}
+
+// markQuarantinedForLog records that a path has been reported as permanently
+// unusable and returns true only for the first caller to do so, so the Error
+// line is emitted once per path per process (#747).
+//
+// Returns true unconditionally once the set is at maxQuarantineLogPaths: the
+// choice there is between repeating a log line and growing a map without a
+// bound, and only one of those is recoverable.
+func (p *Puller) markQuarantinedForLog(path string) bool {
+	p.inflightMu.Lock()
+	defer p.inflightMu.Unlock()
+	if _, ok := p.quarantinedPaths[path]; ok {
+		return false
+	}
+	if len(p.quarantinedPaths) >= maxQuarantineLogPaths {
+		return true
+	}
+	p.quarantinedPaths[path] = struct{}{}
+	return true
 }
 
 // markCatchUp records that a path is being enqueued by the catch-up walker
@@ -688,6 +729,7 @@ func (p *Puller) Stats() map[string]int64 {
 		"peer_lookup_failure":                p.totalPeerLookupFailure.Load(),
 		"bad_offset_server":                  p.totalBadOffsetServer.Load(),
 		"bad_offset_backend":                 p.totalBadOffsetBackend.Load(),
+		"invalid_path":                       p.totalInvalidPath.Load(),
 		"queue_depth":                        int64(len(p.queue)),
 		"inflight_count":                     p.inflightCount.Load(),
 		"catchup_started_at":                 p.catchupStartedAt.Load(),
@@ -805,6 +847,12 @@ func (p *Puller) CatchUpStatus() map[string]int64 {
 		"failed":      p.totalFailed.Load(),
 		"dropped":     p.totalDropped.Load(),
 
+		// Subset of "failed" whose cause is permanent: the manifest entry names
+		// a key no storage backend can address (#747). Surfaced here because it
+		// lands in the query gate's 503 body, and "invalid_path > 0" is the one
+		// reason a red gate will never go green on its own.
+		"invalid_path": p.totalInvalidPath.Load(),
+
 		// Catch-up-batch-scoped counters (added in 26.06.1 for the query
 		// gate). Non-zero means the gate is closed for a reason FullyCaughtUp
 		// can attribute to the cold-start batch specifically.
@@ -892,6 +940,35 @@ func (p *Puller) processEntry(log zerolog.Logger, request *pullRequest) {
 		if statErr == nil && localSize == entry.SizeBytes {
 			p.totalSkippedLocal.Add(1)
 			succeeded = true // File is already here — same as a fresh pull from the gate's perspective.
+			return
+		}
+		if errors.Is(statErr, storage.ErrInvalidPath) {
+			// Permanent (#747). This is the first backend call an entry makes,
+			// and every later one — WriteReader, the partial-file stat, the
+			// delete of a corrupt partial — fails identically on the same key.
+			// Without this branch the worker fetches the whole file body from a
+			// peer and then fails writing it, once per candidate peer, once per
+			// attempt, on every catch-up walk and every reconciliation pass,
+			// forever.
+			//
+			// failed stays TRUE deliberately. The file really is absent, the
+			// read path is a glob so a query over that partition silently
+			// returns fewer rows, and an operator who enabled
+			// query.gate_on_catchup asked for a 503 over exactly that. An entry
+			// no peer holds is equally unsatisfiable and reds the gate today;
+			// this one gets no exemption. What the quarantine removes is the
+			// wasted peer traffic and the retry storm, not the signal.
+			p.totalInvalidPath.Add(1)
+			p.totalFailed.Add(1)
+			metrics.Get().IncStorageInvalidPathQuarantined()
+			failed = true
+			if p.markQuarantinedForLog(entry.Path) {
+				log.Error().
+					Err(statErr).
+					Str("path", entry.Path).
+					Str("origin_node_id", entry.OriginNodeID).
+					Msg("Manifest entry names a storage key no backend can address; not pulling it from any peer. It cannot be replicated here and, if the query gate is enabled, it holds the gate closed until the entry is removed from the cluster manifest AND this node is restarted: only a successful pull of the same path clears the catch-up failure, and this one can never succeed")
+			}
 			return
 		}
 
@@ -1091,6 +1168,13 @@ func (p *Puller) writeFileTail(ctx context.Context, entry *raft.FileEntry, r io.
 // Note: for backends that do not implement AppendingBackend, writeFileTail will
 // return ErrResumeNotSupported when called with a non-zero offset. This is
 // intentional — the puller increments bad_offset_backend and retries from zero.
+//
+// statErr here can no longer be storage.ErrInvalidPath, and the (0, nil) return
+// is therefore not ambiguous between "no partial" and "unusable key": the same
+// key already went through StatFile at the top of processEntry, which
+// quarantines and returns before any of this runs (#747). The same invariant is
+// why deleteFile below cannot be called with an unusable key. Both are pinned
+// by a test asserting the backend sees no Delete for a quarantined entry.
 func (p *Puller) tryResumeFromPartial(log zerolog.Logger, entry *raft.FileEntry) (int64, hash.Hash) {
 	statCtx, statCancel := context.WithTimeout(p.ctx, 5*time.Second)
 	partial, statErr := p.cfg.Backend.StatFile(statCtx, entry.Path)

--- a/internal/cluster/filereplication/puller_invalid_path_test.go
+++ b/internal/cluster/filereplication/puller_invalid_path_test.go
@@ -1,0 +1,228 @@
+package filereplication
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/metrics"
+)
+
+// invalidEntryPath is accepted by raft.ValidateManifestPath and refused by
+// storage.ValidateKey, which is how it reaches the puller from the cluster
+// manifest in the first place. The full reachable set is pinned in
+// internal/cluster/raft/manifest_path_reachability_test.go; backslash is used
+// here because it is the one spelling that also survives the coordinator's
+// sanitizeFetchPath, so the same key exercises every site in #747.
+const invalidEntryPath = `testdb\cpu/2026/04/11/14/file-1.parquet`
+
+// TestPullerQuarantinesUnusableKeyWithoutTouchingPeers is the core of the
+// replication half of #747.
+//
+// Before this, the pre-pull StatFile failed, the worker went to a peer anyway,
+// streamed the whole file body, and only then failed at WriteReader with the
+// same permanent error. That repeated for every candidate peer, every attempt,
+// on every catch-up walk and every reconciliation pass, forever.
+//
+// The load-bearing assertion is fetcher.calls == 0. Everything else could be
+// satisfied by a fix that still pays for the transfer.
+func TestPullerQuarantinesUnusableKeyWithoutTouchingPeers(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newFakeFetcher() // no scripted results: any call is a bug
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	before := metrics.Get().Snapshot()["storage_invalid_path_quarantined_total"].(int64)
+	p.Enqueue(makeEntry(invalidEntryPath, "writer-1", 128))
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["invalid_path"] == 1 })
+	if stats["invalid_path"] != 1 {
+		t.Fatalf("invalid_path = %d, want 1: %+v", stats["invalid_path"], stats)
+	}
+	// The puller has its own counter, but it must also move the shared one:
+	// Stats() is JSON-only, so without this the highest-frequency site is
+	// invisible to the Prometheus alert this change ships.
+	if got := metrics.Get().Snapshot()["storage_invalid_path_quarantined_total"].(int64) - before; got != 1 {
+		t.Errorf("shared quarantine counter moved by %d, want 1", got)
+	}
+	if got := fetcher.calls.Load(); got != 0 {
+		t.Errorf("fetcher was called %d times; a key no backend can accept must never cost peer bandwidth", got)
+	}
+	if stats["pulled"] != 0 {
+		t.Errorf("pulled = %d, want 0", stats["pulled"])
+	}
+
+	// deleteCount pins the claim that tryResumeFromPartial and deleteFile
+	// become unreachable for a quarantined entry, rather than only documenting
+	// it in a comment.
+	if got := backend.deleteCount(); got != 0 {
+		t.Errorf("backend saw %d Delete calls; the quarantine must return before any partial-file handling", got)
+	}
+}
+
+// TestPullerQuarantineKeepsTheQueryGateClosed is the decision this fix turns
+// on, pinned so it cannot be "simplified" later.
+//
+// The entry is unsatisfiable, so it is tempting to stop counting it as a
+// failure and let the reader go ready. That would be wrong. The read path is a
+// glob, so an absent file contributes no rows and raises nothing, and an
+// operator who set query.gate_on_catchup (off by default) asked for a 503 over
+// exactly that silence. An entry no peer holds is equally unsatisfiable and
+// reds the gate today; this one gets no exemption. What the quarantine removes
+// is the wasted work, not the signal.
+func TestPullerQuarantineKeepsTheQueryGateClosed(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newFakeFetcher()
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	// Tag the path as catch-up work and mark the walker finished, which is the
+	// state FullyCaughtUp is written against.
+	p.markCatchUp(invalidEntryPath)
+	p.enqueue(makeEntry(invalidEntryPath, "writer-1", 128), enqueueSourceCatchUp)
+	p.catchupCompletedAt.Store(time.Now().Unix())
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["invalid_path"] == 1 })
+	if stats["failed"] != 1 {
+		t.Errorf("failed = %d, want 1: the file really is absent, so the gate must stay closed", stats["failed"])
+	}
+
+	// The catch-up tag must still be released, or catchupInflight never drains
+	// and the reason the gate is red becomes unreadable.
+	if got := p.catchupInflight.Load(); got != 0 {
+		t.Errorf("catchupInflight = %d, want 0: the quarantine must still clear its in-flight bookkeeping", got)
+	}
+	if p.FullyCaughtUp() {
+		t.Error("FullyCaughtUp() is true while a manifest entry has no local copy; queries would silently return fewer rows")
+	}
+
+	// The operator reading the 503 body must be able to see why it will never
+	// clear on its own.
+	if got := p.CatchUpStatus()["invalid_path"]; got != 1 {
+		t.Errorf("CatchUpStatus()[invalid_path] = %d, want 1", got)
+	}
+}
+
+// TestPullerQuarantineDoesNotPoisonOtherEntries pins that one bad entry among
+// good ones costs only itself. The bad entry is at index 1 of 3 because the
+// worker pool makes a quarantine that aborted its loop order-sensitive.
+func TestPullerQuarantineDoesNotPoisonOtherEntries(t *testing.T) {
+	backend := newFakeBackend()
+	body := []byte("parquet body bytes")
+	fetcher := newRepeatingFetcher(body)
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	good1 := makeEntry("testdb/cpu/2026/04/11/14/a.parquet", "writer-1", int64(len(body)))
+	bad := makeEntry(invalidEntryPath, "writer-1", int64(len(body)))
+	good2 := makeEntry("testdb/cpu/2026/04/11/14/c.parquet", "writer-1", int64(len(body)))
+	for _, e := range []*raft.FileEntry{good1, bad, good2} {
+		p.Enqueue(e)
+	}
+
+	stats := waitStats(t, p, func(s map[string]int64) bool {
+		return s["pulled"] == 2 && s["invalid_path"] == 1
+	})
+	if stats["pulled"] != 2 {
+		t.Fatalf("pulled = %d, want 2: %+v", stats["pulled"], stats)
+	}
+	// waitStats returns the last snapshot on timeout without failing, so the
+	// quarantine half of the predicate has to be re-asserted here or this test
+	// passes on a build where the quarantine never fires.
+	if stats["invalid_path"] != 1 {
+		t.Fatalf("invalid_path = %d, want 1: %+v", stats["invalid_path"], stats)
+	}
+	for _, e := range []*raft.FileEntry{good1, good2} {
+		if _, err := backend.Read(context.Background(), e.Path); err != nil {
+			t.Errorf("Read(%s) after pull: %v", e.Path, err)
+		}
+	}
+}
+
+// TestPullerQuarantineIsIdempotentAcrossReenqueues covers the shape that makes
+// the log-dedupe set necessary: the same path is offered by the reactive FSM
+// callback, the startup catch-up walker and the periodic reconciler, none of
+// which can know another already reported it.
+//
+// The counter advances once per arrival, which is the honest measure of wasted
+// work; only the Error line is deduplicated. What must not happen is in-flight
+// state leaking, since that would pin the gate red for a reason unrelated to
+// the entry itself.
+func TestPullerQuarantineIsIdempotentAcrossReenqueues(t *testing.T) {
+	backend := newFakeBackend()
+	fetcher := newFakeFetcher()
+	resolver := staticResolver{nodeID: "writer-1", addrs: []string{"1.2.3.4:9100"}, ok: true}
+
+	p := newTestPuller(t, backend, fetcher, resolver)
+	p.Start(context.Background())
+	defer p.Stop()
+
+	const rounds = 50
+	for i := 0; i < rounds; i++ {
+		p.Enqueue(makeEntry(invalidEntryPath, "writer-1", 128))
+		// Wait for this arrival to settle before the next, so the inflight
+		// dedup does not silently collapse them into one.
+		waitStats(t, p, func(s map[string]int64) bool { return s["invalid_path"] >= int64(i+1) })
+	}
+
+	stats := waitStats(t, p, func(s map[string]int64) bool { return s["invalid_path"] == rounds })
+	if stats["invalid_path"] != rounds {
+		t.Fatalf("invalid_path = %d, want %d", stats["invalid_path"], rounds)
+	}
+	if got := stats["inflight_count"]; got != 0 {
+		t.Errorf("inflight_count = %d, want 0: quarantined entries must not leak in-flight slots", got)
+	}
+	if got := fetcher.calls.Load(); got != 0 {
+		t.Errorf("fetcher was called %d times across %d re-enqueues", got, rounds)
+	}
+
+	// The dedupe set holds one path, not one entry per arrival.
+	p.inflightMu.Lock()
+	tracked := len(p.quarantinedPaths)
+	p.inflightMu.Unlock()
+	if tracked != 1 {
+		t.Errorf("quarantinedPaths holds %d entries after %d arrivals of one path, want 1", tracked, rounds)
+	}
+}
+
+// TestQuarantineLogSetIsBounded exercises the branch nobody runs in practice:
+// past maxQuarantineLogPaths the set stops growing and every arrival logs
+// again. Repeating a log line is recoverable; an unbounded map fed by manifest
+// entries is not.
+func TestQuarantineLogSetIsBounded(t *testing.T) {
+	p := newTestPuller(t, newFakeBackend(), newFakeFetcher(), staticResolver{ok: false})
+
+	for i := 0; i < maxQuarantineLogPaths+10; i++ {
+		p.markQuarantinedForLog(pathN(i))
+	}
+	p.inflightMu.Lock()
+	size := len(p.quarantinedPaths)
+	p.inflightMu.Unlock()
+	if size != maxQuarantineLogPaths {
+		t.Fatalf("quarantinedPaths grew to %d, want it capped at %d", size, maxQuarantineLogPaths)
+	}
+	// Past the cap, a path that was never recorded still reports "log it",
+	// rather than being silently suppressed.
+	if !p.markQuarantinedForLog("testdb/cpu/2026/04/11/14/past-cap.parquet") {
+		t.Error("past the cap the helper suppressed a log line for an unseen path")
+	}
+	// A path recorded before the cap is still deduplicated.
+	if p.markQuarantinedForLog(pathN(0)) {
+		t.Error("a path already recorded was reported as new")
+	}
+}
+
+func pathN(i int) string {
+	return fmt.Sprintf("testdb/cpu/2026/04/11/14/file-%d.parquet", i)
+}

--- a/internal/cluster/filereplication/puller_test.go
+++ b/internal/cluster/filereplication/puller_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/rs/zerolog"
 )
 
@@ -20,6 +21,12 @@ import (
 
 // fakeBackend is an in-memory storage.Backend used by the puller tests. Only
 // the methods the puller calls are implemented; the rest panic.
+//
+// Every key-taking method enforces storage.ValidateKey, as local, S3 and Azure
+// all do. Without it this double would be MORE PERMISSIVE than any production
+// backend: it would store and stat keys no real backend accepts, which makes
+// the permanent-error branch added for #747 dead code under test and lets a
+// puller test "pass" on a path that can only fail in production.
 type fakeBackend struct {
 	mu    sync.Mutex
 	files map[string][]byte
@@ -35,7 +42,17 @@ func newFakeBackend() *fakeBackend {
 	return &fakeBackend{files: make(map[string][]byte)}
 }
 
+// checkKey mirrors the validation every production backend applies before it
+// touches an object, so errors.Is(err, storage.ErrInvalidPath) behaves here
+// exactly as it does against a real backend.
+func checkKey(path string) error {
+	return storage.ValidateKey(path)
+}
+
 func (f *fakeBackend) Write(ctx context.Context, path string, data []byte) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.writeErr != nil {
@@ -48,6 +65,9 @@ func (f *fakeBackend) Write(ctx context.Context, path string, data []byte) error
 }
 
 func (f *fakeBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	f.mu.Lock()
 	writeErr := f.writeErr
 	f.mu.Unlock()
@@ -89,6 +109,9 @@ func (f *fakeBackend) WriteReader(ctx context.Context, path string, reader io.Re
 }
 
 func (f *fakeBackend) Read(ctx context.Context, path string) ([]byte, error) {
+	if err := checkKey(path); err != nil {
+		return nil, err
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	data, ok := f.files[path]
@@ -99,6 +122,9 @@ func (f *fakeBackend) Read(ctx context.Context, path string) ([]byte, error) {
 }
 
 func (f *fakeBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	// Fall back to staging file so tryResumeFromPartial can hash a partial prefix.
 	f.mu.Lock()
 	data, ok := f.files[path]
@@ -114,6 +140,9 @@ func (f *fakeBackend) ReadTo(ctx context.Context, path string, writer io.Writer)
 }
 
 func (f *fakeBackend) ReadToAt(ctx context.Context, path string, writer io.Writer, offset int64) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	f.mu.Lock()
 	data, ok := f.files[path]
 	if !ok {
@@ -131,6 +160,9 @@ func (f *fakeBackend) ReadToAt(ctx context.Context, path string, writer io.Write
 }
 
 func (f *fakeBackend) StatFile(ctx context.Context, path string) (int64, error) {
+	if err := checkKey(path); err != nil {
+		return -1, err
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if data, ok := f.files[path]; ok {
@@ -144,6 +176,9 @@ func (f *fakeBackend) StatFile(ctx context.Context, path string) (int64, error) 
 }
 
 func (f *fakeBackend) AppendReader(ctx context.Context, path string, reader io.Reader, appendSize int64) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	f.mu.Lock()
 	writeErr := f.writeErr
 	f.mu.Unlock()
@@ -169,6 +204,9 @@ func (f *fakeBackend) AppendReader(ctx context.Context, path string, reader io.R
 }
 
 func (f *fakeBackend) Delete(ctx context.Context, path string) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.files, path)
@@ -182,6 +220,9 @@ func (f *fakeBackend) List(ctx context.Context, prefix string) ([]string, error)
 }
 
 func (f *fakeBackend) Exists(ctx context.Context, path string) (bool, error) {
+	if err := checkKey(path); err != nil {
+		return false, err
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.forceExists != nil {

--- a/internal/cluster/filereplication_integration_test.go
+++ b/internal/cluster/filereplication_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/basekick-labs/arc/internal/cluster/raft"
 	"github.com/basekick-labs/arc/internal/cluster/security"
 	"github.com/basekick-labs/arc/internal/config"
+	"github.com/basekick-labs/arc/internal/storage"
 	hraft "github.com/hashicorp/raft"
 	"github.com/rs/zerolog"
 )
@@ -70,7 +71,17 @@ func newMemBackend() *memBackend {
 	return &memBackend{files: make(map[string][]byte)}
 }
 
+// memCheckKey mirrors the validation every production backend applies. Without
+// it this double is more permissive than local, S3 and Azure, and the
+// permanent-error branch in handleFetchFile could not be exercised at all.
+func memCheckKey(path string) error {
+	return storage.ValidateKey(path)
+}
+
 func (m *memBackend) Write(ctx context.Context, path string, data []byte) error {
+	if err := memCheckKey(path); err != nil {
+		return err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	cp := make([]byte, len(data))
@@ -80,6 +91,9 @@ func (m *memBackend) Write(ctx context.Context, path string, data []byte) error 
 }
 
 func (m *memBackend) WriteReader(ctx context.Context, path string, reader io.Reader, size int64) error {
+	if err := memCheckKey(path); err != nil {
+		return err
+	}
 	data, err := io.ReadAll(reader)
 	if err != nil {
 		return err
@@ -91,6 +105,9 @@ func (m *memBackend) WriteReader(ctx context.Context, path string, reader io.Rea
 }
 
 func (m *memBackend) Read(ctx context.Context, path string) ([]byte, error) {
+	if err := memCheckKey(path); err != nil {
+		return nil, err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	data, ok := m.files[path]
@@ -101,6 +118,9 @@ func (m *memBackend) Read(ctx context.Context, path string) ([]byte, error) {
 }
 
 func (m *memBackend) ReadTo(ctx context.Context, path string, writer io.Writer) error {
+	if err := memCheckKey(path); err != nil {
+		return err
+	}
 	data, err := m.Read(ctx, path)
 	if err != nil {
 		return err
@@ -110,15 +130,24 @@ func (m *memBackend) ReadTo(ctx context.Context, path string, writer io.Writer) 
 }
 
 func (m *memBackend) List(ctx context.Context, prefix string) ([]string, error) {
+	if err := storage.ValidateListPrefix(prefix); err != nil {
+		return nil, err
+	}
 	return nil, nil
 }
 func (m *memBackend) Delete(ctx context.Context, path string) error {
+	if err := memCheckKey(path); err != nil {
+		return err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.files, path)
 	return nil
 }
 func (m *memBackend) Exists(ctx context.Context, path string) (bool, error) {
+	if err := memCheckKey(path); err != nil {
+		return false, err
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	_, ok := m.files[path]
@@ -128,6 +157,9 @@ func (m *memBackend) Close() error       { return nil }
 func (m *memBackend) Type() string       { return "mem" }
 func (m *memBackend) ConfigJSON() string { return "{}" }
 func (m *memBackend) ReadToAt(_ context.Context, path string, w io.Writer, offset int64) error {
+	if err := memCheckKey(path); err != nil {
+		return err
+	}
 	m.mu.Lock()
 	data, ok := m.files[path]
 	m.mu.Unlock()
@@ -141,6 +173,9 @@ func (m *memBackend) ReadToAt(_ context.Context, path string, w io.Writer, offse
 	return err
 }
 func (m *memBackend) StatFile(_ context.Context, path string) (int64, error) {
+	if err := memCheckKey(path); err != nil {
+		return -1, err
+	}
 	m.mu.Lock()
 	data, ok := m.files[path]
 	m.mu.Unlock()
@@ -150,6 +185,9 @@ func (m *memBackend) StatFile(_ context.Context, path string) (int64, error) {
 	return int64(len(data)), nil
 }
 func (m *memBackend) AppendReader(_ context.Context, path string, r io.Reader, _ int64) error {
+	if err := memCheckKey(path); err != nil {
+		return err
+	}
 	tail, err := io.ReadAll(r)
 	if err != nil {
 		return err

--- a/internal/cluster/raft/manifest_path_reachability_test.go
+++ b/internal/cluster/raft/manifest_path_reachability_test.go
@@ -1,0 +1,66 @@
+package raft
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/storage"
+)
+
+// TestManifestReachableKeysAreStorageRejected defines, and pins, the exact set
+// of storage keys that can enter the cluster manifest and then fail every
+// storage call made with them.
+//
+// ValidateManifestPath is deliberately looser than storage.ValidateKey and must
+// stay that way: it runs inside FSM Apply, which includes log replay, so
+// tightening it makes a node reject an entry an older binary accepted and two
+// versions build different state from one log. The consequence is this gap, and
+// #747 closes it at the consumers rather than here.
+//
+// This test is the gap's definition. Every quarantine branch added for #747 is
+// written against these six spellings, and the table in
+// internal/storage/invalid_path_contract_test.go mirrors them. If someone
+// later tightens ValidateManifestPath, this test fails and names exactly which
+// consumer branches became unreachable, instead of leaving dead code behind.
+func TestManifestReachableKeysAreStorageRejected(t *testing.T) {
+	reachable := []struct {
+		name string
+		key  string
+	}{
+		{"trailing separator", "testdb/cpu/2026/04/11/14/"},
+		{"dot segment", "testdb/./cpu/2026/04/11/14/f.parquet"},
+		{"empty interior segment", "testdb//cpu/2026/04/11/14/f.parquet"},
+		{"backslash", `testdb\cpu/2026/04/11/14/f.parquet`},
+		{"oversize segment", "testdb/" + strings.Repeat("m", storage.MaxKeySegmentLen+1) + "/f.parquet"},
+		{"oversize key", "testdb/" + strings.Repeat(strings.Repeat("a", 200)+"/", 6) + "f.parquet"},
+	}
+
+	for _, tc := range reachable {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateManifestPath(tc.key); err != nil {
+				t.Fatalf("ValidateManifestPath(%q) = %v; this key is no longer reachable, so the #747 consumer branches written for it are now dead code and should be revisited", tc.key, err)
+			}
+			if err := storage.ValidateKey(tc.key); err == nil {
+				t.Fatalf("storage.ValidateKey(%q) now accepts this key, so it is no longer part of the gap", tc.key)
+			}
+		})
+	}
+}
+
+// TestKeysRejectedByBothValidatorsAreUnreachable records the other half: these
+// spellings are refused by ValidateManifestPath too, so they can never reach a
+// cleanup or replication loop from the manifest.
+//
+// It exists because they are the obvious thing to reach for when writing a test
+// for an "invalid path", and a consumer-side test built on one of them would be
+// testing a code path no manifest entry can trigger.
+func TestKeysRejectedByBothValidatorsAreUnreachable(t *testing.T) {
+	for _, key := range []string{"", "/testdb/cpu/f.parquet", "testdb/../cpu/f.parquet"} {
+		if err := ValidateManifestPath(key); err == nil {
+			t.Errorf("ValidateManifestPath(%q) was accepted; the reachable set in TestManifestReachableKeysAreStorageRejected is now incomplete", key)
+		}
+		if err := storage.ValidateKey(key); err == nil {
+			t.Errorf("storage.ValidateKey(%q) was accepted", key)
+		}
+	}
+}

--- a/internal/compaction/job.go
+++ b/internal/compaction/job.go
@@ -576,7 +576,7 @@ func (j *Job) downloadFiles(ctx context.Context, tempDir string) ([]downloadedFi
 	j.BytesBefore = totalSize
 
 	if skippedCount > 0 {
-		j.logger.Info().Int("skipped", skippedCount).Msg("Skipped already-compacted files")
+		j.logger.Info().Int("skipped", skippedCount).Msg("Skipped inputs during download (already compacted, or key permanently unusable)")
 	}
 
 	return finalFiles, nil
@@ -607,6 +607,24 @@ func (j *Job) downloadSingleFile(ctx context.Context, tempDir string, index int,
 		file.Close()
 		if removeErr := os.Remove(localPath); removeErr != nil {
 			j.logger.Warn().Err(removeErr).Str("path", localPath).Msg("Failed to clean up partial download file")
+		}
+
+		if errors.Is(err, storage.ErrInvalidPath) {
+			// Permanent: no backend can address this key, so every cycle would
+			// re-select this input and fail the whole job on it (#747). The
+			// Exists call below cannot rescue it either — it fails identically,
+			// leaving checkErr non-nil, which is exactly what makes the
+			// "already compacted, skip" escape hatch unreachable here.
+			//
+			// Skipping is safe: compactedFiles is built from the keys DuckDB
+			// actually read, so a skipped input is never deleted from storage
+			// and its manifest entry is never dropped. The job degrades to a
+			// partial compaction instead of failing outright.
+			metrics.Get().IncStorageInvalidPathQuarantined()
+			j.logger.Error().Err(err).
+				Str("file", fileKey).
+				Msg("Compaction input has a permanently unusable storage key; skipping it and compacting the rest. The file is not deleted and stays in the partition")
+			return downloadResult{index: index, skipped: true}
 		}
 
 		// Check if file doesn't exist (already compacted)

--- a/internal/compaction/job_invalid_path_test.go
+++ b/internal/compaction/job_invalid_path_test.go
@@ -1,0 +1,116 @@
+package compaction
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// newDownloadJob builds the smallest Job that downloadFiles needs. It is driven
+// directly rather than through Job.Run because running a compaction requires
+// DuckDB (the only Job-level tests are behind the duckdb_arrow build tag), and
+// the behaviour under test is entirely in the download stage.
+func newDownloadJob(t *testing.T, backend storage.Backend, files []string) *Job {
+	t.Helper()
+	return &Job{
+		Measurement:    "cpu",
+		PartitionPath:  "testdb/cpu/2026/04/11/14",
+		Files:          files,
+		StorageBackend: backend,
+		Database:       "testdb",
+		Tier:           "hourly",
+		JobID:          "job_download",
+		logger:         zerolog.Nop(),
+	}
+}
+
+// TestDownloadFilesSkipsUnusableInput covers the site the issue describes as
+// "a skippable input becomes a hard job failure": ReadTo fails permanently, the
+// recovery calls Exists and gates on checkErr == nil, and because Exists fails
+// identically on the same key the "already compacted, skipping" escape hatch is
+// unreachable. Every compaction cycle then failed the whole job on it.
+//
+// The unusable key sits at index 1 of 3 deliberately. downloadFiles runs a
+// worker pool, so a bug that depends on the bad entry arriving first or last
+// would survive a two-file table.
+func TestDownloadFilesSkipsUnusableInput(t *testing.T) {
+	backend, err := storage.NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	defer backend.Close()
+	ctx := context.Background()
+
+	good1 := "testdb/cpu/2026/04/11/14/a.parquet"
+	bad := `testdb\cpu/2026/04/11/14/b.parquet`
+	good2 := "testdb/cpu/2026/04/11/14/c.parquet"
+	for _, k := range []string{good1, good2} {
+		if err := backend.Write(ctx, k, []byte("parquet-bytes")); err != nil {
+			t.Fatalf("seed %s: %v", k, err)
+		}
+	}
+
+	job := newDownloadJob(t, backend, []string{good1, bad, good2})
+	files, err := job.downloadFiles(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("downloadFiles failed the whole job on one unusable input: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("downloaded %d files, want 2 (the two addressable inputs)", len(files))
+	}
+	for _, f := range files {
+		if f.storageKey == bad {
+			t.Fatal("the unusable key was reported as downloaded")
+		}
+	}
+	// BytesBefore must not count the skipped input, or the job reports a
+	// compaction ratio computed against bytes it never read.
+	if job.BytesBefore != int64(2*len("parquet-bytes")) {
+		t.Fatalf("BytesBefore = %d, want %d", job.BytesBefore, 2*len("parquet-bytes"))
+	}
+}
+
+// readFailingBackend fails ReadTo for one key with a transient error while
+// everything else goes to a real LocalBackend.
+type readFailingBackend struct {
+	storage.Backend
+	failKey string
+}
+
+func (b *readFailingBackend) ReadTo(ctx context.Context, path string, w io.Writer) error {
+	if path == b.failKey {
+		return errors.New("connection reset by peer")
+	}
+	return b.Backend.ReadTo(ctx, path, w)
+}
+
+// TestDownloadFilesFailsJobOnTransientReadError is the over-correction guard.
+// A quarantine widened to "any ReadTo error, skip the file" would turn a
+// network blip into a silent partial compaction: the surviving inputs get
+// merged and deleted while the unread one is quietly dropped from the set, and
+// nothing reports that the output is incomplete.
+func TestDownloadFilesFailsJobOnTransientReadError(t *testing.T) {
+	base, err := storage.NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	defer base.Close()
+	ctx := context.Background()
+
+	good := "testdb/cpu/2026/04/11/14/a.parquet"
+	flaky := "testdb/cpu/2026/04/11/14/b.parquet"
+	for _, k := range []string{good, flaky} {
+		if err := base.Write(ctx, k, []byte("parquet-bytes")); err != nil {
+			t.Fatalf("seed %s: %v", k, err)
+		}
+	}
+
+	job := newDownloadJob(t, &readFailingBackend{Backend: base, failKey: flaky}, []string{good, flaky})
+	if _, err := job.downloadFiles(ctx, t.TempDir()); err == nil {
+		t.Fatal("a transient read failure must fail the job; silently compacting the rest loses the unread input's rows")
+	}
+}

--- a/internal/compaction/manifest.go
+++ b/internal/compaction/manifest.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -26,6 +27,13 @@ const (
 
 // ManifestBasePath is the base directory for storing compaction manifests
 const ManifestBasePath = "_compaction_state"
+
+// ManifestQuarantineSuffix is appended to a manifest whose contents name a
+// storage key no backend can address (#747). ListManifests selects on a
+// ".json" suffix, so a parked manifest leaves the recovery work set and stops
+// excluding its inputs from compaction, while the record of which output and
+// inputs were involved survives for an operator to act on.
+const ManifestQuarantineSuffix = ".quarantined"
 
 // ManifestMaxAge is the maximum age for manifests before they're considered stale.
 // Manifests older than this are deleted during recovery - they likely indicate
@@ -107,7 +115,11 @@ func (m *ManifestManager) GenerateManifestPath(tier, database, partitionPath, jo
 		jobID = "unidentified-job"
 	}
 	name := jobID + ".json"
-	if len(name) > storage.MaxKeySegmentLen {
+	// MaxUsableKeySegmentLen, not MaxKeySegmentLen: ValidateKey subtracts
+	// PartSuffix from the bound, so comparing against the raw limit left names
+	// of 251 to 255 bytes passing this check and then being refused by every
+	// write, which is the failure #744 set out to remove.
+	if len(name) > storage.MaxUsableKeySegmentLen {
 		sum := sha256.Sum256([]byte(jobID))
 		name = hex.EncodeToString(sum[:16]) + ".json"
 	}
@@ -286,6 +298,32 @@ func (m *ManifestManager) recoverManifest(ctx context.Context, manifestPath stri
 
 	// Check if output file exists
 	exists, err := m.backend.Exists(ctx, manifest.OutputPath)
+	if errors.Is(err, storage.ErrInvalidPath) {
+		// The output key names nothing any backend can address, so Exists,
+		// Delete and Read all fail the same way every cycle and this manifest
+		// would be retried forever (#747). Park it rather than process it.
+		//
+		// Parked rather than deleted, and the difference is narrower than it
+		// looks: the consumed-inputs marks do NOT survive either way, because
+		// this returns before the deletion loop and a parked manifest is
+		// invisible to every later pass. What parking buys is that the record
+		// of which output and which inputs were involved still exists, and an
+		// operator is the only party who can act on it.
+		//
+		// That matters here because the inputs may already be gone. An older
+		// binary that folded the key is the only thing that could have written
+		// this manifest, and that same binary's upload and source deletion both
+		// SUCCEEDED. Job.Run leaves the manifest behind on purpose when the
+		// parent finalizes it (job.go), so a live manifest whose inputs are
+		// already deleted is a designed state, not a corruption.
+		//
+		// Nothing sweeps a parked manifest, which is deliberate rather than an
+		// oversight: it is a small JSON file, each affected manifest parks
+		// exactly once (a later pass cannot see it), so the count is bounded by
+		// how many bad manifests an earlier version wrote and cannot grow from
+		// a loop.
+		return m.quarantineManifest(ctx, manifestPath, manifest.OutputPath, err)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to check output file existence: %w", err)
 	}
@@ -339,6 +377,27 @@ func (m *ManifestManager) recoverManifest(ctx context.Context, manifestPath stri
 	var deleteErrors int
 	for _, inputFile := range manifest.InputFiles {
 		if err := m.backend.Delete(ctx, inputFile); err != nil {
+			if errors.Is(err, storage.ErrInvalidPath) {
+				// Permanent: this input cannot be deleted by this key, now or
+				// ever, so counting it as a delete error would keep the whole
+				// manifest for a retry that can only fail again (#747). Drop it
+				// from the work set and let the rest of the recovery finish.
+				//
+				// The file is NOT reclaimable by anything downstream: the
+				// reconciler's storage sweep addresses files by the same kind of
+				// key and fails identically. It needs operator action, and
+				// urgently, because this is the one site where the undeleted
+				// file's rows are CERTAINLY also in the output: InputFiles holds
+				// the keys DuckDB actually read. Whether the query path serves
+				// both copies depends on the backend, and the log line says so
+				// rather than assuming local.
+				metrics.Get().IncStorageInvalidPathQuarantined()
+				m.logger.Error().Err(err).
+					Str("file", inputFile).
+					Str("manifest", manifestPath).
+					Msg("Compaction input cannot be deleted: its key is permanently unusable. Skipping it so recovery can finish. Its rows are already in the compacted output, so wherever the query path can still reach this file it is now serving them twice: on Azure a backslash key IS the separator-spelled blob, and on local disk the file is a normal filename inside the partition glob. Remove it by hand")
+				continue
+			}
 			// Check if file already deleted
 			exists, checkErr := m.backend.Exists(ctx, inputFile)
 			if checkErr == nil && !exists {
@@ -370,6 +429,93 @@ func (m *ManifestManager) recoverManifest(ctx context.Context, manifestPath stri
 
 	// All input files deleted — safe to remove manifest
 	return m.DeleteManifest(ctx, manifestPath)
+}
+
+// quarantinePathFor derives the parked name for a manifest, alongside it and
+// out of the ".json" suffix ListManifests selects on.
+//
+// Appending can overflow: GenerateManifestPath allows a filename right up to
+// the 255-byte segment limit (#744), and the suffix pushes those past it.
+// Rather than give up on parking for exactly the manifests with the longest
+// names, fall back to the same deterministic hash that function uses, so a
+// record always survives and a repeated pass addresses the same parked object.
+func quarantinePathFor(manifestPath string) (string, error) {
+	parked := manifestPath + ManifestQuarantineSuffix
+	if storage.ValidateKey(parked) == nil {
+		return parked, nil
+	}
+	dir, name := filepath.Split(manifestPath)
+	sum := sha256.Sum256([]byte(name))
+	parked = filepath.Join(dir, hex.EncodeToString(sum[:16])+ManifestQuarantineSuffix)
+	if err := storage.ValidateKey(parked); err != nil {
+		return "", err
+	}
+	return parked, nil
+}
+
+// quarantineManifest parks a manifest whose contents name a permanently
+// unusable storage key, so recovery stops retrying work that cannot succeed
+// (#747) without discarding the record of what the manifest described.
+//
+// Parking is a copy followed by a delete rather than a rename, because the
+// Backend interface has no rename. The copy re-reads the raw bytes instead of
+// re-marshalling the parsed struct so a manifest written by a different version
+// keeps any fields this binary does not know about.
+//
+// Ordering matters and is deliberate: write the parked copy FIRST, and only
+// delete the original once it lands. A crash between the two leaves both, and
+// the next recovery pass re-parks idempotently. The reverse order could lose
+// the manifest entirely.
+//
+// A failure here returns an error, which keeps the manifest for the next cycle.
+// That is right for the transient case (the backend is down). The one way it
+// could loop forever, the parked name being too long to be a valid key itself,
+// is removed by quarantinePathFor falling back to a hashed name.
+func (m *ManifestManager) quarantineManifest(ctx context.Context, manifestPath, badKey string, cause error) error {
+	parkedPath, err := quarantinePathFor(manifestPath)
+	if err != nil {
+		// Unreachable in practice: quarantinePathFor falls back to a fixed-size
+		// hashed name that cannot overflow. Kept because the only alternative
+		// to handling it is a manifest retried forever, which is the bug being
+		// fixed. Delete rather than loop, and let the log line be the record.
+		if delErr := m.DeleteManifest(ctx, manifestPath); delErr != nil {
+			return delErr
+		}
+		metrics.Get().IncStorageInvalidPathQuarantined()
+		m.logger.Error().
+			Err(cause).
+			Str("manifest", manifestPath).
+			Str("output", badKey).
+			AnErr("park_error", err).
+			Msg("Compaction manifest names an unusable output key and could not be parked under any name; deleted it to stop an endless retry. This line is the only surviving record of the paths involved")
+		return nil
+	}
+
+	raw, err := m.backend.Read(ctx, manifestPath)
+	if err != nil {
+		return fmt.Errorf("quarantine manifest %s: read: %w", manifestPath, err)
+	}
+	if err := m.backend.Write(ctx, parkedPath, raw); err != nil {
+		return fmt.Errorf("quarantine manifest %s: park to %s: %w", manifestPath, parkedPath, err)
+	}
+	if err := m.DeleteManifest(ctx, manifestPath); err != nil {
+		return fmt.Errorf("quarantine manifest %s: remove original after parking: %w", manifestPath, err)
+	}
+
+	// Counted here, not on entry: every step above can fail transiently, and
+	// each failure keeps the manifest for the next cycle. Counting earlier
+	// would report a drop from the work set that did not happen, once per
+	// cycle, for an entry still being retried.
+	metrics.Get().IncStorageInvalidPathQuarantined()
+
+	m.logger.Error().
+		Err(cause).
+		Str("manifest", manifestPath).
+		Str("parked_to", parkedPath).
+		Str("output", badKey).
+		Msg("Compaction manifest names an output key no storage backend can address; parked instead of retried. Its inputs are no longer held back from compaction. The output may still exist and still be served by the query path even though storage cannot address it: on Azure a backslash key IS the separator-spelled blob, and on local disk it is a normal filename inside the partition glob. Check that partition for duplicate rows")
+
+	return nil
 }
 
 // GetFilesInManifests returns a set of all input files currently tracked by manifests.

--- a/internal/compaction/manifest_invalid_path_test.go
+++ b/internal/compaction/manifest_invalid_path_test.go
@@ -1,0 +1,510 @@
+package compaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// invalidOutputKey is the one spelling usable at every site in #747: raft
+// ValidateManifestPath accepts it, storage.ValidateKey refuses it, and unlike
+// the other five it also survives coordinator sanitizeFetchPath. Pinned in
+// internal/cluster/raft/manifest_path_reachability_test.go.
+const invalidOutputKey = `testdb\cpu/2026/04/11/14/out.parquet`
+
+func newManifestFixture(t *testing.T) (*ManifestManager, storage.Backend, context.Context) {
+	t.Helper()
+	backend, err := storage.NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	return NewManifestManager(backend, zerolog.Nop()), backend, context.Background()
+}
+
+func seedInput(t *testing.T, backend storage.Backend, ctx context.Context, key string) {
+	t.Helper()
+	if err := backend.Write(ctx, key, []byte("parquet")); err != nil {
+		t.Fatalf("seed %s: %v", key, err)
+	}
+}
+
+// TestRecoverManifestParksUnusableOutput covers the loop the issue opens with:
+// an output key no backend can address makes Exists, Delete and Read all fail
+// permanently, so recovery reprocesses the same manifest every cycle and
+// GetFilesInManifests keeps its inputs out of compaction forever.
+//
+// Before the fix this left the manifest in place indefinitely. The load-bearing
+// assertion is that it leaves the recovery work set, not that the call returns
+// nil: RecoverOrphanedManifests swallows per-manifest errors with a continue,
+// so the returned error was already nil.
+func TestRecoverManifestParksUnusableOutput(t *testing.T) {
+	mm, backend, ctx := newManifestFixture(t)
+	const input = "testdb/cpu/2026/04/11/14/in.parquet"
+	seedInput(t, backend, ctx, input)
+
+	manifestPath, err := mm.WriteManifest(ctx, &Manifest{
+		OutputPath:    invalidOutputKey,
+		OutputSize:    7,
+		InputFiles:    []string{input},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu/2026/04/11/14",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "job_invalid_output",
+	})
+	if err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	if _, err := mm.RecoverOrphanedManifests(ctx, nil, nil); err != nil {
+		t.Fatalf("RecoverOrphanedManifests: %v", err)
+	}
+
+	remaining, err := mm.ListManifests(ctx)
+	if err != nil {
+		t.Fatalf("ListManifests: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("manifest is still in the recovery work set after quarantine: %v", remaining)
+	}
+
+	parked := manifestPath + ManifestQuarantineSuffix
+	exists, err := backend.Exists(ctx, parked)
+	if err != nil {
+		t.Fatalf("Exists(%s): %v", parked, err)
+	}
+	if !exists {
+		t.Fatal("manifest was removed without being parked; the record of which output and inputs were involved is lost")
+	}
+
+	// The inputs must survive. Parking is not a completion: nothing here
+	// established that the output was written, so deleting the inputs would
+	// destroy the only copy of the data.
+	if ok, err := backend.Exists(ctx, input); err != nil || !ok {
+		t.Fatalf("input file was removed by a quarantine that proved nothing about the output (exists=%v err=%v)", ok, err)
+	}
+}
+
+// TestRecoverManifestParkedCopyKeepsBytes pins that parking preserves the
+// manifest verbatim, including fields this binary does not know about. The
+// quarantine re-reads raw bytes for exactly this reason: a manifest written by
+// a different version must survive a round trip through a parking operation
+// that never parses it.
+func TestRecoverManifestParkedCopyKeepsBytes(t *testing.T) {
+	mm, backend, ctx := newManifestFixture(t)
+
+	manifestPath, err := mm.WriteManifest(ctx, &Manifest{
+		OutputPath:    invalidOutputKey,
+		InputFiles:    []string{"testdb/cpu/2026/04/11/14/in.parquet"},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu/2026/04/11/14",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "job_bytes",
+	})
+	if err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+	original, err := backend.Read(ctx, manifestPath)
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+
+	if _, err := mm.RecoverOrphanedManifests(ctx, nil, nil); err != nil {
+		t.Fatalf("RecoverOrphanedManifests: %v", err)
+	}
+
+	parkedBytes, err := backend.Read(ctx, manifestPath+ManifestQuarantineSuffix)
+	if err != nil {
+		t.Fatalf("read parked: %v", err)
+	}
+	if string(parkedBytes) != string(original) {
+		t.Fatalf("parked copy differs from the original:\n got: %s\nwant: %s", parkedBytes, original)
+	}
+}
+
+// TestRecoverManifestSkipsUnusableInput covers the second site: one input whose
+// Delete fails permanently used to count as a delete error, which kept the
+// whole manifest for a retry that could only fail the same way, so the valid
+// siblings were never deleted and the consumed-inputs marks never fired.
+func TestRecoverManifestSkipsUnusableInput(t *testing.T) {
+	mm, backend, ctx := newManifestFixture(t)
+	const output = "testdb/cpu/2026/04/11/14/out.parquet"
+	const goodInput = "testdb/cpu/2026/04/11/14/in-good.parquet"
+	const badInput = `testdb\cpu/2026/04/11/14/in-bad.parquet`
+
+	seedInput(t, backend, ctx, output)
+	seedInput(t, backend, ctx, goodInput)
+
+	// Bad input at index 1 of 3, not first and not last: a quarantine that
+	// aborted its loop rather than continuing would still pass with it first.
+	if _, err := mm.WriteManifest(ctx, &Manifest{
+		OutputPath:    output,
+		OutputSize:    int64(len("parquet")),
+		InputFiles:    []string{goodInput, badInput, goodInput},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu/2026/04/11/14",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "job_invalid_input",
+	}); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	var consumed []string
+	recovered, err := mm.RecoverOrphanedManifests(ctx, nil, func(inputs []string) error {
+		consumed = append(consumed, inputs...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RecoverOrphanedManifests: %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("recovered = %d, want 1: the manifest must complete rather than be held for a retry that cannot succeed", recovered)
+	}
+
+	if ok, _ := backend.Exists(ctx, goodInput); ok {
+		t.Fatal("the deletable input was not deleted; one unusable sibling poisoned the whole recovery")
+	}
+	if len(consumed) != 3 {
+		t.Fatalf("consumed inputs = %v, want all three: the content is in the output either way, and an unmarked receipt makes the spoke re-upload the raw beside it", consumed)
+	}
+	remaining, err := mm.ListManifests(ctx)
+	if err != nil {
+		t.Fatalf("ListManifests: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("manifest kept for retry: %v", remaining)
+	}
+}
+
+// transientBackend fails one key with an ordinary error. Everything else
+// delegates to a real LocalBackend, so the contract under test is the real one.
+type transientBackend struct {
+	storage.Backend
+	failKey string
+	failErr error
+}
+
+func (b *transientBackend) Exists(ctx context.Context, path string) (bool, error) {
+	if path == b.failKey {
+		return false, b.failErr
+	}
+	return b.Backend.Exists(ctx, path)
+}
+
+func (b *transientBackend) Delete(ctx context.Context, path string) error {
+	if path == b.failKey {
+		return b.failErr
+	}
+	return b.Backend.Delete(ctx, path)
+}
+
+// TestRecoverManifestKeepsManifestOnTransientError is the over-correction
+// guard, and it is the dangerous direction.
+//
+// A widened quarantine that parked or dropped the manifest on ANY Exists
+// failure would re-queue an already-compacted partition on a throttle from S3,
+// producing a duplicate compaction and an orphaned output. The quarantine must
+// fire only for the permanent error.
+func TestRecoverManifestKeepsManifestOnTransientError(t *testing.T) {
+	base, err := storage.NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	defer base.Close()
+	ctx := context.Background()
+
+	const output = "testdb/cpu/2026/04/11/14/out.parquet"
+	backend := &transientBackend{Backend: base, failKey: output, failErr: errors.New("SlowDown: please reduce your request rate")}
+	mm := NewManifestManager(backend, zerolog.Nop())
+
+	manifestPath, err := mm.WriteManifest(ctx, &Manifest{
+		OutputPath:    output,
+		OutputSize:    7,
+		InputFiles:    []string{"testdb/cpu/2026/04/11/14/in.parquet"},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu/2026/04/11/14",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "job_transient",
+	})
+	if err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	if _, err := mm.RecoverOrphanedManifests(ctx, nil, nil); err != nil {
+		t.Fatalf("RecoverOrphanedManifests: %v", err)
+	}
+
+	remaining, err := mm.ListManifests(ctx)
+	if err != nil {
+		t.Fatalf("ListManifests: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0] != manifestPath {
+		t.Fatalf("a transient Exists failure must keep the manifest for the next cycle; work set is now %v", remaining)
+	}
+	if ok, _ := backend.Exists(ctx, manifestPath+ManifestQuarantineSuffix); ok {
+		t.Fatal("a transient failure was treated as permanent and parked the manifest")
+	}
+}
+
+// TestRecoverManifestCountsTransientInputDeleteFailure is the same guard on the
+// input-deletion loop: a transient Delete failure must still hold the manifest
+// for a retry, or the marks fire and the manifest is dropped while files that
+// could have been deleted are left behind with nothing tracking them.
+func TestRecoverManifestCountsTransientInputDeleteFailure(t *testing.T) {
+	base, err := storage.NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	defer base.Close()
+	ctx := context.Background()
+
+	const output = "testdb/cpu/2026/04/11/14/out.parquet"
+	const input = "testdb/cpu/2026/04/11/14/in.parquet"
+	if err := base.Write(ctx, output, []byte("parquet")); err != nil {
+		t.Fatalf("seed output: %v", err)
+	}
+	if err := base.Write(ctx, input, []byte("parquet")); err != nil {
+		t.Fatalf("seed input: %v", err)
+	}
+
+	backend := &transientBackend{Backend: base, failKey: input, failErr: fmt.Errorf("connection reset by peer")}
+	mm := NewManifestManager(backend, zerolog.Nop())
+
+	if _, err := mm.WriteManifest(ctx, &Manifest{
+		OutputPath:    output,
+		OutputSize:    int64(len("parquet")),
+		InputFiles:    []string{input},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu/2026/04/11/14",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "job_transient_input",
+	}); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	marked := false
+	recovered, err := mm.RecoverOrphanedManifests(ctx, nil, func([]string) error {
+		marked = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RecoverOrphanedManifests: %v", err)
+	}
+	if recovered != 0 {
+		t.Fatalf("recovered = %d, want 0 for a transient input delete failure", recovered)
+	}
+	if marked {
+		t.Fatal("consumed-inputs marks fired even though an input deletion failed transiently")
+	}
+	remaining, _ := mm.ListManifests(ctx)
+	if len(remaining) != 1 {
+		t.Fatalf("manifest must be kept for the retry; work set is %v", remaining)
+	}
+}
+
+// TestQuarantinedManifestLeavesRecoveryWorkSet pins the mechanism the parking
+// name depends on: ListManifests selects on a ".json" suffix, so the parked
+// object is invisible to both recovery and GetFilesInManifests. If that filter
+// ever changes, the quarantine turns back into an endless retry and this test
+// is what says so.
+func TestQuarantinedManifestLeavesRecoveryWorkSet(t *testing.T) {
+	mm, backend, ctx := newManifestFixture(t)
+	const input = "testdb/cpu/2026/04/11/14/in.parquet"
+	seedInput(t, backend, ctx, input)
+
+	if _, err := mm.WriteManifest(ctx, &Manifest{
+		OutputPath:    invalidOutputKey,
+		InputFiles:    []string{input},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu/2026/04/11/14",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "job_worklist",
+	}); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	if _, err := mm.RecoverOrphanedManifests(ctx, nil, nil); err != nil {
+		t.Fatalf("first recovery: %v", err)
+	}
+
+	// The input must no longer be held back from compaction: that exclusion
+	// lasting forever is the operator-visible harm the issue describes.
+	held, err := mm.GetFilesInManifests(ctx)
+	if err != nil {
+		t.Fatalf("GetFilesInManifests: %v", err)
+	}
+	if _, stillHeld := held[input]; stillHeld {
+		t.Fatal("a parked manifest is still excluding its inputs from compaction")
+	}
+
+	// And a second pass must find nothing to do, rather than re-parking.
+	recovered, err := mm.RecoverOrphanedManifests(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("second recovery: %v", err)
+	}
+	if recovered != 0 {
+		t.Fatalf("second recovery processed %d manifests; the quarantine did not converge", recovered)
+	}
+}
+
+// TestQuarantinePathFitsWithinTheKeyLimit covers the case that used to make
+// parking impossible and fall back to deleting the record.
+//
+// GenerateManifestPath allows a filename right up to the 255-byte segment
+// limit, so appending the suffix to the longest ones overflowed. Reachable in
+// production: the job id is built from the database and the folded partition
+// path, both operator- and ingest-controlled.
+func TestQuarantinePathFitsWithinTheKeyLimit(t *testing.T) {
+	mm, _, _ := newManifestFixture(t)
+
+	for _, tc := range []struct {
+		name  string
+		jobID string
+	}{
+		{"ordinary", "job_20260411_140000_testdb_cpu"},
+		// 250 bytes + ".json" = 255, exactly at the limit, so the suffix
+		// overflows by the full length of the suffix.
+		{"filename at the segment limit", strings.Repeat("j", 250)},
+		{"filename one under the limit", strings.Repeat("j", 249)},
+		// Past the limit GenerateManifestPath already hashes, so the parked
+		// name is short again; included so the boundary is covered on both
+		// sides.
+		{"filename past the limit", strings.Repeat("j", 400)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifestPath := mm.GenerateManifestPath("hourly", "testdb", "testdb/cpu/2026/04/11/14", tc.jobID)
+			if err := storage.ValidateKey(manifestPath); err != nil {
+				t.Fatalf("GenerateManifestPath produced an unusable key: %v", err)
+			}
+			parked, err := quarantinePathFor(manifestPath)
+			if err != nil {
+				t.Fatalf("no parked name could be derived, so the record would be deleted instead: %v", err)
+			}
+			if err := storage.ValidateKey(parked); err != nil {
+				t.Fatalf("parked name %q is not a usable key: %v", parked, err)
+			}
+			if parked == manifestPath {
+				t.Fatal("parked name equals the manifest path, so parking would overwrite the original")
+			}
+			if strings.HasSuffix(parked, ".json") {
+				t.Fatalf("parked name %q still ends in .json, so ListManifests would keep returning it", parked)
+			}
+		})
+	}
+}
+
+// TestQuarantinePathIsDeterministic pins that a repeated recovery pass
+// addresses the same parked object rather than accumulating copies, including
+// on the hashed branch.
+func TestQuarantinePathIsDeterministic(t *testing.T) {
+	mm, _, _ := newManifestFixture(t)
+	for _, jobID := range []string{"job_short", strings.Repeat("j", 250)} {
+		manifestPath := mm.GenerateManifestPath("hourly", "testdb", "p", jobID)
+		first, err := quarantinePathFor(manifestPath)
+		if err != nil {
+			t.Fatalf("quarantinePathFor: %v", err)
+		}
+		second, err := quarantinePathFor(manifestPath)
+		if err != nil {
+			t.Fatalf("quarantinePathFor (second call): %v", err)
+		}
+		if first != second {
+			t.Fatalf("parked name is not deterministic: %q then %q", first, second)
+		}
+	}
+}
+
+// TestRecoverManifestParkingCountsTheMetricOnce pins that the counter tracks
+// entries that actually left the work set. It used to be incremented on entry,
+// so a transient backend failure during parking counted a drop that did not
+// happen, once per recovery cycle, for a manifest still being retried.
+func TestRecoverManifestParkingCountsTheMetricOnce(t *testing.T) {
+	mm, backend, ctx := newManifestFixture(t)
+	const input = "testdb/cpu/2026/04/11/14/in.parquet"
+	seedInput(t, backend, ctx, input)
+
+	if _, err := mm.WriteManifest(ctx, &Manifest{
+		OutputPath:    invalidOutputKey,
+		InputFiles:    []string{input},
+		Database:      "testdb",
+		Measurement:   "cpu",
+		PartitionPath: "testdb/cpu/2026/04/11/14",
+		Tier:          "hourly",
+		Status:        ManifestStatusPending,
+		CreatedAt:     time.Now().UTC(),
+		JobID:         "job_metric",
+	}); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	before := quarantineCount()
+	if _, err := mm.RecoverOrphanedManifests(ctx, nil, nil); err != nil {
+		t.Fatalf("RecoverOrphanedManifests: %v", err)
+	}
+	if got := quarantineCount() - before; got != 1 {
+		t.Fatalf("counter moved by %d, want 1", got)
+	}
+
+	// A second pass has nothing left to do, so the counter must not move again.
+	if _, err := mm.RecoverOrphanedManifests(ctx, nil, nil); err != nil {
+		t.Fatalf("second recovery: %v", err)
+	}
+	if got := quarantineCount() - before; got != 1 {
+		t.Fatalf("counter moved by %d across two passes, want 1", got)
+	}
+}
+
+func quarantineCount() int64 {
+	return metrics.Get().Snapshot()["storage_invalid_path_quarantined_total"].(int64)
+}
+
+// TestGenerateManifestPathAlwaysProducesAUsableKey closes the window this PR
+// found while testing the parked name.
+//
+// The generator hashed only past MaxKeySegmentLen (255), but ValidateKey
+// subtracts PartSuffix and refuses anything over 250, so a job id of 246 to 250
+// characters produced a filename the generator considered fine and every write
+// refused. That is the same failure #744 removed, in the last five bytes of the
+// range, and it is silent: WriteManifest fails, compaction for the partition
+// fails, and it repeats every cycle.
+func TestGenerateManifestPathAlwaysProducesAUsableKey(t *testing.T) {
+	mm, backend, ctx := newManifestFixture(t)
+
+	for n := 240; n <= 260; n++ {
+		jobID := strings.Repeat("j", n)
+		path := mm.GenerateManifestPath("hourly", "testdb", "testdb/cpu/2026/04/11/14", jobID)
+		if err := storage.ValidateKey(path); err != nil {
+			t.Fatalf("job id of %d bytes produced a key the backend refuses: %v", n, err)
+		}
+		// And prove it round-trips through a real backend rather than only
+		// through the validator.
+		if err := backend.Write(ctx, path, []byte("{}")); err != nil {
+			t.Fatalf("job id of %d bytes: write failed: %v", n, err)
+		}
+	}
+}

--- a/internal/edgesync/exporter.go
+++ b/internal/edgesync/exporter.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/storage"
 	"github.com/rs/zerolog"
 )
 
@@ -154,6 +156,42 @@ func (e *Exporter) Export(ctx context.Context, dest string, limit int) (*ExportR
 	skipped := 0
 	for _, entry := range entries {
 		present, existsErr := e.writer.backend.Exists(ctx, entry.Path)
+		if errors.Is(existsErr, storage.ErrInvalidPath) {
+			// The keep-on-error rule above is about TRANSIENT errors, and this
+			// one is permanent (#747): no backend can address this key, so the
+			// copy below would fail, and a copy failure aborts the whole export
+			// rather than one entry. Nothing in this path caps attempts, so the
+			// next export re-selects the same row and aborts again, the exact
+			// wedge the comment above was written to prevent, on exactly the
+			// air-gapped box where hand-editing SQLite is not an option.
+			//
+			// Skipped is terminal here and RequeueFailed will not resurrect it,
+			// which is right rather than a gap. The only real remedy for an
+			// unusable key is renaming the object in storage, and a renamed
+			// object has a NEW key: discovery tracks it as a fresh pending row
+			// and exports it normally. The row left behind names a spelling
+			// that no longer exists, so resurrecting it would only re-wedge the
+			// export.
+			metrics.Get().IncStorageInvalidPathQuarantined()
+			if markErr := e.ledger.MarkSkipped(ctx, e.hubID, entry.Path,
+				"source key is permanently unusable by the storage backend"); markErr != nil {
+				// Cannot record the skip, so keeping it would wedge the export.
+				// Drop it from THIS bundle instead: the ledger still lists it as
+				// unexported, so the next run retries the mark rather than
+				// silently forgetting the file.
+				//
+				// Not counted into skipped: that number is reported to the
+				// operator as work the ledger now reflects, and here it does
+				// not. Same choice the vanished-file arm below makes.
+				e.logger.Error().Err(markErr).Str("path", entry.Path).
+					Msg("Could not mark a permanently unusable source skipped; excluding it from this bundle so the export can proceed")
+				continue
+			}
+			skipped++
+			e.logger.Error().Err(existsErr).Str("path", entry.Path).
+				Msg("Export source names a storage key no backend can address; marked skipped so the bundle can be written. The row is out of the export set and needs operator action")
+			continue
+		}
 		if existsErr != nil || present {
 			alive = append(alive, entry)
 			continue

--- a/internal/edgesync/exporter_invalid_path_test.go
+++ b/internal/edgesync/exporter_invalid_path_test.go
@@ -1,0 +1,108 @@
+package edgesync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/metrics"
+	"github.com/basekick-labs/arc/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+// TestExporter_ExportSkipsAnUnusableKeyInsteadOfWedging is the air-gap half of
+// #747, and it is the worst case found: nothing on this path caps attempts.
+//
+// The keep-on-Exists-error rule in selectEntries is written for TRANSIENT
+// errors, so a permanent one kept the entry, the copy then failed, and a copy
+// failure aborts the WHOLE export rather than one file. The next export
+// re-selected the same row and aborted again, so one unusable file stopped all
+// telemetry leaving the site, forever, with no self-heal and no attempt cap —
+// on exactly the box where editing SQLite by hand is not an option.
+//
+// The row is inserted with Ledger.Track rather than produced by discovery,
+// because that is its real provenance. The ledger is persisted SQLite state
+// that survives upgrades, so the row dates from a binary that still accepted
+// the key; today's discovery drops such a file earlier, at hashFile. Same
+// provenance class as a compaction manifest carrying an unusable OutputPath.
+func TestExporter_ExportSkipsAnUnusableKeyInsteadOfWedging(t *testing.T) {
+	ctx := context.Background()
+	rig := newAgentRig(t)
+
+	rig.writeFile(t, "metrics/cpu/2026/08/07/14/keep.parquet", []byte("kept"))
+
+	// A backslash is a legal character in a POSIX filename and an unusable
+	// storage key, because Azure treats it as a separator.
+	const unusableKey = `metrics/cpu/2026/08/07/15/bad\name.parquet`
+	if err := storage.ValidateKey(unusableKey); err == nil {
+		t.Fatal("the key under test is accepted by ValidateKey, so this test proves nothing")
+	}
+
+	dest := t.TempDir()
+	policy, err := NewDestinationPolicy([]string{dest}, "")
+	if err != nil {
+		t.Fatalf("policy: %v", err)
+	}
+	writer, err := NewBundleWriter(BundleWriterConfig{
+		Backend: rig.backend,
+		SpokeID: "rocket-01",
+		HubID:   DefaultHubID,
+		Secret:  "0123456789abcdef0123456789abcdef",
+		Logger:  zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	discoverer, err := NewDiscoverer(rig.ledger, rig.backend, DefaultHubID, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("discoverer: %v", err)
+	}
+	exporter, err := NewExporter(ExporterConfig{
+		Ledger:     rig.ledger,
+		Writer:     writer,
+		Policy:     policy,
+		Discoverer: discoverer,
+		HubID:      DefaultHubID,
+		Logger:     zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatalf("exporter: %v", err)
+	}
+
+	if _, err := discoverer.Discover(ctx); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	// The row an older binary left behind.
+	if err := rig.ledger.Track(ctx, &LedgerEntry{
+		HubID:         DefaultHubID,
+		Path:          unusableKey,
+		SHA256:        "deadbeef",
+		SizeBytes:     11,
+		Database:      "metrics",
+		Measurement:   "cpu",
+		PartitionTime: time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("track: %v", err)
+	}
+
+	beforeMetric := metrics.Get().Snapshot()["storage_invalid_path_quarantined_total"].(int64)
+
+	res, err := exporter.Export(ctx, dest, 0)
+	if err != nil {
+		t.Fatalf("Export aborted on one unusable key instead of skipping it: %v", err)
+	}
+	if res.FileCount != 1 {
+		t.Errorf("bundle files = %d, want 1 (the addressable file)", res.FileCount)
+	}
+	if res.Skipped != 1 {
+		t.Errorf("export skipped = %d, want 1", res.Skipped)
+	}
+	if got := metrics.Get().Snapshot()["storage_invalid_path_quarantined_total"].(int64) - beforeMetric; got != 1 {
+		t.Errorf("quarantine counter moved by %d, want 1", got)
+	}
+
+	// The wedge regression proper: the next export must not re-select it.
+	if _, err := exporter.Export(ctx, dest, 0); err != ErrNothingToExport {
+		t.Errorf("second export = %v, want ErrNothingToExport; the unusable key was re-selected and the bundle path is still wedged", err)
+	}
+}

--- a/internal/metrics/invalid_path_test.go
+++ b/internal/metrics/invalid_path_test.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStorageInvalidPathQuarantinedIsExposedOnBothSurfaces pins that the
+// counter #747 introduced reaches the two places operators read.
+//
+// The counter matters more than most: the entries it counts are dropped from
+// their work sets, so after the fix there is no retry storm, no growing error
+// log and no stuck queue to notice. This number is the only aggregated signal
+// that anything is wrong, which makes "it is exported" part of the fix rather
+// than decoration.
+func TestStorageInvalidPathQuarantinedIsExposedOnBothSurfaces(t *testing.T) {
+	m := Get()
+	before := m.Snapshot()["storage_invalid_path_quarantined_total"].(int64)
+
+	m.IncStorageInvalidPathQuarantined()
+
+	after, ok := m.Snapshot()["storage_invalid_path_quarantined_total"].(int64)
+	if !ok {
+		t.Fatal("storage_invalid_path_quarantined_total is missing from the JSON snapshot")
+	}
+	if after != before+1 {
+		t.Errorf("counter = %d, want %d", after, before+1)
+	}
+
+	prom := m.PrometheusFormat()
+	for _, want := range []string{
+		"# HELP arc_storage_invalid_path_quarantined_total",
+		"# TYPE arc_storage_invalid_path_quarantined_total counter",
+		"arc_storage_invalid_path_quarantined_total ",
+	} {
+		if !strings.Contains(prom, want) {
+			t.Errorf("Prometheus output is missing %q", want)
+		}
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -146,6 +146,16 @@ type Metrics struct {
 	// Alert on this.
 	clusterManifestRejectedPathsTotal atomic.Int64
 
+	// storageInvalidPathQuarantinedTotal counts entries a cleanup,
+	// reconciliation or replication loop refused to keep retrying because a
+	// storage call returned storage.ErrInvalidPath, which is permanent (#747).
+	// Same operator semantics as clusterManifestRejectedPathsTotal above: the
+	// value should sit at zero, and any growth means a stored key (a compaction
+	// manifest, a Raft manifest entry, an edge-sync ledger row) names something
+	// no backend can address. Those entries are dropped from their work set, so
+	// this counter is the only place the condition is aggregated.
+	storageInvalidPathQuarantinedTotal atomic.Int64
+
 	// Cluster auth metrics (Enterprise only — mutated on every FSM apply
 	// of a token command). clusterAuthApplyTotal increments per applied
 	// command type so operators can see "create vs update vs revoke"
@@ -400,6 +410,12 @@ func (m *Metrics) IncReplicationSequenceGaps(n int64) { m.replicationSequenceGap
 // See GHSA-f85q-mvg8-qf37 for the security context.
 func (m *Metrics) IncClusterManifestRejectedPaths() { m.clusterManifestRejectedPathsTotal.Add(1) }
 
+// IncStorageInvalidPathQuarantined records one entry dropped from a cleanup,
+// reconciliation or replication work set because a storage call returned
+// storage.ErrInvalidPath (#747). That error is permanent, so the alternative
+// to counting it here is a loop that retries the same key forever.
+func (m *Metrics) IncStorageInvalidPathQuarantined() { m.storageInvalidPathQuarantinedTotal.Add(1) }
+
 // Cluster Auth metrics — incremented from the FSM apply path on every
 // Token command. apply_* counts successful applies per type;
 // IncClusterAuthRejected counts applier-side validation refusals.
@@ -585,7 +601,8 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 		"replication_sequence_gaps_total":   m.replicationSequenceGapsTotal.Load(),
 
 		// Cluster FSM security (Enterprise)
-		"cluster_manifest_rejected_paths_total": m.clusterManifestRejectedPathsTotal.Load(),
+		"cluster_manifest_rejected_paths_total":  m.clusterManifestRejectedPathsTotal.Load(),
+		"storage_invalid_path_quarantined_total": m.storageInvalidPathQuarantinedTotal.Load(),
 
 		// Cluster Auth (Enterprise, Phase A)
 		"cluster_auth_apply_create_total": m.clusterAuthApplyCreateTotal.Load(),
@@ -941,6 +958,10 @@ func (m *Metrics) PrometheusFormat() string {
 	b = append(b, "# HELP arc_cluster_manifest_rejected_paths_total Total manifest path proposals refused by the cluster FSM. Non-zero growth indicates a peer/snapshot/log entry proposed a path validation refused (URL scheme, absolute, parent-traversal, NUL, oversize).\n"...)
 	b = append(b, "# TYPE arc_cluster_manifest_rejected_paths_total counter\n"...)
 	b = appendMetric(b, "arc_cluster_manifest_rejected_paths_total", float64(m.clusterManifestRejectedPathsTotal.Load()))
+
+	b = append(b, "# HELP arc_storage_invalid_path_quarantined_total Total entries dropped from a cleanup, reconciliation or replication work set because a storage key was permanently unusable. Non-zero growth means a stored key (compaction manifest, cluster manifest entry, edge-sync ledger row) names something no storage backend can address; the entry is no longer retried and needs operator action.\n"...)
+	b = append(b, "# TYPE arc_storage_invalid_path_quarantined_total counter\n"...)
+	b = appendMetric(b, "arc_storage_invalid_path_quarantined_total", float64(m.storageInvalidPathQuarantinedTotal.Load()))
 
 	// Cluster Auth metrics (Enterprise, Phase A — Cluster Auth Convergence).
 	// apply_* counters increment per applied token command, per node — so

--- a/internal/reconciliation/helpers.go
+++ b/internal/reconciliation/helpers.go
@@ -1,6 +1,11 @@
 package reconciliation
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/basekick-labs/arc/internal/metrics"
+)
 
 // Cap and sample helpers used across the package. All four functions
 // share the same shape (cap a slice to a maximum length) so they live
@@ -71,4 +76,19 @@ func boolStr(b bool) string {
 		return "true"
 	}
 	return "false"
+}
+
+// noteInvalidPath records one entry a sweep refused to keep retrying because
+// its storage key is permanently unusable (#747).
+//
+// Shared by both sweeps so the run report, the bounded error list and the
+// process-wide counter can never drift apart, and so the counter is moved in
+// exactly one place. dryRun is not a parameter: the storage sweep never
+// reaches its delete path in dry-run mode, and the manifest sweep guards the
+// counter itself because it DOES run its re-check in dry-run to produce
+// accurate counts.
+func (r *Reconciler) noteInvalidPath(run *Run, op, path string, err error) {
+	run.SkippedInvalidPath++
+	metrics.Get().IncStorageInvalidPathQuarantined()
+	run.Errors = appendBounded(run.Errors, fmt.Sprintf("%s %q: permanently unusable key: %v", op, path, err), 32)
 }

--- a/internal/reconciliation/reconciler.go
+++ b/internal/reconciliation/reconciler.go
@@ -299,6 +299,20 @@ type Run struct {
 	SkippedGrace        int `json:"skipped_grace"`
 	SkippedRecheck      int `json:"skipped_recheck"`
 
+	// SkippedTransient counts entries a sweep passed over because a storage
+	// call failed in a way that may succeed later (a throttle, a timeout, an
+	// expired credential). The next run retries them, and that is what the
+	// summary log for this bucket says.
+	//
+	// SkippedInvalidPath counts entries passed over because the storage call
+	// returned storage.ErrInvalidPath, which is permanent (#747): the key names
+	// nothing any backend can address, so no later run can do better. Kept
+	// apart from SkippedTransient precisely because "retry next run" is true of
+	// one and false of the other, and a run report that merges them tells an
+	// operator to wait for a convergence that will never happen.
+	SkippedTransient   int `json:"skipped_transient"`
+	SkippedInvalidPath int `json:"skipped_invalid_path"`
+
 	// Bounded samples for operator visibility
 	OrphanManifestSample []string `json:"orphan_manifest_sample,omitempty"`
 	OrphanStorageSample  []string `json:"orphan_storage_sample,omitempty"`
@@ -660,6 +674,7 @@ func (r *Reconciler) finalizeRun(run *Run) {
 		Int("manifest_deletes", run.ManifestDeletes).
 		Int("storage_deletes", run.StorageDeletes).
 		Int("skipped_grace", run.SkippedGrace).
+		Int("skipped_invalid_path", run.SkippedInvalidPath).
 		Dur("duration", duration)
 	if run.Aborted {
 		logEv = logEv.Str("abort_reason", string(run.AbortReason))
@@ -674,27 +689,31 @@ func (r *Reconciler) finalizeRun(run *Run) {
 	// queryable on the same shape.
 	if run.Aborted {
 		r.emitAudit("reconcile.run_aborted", run, map[string]string{
-			"run_id":           run.ID,
-			"backend_kind":     string(run.BackendKind),
-			"abort_reason":    string(run.AbortReason),
-			"abort_message":   run.AbortMessage,
-			"manifest_deletes": strconv.Itoa(run.ManifestDeletes),
-			"storage_deletes":  strconv.Itoa(run.StorageDeletes),
-			"walk_partial":    boolStr(run.WalkPartial),
-			"cap_hit":         boolStr(run.CapHit),
-			"duration_ms":     strconv.FormatInt(duration.Milliseconds(), 10),
+			"run_id":               run.ID,
+			"backend_kind":         string(run.BackendKind),
+			"abort_reason":         string(run.AbortReason),
+			"abort_message":        run.AbortMessage,
+			"manifest_deletes":     strconv.Itoa(run.ManifestDeletes),
+			"storage_deletes":      strconv.Itoa(run.StorageDeletes),
+			"skipped_transient":    strconv.Itoa(run.SkippedTransient),
+			"skipped_invalid_path": strconv.Itoa(run.SkippedInvalidPath),
+			"walk_partial":         boolStr(run.WalkPartial),
+			"cap_hit":              boolStr(run.CapHit),
+			"duration_ms":          strconv.FormatInt(duration.Milliseconds(), 10),
 		})
 	} else {
 		r.emitAudit("reconcile.run_completed", run, map[string]string{
-			"run_id":           run.ID,
-			"backend_kind":     string(run.BackendKind),
-			"manifest_deletes": strconv.Itoa(run.ManifestDeletes),
-			"storage_deletes":  strconv.Itoa(run.StorageDeletes),
-			"skipped_grace":    strconv.Itoa(run.SkippedGrace),
-			"skipped_recheck":  strconv.Itoa(run.SkippedRecheck),
-			"walk_partial":     boolStr(run.WalkPartial),
-			"cap_hit":          boolStr(run.CapHit),
-			"duration_ms":      strconv.FormatInt(duration.Milliseconds(), 10),
+			"run_id":               run.ID,
+			"backend_kind":         string(run.BackendKind),
+			"manifest_deletes":     strconv.Itoa(run.ManifestDeletes),
+			"storage_deletes":      strconv.Itoa(run.StorageDeletes),
+			"skipped_grace":        strconv.Itoa(run.SkippedGrace),
+			"skipped_recheck":      strconv.Itoa(run.SkippedRecheck),
+			"skipped_transient":    strconv.Itoa(run.SkippedTransient),
+			"skipped_invalid_path": strconv.Itoa(run.SkippedInvalidPath),
+			"walk_partial":         boolStr(run.WalkPartial),
+			"cap_hit":              boolStr(run.CapHit),
+			"duration_ms":          strconv.FormatInt(duration.Milliseconds(), 10),
 		})
 	}
 

--- a/internal/reconciliation/reconciler_test.go
+++ b/internal/reconciliation/reconciler_test.go
@@ -92,6 +92,12 @@ func (f *fakeCoordinator) BatchFileOpsInManifest(ops []raft.BatchFileOp) error {
 // fakeBackend is an in-memory storage.Backend. Only the methods the
 // reconciler actually exercises are implemented meaningfully; unused
 // ones return zero values.
+//
+// Every key-taking method enforces storage.ValidateKey, exactly as local, S3
+// and Azure do. Without that this double is MORE PERMISSIVE than any real
+// backend, which would make the permanent-error branches added for #747 dead
+// code under test: the fake would happily store and stat a key no production
+// backend can address. Enforcement is one call per method via checkKey.
 type fakeBackend struct {
 	mu    sync.Mutex
 	files map[string]*fakeObject
@@ -106,6 +112,13 @@ func newFakeBackend() *fakeBackend {
 	return &fakeBackend{files: make(map[string]*fakeObject)}
 }
 
+// checkKey mirrors what every production backend does before touching an
+// object. Returns an error matching storage.ErrInvalidPath, so callers using
+// errors.Is see the same thing they see against a real backend.
+func checkKey(path string) error {
+	return storage.ValidateKey(path)
+}
+
 func (b *fakeBackend) put(path string, mtime time.Time) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -113,6 +126,9 @@ func (b *fakeBackend) put(path string, mtime time.Time) {
 }
 
 func (b *fakeBackend) Write(_ context.Context, path string, data []byte) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.files[path] = &fakeObject{data: data, lastModified: time.Now().UTC()}
@@ -120,6 +136,9 @@ func (b *fakeBackend) Write(_ context.Context, path string, data []byte) error {
 }
 
 func (b *fakeBackend) WriteReader(_ context.Context, path string, r io.Reader, size int64) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
@@ -131,6 +150,9 @@ func (b *fakeBackend) WriteReader(_ context.Context, path string, r io.Reader, s
 }
 
 func (b *fakeBackend) Read(_ context.Context, path string) ([]byte, error) {
+	if err := checkKey(path); err != nil {
+		return nil, err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	obj, ok := b.files[path]
@@ -143,6 +165,9 @@ func (b *fakeBackend) Read(_ context.Context, path string) ([]byte, error) {
 }
 
 func (b *fakeBackend) ReadTo(_ context.Context, path string, w io.Writer) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	data, err := b.Read(context.Background(), path)
 	if err != nil {
 		return err
@@ -152,6 +177,9 @@ func (b *fakeBackend) ReadTo(_ context.Context, path string, w io.Writer) error 
 }
 
 func (b *fakeBackend) ReadToAt(_ context.Context, path string, w io.Writer, offset int64) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	data, err := b.Read(context.Background(), path)
 	if err != nil {
 		return err
@@ -164,6 +192,9 @@ func (b *fakeBackend) ReadToAt(_ context.Context, path string, w io.Writer, offs
 }
 
 func (b *fakeBackend) StatFile(_ context.Context, path string) (int64, error) {
+	if err := checkKey(path); err != nil {
+		return -1, err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	obj, ok := b.files[path]
@@ -174,6 +205,9 @@ func (b *fakeBackend) StatFile(_ context.Context, path string) (int64, error) {
 }
 
 func (b *fakeBackend) List(_ context.Context, prefix string) ([]string, error) {
+	if err := storage.ValidateListPrefix(prefix); err != nil {
+		return nil, err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	out := make([]string, 0)
@@ -186,6 +220,9 @@ func (b *fakeBackend) List(_ context.Context, prefix string) ([]string, error) {
 }
 
 func (b *fakeBackend) Delete(_ context.Context, path string) error {
+	if err := checkKey(path); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	delete(b.files, path)
@@ -193,6 +230,9 @@ func (b *fakeBackend) Delete(_ context.Context, path string) error {
 }
 
 func (b *fakeBackend) Exists(_ context.Context, path string) (bool, error) {
+	if err := checkKey(path); err != nil {
+		return false, err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	_, ok := b.files[path]
@@ -207,6 +247,9 @@ func (b *fakeBackend) ConfigJSON() string { return "{}" }
 // on each object, matching what the local/S3/Azure backends do in
 // production.
 func (b *fakeBackend) ListObjects(_ context.Context, prefix string) ([]storage.ObjectInfo, error) {
+	if err := storage.ValidateListPrefix(prefix); err != nil {
+		return nil, err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	out := make([]storage.ObjectInfo, 0)
@@ -227,8 +270,18 @@ func (b *fakeBackend) ListObjects(_ context.Context, prefix string) ([]storage.O
 func (b *fakeBackend) DeleteBatch(_ context.Context, paths []string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	var bad []error
 	for _, p := range paths {
+		if err := checkKey(p); err != nil {
+			// Aggregated, not fatal, matching local and S3: one unusable key
+			// must not stop the rest of the batch from being deleted.
+			bad = append(bad, err)
+			continue
+		}
 		delete(b.files, p)
+	}
+	if len(bad) > 0 {
+		return errors.Join(bad...)
 	}
 	return nil
 }
@@ -237,6 +290,9 @@ func (b *fakeBackend) DeleteBatch(_ context.Context, paths []string) error {
 // reconciler's root walk to find files under databases/measurements
 // that aren't in the manifest. Returns one segment deeper than prefix.
 func (b *fakeBackend) ListDirectories(_ context.Context, prefix string) ([]string, error) {
+	if err := storage.ValidateListPrefix(prefix); err != nil {
+		return nil, err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	dirs := make(map[string]struct{})

--- a/internal/reconciliation/sweep_invalid_path_test.go
+++ b/internal/reconciliation/sweep_invalid_path_test.go
@@ -1,0 +1,213 @@
+package reconciliation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/metrics"
+)
+
+// invalidManifestKey is accepted by raft.ValidateManifestPath and refused by
+// storage.ValidateKey, which is what lets it into the cluster manifest and then
+// makes every storage call with it fail permanently. The full reachable set is
+// pinned in internal/cluster/raft/manifest_path_reachability_test.go.
+const invalidManifestKey = `db\m/2026/04/11/14/bad.parquet`
+
+// flakyBackend fails one key with an ordinary, retryable error. Everything
+// else, including key validation, behaves like fakeBackend.
+type flakyBackend struct {
+	*fakeBackend
+	flakyKey string
+}
+
+func (b *flakyBackend) Exists(ctx context.Context, path string) (bool, error) {
+	if path == b.flakyKey {
+		return false, errors.New("RequestTimeout: your socket connection to the server was not read from")
+	}
+	return b.fakeBackend.Exists(ctx, path)
+}
+
+func (b *flakyBackend) Delete(ctx context.Context, path string) error {
+	if path == b.flakyKey {
+		return errors.New("RequestTimeout: your socket connection to the server was not read from")
+	}
+	return b.fakeBackend.Delete(ctx, path)
+}
+
+func deletedPaths(t *testing.T, coord *fakeCoordinator) []string {
+	t.Helper()
+	var out []string
+	for _, batch := range coord.batchCalls {
+		for _, op := range batch {
+			var payload raft.DeleteFilePayload
+			if err := json.Unmarshal(op.Payload, &payload); err != nil {
+				t.Fatalf("unmarshal op payload: %v", err)
+			}
+			out = append(out, payload.Path)
+		}
+	}
+	return out
+}
+
+// TestManifestSweepSeparatesPermanentFromTransient is the discriminating test
+// for the manifest sweep. Before #747 both failure kinds landed in one bucket
+// whose log line promises "next run retries", which is true of a timeout and
+// false of a key no backend can address: that entry was re-listed, re-checked
+// and re-skipped on every run forever, with nothing in the run report saying so.
+//
+// The two failing keys are asserted together on purpose. Testing the permanent
+// one alone cannot fail for a reason that matters, because skipping it was
+// already the behaviour; what changed is that the two are now told apart.
+func TestManifestSweepSeparatesPermanentFromTransient(t *testing.T) {
+	const goodOrphan = "db/m/2026/04/11/14/gone.parquet"
+	const flakyOrphan = "db/m/2026/04/11/14/timeout.parquet"
+
+	coord := newFakeCoordinator()
+	store := &flakyBackend{fakeBackend: newFakeBackend(), flakyKey: flakyOrphan}
+	r := newReconciler(t, Config{
+		Enabled:          true,
+		BackendKind:      BackendShared,
+		BatchSize:        100,
+		MaxDeletesPerRun: 100,
+		SamplePathsCap:   10,
+	}, coord, store, &fakeGate{scan: true, sweep: true, role: "leader"})
+
+	before := quarantineMetric()
+	run := &Run{ID: "run-1"}
+	// Invalid key at index 1 of 3: a quarantine that aborted its loop instead
+	// of continuing would still pass with it first or last.
+	paths := []string{goodOrphan, invalidManifestKey, flakyOrphan}
+	if err := r.sweepOrphanManifest(context.Background(), run, paths, false); err != nil {
+		t.Fatalf("sweepOrphanManifest: %v", err)
+	}
+
+	if run.SkippedInvalidPath != 1 {
+		t.Errorf("SkippedInvalidPath = %d, want 1", run.SkippedInvalidPath)
+	}
+	if run.SkippedTransient != 1 {
+		t.Errorf("SkippedTransient = %d, want 1; a timeout must stay in the retryable bucket", run.SkippedTransient)
+	}
+	// The counter must move for the permanent entry and only for it, or the
+	// one aggregated signal this change ships disagrees with the run report.
+	if got := quarantineMetric() - before; got != 1 {
+		t.Errorf("quarantine counter moved by %d, want 1", got)
+	}
+
+	deleted := deletedPaths(t, coord)
+	if len(deleted) != 1 || deleted[0] != goodOrphan {
+		t.Fatalf("manifest deletes = %v, want exactly [%s]: neither failure kind may poison the batch, and neither may be deleted", deleted, goodOrphan)
+	}
+
+	// The permanent entry must be reported in a way an operator can act on,
+	// and must not be dropped from the manifest: this sweep issues Raft
+	// deletes, and an object can sit under the literal key on an object store
+	// where the listing filter hides it, so absence is unobservable here
+	// rather than established.
+	// The path is %q-quoted in the entry, so match on the quoted form rather
+	// than the raw key: a backslash appears escaped there.
+	var sawPermanent bool
+	for _, e := range run.Errors {
+		if strings.Contains(e, fmt.Sprintf("%q", invalidManifestKey)) && strings.Contains(e, "permanently unusable") {
+			sawPermanent = true
+		}
+	}
+	if !sawPermanent {
+		t.Errorf("run.Errors does not name the permanently unusable key: %v", run.Errors)
+	}
+}
+
+// TestStorageSweepSeparatesPermanentFromTransient is the same split one file
+// over, in the sweep that deletes bytes rather than manifest entries. Its log
+// line carried the same false promise.
+func TestStorageSweepSeparatesPermanentFromTransient(t *testing.T) {
+	const goodOrphan = "db/m/2026/04/11/14/orphan.parquet"
+	const flakyOrphan = "db/m/2026/04/11/14/timeout.parquet"
+
+	store := &flakyBackend{fakeBackend: newFakeBackend(), flakyKey: flakyOrphan}
+	store.put(goodOrphan, time.Now().UTC().Add(-24*time.Hour))
+	store.put(flakyOrphan, time.Now().UTC().Add(-24*time.Hour))
+
+	r := newReconciler(t, Config{
+		Enabled:          true,
+		BackendKind:      BackendShared,
+		BatchSize:        100,
+		MaxDeletesPerRun: 100,
+	}, newFakeCoordinator(), store, &fakeGate{scan: true, sweep: true, role: "leader"})
+
+	run := &Run{ID: "run-2"}
+	// hasBatchDelete is false so the per-file loop runs. Classification lives
+	// there on purpose: DeleteBatch joins per-key failures into one error, so a
+	// batch error matches ErrInvalidPath when a single member is bad, and
+	// quarantining on that would discard every valid delete in the batch.
+	applied := r.applyStorageDeletes(context.Background(), run, []string{goodOrphan, invalidManifestKey, flakyOrphan}, nil, false)
+
+	if applied != 1 {
+		t.Errorf("applied = %d, want 1", applied)
+	}
+	if run.SkippedInvalidPath != 1 {
+		t.Errorf("SkippedInvalidPath = %d, want 1", run.SkippedInvalidPath)
+	}
+	if run.SkippedTransient != 1 {
+		t.Errorf("SkippedTransient = %d, want 1", run.SkippedTransient)
+	}
+	if ok, _ := store.fakeBackend.Exists(context.Background(), goodOrphan); ok {
+		t.Error("the deletable orphan survived; one unusable key poisoned the batch")
+	}
+}
+
+// TestRunReportDistinguishesUnconvergedRuns pins why the two counters are
+// separate fields rather than one "skipped" number. An operator watching a run
+// report needs to know whether waiting helps.
+func TestRunReportDistinguishesUnconvergedRuns(t *testing.T) {
+	run := &Run{SkippedTransient: 3, SkippedInvalidPath: 2}
+	blob, err := json.Marshal(run)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(blob, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"skipped_transient", "skipped_invalid_path"} {
+		if _, ok := decoded[key]; !ok {
+			t.Errorf("run report is missing %q, so the API surface cannot show it", key)
+		}
+	}
+}
+
+func quarantineMetric() int64 {
+	return metrics.Get().Snapshot()["storage_invalid_path_quarantined_total"].(int64)
+}
+
+// TestDryRunDoesNotMoveTheGlobalCounter pins that a dry run reports what it
+// would have done without touching a process-wide counter operators alert on.
+// The manifest sweep runs its re-check even in dry-run mode, to produce
+// accurate counts, so this is the one site where the distinction is live.
+func TestDryRunDoesNotMoveTheGlobalCounter(t *testing.T) {
+	coord := newFakeCoordinator()
+	store := newFakeBackend()
+	r := newReconciler(t, Config{
+		Enabled:          true,
+		BackendKind:      BackendShared,
+		BatchSize:        100,
+		MaxDeletesPerRun: 100,
+	}, coord, store, &fakeGate{scan: true, sweep: true, role: "leader"})
+
+	before := quarantineMetric()
+	run := &Run{ID: "run-dry"}
+	if err := r.sweepOrphanManifest(context.Background(), run, []string{invalidManifestKey}, true); err != nil {
+		t.Fatalf("sweepOrphanManifest: %v", err)
+	}
+	if run.SkippedInvalidPath != 1 {
+		t.Errorf("SkippedInvalidPath = %d, want 1: a dry run still reports what it found", run.SkippedInvalidPath)
+	}
+	if got := quarantineMetric() - before; got != 0 {
+		t.Errorf("dry run moved the global counter by %d, want 0", got)
+	}
+}

--- a/internal/reconciliation/sweep_manifest.go
+++ b/internal/reconciliation/sweep_manifest.go
@@ -3,11 +3,13 @@ package reconciliation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
 
 	"github.com/basekick-labs/arc/internal/cluster/raft"
+	"github.com/basekick-labs/arc/internal/storage"
 )
 
 // sweepOrphanManifest issues chunked Raft deletes for manifest entries
@@ -109,14 +111,44 @@ func (r *Reconciler) sweepOrphanManifest(
 		// summary Warn at the end of the batch.
 		recheckResults := r.parallelExists(ctx, recheckPaths)
 		existsErrCount := 0
+		invalidPathCount := 0
 		var existsLastErr error
+		var invalidLastErr error
 		for idx, res := range recheckResults {
 			p := recheckPaths[idx]
 			if res.err != nil {
+				if errors.Is(res.err, storage.ErrInvalidPath) {
+					// Permanent (#747). The key names nothing any backend can
+					// address, so no later run can resolve this entry and the
+					// "next run retries" bucket would be a lie about it.
+					//
+					// Reported, not deleted. It is tempting to read "no backend
+					// can address it" as "the file provably does not exist" and
+					// issue the Raft delete, but that does not follow: on the
+					// object stores an object CAN sit under the literal key, and
+					// it is #743's own listing filter that hides it from the
+					// walk, so absence here is unobservable rather than
+					// established. This sweep is the irreversible direction, so
+					// an unevaluable premise does not license it.
+					invalidPathCount++
+					invalidLastErr = res.err
+					if dryRun {
+						// A dry run reports what it would have done. It still
+						// runs this re-check, to produce accurate counts, so
+						// the run report is updated and the process-wide
+						// counter an operator alerts on is not.
+						run.SkippedInvalidPath++
+						run.Errors = appendBounded(run.Errors, fmt.Sprintf("Exists %q: permanently unusable key: %v", p, res.err), 32)
+					} else {
+						r.noteInvalidPath(run, "Exists", p, res.err)
+					}
+					continue
+				}
 				// Treat exists-check failures as "skip and let the
 				// next run retry" — better than risking a wrong delete.
 				existsErrCount++
 				existsLastErr = res.err
+				run.SkippedTransient++
 				run.Errors = appendBounded(run.Errors, fmt.Sprintf("Exists %q: %v", p, res.err), 32)
 				continue
 			}
@@ -142,6 +174,16 @@ func (r *Reconciler) sweepOrphanManifest(
 				Int("batch_failed_exists", existsErrCount).
 				Int("batch_size", len(chunk)).
 				Msg("Reconciliation: storage.Exists failures during manifest sweep — affected files skipped (next run retries)")
+		}
+		// Permanent failures get their own line for the same anti-spam reason,
+		// and because the transient line above promises a retry that does not
+		// apply to them.
+		if invalidPathCount > 0 {
+			r.logger.Error().
+				Err(invalidLastErr).
+				Int("batch_invalid_paths", invalidPathCount).
+				Int("batch_size", len(chunk)).
+				Msg("Reconciliation: manifest entries name permanently unusable storage keys, skipped and NOT retried. Nothing in Arc can remove them: the row-delete path and retention both have to read the file first, and neither can open this key. They stay until the manifest is edited out of band")
 		}
 
 		// If len(ops)==0 we have no Raft work for this chunk (every file

--- a/internal/reconciliation/sweep_storage.go
+++ b/internal/reconciliation/sweep_storage.go
@@ -2,6 +2,7 @@ package reconciliation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -196,6 +197,34 @@ func (r *Reconciler) applyStorageDeletes(
 	bd storage.BatchDeleter,
 	hasBatchDelete bool,
 ) int {
+	// Classify permanently unusable keys BEFORE the batch call, not after it.
+	// DeleteBatch aggregates per-key failures with errors.Join on every
+	// backend, so one bad key in a chunk of up to a thousand fails the whole
+	// batch and drops every member to the per-file path. The deletes still
+	// happen there, so this is not a correctness problem, but re-issuing a
+	// thousand individual deletes on every run because of one key is exactly
+	// the wasted work #747 is about.
+	if len(paths) > 0 {
+		usable := make([]string, 0, len(paths))
+		for _, p := range paths {
+			if err := storage.ValidateKey(p); err != nil {
+				r.noteInvalidPath(run, "delete", p, err)
+				continue
+			}
+			usable = append(usable, p)
+		}
+		if len(usable) != len(paths) {
+			r.logger.Error().
+				Int("invalid_paths", len(paths)-len(usable)).
+				Int("batch_size", len(paths)).
+				Msg("Reconciliation: orphan files have permanently unusable storage keys, skipped and NOT retried. Arc cannot delete them, because every path to them addresses the same key; remove them with the storage provider's own tooling")
+		}
+		paths = usable
+		if len(paths) == 0 {
+			return 0
+		}
+	}
+
 	if hasBatchDelete && len(paths) > 1 {
 		if err := bd.DeleteBatch(ctx, paths); err != nil {
 			// Batch delete failures fall through to per-file delete so
@@ -210,11 +239,29 @@ func (r *Reconciler) applyStorageDeletes(
 	}
 	applied := 0
 	deleteErrCount := 0
+	invalidPathCount := 0
 	var deleteLastErr error
+	var invalidLastErr error
 	for _, p := range paths {
 		if err := r.storage.Delete(ctx, p); err != nil {
+			if errors.Is(err, storage.ErrInvalidPath) {
+				// Defence in depth. The pre-filter above should have removed
+				// these, so reaching here means a backend refused a key
+				// ValidateKey accepts; classify it the same way rather than
+				// spinning on it every run.
+				//
+				// Note this is the PER-FILE error, never the batch error: that
+				// one is an errors.Join, so it matches ErrInvalidPath when a
+				// single member is bad, and quarantining on it would discard
+				// every valid delete in the batch.
+				invalidPathCount++
+				invalidLastErr = err
+				r.noteInvalidPath(run, "delete", p, err)
+				continue
+			}
 			deleteErrCount++
 			deleteLastErr = err
+			run.SkippedTransient++
 			run.Errors = appendBounded(run.Errors, fmt.Sprintf("delete %q: %v", p, err), 32)
 			continue
 		}
@@ -226,6 +273,13 @@ func (r *Reconciler) applyStorageDeletes(
 			Int("batch_failed_deletes", deleteErrCount).
 			Int("batch_size", len(paths)).
 			Msg("Reconciliation: storage.Delete failures — affected files will retry on next run")
+	}
+	if invalidPathCount > 0 {
+		r.logger.Error().
+			Err(invalidLastErr).
+			Int("batch_invalid_paths", invalidPathCount).
+			Int("batch_size", len(paths)).
+			Msg("Reconciliation: orphan files have permanently unusable storage keys, skipped and NOT retried. Arc cannot delete them, because every path to them addresses the same key; remove them with the storage provider's own tooling")
 	}
 	return applied
 }

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -163,6 +163,33 @@ func (b *AzureBlobBackend) blobKey(key string) (string, error) {
 	return key, nil
 }
 
+// partitionValidKeys splits a batch into the keys that satisfy the storage
+// contract and one error per key that does not.
+//
+// DeleteBatch was the only key-taking method on any backend that reached the
+// service without validating, and on Azure that is not merely a missed
+// rejection: a backslash IS a path separator there, verified against Azurite in
+// #743, so "a\b.parquet" and "a/b.parquet" are ONE blob and a batch carrying
+// the first would delete the second. Nothing else in the codebase can make a
+// delete address a different object than the caller named.
+//
+// Rejections are collected rather than fatal, matching S3: callers such as
+// compaction and the reconciler submit whole batches with no per-file fallback,
+// so failing the batch on one key would leave every other file undeleted
+// forever. Split out as a function because AzureBlobBackend cannot be built
+// without live credentials, and this behaviour deserves a test that needs none.
+func partitionValidKeys(batch []string) (usable []string, rejected []error) {
+	usable = make([]string, 0, len(batch))
+	for _, path := range batch {
+		if err := ValidateKey(path); err != nil {
+			rejected = append(rejected, err)
+			continue
+		}
+		usable = append(usable, path)
+	}
+	return usable, rejected
+}
+
 func (b *AzureBlobBackend) Write(ctx context.Context, path string, data []byte) error {
 	return b.WriteReader(ctx, path, bytes.NewReader(data), int64(len(data)))
 }
@@ -431,10 +458,17 @@ func (b *AzureBlobBackend) DeleteBatch(ctx context.Context, paths []string) erro
 			return fmt.Errorf("failed to create Azure batch builder: %w", err)
 		}
 
-		for _, path := range batch {
-			if err := bb.Delete(path, nil); err != nil {
-				return fmt.Errorf("failed to add delete to Azure batch for %q: %w", path, err)
+		usable, rejected := partitionValidKeys(batch)
+		nonFatalErrs = append(nonFatalErrs, rejected...)
+		for _, key := range usable {
+			if err := bb.Delete(key, nil); err != nil {
+				return fmt.Errorf("failed to add delete to Azure batch for %q: %w", key, err)
 			}
+		}
+		if len(usable) == 0 {
+			// Every key in this batch was refused; there is nothing to submit
+			// and SubmitBatch rejects an empty builder.
+			continue
 		}
 
 		resp, err := containerClient.SubmitBatch(ctx, bb, nil)

--- a/internal/storage/azure_batch_keys_test.go
+++ b/internal/storage/azure_batch_keys_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestPartitionValidKeysGuardsAzureBatchDeletes covers the one key-taking
+// method on any backend that used to reach the service without validating.
+//
+// On Azure this is not a missed rejection, it is a wrong delete: a backslash IS
+// a path separator there (measured against Azurite in #743), so a batch
+// carrying `a\b.parquet` removed the unrelated blob `a/b.parquet`.
+//
+// Tested through this function rather than through DeleteBatch because
+// AzureBlobBackend cannot be constructed without live credentials, and the
+// property worth pinning is entirely in the key handling: nothing invalid
+// reaches the delete builder, and one bad key does not cost the batch.
+func TestPartitionValidKeysGuardsAzureBatchDeletes(t *testing.T) {
+	const good1 = "testdb/cpu/2026/04/11/14/a.parquet"
+	const good2 = "testdb/cpu/2026/04/11/14/b.parquet"
+
+	for _, bad := range []string{
+		`testdb\cpu/2026/04/11/14/folds-onto-a-separator.parquet`,
+		"testdb/cpu/2026/04/11/14/",
+		"testdb//cpu/2026/04/11/14/c.parquet",
+		"/testdb/cpu/2026/04/11/14/d.parquet",
+		"testdb/cpu/" + strings.Repeat("x", MaxUsableKeySegmentLen+1) + ".parquet",
+	} {
+		// Bad key in the middle, so a bug that stops at the first rejection
+		// still loses good2.
+		usable, rejected := partitionValidKeys([]string{good1, bad, good2})
+
+		if len(rejected) != 1 {
+			t.Errorf("key %q: rejected %d keys, want 1", bad, len(rejected))
+		}
+		for _, err := range rejected {
+			if !errors.Is(err, ErrInvalidPath) {
+				t.Errorf("key %q: rejection %v does not match ErrInvalidPath", bad, err)
+			}
+		}
+		if len(usable) != 2 || usable[0] != good1 || usable[1] != good2 {
+			t.Errorf("key %q: usable = %v, want both addressable keys; one bad key must not cost the batch", bad, usable)
+		}
+		for _, k := range usable {
+			if k == bad {
+				t.Errorf("key %q reached the delete builder", bad)
+			}
+		}
+	}
+}
+
+// TestPartitionValidKeysPassesACleanBatchThrough pins that validation does not
+// rewrite or reorder anything on the ordinary path. Azure has no prefix, so the
+// key IS the blob name and any transformation here would be a wrong delete of
+// its own.
+func TestPartitionValidKeysPassesACleanBatchThrough(t *testing.T) {
+	in := []string{"a/b.parquet", "a/c.parquet", "d/e..f.parquet"}
+	usable, rejected := partitionValidKeys(in)
+	if len(rejected) != 0 {
+		t.Fatalf("rejected %v from a clean batch", rejected)
+	}
+	if len(usable) != len(in) {
+		t.Fatalf("usable = %v, want %v", usable, in)
+	}
+	for i := range in {
+		if usable[i] != in[i] {
+			t.Fatalf("key %d changed: %q became %q", i, in[i], usable[i])
+		}
+	}
+}

--- a/internal/storage/invalid_path_contract_test.go
+++ b/internal/storage/invalid_path_contract_test.go
@@ -1,0 +1,168 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// manifestReachableKeys is the closed set of spellings that raft
+// ValidateManifestPath accepts and storage ValidateKey refuses. It is the exact
+// input set the quarantine branches added for #747 must handle, because these
+// are the only keys that can reach a cleanup or replication loop from the
+// cluster manifest.
+//
+// It is a closed set rather than a sample: ValidateManifestPath rejects empty,
+// absolute and ".." outright, and those three are therefore unreachable by
+// construction. A test that uses one of them as its representative case proves
+// nothing about these loops.
+//
+// Kept here, next to the contract it is derived from, so tightening either
+// validator shows up as a failure in one place.
+func manifestReachableKeys() []struct {
+	name string
+	key  string
+} {
+	return []struct {
+		name string
+		key  string
+	}{
+		{"trailing separator", "testdb/cpu/2026/04/11/14/"},
+		{"dot segment", "testdb/./cpu/2026/04/11/14/f.parquet"},
+		{"empty interior segment", "testdb//cpu/2026/04/11/14/f.parquet"},
+		{"backslash", `testdb\cpu/2026/04/11/14/f.parquet`},
+		{"oversize segment", "testdb/" + strings.Repeat("m", MaxKeySegmentLen+1) + "/f.parquet"},
+		// Every segment here is inside MaxKeySegmentLen, so this case exercises
+		// the whole-key length rule rather than re-testing the segment rule.
+		{"oversize key", "testdb/" + strings.Repeat(strings.Repeat("a", 200)+"/", 6) + "f.parquet"},
+	}
+}
+
+// TestBackendMethodsReportInvalidPath pins the property every #747 quarantine
+// branch depends on: for a key ValidateKey refuses, EVERY key-taking method
+// returns an error that matches ErrInvalidPath, through whatever wrapping the
+// method applies.
+//
+// The table is over methods, not over backends, so a tenth method added without
+// validation fails here rather than in whichever cleanup loop reaches it first.
+// S3 and Azure enforce the same contract through prefixedKey and blobKey, and
+// are covered against live servers in objectstore_contract_test.go.
+func TestBackendMethodsReportInvalidPath(t *testing.T) {
+	b, err := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	ctx := context.Background()
+
+	methods := []struct {
+		name string
+		call func(key string) error
+	}{
+		{"Write", func(k string) error { return b.Write(ctx, k, []byte("x")) }},
+		{"WriteReader", func(k string) error { return b.WriteReader(ctx, k, strings.NewReader("x"), 1) }},
+		{"Read", func(k string) error { _, err := b.Read(ctx, k); return err }},
+		{"ReadTo", func(k string) error { return b.ReadTo(ctx, k, io.Discard) }},
+		{"ReadToAt", func(k string) error { return b.ReadToAt(ctx, k, io.Discard, 0) }},
+		{"StatFile", func(k string) error { _, err := b.StatFile(ctx, k); return err }},
+		{"Delete", func(k string) error { return b.Delete(ctx, k) }},
+		{"Exists", func(k string) error { _, err := b.Exists(ctx, k); return err }},
+		{"AppendReader", func(k string) error { return b.AppendReader(ctx, k, strings.NewReader("x"), 1) }},
+		{"RemoveDirectory", func(k string) error { return b.RemoveDirectory(ctx, k) }},
+	}
+
+	for _, tc := range manifestReachableKeys() {
+		for _, m := range methods {
+			t.Run(m.name+"/"+tc.name, func(t *testing.T) {
+				err := m.call(tc.key)
+				if err == nil {
+					t.Fatalf("%s(%q) succeeded; the key is not addressable", m.name, tc.key)
+				}
+				if !errors.Is(err, ErrInvalidPath) {
+					t.Errorf("%s(%q) = %v, which does not match ErrInvalidPath, so a caller cannot tell it apart from a transient failure", m.name, tc.key, err)
+				}
+			})
+		}
+	}
+}
+
+// TestInvalidPathSurvivesDoubleWrapping pins that errors.Is still matches after
+// a caller re-wraps, which is what compaction's downloadSingleFile does. Any
+// quarantine check that string-matched the message instead would pass the test
+// above and fail here.
+func TestInvalidPathSurvivesDoubleWrapping(t *testing.T) {
+	b, err := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	inner := b.ReadTo(context.Background(), `db\m/f.parquet`, io.Discard)
+	wrapped := errWrap(errWrap(inner))
+	if !errors.Is(wrapped, ErrInvalidPath) {
+		t.Fatalf("errors.Is failed after two wraps: %v", wrapped)
+	}
+	if strings.Count(wrapped.Error(), "invalid path") == 0 {
+		t.Fatalf("wrapped message lost the cause: %v", wrapped)
+	}
+}
+
+func errWrap(err error) error {
+	return fmt.Errorf("layer: %w", err)
+}
+
+// TestDeleteBatchAggregatesRatherThanShortCircuits is a warning pinned as a
+// test. Both LocalBackend and S3Backend join per-key failures into one error,
+// so a BATCH error matches ErrInvalidPath when as little as one key in a
+// thousand is bad. Quarantine logic must therefore classify per file; a caller
+// that wrote errors.Is(batchErr, ErrInvalidPath) and dropped the batch would
+// silently discard every valid delete in it.
+//
+// The assertion is deliberately in both directions: the match happens, AND the
+// valid key was still deleted, which is what makes acting on the batch error
+// wrong rather than merely imprecise.
+func TestDeleteBatchAggregatesRatherThanShortCircuits(t *testing.T) {
+	root := t.TempDir()
+	b, err := NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	ctx := context.Background()
+	const good = "testdb/cpu/2026/04/11/14/good.parquet"
+	if err := b.Write(ctx, good, []byte("payload")); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	batchErr := b.DeleteBatch(ctx, []string{good, `testdb\cpu/bad.parquet`})
+	if batchErr == nil {
+		t.Fatal("DeleteBatch accepted an unusable key without reporting it")
+	}
+	if !errors.Is(batchErr, ErrInvalidPath) {
+		t.Fatalf("batch error = %v, expected it to match ErrInvalidPath", batchErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, good)); !os.IsNotExist(statErr) {
+		t.Fatal("the valid key was NOT deleted, so treating the batch error as permanent would lose it")
+	}
+}
+
+// TestWriteReaderRejectsBeforeConsumingBody pins why the puller quarantines at
+// StatFile rather than at the write: a rejected key does not consume the body,
+// so a puller that reached the write would already have paid for the transfer.
+func TestWriteReaderRejectsBeforeConsumingBody(t *testing.T) {
+	b, err := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	body := bytes.NewReader(make([]byte, 4096))
+	if err := b.WriteReader(context.Background(), `db\m/f.parquet`, body, 4096); !errors.Is(err, ErrInvalidPath) {
+		t.Fatalf("WriteReader = %v, want ErrInvalidPath", err)
+	}
+	if body.Len() != 4096 {
+		t.Fatalf("body was consumed (%d bytes left of 4096); the rejection must precede the transfer", body.Len())
+	}
+}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -744,6 +744,20 @@ const MaxKeyLen = 1024
 // syscall.
 const MaxKeySegmentLen = 255
 
+// MaxUsableKeyLen and MaxUsableKeySegmentLen are what ValidateKey actually
+// enforces. They are the raw limits minus PartSuffix, because LocalBackend
+// appends it to build the staging file a write lands in, so a key at the raw
+// limit passes validation and then fails the write with ENAMETOOLONG (#744).
+//
+// Exported because callers that BUILD a key have to bound it by the same
+// number. Computing MaxKeySegmentLen themselves is the mistake: it leaves a
+// five-byte window in which the caller believes the name fits and every write
+// of it is refused. GenerateManifestPath had exactly that window.
+const (
+	MaxUsableKeyLen        = MaxKeyLen - len(PartSuffix)
+	MaxUsableKeySegmentLen = MaxKeySegmentLen - len(PartSuffix)
+)
+
 // ValidateKey reports whether key names exactly one object.
 //
 // This is the contract every Backend implementation enforces, and it exists so
@@ -830,8 +844,8 @@ func validateKeyBody(p string) error {
 	// the staging file. A key at exactly the limit passes the contract and
 	// then fails the write with ENAMETOOLONG, which is the same
 	// blessed-but-unstorable shape the manifest half of #744 fixes.
-	if len(p) > MaxKeyLen-len(PartSuffix) {
-		return fmt.Errorf("%w: key is %d bytes, over the %d-byte limit", ErrInvalidPath, len(p), MaxKeyLen-len(PartSuffix))
+	if len(p) > MaxUsableKeyLen {
+		return fmt.Errorf("%w: key is %d bytes, over the %d-byte limit", ErrInvalidPath, len(p), MaxUsableKeyLen)
 	}
 	if p[0] == '/' {
 		return fmt.Errorf("%w: %q must be relative to the backend root", ErrInvalidPath, p)
@@ -857,8 +871,8 @@ func validateKeyBody(p string) error {
 		case ".", "..":
 			return fmt.Errorf("%w: %q contains a %q segment", ErrInvalidPath, p, seg)
 		}
-		if len(seg) > MaxKeySegmentLen-len(PartSuffix) {
-			return fmt.Errorf("%w: %q has a %d-byte segment, over the %d-byte limit", ErrInvalidPath, p, len(seg), MaxKeySegmentLen-len(PartSuffix))
+		if len(seg) > MaxUsableKeySegmentLen {
+			return fmt.Errorf("%w: %q has a %d-byte segment, over the %d-byte limit", ErrInvalidPath, p, len(seg), MaxUsableKeySegmentLen)
 		}
 		start = i + 1
 	}


### PR DESCRIPTION
Fixes #747.

## What was wrong

[#743](https://github.com/Basekick-Labs/arc/issues/743) made a refused storage key a permanent, identifiable error and documented that a loop meeting one should quarantine the entry rather than retry it. Nothing branched on it yet, and the loops the note was about kept treating it as a passing I/O failure.

A key reaches this state by being **stored, not typed**. `raft.ValidateManifestPath` stays looser than the storage contract on purpose (FSM `Apply` includes log replay), so the gap is exactly six spellings, and that set is now pinned as a test against *both* validators:

| spelling | in the manifest | usable by storage |
|---|---|---|
| `db/cpu/2026/04/11/14/` | yes | no |
| `db/./cpu/.../f.parquet` | yes | no |
| `db//cpu/.../f.parquet` | yes | no |
| `db\cpu/.../f.parquet` | yes | no |
| segment over 250 bytes | yes | no |
| key over 1019 bytes | yes | no |
| `""`, `/abs`, `a/../b` | **no** | no |

The last row matters: those are the obvious keys to reach for in a test, and a consumer test built on one would exercise a path no manifest entry can trigger. Compaction manifests and edge-sync ledger rows are persisted state that can carry one of the first six, written by an earlier version.

## The puller case is worse than the issue says

`processEntry` set `failed` after exhausting retries, `finishEntry` turned that into a catch-up failure, and `FullyCaughtUp` requires `catchupFailed == 0` while **only a successful pull of the same path clears it**. So one unusable entry present at startup held the query gate red for the life of the process, and every catch-up walk and reconciliation pass re-streamed the whole file body from a peer before failing the write.

Measured, not estimated: the puller suite runs in **3 seconds** with this change and took **108** without it.

**The gate still stays closed, deliberately.** My first draft opened it, reasoning that an unsatisfiable entry should not hold readiness hostage. That was backwards. `query.gate_on_catchup` is off by default, the read path is a glob so an absent file silently returns fewer rows, and the operator who turns that switch on asked for a 503 over exactly that silence. An entry no peer holds is equally unsatisfiable and holds the gate today; this one gets no exemption. What the quarantine removes is the peer traffic and the retry storm, not the signal.

## Compaction manifests are parked, not deleted

Deleting looked right until review. `Job.Run` deletes the sources itself and **deliberately leaves the manifest** for the parent to finalize, so a live manifest whose inputs are already gone is a designed state, and it is the likely one here: the only binary that could have written such a manifest is one whose upload and source deletion both succeeded. Parking takes it out of the recovery work set, which is what releases its inputs from the compaction exclusion, and keeps the record. The parked name falls back to a hash so the longest manifest names can be parked too.

Nothing sweeps a parked manifest, and that is deliberate rather than an oversight: each affected manifest parks exactly once, so the count is bounded by how many an earlier version wrote and cannot grow from a loop.

## Reconciliation reports rather than deletes

The reason is narrower than "provably an orphan": on an object store an object *can* sit under the literal key, where #743's own listing filter hides it, so absence there is unobservable rather than established. Both sweeps now separate permanent from transient, and a run report carries `skipped_transient` and `skipped_invalid_path` as separate numbers, because waiting helps with one and never with the other.

Keys are classified **per file, never on a `DeleteBatch` error**: that one is an `errors.Join`, so it matches when a single member is bad, and quarantining on it would discard every valid delete in the batch. There is a test that pins this specifically.

## Two things outside the issue, fixed because the work exposed them

**`AzureBlobBackend.DeleteBatch` deleted the wrong blob.** It was the only key-taking method on any backend that reached the service without validating. On Azure a backslash IS a separator, verified against Azurite in #743, so a batch carrying `a\b.parquet` deleted the unrelated blob `a/b.parquet`. The contract test added here is what surfaced it.

**A five-byte window in #744, found while testing the parked name.** `GenerateManifestPath` hashes past `MaxKeySegmentLen` (255), but `ValidateKey` subtracts `PartSuffix` and refuses past 250. A job id of 246 to 250 characters produced a filename the generator accepted and every write refused, so the manifest write failed and that partition's compaction failed on every cycle, which is the failure dca623f set out to remove. The limits the validator actually enforces are now exported, so a caller that builds a key bounds it by the same number the backend checks. Neither the window nor the fix ever appeared in a release.

## Sites changed

| site | before | after |
|---|---|---|
| `filereplication/puller.go` | fetched the body from every peer, then failed the write, forever | quarantined at the first backend call, no peer contacted, gate still red |
| `compaction/manifest.go` recovery | manifest never deleted, inputs excluded from compaction indefinitely | parked, inputs released |
| `compaction/manifest.go` input delete | one unusable input kept the whole manifest for retry | skipped, recovery completes, receipts fire |
| `compaction/job.go` | one unusable input failed the whole job every cycle | skipped, the rest of the partition compacts |
| `reconciliation/sweep_manifest.go` | counted transient, "next run retries" | classified, counted, reported |
| `reconciliation/sweep_storage.go` | same, one file over | same, plus pre-filtered before the batch |
| `edgesync/exporter.go` | aborted the **entire** export, no attempt cap anywhere | marked skipped |
| `cluster/coordinator.go` fetch | answered `backend` (reads as transient) | answers `invalid_path`, rate-limited log |
| `cluster/coordinator.go` delete worker | permanent condition logged as a hiccup | says the copy can never be removed by Arc |

`arc_storage_invalid_path_quarantined_total` aggregates all of them. It matters more than most: after this change there is no retry storm, no growing error log and no stuck queue to notice, so the counter and the per-site Error lines are the whole signal.

## Testing

Every quarantine test was verified to **fail with its branch neutralised**, and each site also carries an over-correction guard proving a *transient* error still behaves transiently, which is the dangerous direction. The three storage test doubles now enforce `ValidateKey`, because an untaught double is more permissive than all three production backends and would make these branches dead code under test; that change broke zero existing tests.

Full suite green, `-race` clean, `duckdb_arrow` tagged tests green. The only `gofmt -l` output is the eight files already dirty on main.

## Left alone, on purpose

Local listings do not filter unusable keys the way S3 and Azure have since #743, so on the default deployment these loops are **live today rather than latent**, contrary to what the issue assumed. Filtering would be consistent, but on local these are real data files rather than the object stores' directory markers, and silently omitting them from a backup is worse than the inconsistency. That deserves its own decision rather than a drive-by, and it is filed separately along with three other follow-ups.
