### PR TITLE
docs(sandbox): record why per-tenant allowed_directories scoping is not buildable (#641)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -207,6 +207,51 @@ the cache immediately and was never affected; only passive expiry was.
 Full technical detail will accompany the corresponding security advisory once it
 is published. Responsibly reported by **[@rexpository](https://github.com/rexpository)**.
 
+### Investigated: per-tenant scoping of the DuckDB sandbox ([#641](https://github.com/Basekick-Labs/arc/issues/641))
+
+No behaviour change in this release. Recorded here because the investigation
+settled a question that had been open since the sandbox shipped, and the answer
+constrains anything built on top of it.
+
+Arc locks DuckDB down once at startup: it sets `allowed_directories` to every
+prefix the deployment needs, then sets `enable_external_access = false`. The
+allowlist is therefore the union of all tenants' directories for the life of the
+process, so an attacker who got past the read-SQL validator would be bounded by
+the deployment, not by the database their token can read. #641 asked whether the
+allowlist could be narrowed per query to close that gap.
+
+It cannot, on the handle Arc runs queries through. Measured against DuckDB
+1.5.5: `allowed_directories` is GLOBAL-only (there is no session or connection
+scope, so two concurrent queries on one handle cannot see different allowlists),
+it is immutable once external access is off, and the lockdown is deliberately
+one-way. It also cannot be set in the connection string, and no LOCAL-scope
+setting in 1.5.5 affects file access. The only mechanism that gives two queries
+different filesystem scopes is a second DuckDB instance.
+
+Routing queries to per-scope instances was designed and rejected. The decisive
+problem is that the routing key could only come from the same SQL reference
+extractor the threat model assumes has already been defeated: a query written as
+`read_parquet('...')` yields no table references at all, so the queries the
+feature exists to contain are exactly the ones that would produce no key. The
+supporting costs were also severe, since DuckDB's thread count and memory limit
+are both per instance, and Arc's S3 and Azure credential refreshers are keyed by
+secret name in a way that would let a second instance silently stop the first
+one's refresher.
+
+`lock_configuration` was evaluated as cheap hardening in the same pass and
+rejected for a concrete reason: it blocks the `parquet_metadata_cache` toggle
+that Arc performs after every delete, compaction, and retention pass to drop
+cached metadata pointing at deleted files, and DuckDB 1.5.5 offers no
+lock-immune substitute.
+
+The full analysis, including the measurements and the enforcement point that is
+worth building instead (a Go-side assertion that every path literal in the
+rewritten SQL is one Arc emitted, tracked in
+[#764](https://github.com/Basekick-Labs/arc/issues/764)), is in
+`docs/progress/2026-09-12-duckdb-sandbox-scoping.md`. The DuckDB constraints the
+decision rests on are pinned by tests, so a future DuckDB bump that lifts one
+fails the build rather than leaving the note quietly wrong.
+
 ## Upgrade notes
 
 1. **Clustered Enterprise deployments require a coordinated restart.** The

--- a/docs/progress/2026-09-12-duckdb-sandbox-scoping.md
+++ b/docs/progress/2026-09-12-duckdb-sandbox-scoping.md
@@ -1,0 +1,256 @@
+# DuckDB sandbox scoping: what is and is not possible
+
+Date: 2026-09-12
+Issue: #641 (per-tenant scoping of the DuckDB sandbox `allowed_directories`)
+Status: design note. No per-tenant scoping shipped. See "Decision" below.
+
+## The question
+
+Arc locks DuckDB down once at startup (`internal/database/sandbox.go`): it sets
+`allowed_directories` to every prefix the deployment legitimately needs, then
+sets `enable_external_access = false`. The allowlist is therefore the union of
+all tenants' directories, for the life of the process.
+
+#641 asked whether that allowlist can be narrowed per query, so that a query
+authorised only for `db1` cannot open a file under `db2` even if the SQL
+validator is bypassed. This note records what was measured, and why the answer
+is "not on the shared handle, and not worth it on separate handles".
+
+## Measured constraints
+
+Measured against the DuckDB that Arc ships, `github.com/duckdb/duckdb-go/v2`
+v2.10505.0 (DuckDB 1.5.5). Each of these was reproduced directly, and the ones
+that guard Arc's own behaviour are pinned by tests in
+`internal/database/duckdb_sandbox_constraints_test.go`; see "When to revisit"
+for exactly which.
+
+1. **`allowed_directories` is GLOBAL-only.** `duckdb_settings()` reports scope
+   `GLOBAL`. `SET SESSION allowed_directories = [...]` fails with
+   `Catalog Error: option "allowed_directories" cannot be set locally`, and
+   `SET LOCAL` with `Not implemented Error`. There is no per-connection or
+   per-statement scope, so two concurrent queries on one handle cannot see
+   different allowlists.
+
+2. **It is immutable after lockdown.** Once `enable_external_access` is false,
+   narrowing the list fails with `Invalid Input Error: Cannot change
+   allowed_directories when enable_external_access is disabled`. `RESET` fails
+   the same way. Re-enabling external access to get the setting back is also
+   refused: `Cannot enable external access while database is running`. The
+   lockdown is deliberately one-way.
+
+3. **It is inert before lockdown.** With the allowlist narrowed to `db1` but
+   `enable_external_access` still true, reading a file under `db2` succeeds.
+   The allowlist only becomes an access check once external access is off.
+   This is why `lockdownExternalAccess` sets the two in that order and verifies
+   the flip, and it means there is no such thing as a cheap "born scoped"
+   handle: an instance must complete its whole INSTALL/LOAD/CREATE SECRET
+   sequence first, and is entirely unsandboxed until it does.
+
+4. **It cannot be set in the DSN.** Opening with
+   `?allowed_directories=[...]&enable_external_access=false` fails at open with
+   `database/sql/driver: could not set invalid or local option for global
+   database config`. The SET-then-lockdown sequence after open is mandatory.
+
+5. **No LOCAL-scope setting opens a file of the query's choosing.** The
+   complete LOCAL-scope set in 1.5.5 is 16 settings: profiling (including
+   `custom_profiling_settings` and `profiling_coverage`), progress bar, search
+   path, schema, streaming buffer size, caching operators, HTTP logging, and
+   `debug_force_external`. Three of them name a file DuckDB *writes*
+   (`profile_output`, `profiling_output`, `http_logging_output`); the sandbox
+   still gates those writes after lockdown, which is asserted rather than
+   assumed. None of the 16 reads a path the query supplies.
+   `disabled_filesystems` is GLOBAL-only too, and is all-or-nothing per
+   filesystem rather than per path.
+
+6. **The allowlist is per DuckDB instance.** Two instances in one process hold
+   independent allowlists and genuinely deny each other's directories with
+   `Permission Error: ... file system operations are disabled by
+   configuration`. This is the only mechanism in DuckDB 1.5.5 that can give two
+   queries different filesystem scopes.
+
+Consequence: the mechanism #641 proposed does not exist. Per-query scoping is
+reachable only by routing the query to a different DuckDB instance.
+
+## Why the instance pool was not built
+
+The natural design is a bounded LRU pool of DuckDB instances keyed by the
+query's authorisation scope (the set of databases it references, each already
+checked by `checkQueryPermissions`). It was rejected for one structural reason
+and several cost reasons.
+
+### The structural reason: the key comes from the parser the threat model assumes is defeated
+
+The scope key can only be derived from `extractTableReferences`
+(`internal/api/query.go`), which matches identifiers after `FROM` and `JOIN`
+and deliberately skips anything followed by `(` (`isFunctionCallAt`).
+`checkQueryPermissions` then returns early when that set is empty.
+
+So the queries this feature exists to contain are exactly the queries that
+produce no key at all:
+
+| query | derived scope |
+|---|---|
+| `SELECT * FROM read_parquet('<root>/db2/**/*.parquet')` | empty |
+| `SELECT * FROM parquet_scan('<root>/db2/**/*.parquet')` | empty |
+| `SELECT * FROM glob('<root>/**')` | empty |
+| `SELECT * FROM read_text('/etc/passwd')` | empty |
+| `WITH t AS (SELECT * FROM read_parquet('<root>/db2/**')) SELECT * FROM t` | empty |
+| `SELECT * FROM db1.cpu, '<root>/db2/x.parquet' b` | `[db1]` |
+
+#641's acceptance criterion says to test with validation stubbed. With
+validation stubbed, the attack query is a bare `read_parquet(...)`, and the
+routing decision that would select a narrow instance is made by the same
+function that failed to see it. Routing an unkeyed query to the full-root
+instance gives zero protection.
+
+The design does contain the mixed shapes (last row): a `[db1]`-keyed instance
+does deny the `db2` path. That is real but partial coverage, and it is the
+harder class for an attacker to be forced into.
+
+### The cheap variant of this, costed out
+
+Most of what follows is an objection to keying N instances by scope. There is a
+much cheaper shape that deserves its own accounting, because none of the cost
+objections below apply to it: **one** extra DuckDB instance, created once at
+startup with an empty allowlist, used only for queries whose derived scope is
+empty.
+
+It inverts the structural problem rather than suffering from it. The rule is
+"a query the extractor could not attribute runs where nothing can be read", so
+the parser failing to see `read_parquet` is precisely what routes the query
+somewhere it cannot read. Every cost objection below dissolves: there is one
+fixed instance rather than N, it creates no S3 or Azure secret so the refresher
+collision cannot arise, it can take a token `memory_limit` and thread count
+because it has no data to scan, it is built at startup so no query pays a pool
+miss, and it is never evicted. An empty `allowed_directories` plus lockdown is
+accepted by DuckDB, and such an instance still serves `SELECT 1` and
+`range(1000000)` normally while denying `read_csv` and `glob('/**')`.
+
+Its soundness rests on one invariant: a query with no extracted table
+references must never need a storage path. That was measured rather than
+assumed, by running Arc's real extractor and its real transform over the same
+corpus. Every zero-reference query produced no emitted path, with one
+exception: a bare single-quoted string in table position
+(`SELECT * FROM '/root/db2/x.parquet'`) yields no references yet still reaches
+the path builder. That shape is rejected by `ValidateSQLRequest` today, and
+with validation stubbed the transform emits syntactically invalid SQL for it
+(the literal is interpolated with its own quotes intact), so DuckDB fails it at
+parse or bind time and the attacker's path never reaches a file-opening
+function. The invariant holds in practice, and the exception fails closed.
+
+Two things stop it from being the answer here. It contains only the unkeyed
+class, so the mixed shape in the last table row still reads `db2` through the
+full-root handle. And it still needs the routing hook at every dispatch site,
+which is the entire integration cost of the pool design and the part that
+actually touches the hot path. The Go-side assertion described under "Decision"
+covers both classes, covers the arcx engine as well, and needs one insertion
+point rather than fourteen, which is why it is preferred. If that assertion
+proves unworkable, this variant is the fallback worth building, and it is
+recorded in #764 rather than discarded.
+
+### The cost reasons
+
+- **Threads multiply.** `configureDatabase` issues `SET GLOBAL threads` per
+  instance from `database.thread_count`, which defaults to `runtime.NumCPU()`,
+  and DuckDB spawns the workers eagerly. The cost is one OS worker thread per
+  configured DuckDB thread, so it scales with the host: measured 15 per
+  instance at `threads=16` (6 baseline, 21 with one instance, 126 with eight),
+  and 7 per instance at the default on an 8-core box. Because the default is
+  `NumCPU`, an eight-entry pool on a 64-core host is roughly 512 DuckDB worker
+  threads in one process.
+- **Memory budget multiplies.** `memory_limit` is per instance, so N instances
+  can allocate N times the configured budget before any of them spills, which
+  removes DuckDB's spill-to-disk pressure valve and converts graceful
+  degradation into an OOM kill. Arc already fixed this exact class of bug once
+  for compaction subprocesses (`internal/config/config.go`, the derived
+  per-subprocess budget). Dividing the limit by the pool bound instead makes
+  every ordinary single-tenant query N times more likely to spill.
+- **The credential refreshers collide.** `d.s3Refreshers` is keyed by secret
+  name and each refresher is bound to one handle, and `startRefresher` stops
+  any existing refresher with the same name. A second instance needing
+  `arc_s3_primary` would stop the first instance's refresher, so that handle
+  keeps a static copy of an STS credential until it expires while `/health`
+  still reports healthy. Correcting this needs per-instance keying and
+  multiplies the IMDS/STS call rate by the pool size.
+- **A pool miss lands on the query hot path.** A miss pays extension
+  INSTALL/LOAD (including `cache_httpfs` from the community repo and arcx with
+  a 30s timeout) plus secret creation, whose first credential resolve is
+  synchronous and bounded at 10s. A thrashing pool pays that continuously.
+- **Eviction does not bound anything.** Closing a handle with a live streaming
+  result does not free it: DuckDB refcounts internally, so reads continue
+  correctly, and the evicted instance keeps its buffer pool and its worker
+  threads until the query finishes. The bound that justifies the pool does not
+  actually bound memory or threads.
+
+### It also would not cover both engines or all dispatch sites
+
+The plan assumed two execution seams. There are at least nine, and one of them
+holds a separately captured handle: `query.NewParallelExecutor(db.DB(), ...)`
+stores the raw `*sql.DB` at handler construction, and serves the largest
+queries (those over the partition threshold). Any seam left on the unscoped
+handle is a complete bypass.
+
+Separately, arcx is a second execution engine. On an `arcx_engine` build with
+`ARC_ROUTER=serve`, eligible queries never reach DuckDB at all; arcx does its
+own file reads in Go, bounded by the `AllowedDirs` slice it is handed from
+`(*database.DuckDB).AllowedDirectories()`. DuckDB-level scoping enforces
+nothing on that path.
+
+## Why `lock_configuration` was not enabled either
+
+`SET GLOBAL lock_configuration = true` looked like free hardening: after
+lockdown, `SET GLOBAL disabled_filesystems = 'LocalFileSystem'` still succeeds
+and bricks the instance for its own reads, and `lock_configuration` blocks it
+(along with `memory_limit` and `threads`) while leaving allowed reads working.
+It is not reachable from user SQL today, since `dangerousSQLPattern` rejects
+bare `SET`, so it would be defence in depth for exactly the "validator
+bypassed" threat model of this issue.
+
+It was rejected because it also blocks `parquet_metadata_cache`, and Arc
+toggles that setting at runtime in `ClearHTTPCache` after every delete,
+compaction, and retention pass to drop cached metadata pointing at files that
+no longer exist. Under `lock_configuration` that toggle fails permanently, so
+the cache is never reset.
+
+There is no lock-immune substitute in 1.5.5. `PRAGMA disable_object_cache` and
+`PRAGMA enable_object_cache` do survive the lock, but they are inert: neither
+changes `parquet_metadata_cache`, and neither changes `enable_object_cache`
+itself. `lock_configuration` is also one-way, so it cannot be lifted for the
+toggle and restored.
+
+Enabling it would trade a hardening that is only reachable after another
+control has already failed for a correctness regression operators would hit on
+every delete. If `ClearHTTPCache` is ever reworked to avoid the setting toggle,
+this is worth revisiting.
+
+## Decision
+
+No per-tenant `allowed_directories` scoping. The startup lockdown stays as it
+is, and this note is the record of why.
+
+The enforcement point worth building instead is in Go, not in DuckDB: assert,
+on the final rewritten SQL immediately before dispatch, that every path literal
+it contains is one Arc itself emitted and lies under an allowlist derived from
+the RBAC decision just made. That inverts the broken dependency, because it
+inspects the SQL actually being executed rather than what the reference
+extractor managed to parse, so the unkeyed `read_parquet` case is caught by
+construction. It is also the mechanism arcx already uses, so it can cover both
+engines, and it needs no second instance and therefore none of the thread,
+memory, credential, or latency costs above. Its weakness is honest: it is Arc
+code checking Arc code rather than the engine refusing. It is tracked in #764,
+which also carries #641's three unmet acceptance criteria.
+
+## When to revisit
+
+`TestSandboxScopingConstraints` pins constraints 1, 2, 3 and 6.
+`TestNoLocalScopeSettingAffectsFileAccess` pins constraint 5, both the set of
+LOCAL-scope settings and the fact that the sandbox still gates
+`profile_output`. Constraint 4 (the DSN rejection) is not pinned, because it is
+a driver-level behaviour rather than a DuckDB one and it is not what the
+decision rests on. `TestLockConfigurationStillBlocksCacheInvalidation` pins the
+`lock_configuration` trade-off.
+
+If a DuckDB bump makes `allowed_directories` settable per session or mutable
+after lockdown, or gives `lock_configuration` a way to coexist with cache
+invalidation, those tests fail and say so, and this note plus #641 should be
+reopened.

--- a/internal/database/duckdb_sandbox_constraints_test.go
+++ b/internal/database/duckdb_sandbox_constraints_test.go
@@ -1,0 +1,413 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file pins the DuckDB behaviours that decide issue #641 (per-tenant
+// scoping of allowed_directories). The design note is
+// docs/progress/2026-09-12-duckdb-sandbox-scoping.md; these tests exist so the
+// note cannot go quietly stale across a DuckDB bump.
+//
+// Every assertion here is deliberately "this is still impossible". A failure is
+// therefore good news, not a regression in Arc: it means the constraint that
+// made per-query scoping unbuildable has lifted, and #641 plus the note should
+// be reopened. Each failure message says so.
+
+// openRawDuckDB returns a fresh in-memory DuckDB instance. A separate instance
+// per subtest is mandatory: enable_external_access=false is one-way for the
+// life of the instance, so a shared handle would leak lockdown state between
+// subtests and make the ordering assertions meaningless.
+func openRawDuckDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// sandboxFixture lays out <root>/db1/t.csv and <root>/db2/t.csv, standing in
+// for two tenants' storage directories.
+func sandboxFixture(t *testing.T) (root, db1File, db2File string) {
+	t.Helper()
+	root = t.TempDir()
+	write := func(db string) string {
+		dir := filepath.Join(root, db)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		p := filepath.Join(dir, "t.csv")
+		if err := os.WriteFile(p, []byte("a\n1\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+		return p
+	}
+	return root, write("db1"), write("db2")
+}
+
+func allowDir(t *testing.T, db *sql.DB, dir string) error {
+	t.Helper()
+	_, err := db.Exec(fmt.Sprintf("SET GLOBAL allowed_directories = ['%s']", escapeSQLString(dir)))
+	return err
+}
+
+func lockdown(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec("SET GLOBAL enable_external_access = false"); err != nil {
+		t.Fatalf("lockdown: %v", err)
+	}
+}
+
+// readCSV reports the error from reading path, or nil when the read succeeded.
+func readCSV(db *sql.DB, path string) error {
+	var n int
+	return db.QueryRow(fmt.Sprintf("SELECT count(*) FROM read_csv('%s')", escapeSQLString(path))).Scan(&n)
+}
+
+const reopen641 = "this constraint has lifted: reopen #641 and revisit docs/progress/2026-09-12-duckdb-sandbox-scoping.md"
+
+func TestSandboxScopingConstraints(t *testing.T) {
+	// Constraint 1: allowed_directories has no per-connection scope, so two
+	// concurrent queries on Arc's shared handle cannot see different
+	// allowlists. This is the reason per-query scoping needs a second
+	// instance rather than a SET on the query's own connection.
+	t.Run("no session or local scope", func(t *testing.T) {
+		db := openRawDuckDB(t)
+		root, _, _ := sandboxFixture(t)
+
+		var scope string
+		if err := db.QueryRow(
+			"SELECT scope FROM duckdb_settings() WHERE name = 'allowed_directories'",
+		).Scan(&scope); err != nil {
+			t.Fatalf("read allowed_directories scope: %v", err)
+		}
+		if scope != "GLOBAL" {
+			t.Errorf("allowed_directories scope = %q, want GLOBAL: %s", scope, reopen641)
+		}
+
+		// The two qualifiers fail for different reasons, and only the first
+		// is evidence about this setting: SESSION is refused because
+		// allowed_directories has no local scope, whereas SET LOCAL is
+		// unimplemented in 1.5.5 for every setting. Asserting the substrings
+		// keeps a future generic parse error from passing this as a silent
+		// "still rejected".
+		for _, tc := range []struct {
+			qualifier   string
+			wantSubstrs []string
+		}{
+			{"SESSION", []string{"cannot be set locally"}},
+			// SET LOCAL is unimplemented in 1.5.5 for every setting, so its
+			// rejection is not by itself evidence about this one. Either
+			// spelling is accepted: if DuckDB implements SET LOCAL generically
+			// while allowed_directories stays GLOBAL-only, the message becomes
+			// the "cannot be set locally" form and nothing relevant has
+			// changed. Requiring only "not implemented" would fail the build
+			// on that entirely uninteresting day.
+			{"LOCAL", []string{"not implemented", "cannot be set locally"}},
+		} {
+			stmt := fmt.Sprintf("SET %s allowed_directories = ['%s']", tc.qualifier, escapeSQLString(root))
+			_, err := db.Exec(stmt)
+			if err == nil {
+				t.Errorf("SET %s allowed_directories succeeded, want rejection: %s", tc.qualifier, reopen641)
+				continue
+			}
+			got := strings.ToLower(err.Error())
+			matched := false
+			for _, want := range tc.wantSubstrs {
+				if strings.Contains(got, want) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				t.Errorf("SET %s allowed_directories failed with %q, want one of %q",
+					tc.qualifier, err, tc.wantSubstrs)
+			}
+		}
+	})
+
+	// Constraint 3: the allowlist is inert until external access is off. This
+	// pins the ordering inside lockdownExternalAccess. If the two statements
+	// were ever reordered, or the lockdown step were dropped, the allowlist
+	// would be decorative and every I/O function would reach any path.
+	t.Run("allowlist is inert until lockdown", func(t *testing.T) {
+		db := openRawDuckDB(t)
+		root, _, db2File := sandboxFixture(t)
+
+		if err := allowDir(t, db, filepath.Join(root, "db1")); err != nil {
+			t.Fatalf("set allowlist: %v", err)
+		}
+		if err := readCSV(db, db2File); err != nil {
+			t.Fatalf("pre-lockdown read of a non-allowlisted path failed: %v\n"+
+				"If the fixture is sound, DuckDB has started enforcing allowed_directories "+
+				"eagerly rather than only after lockdown. That would mean a scoped instance "+
+				"can be sandboxed before it finishes loading extensions and creating secrets, "+
+				"which is the expensive constraint in the rejected design: %s", err, reopen641)
+		}
+
+		lockdown(t, db)
+
+		err := readCSV(db, db2File)
+		if err == nil {
+			t.Fatalf("post-lockdown read of a non-allowlisted path succeeded, want Permission Error: %s", reopen641)
+		}
+		if !strings.Contains(err.Error(), "Permission Error") {
+			t.Errorf("post-lockdown read failed with %q, want a Permission Error; the denial may "+
+				"be coming from something other than the sandbox", err)
+		}
+	})
+
+	// Constraint 2: the allowlist cannot be narrowed after lockdown, and
+	// lockdown cannot be undone to get it back. Together with constraint 1
+	// this is what makes per-query scoping on Arc's startup-locked handle
+	// impossible rather than merely awkward.
+	t.Run("immutable after lockdown", func(t *testing.T) {
+		db := openRawDuckDB(t)
+		root, db1File, _ := sandboxFixture(t)
+
+		if err := allowDir(t, db, root); err != nil {
+			t.Fatalf("set allowlist: %v", err)
+		}
+		lockdown(t, db)
+
+		// Substring-matched so a future unrelated failure (a parse error, a
+		// renamed setting) cannot pass as "still immutable".
+		mustReject := func(what, wantSubstr string, err error) {
+			t.Helper()
+			if err == nil {
+				t.Errorf("%s succeeded after lockdown, want rejection: %s", what, reopen641)
+				return
+			}
+			if !strings.Contains(err.Error(), wantSubstr) {
+				t.Errorf("%s failed with %q, want a %q rejection", what, err, wantSubstr)
+			}
+		}
+
+		mustReject("narrowing allowed_directories", "Cannot change allowed_directories",
+			allowDir(t, db, filepath.Join(root, "db1")))
+		_, resetErr := db.Exec("RESET GLOBAL allowed_directories")
+		mustReject("RESET allowed_directories", "Cannot change allowed_directories", resetErr)
+		_, reenableErr := db.Exec("SET GLOBAL enable_external_access = true")
+		mustReject("re-enabling external access", "Cannot enable external access", reenableErr)
+
+		// The sandbox must still permit Arc's own reads inside the allowlist,
+		// so a failure above is not masked by a wholly broken instance.
+		if err := readCSV(db, db1File); err != nil {
+			t.Errorf("allowlisted read failed after lockdown: %v", err)
+		}
+	})
+
+	// Constraint 6: scoping is available per instance, and only per instance.
+	// This is the mechanism the rejected instance-pool design would have used;
+	// it is pinned so the note's "the only available mechanism" claim stays
+	// checkable.
+	t.Run("scope is per instance", func(t *testing.T) {
+		root, db1File, db2File := sandboxFixture(t)
+
+		newScoped := func(dir string) *sql.DB {
+			db := openRawDuckDB(t)
+			if err := allowDir(t, db, dir); err != nil {
+				t.Fatalf("set allowlist %s: %v", dir, err)
+			}
+			lockdown(t, db)
+			return db
+		}
+
+		instanceA := newScoped(filepath.Join(root, "db1"))
+		instanceB := newScoped(filepath.Join(root, "db2"))
+
+		if err := readCSV(instanceA, db1File); err != nil {
+			t.Errorf("instance A cannot read its own directory: %v", err)
+		}
+		if err := readCSV(instanceB, db2File); err != nil {
+			t.Errorf("instance B cannot read its own directory: %v", err)
+		}
+		// Substring-matched like the other denials: "any error" would also be
+		// satisfied by a missing fixture file, which would quietly stop this
+		// subtest from testing isolation at all.
+		mustDeny := func(what string, err error) {
+			t.Helper()
+			if err == nil {
+				t.Errorf("%s, want Permission Error; per-instance allowlists are no longer "+
+					"isolated: %s", what, reopen641)
+				return
+			}
+			if !strings.Contains(err.Error(), "Permission Error") {
+				t.Errorf("%s and failed with %q, want a Permission Error", what, err)
+			}
+		}
+		mustDeny("instance A read instance B's directory", readCSV(instanceA, db2File))
+		mustDeny("instance B read instance A's directory", readCSV(instanceB, db1File))
+	})
+}
+
+// TestLockConfigurationStillBlocksCacheInvalidation pins the reason
+// lock_configuration is not enabled in lockdownExternalAccess: it would block
+// the parquet_metadata_cache toggle that ClearHTTPCache performs after every
+// delete, compaction and retention pass, and 1.5.5 offers no lock-immune
+// substitute. If this test fails, the trade-off recorded in the design note has
+// changed and lock_configuration becomes cheap hardening worth adopting.
+func TestLockConfigurationStillBlocksCacheInvalidation(t *testing.T) {
+	db := openRawDuckDB(t)
+
+	// Match Arc: configureDatabase sets parquet_metadata_cache=true
+	// (internal/database/duckdb.go). A raw instance defaults to false, and
+	// starting from false hides a regression in the disable direction, which is
+	// the direction ClearHTTPCache actually needs for invalidation.
+	if _, err := db.Exec("SET GLOBAL parquet_metadata_cache=true"); err != nil {
+		t.Fatalf("seed parquet_metadata_cache: %v", err)
+	}
+
+	if _, err := db.Exec("SET GLOBAL lock_configuration = true"); err != nil {
+		t.Fatalf("lock_configuration is unavailable (%v); the design note assumes it exists", err)
+	}
+
+	// The exact pair ClearHTTPCache issues.
+	for _, stmt := range []string{
+		"SET GLOBAL parquet_metadata_cache=false",
+		"SET GLOBAL parquet_metadata_cache=true",
+	} {
+		if _, err := db.Exec(stmt); err == nil {
+			t.Errorf("%q succeeded under lock_configuration; lock_configuration no longer "+
+				"conflicts with ClearHTTPCache, so revisit enabling it in lockdownExternalAccess "+
+				"(docs/progress/2026-09-12-duckdb-sandbox-scoping.md)", stmt)
+		} else if !strings.Contains(err.Error(), "locked") {
+			t.Errorf("%q failed for an unexpected reason: %v", stmt, err)
+		}
+	}
+
+	// The object-cache pragmas survive the lock but are inert, so they are not
+	// a substitute. Pinned because "use the pragma instead" is the obvious
+	// wrong fix for someone revisiting this.
+	// Sample BETWEEN the two pragmas, not just around the pair. Running both and
+	// comparing only the endpoints cannot see a wired disable_object_cache that
+	// a following enable_object_cache puts back, and disable is the half that
+	// would matter.
+	before := currentSetting(t, db, "parquet_metadata_cache")
+	if _, err := db.Exec("PRAGMA disable_object_cache"); err != nil {
+		t.Fatalf("PRAGMA disable_object_cache failed: %v", err)
+	}
+	mid := currentSetting(t, db, "parquet_metadata_cache")
+	if _, err := db.Exec("PRAGMA enable_object_cache"); err != nil {
+		t.Fatalf("PRAGMA enable_object_cache failed: %v", err)
+	}
+	after := currentSetting(t, db, "parquet_metadata_cache")
+
+	const pragmaNowWorks = "object-cache pragmas now move parquet_metadata_cache under " +
+		"lock_configuration, so they may be the lock-immune substitute for the ClearHTTPCache " +
+		"toggle that 1.5.5 lacked; revisit enabling lock_configuration " +
+		"(docs/progress/2026-09-12-duckdb-sandbox-scoping.md)"
+	if mid != before {
+		t.Errorf("PRAGMA disable_object_cache changed parquet_metadata_cache (%s -> %s): %s",
+			before, mid, pragmaNowWorks)
+	}
+	if after != before {
+		t.Errorf("PRAGMA enable_object_cache changed parquet_metadata_cache (%s -> %s): %s",
+			mid, after, pragmaNowWorks)
+	}
+}
+
+// TestNoLocalScopeSettingAffectsFileAccess pins constraint 5 of the design
+// note. A per-connection setting that gated file access would be a way to scope
+// a query without a second instance, which is the mechanism #641 wanted. This
+// asserts the LOCAL-scope surface is still confined to the known-harmless set,
+// so a DuckDB bump that adds a file-access-relevant LOCAL setting shows up as a
+// build failure rather than as a stale sentence in the note.
+//
+// profile_output, profiling_output and http_logging_output are the interesting
+// members: they are LOCAL and they name a file DuckDB writes. They are listed as
+// known because the sandbox still gates that write after lockdown, which the
+// subtest below verifies rather than assumes.
+func TestNoLocalScopeSettingAffectsFileAccess(t *testing.T) {
+	// The complete LOCAL-scope set in DuckDB 1.5.5, read from duckdb_settings().
+	// Three of these name a file DuckDB writes (profile_output,
+	// profiling_output, http_logging_output); the rest are profiling, progress
+	// bar, schema resolution, buffer sizing, and optimiser toggles. None opens
+	// a file of the query's choosing for reading.
+	known := map[string]bool{
+		"custom_profiling_settings": true,
+		"debug_force_external":      true,
+		"enable_caching_operators":  true,
+		"enable_http_logging":       true,
+		"enable_profiling":          true,
+		"enable_progress_bar":       true,
+		"enable_progress_bar_print": true,
+		"http_logging_output":       true,
+		"profile_output":            true,
+		"profiling_coverage":        true,
+		"profiling_mode":            true,
+		"profiling_output":          true,
+		"progress_bar_time":         true,
+		"schema":                    true,
+		"search_path":               true,
+		"streaming_buffer_size":     true,
+	}
+
+	db := openRawDuckDB(t)
+	rows, err := db.Query("SELECT name FROM duckdb_settings() WHERE scope = 'LOCAL' ORDER BY name")
+	if err != nil {
+		t.Fatalf("list LOCAL settings: %v", err)
+	}
+	defer rows.Close()
+
+	var unexpected []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan setting name: %v", err)
+		}
+		if !known[name] {
+			unexpected = append(unexpected, name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate LOCAL settings: %v", err)
+	}
+	if len(unexpected) > 0 {
+		t.Errorf("new LOCAL-scope settings present: %v\n"+
+			"If any of these gates file access, DuckDB now has a per-connection knob that could "+
+			"scope a query without a second instance: %s", unexpected, reopen641)
+	}
+
+	// The one LOCAL setting that names a written file must still be gated by
+	// the sandbox, otherwise it is a post-lockdown write primitive.
+	t.Run("profile_output is still sandboxed", func(t *testing.T) {
+		scoped := openRawDuckDB(t)
+		root := t.TempDir()
+		if err := allowDir(t, scoped, filepath.Join(root, "allowed")); err != nil {
+			t.Fatalf("set allowlist: %v", err)
+		}
+		lockdown(t, scoped)
+
+		outside := filepath.Join(root, "outside", "profile.json")
+		if _, err := scoped.Exec("SET enable_profiling = 'json'"); err != nil {
+			t.Fatalf("enable profiling: %v", err)
+		}
+		if _, err := scoped.Exec(fmt.Sprintf("SET profile_output = '%s'", escapeSQLString(outside))); err != nil {
+			t.Fatalf("set profile_output: %v", err)
+		}
+
+		var n int
+		err := scoped.QueryRow("SELECT count(*) FROM range(0, 10)").Scan(&n)
+		if _, statErr := os.Stat(outside); statErr == nil {
+			t.Errorf("profile_output wrote %s outside the allowlist (query err: %v); a LOCAL "+
+				"setting is now a post-lockdown write primitive: %s", outside, err, reopen641)
+		}
+	})
+}
+
+func currentSetting(t *testing.T, db *sql.DB, name string) string {
+	t.Helper()
+	var v string
+	if err := db.QueryRow(fmt.Sprintf("SELECT current_setting('%s')", escapeSQLString(name))).Scan(&v); err != nil {
+		t.Fatalf("read setting %s: %v", name, err)
+	}
+	return v
+}


### PR DESCRIPTION
Closes the design half of #641. **No behaviour change**: this adds a design note, tests that pin the DuckDB constraints the design decision rests on, and a release-notes entry.

## What #641 asked

Arc locks DuckDB down once at startup (`internal/database/sandbox.go`): `allowed_directories` is set to every prefix the deployment needs, then `enable_external_access` is set false. The allowlist is therefore the union of all tenants' directories for the life of the process, so a token that got past `ValidateSQLRequest` would be bounded by the deployment rather than by the databases it is allowed to read. #641 asked whether the allowlist could be narrowed per query.

The issue anticipated this being the hard part: its scope section says per-query scoping needs "a mechanism that doesn't reopen/reconfigure the handle per request, **or an alternative enforcement point. Design work required**." This is that design work.

## The answer

It cannot be done on the handle Arc runs queries through. Measured against the DuckDB this repo ships (duckdb-go/v2 v2.10505.0, DuckDB 1.5.5):

| constraint | evidence |
|---|---|
| `allowed_directories` is GLOBAL-only | `SET SESSION` gives `Catalog Error: option "allowed_directories" cannot be set locally`; no connection scope exists |
| immutable after lockdown | narrowing and `RESET` give `Cannot change allowed_directories when enable_external_access is disabled`; re-enabling gives `Cannot enable external access while database is running` |
| inert *before* lockdown | with the allowlist narrowed but external access still on, a non-allowlisted read succeeds |
| not settable in the DSN | `could not set invalid or local option for global database config` |
| no LOCAL-scope file access | all 16 LOCAL settings are profiling, progress bar, schema, buffer sizing, caching, HTTP logging, `debug_force_external` |
| scoped per instance | two instances each deny the other's directory |

So per-query scoping is reachable only by routing the query to a different DuckDB instance.

## Why the instance pool is not built

The structural reason, not the cost: the routing key could only come from `extractTableReferences`, which skips anything followed by `(` and whose empty result short-circuits `checkQueryPermissions`. #641's own acceptance criterion says to test with validation stubbed, and with validation stubbed the attack query is a bare `read_parquet('...')`, which yields **no key at all**. The queries the feature exists to contain are exactly the ones the routing decision cannot see.

It would also have missed dispatch sites (the parallel executor holds a separately captured `*sql.DB` from `db.DB()`) and enforced nothing on the arcx engine, which reads files in Go. Independently, DuckDB spawns one OS worker thread per configured thread with `thread_count` defaulting to `NumCPU`, `memory_limit` is per instance, and the credential refreshers are keyed by secret name such that a second instance would stop the first one's refresher.

The note also costs out the cheaper variant on its own terms (a single storage-less instance for unkeyed queries), since none of those objections apply to it. Its soundness invariant was measured against Arc's real extractor and transform rather than assumed.

## `lock_configuration` was evaluated and rejected

It looked like free hardening: after lockdown `SET GLOBAL disabled_filesystems='LocalFileSystem'` still succeeds and bricks the instance for its own reads, and `lock_configuration` blocks that. It is rejected because it also permanently blocks the `parquet_metadata_cache` toggle `ClearHTTPCache` runs after every delete, compaction and retention pass to drop metadata pointing at deleted files. `PRAGMA enable_object_cache` survives the lock but is inert, so 1.5.5 offers no substitute. Enabling it would trade a hardening only reachable after another control has already failed for a correctness regression operators would hit on every delete.

## Acceptance criteria

- [x] Design note: where per-query scoping is enforced given the shared handle constraint
- [ ] A query authorized for `db1.cpu` cannot read a `db2` file under a stubbed validator
- [ ] Local, S3 and Azure backends all scoped
- [ ] No regression on legitimate cross-measurement / JOIN queries

The last three are not met, because the feature is not built. They carry forward to the follow-up issue against the enforcement point the note recommends (a Go-side assertion that every path literal in the rewritten SQL is one Arc emitted), which covers both query classes and both execution engines at one insertion point instead of fourteen.

## Testing

`TestSandboxScopingConstraints` pins constraints 1, 2, 3 and 6; `TestNoLocalScopeSettingAffectsFileAccess` pins constraint 5 including that the sandbox still gates `profile_output`; `TestLockConfigurationStillBlocksCacheInvalidation` pins the cache-invalidation trade-off. Every assertion is deliberately "this is still impossible", so a failure means the constraint lifted and #641 should be reopened; each failure message says so.

Every assertion was mutation-tested against a version with the constraint removed. Full `internal/database` suite: 5.68s with these tests, 5.43s without.