### PR TITLE
fix(backup): report data files no listing returns (#756)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -268,6 +268,58 @@ is published. Responsibly reported by **[@rexpository](https://github.com/rexpos
 
 ## Bug fixes
 
+### A backup no longer reports success while silently omitting files ([#756](https://github.com/Basekick-Labs/arc/issues/756))
+
+A backup could finish, report success, and be missing data files that exist in
+storage, with nothing anywhere saying so.
+
+Listings deliberately hide a file whose key does not follow the storage key
+rules, because handing that key back turns every read that follows into a
+failure. On local storage those hidden files are not debris: they are real
+Parquet files holding real rows, and the query path still returns those rows,
+because it matches files on the filesystem rather than going through the storage
+layer. So the file was queryable and invisible at the same time.
+
+Backup inventories what a listing returns, and everything that exists to make an
+incomplete backup visible (the skipped-file count, the "backup will be
+incomplete" warning, and the guard that fails a backup when too much of it could
+not be read) counts only files that were inventoried and then failed to copy. A
+file the listing never returned reached none of them. Before the listings
+started filtering, the same file failed loudly when the backup tried to read it,
+and was counted.
+
+Two shapes produce such a file, and both are what an older Arc wrote rather than
+anything you can create today: a filename containing a backslash, which is a
+legal filename on Linux and refused because Azure treats it as a separator, and
+a path longer than the key limit, which is reachable by nesting.
+
+What changes:
+
+- A backup now reports these files: a count and a sample of their paths in the
+  backup manifest, a warning naming them, and a metric
+  (`arc_storage_unaddressable_files_total`) so it is visible without reading a
+  manifest. The message says to rename them, which is what actually recovers the
+  data.
+- **A backup whose data files are all unaddressable now fails.** It previously
+  reported success over a backup containing nothing, because the guard that
+  catches a partial backup divides by the number of files it inventoried, and
+  that number was zero.
+- Storage backends gained a way to enumerate what a listing hid, which is what
+  makes any of the above possible. This is the counterpart the previous release
+  already established for write-staging partials, which were hidden from
+  listings and given their own way to be found; the key-rule drop had no
+  equivalent.
+
+The enumeration is defined as what a full listing sees and the ordinary listing
+does not return, rather than by re-checking the key rules. That distinction
+found a second case: a file whose name begins with a dot passes the key rules
+and is writable and readable through the storage layer, yet listings skip it, so
+it was missing from backups too. Checking the rules again would never have
+reported it.
+
+Nothing about which files are queryable changes, and a healthy deployment
+reports nothing.
+
 ### Cleanup and replication loops no longer retry an unusable storage key forever ([#747](https://github.com/Basekick-Labs/arc/issues/747))
 
 [#743](https://github.com/Basekick-Labs/arc/issues/743) made a refused storage

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -13,6 +13,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/basekick-labs/arc/internal/metrics"
 	"github.com/basekick-labs/arc/internal/storage"
 )
 
@@ -98,6 +99,14 @@ func (m *Manager) CreateBackup(ctx context.Context, opts BackupOptions) (*Backup
 		return nil, fmt.Errorf("storage backend does not support ListObjects")
 	}
 
+	// Enumerate the hidden set FIRST, and the inventory second. The two are
+	// separate passes, so a file renamed between them is seen by one or the
+	// other depending on the order: this way a key fixed mid-backup is reported
+	// as unaddressable AND copied, which is a spurious warning. The reverse
+	// order loses it from both, which is silently the very bug this guards
+	// against (#756).
+	unaddressable := m.findUnaddressable(ctx, progress)
+
 	objects, err := objectLister.ListObjects(ctx, "")
 	if err != nil {
 		progress.Status = "failed"
@@ -120,6 +129,19 @@ func (m *Manager) CreateBackup(ctx context.Context, opts BackupOptions) (*Backup
 		case isIcebergMetadata(obj.Path):
 			icebergMetaFiles = append(icebergMetaFiles, obj)
 		}
+	}
+
+	// MEDIUM: decide the fatal case before doing any work. Copying every
+	// Iceberg metadata file and only then failing would leave a half-written
+	// backupID/data/... tree in backup storage with no manifest, which
+	// ListBackups keys on and therefore can neither show nor clean up.
+	if len(unaddressable) > 0 && len(parquetFiles) == 0 {
+		err := fmt.Errorf("backup failed: all %d data file(s) in source storage have a key that cannot be addressed, so the backup would contain no data; rename them to conform to the storage key rules (see the log for paths)", len(unaddressable))
+		m.logger.Error().Int("unaddressable", len(unaddressable)).
+			Strs("sample", sampleUnaddressable(unaddressable)).Msg(err.Error())
+		progress.Status = "failed"
+		progress.Error = err.Error()
+		return nil, err
 	}
 
 	// Build manifest inventory
@@ -198,6 +220,10 @@ func (m *Manager) CreateBackup(ctx context.Context, opts BackupOptions) (*Backup
 		progress.Error = err.Error()
 		return nil, err
 	}
+
+	// Record files that could never be copied because no listing returns them.
+	// The fatal case was decided before any copying began.
+	m.recordUnaddressable(manifest, unaddressable, len(parquetFiles))
 
 	// ── 3. Copy SQLite metadata ─────────────────────────────────────────
 	if opts.IncludeMetadata && m.sqliteDBPath != "" {
@@ -331,6 +357,113 @@ func (m *Manager) copyDataFiles(ctx context.Context, backupID string, files []st
 		Msg("Files skipped during backup — backup will be incomplete")
 
 	return nil
+}
+
+// findUnaddressable inventories data files that exist in source storage but
+// that no listing returns, so nothing driven by a listing could copy them.
+//
+// Filtered with the same rule the inventory uses, because the storage layer
+// reports everything a listing hid and only what a backup would have carried is
+// the operator's loss: OS debris such as .DS_Store is hidden for good reason and
+// naming it here would cry wolf on every macOS deployment.
+//
+// A backend that cannot enumerate them contributes nothing, which is correct
+// rather than optimistic: it is the same position every caller was in before.
+func (m *Manager) findUnaddressable(ctx context.Context, progress *Progress) []storage.UnusableObject {
+	lister, ok := m.dataStorage.(storage.UnusableLister)
+	if !ok {
+		// Not clean, unchecked. Said out loud so a zero in the manifest is not
+		// read as a guarantee.
+		m.logger.Debug().Msg("Storage backend cannot enumerate hidden files; the backup cannot confirm it is complete")
+		return nil
+	}
+	hidden, err := lister.ListUnusable(ctx, "")
+	if err != nil {
+		// Not fatal: failing the backup because the diagnostic failed would be
+		// worse than the gap it reports. Loud, because the count is now part of
+		// whether the backup can call itself complete.
+		m.logger.Warn().Err(err).Msg("Could not check for unaddressable files; the backup cannot confirm it is complete")
+		return nil
+	}
+	var out []storage.UnusableObject
+	for _, o := range hidden {
+		if isBackupPayload(o.Path) {
+			out = append(out, o)
+		}
+	}
+	// Set unconditionally, including 0: the gauge describes the store as of the
+	// backup that just ran, so a deployment that fixed its keys must see it
+	// fall back to zero rather than stay latched on the first bad file.
+	metrics.Get().SetStorageUnaddressableFiles(int64(len(out)))
+	if len(out) > 0 {
+		atomic.AddInt64(&progress.UnaddressableFiles, int64(len(out)))
+	}
+	return out
+}
+
+// isBackupPayload reports whether a path is something CreateBackup would have
+// copied had it been addressable, and therefore something whose absence is the
+// operator's loss.
+//
+// It mirrors the inventory split above, and deliberately covers more than
+// ".parquet". Iceberg metadata is the reason that split exists at all: losing a
+// metadata.json or .avro loses a whole table even when every Parquet file it
+// references survives, so an unaddressable one is worse than an unaddressable
+// data file, not lesser. And a ".parquet.part" key on an object store is an
+// ordinary committed object there (S3 and Azure do not stage), which the
+// storage layer reports precisely because nothing else can name it.
+func isBackupPayload(p string) bool {
+	if isIcebergMetadata(p) {
+		return true
+	}
+	return strings.HasSuffix(strings.TrimSuffix(p, storage.PartSuffix), ".parquet")
+}
+
+// unaddressableSampleCap bounds how many paths land in the manifest. The
+// manifest is one JSON blob written to storage, and the over-length key shape
+// makes each path up to a kilobyte, so an unbounded list could dwarf the
+// manifest it is reported in.
+const unaddressableSampleCap = 32
+
+// recordUnaddressable puts the finding in the manifest and decides whether the
+// run may still call itself a complete backup.
+//
+// Deliberately NOT folded into checkSkipRatio. That guard exists for a
+// transient race (a file compaction removed between listing and copy), its
+// denominator is the addressable inventory, and it short-circuits when
+// SkippedFiles is zero, which is exactly the case here. Worse, its ratio would
+// hard-fail a nine-file deployment with one legacy file forever, and its
+// message sends the operator to diagnose storage rather than rename a file.
+func (m *Manager) recordUnaddressable(manifest *Manifest, unaddressable []storage.UnusableObject, addressableFiles int) {
+	if len(unaddressable) == 0 {
+		return
+	}
+
+	manifest.UnaddressableFiles = int64(len(unaddressable))
+	for i, o := range unaddressable {
+		if i == unaddressableSampleCap {
+			break
+		}
+		manifest.UnaddressableSample = append(manifest.UnaddressableSample, o.Path)
+	}
+
+	m.logger.Warn().
+		Int("unaddressable", len(unaddressable)).
+		Int("addressable", addressableFiles).
+		Strs("sample", manifest.UnaddressableSample).
+		Msg("Backup is incomplete: these files exist in storage but their key cannot be addressed, so they were not copied; rename them to conform to the storage key rules")
+}
+
+// sampleUnaddressable bounds a path list for logging, same cap as the manifest.
+func sampleUnaddressable(objs []storage.UnusableObject) []string {
+	out := make([]string, 0, unaddressableSampleCap)
+	for i, o := range objs {
+		if i == unaddressableSampleCap {
+			break
+		}
+		out = append(out, o.Path)
+	}
+	return out
 }
 
 // checkSkipRatio fails the backup when too large a fraction of it was unreadable.

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -20,7 +20,16 @@ type Manifest struct {
 	// incomplete: TotalFiles/TotalSizeBytes describe what was inventoried, not
 	// what was actually stored.
 	SkippedFiles int64 `json:"skipped_files,omitempty"`
-	HasMetadata  bool  `json:"has_metadata"`
+	// UnaddressableFiles counts data files that exist in source storage but
+	// that no listing returns, because their key fails the storage key rules.
+	// They were never inventoried and could not be copied, so when this is
+	// non-zero the backup is incomplete in a way SkippedFiles does not describe:
+	// those were listed and then unreadable, these were never listable at all
+	// (#756). UnaddressableSample names up to 32 of them so an operator can find
+	// and rename them.
+	UnaddressableFiles  int64    `json:"unaddressable_files,omitempty"`
+	UnaddressableSample []string `json:"unaddressable_sample,omitempty"`
+	HasMetadata         bool     `json:"has_metadata"`
 	// HasIcebergCatalog records that the Iceberg SQL catalog was stored as a
 	// separate database (metadata/iceberg-catalog.db) because the operator
 	// configured iceberg.catalog_db_path away from the shared database. When
@@ -56,17 +65,19 @@ type BackupSummary struct {
 
 // Progress tracks the state of a running backup or restore operation.
 type Progress struct {
-	Operation      string     `json:"operation"` // "backup" or "restore"
-	BackupID       string     `json:"backup_id"`
-	Status         string     `json:"status"` // "running", "completed", "failed"
-	TotalFiles     int64      `json:"total_files"`
-	ProcessedFiles int64      `json:"processed_files"`
-	SkippedFiles   int64      `json:"skipped_files"`
-	TotalBytes     int64      `json:"total_bytes"`
-	ProcessedBytes int64      `json:"processed_bytes"`
-	StartedAt      time.Time  `json:"started_at"`
-	CompletedAt    *time.Time `json:"completed_at,omitempty"`
-	Error          string     `json:"error,omitempty"`
+	Operation      string `json:"operation"` // "backup" or "restore"
+	BackupID       string `json:"backup_id"`
+	Status         string `json:"status"` // "running", "completed", "failed"
+	TotalFiles     int64  `json:"total_files"`
+	ProcessedFiles int64  `json:"processed_files"`
+	SkippedFiles   int64  `json:"skipped_files"`
+	// UnaddressableFiles mirrors Manifest.UnaddressableFiles for live progress.
+	UnaddressableFiles int64      `json:"unaddressable_files,omitempty"`
+	TotalBytes         int64      `json:"total_bytes"`
+	ProcessedBytes     int64      `json:"processed_bytes"`
+	StartedAt          time.Time  `json:"started_at"`
+	CompletedAt        *time.Time `json:"completed_at,omitempty"`
+	Error              string     `json:"error,omitempty"`
 }
 
 // MarshalManifest serializes a manifest to JSON.

--- a/internal/backup/unaddressable_test.go
+++ b/internal/backup/unaddressable_test.go
@@ -1,0 +1,225 @@
+package backup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/basekick-labs/arc/internal/storage"
+)
+
+// writeRaw puts a file straight on disk, bypassing Backend.Write, because the
+// whole point is a file whose key Backend cannot address.
+func writeRaw(t *testing.T, root, rel, body string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+		t.Skipf("filesystem will not hold %q: %v", rel, err)
+	}
+}
+
+func newBackupManager(t *testing.T, dataDir string) *Manager {
+	t.Helper()
+	data, err := storage.NewLocalBackend(dataDir, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := NewManager(&ManagerConfig{
+		DataStorage: data,
+		BackupPath:  t.TempDir(),
+		Logger:      zerolog.Nop(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+// A backup that could not copy a file which exists in storage must say so.
+//
+// This is the regression for #756 and it fails against the code before it. The
+// file is a real Parquet file holding rows, the query path still serves it, and
+// every mechanism that makes an incomplete backup visible (SkippedFiles, the
+// "backup will be incomplete" warning, checkSkipRatio) reads the inventory,
+// which by construction cannot contain it. The backup copied one file out of
+// two and reported a clean success.
+func TestBackupReportsFilesItCouldNotAddress(t *testing.T) {
+	dataDir := t.TempDir()
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/good.parquet", "PAR1-good")
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/ba\\d.parquet", "PAR1-rows-that-exist")
+
+	m := newBackupManager(t, dataDir)
+	res, err := m.CreateBackup(context.Background(), BackupOptions{})
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+
+	if res.Manifest.TotalFiles != 1 {
+		t.Fatalf("premise: exactly one file is addressable, got TotalFiles=%d", res.Manifest.TotalFiles)
+	}
+	if res.Manifest.UnaddressableFiles != 1 {
+		t.Errorf("UnaddressableFiles = %d, want 1; the backup is missing a file and does not say so",
+			res.Manifest.UnaddressableFiles)
+	}
+	if len(res.Manifest.UnaddressableSample) != 1 ||
+		!strings.Contains(res.Manifest.UnaddressableSample[0], "ba\\d.parquet") {
+		t.Errorf("UnaddressableSample = %v, want it to name the file so an operator can find it",
+			res.Manifest.UnaddressableSample)
+	}
+}
+
+// The case the skip-ratio guard structurally cannot see: every data file is
+// unaddressable, so the inventory is empty, so `totalFiles == 0` short-circuits
+// and the run reports completed over a backup containing no data at all.
+func TestBackupFailsWhenNoDataFileIsAddressable(t *testing.T) {
+	dataDir := t.TempDir()
+	for _, name := range []string{"a", "b", "c"} {
+		writeRaw(t, dataDir, "db/cpu/2026/09/12/13/"+name+"\\x.parquet", "PAR1-rows")
+	}
+
+	m := newBackupManager(t, dataDir)
+	_, err := m.CreateBackup(context.Background(), BackupOptions{})
+	if err == nil {
+		t.Fatal("a backup containing no data must fail, not report success")
+	}
+	if !strings.Contains(err.Error(), "cannot be addressed") {
+		t.Errorf("error %q should name the cause and the remedy", err)
+	}
+	if p := m.GetProgress(); p != nil && p.Status == "completed" {
+		t.Errorf("progress status = %q, want it not to be completed", p.Status)
+	}
+}
+
+// A healthy store reports nothing, so the field stays absent from the manifest
+// JSON and this cannot cry wolf on every deployment.
+func TestBackupReportsNothingOnAHealthyStore(t *testing.T) {
+	dataDir := t.TempDir()
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/good.parquet", "PAR1-good")
+	// In-flight write and an ordinary staging partial: both are normal and
+	// neither is a file an operator lost.
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/.arc-9988.tmp", "in-flight")
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/good.parquet.part", "staging")
+
+	m := newBackupManager(t, dataDir)
+	res, err := m.CreateBackup(context.Background(), BackupOptions{})
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+	if res.Manifest.UnaddressableFiles != 0 {
+		t.Errorf("UnaddressableFiles = %d on a healthy store, want 0 (sample: %v)",
+			res.Manifest.UnaddressableFiles, res.Manifest.UnaddressableSample)
+	}
+	if res.Manifest.TotalFiles != 1 {
+		t.Errorf("TotalFiles = %d, want 1", res.Manifest.TotalFiles)
+	}
+}
+
+// Non-data debris is hidden from listings for good reason and must not be
+// reported as data loss.
+func TestBackupIgnoresNonDataDebris(t *testing.T) {
+	dataDir := t.TempDir()
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/good.parquet", "PAR1-good")
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/.DS_Store", "macos debris")
+
+	m := newBackupManager(t, dataDir)
+	res, err := m.CreateBackup(context.Background(), BackupOptions{})
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+	if res.Manifest.UnaddressableFiles != 0 {
+		t.Errorf("UnaddressableFiles = %d, want 0; .DS_Store is not data (sample: %v)",
+			res.Manifest.UnaddressableFiles, res.Manifest.UnaddressableSample)
+	}
+}
+
+// The sample is bounded: the over-length key shape makes each path up to a
+// kilobyte, and the manifest is a single JSON blob.
+func TestUnaddressableSampleIsBounded(t *testing.T) {
+	dataDir := t.TempDir()
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/good.parquet", "PAR1-good")
+	for i := 0; i < unaddressableSampleCap+10; i++ {
+		writeRaw(t, dataDir, "db/cpu/2026/09/12/13/b"+string(rune('a'+i%26))+strings.Repeat("z", i)+"\\x.parquet", "rows")
+	}
+
+	m := newBackupManager(t, dataDir)
+	res, err := m.CreateBackup(context.Background(), BackupOptions{})
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+	if res.Manifest.UnaddressableFiles <= int64(unaddressableSampleCap) {
+		t.Fatalf("premise: need more than the cap, got %d", res.Manifest.UnaddressableFiles)
+	}
+	if len(res.Manifest.UnaddressableSample) != unaddressableSampleCap {
+		t.Errorf("sample length = %d, want it capped at %d",
+			len(res.Manifest.UnaddressableSample), unaddressableSampleCap)
+	}
+}
+
+// Iceberg metadata is a backup payload too, and an unaddressable one is worse
+// than an unaddressable data file: losing a metadata.json loses a whole table
+// even when every Parquet file it references survives. A ".parquet"-only filter
+// on the hidden set threw these away, so they were reported by nothing at all.
+func TestBackupReportsUnaddressableIcebergMetadata(t *testing.T) {
+	dataDir := t.TempDir()
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/good.parquet", "PAR1-good")
+	writeRaw(t, dataDir, "arc_db.db/cpu/metadata/00001-ba\\d.metadata.json", "{\"iceberg\":true}")
+
+	m := newBackupManager(t, dataDir)
+	res, err := m.CreateBackup(context.Background(), BackupOptions{})
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+	if res.Manifest.UnaddressableFiles != 1 {
+		t.Fatalf("UnaddressableFiles = %d, want 1; unaddressable Iceberg metadata must be reported (sample %v)",
+			res.Manifest.UnaddressableFiles, res.Manifest.UnaddressableSample)
+	}
+	if len(res.Manifest.UnaddressableSample) != 1 ||
+		!strings.Contains(res.Manifest.UnaddressableSample[0], "metadata.json") {
+		t.Errorf("sample = %v, want it to name the metadata file", res.Manifest.UnaddressableSample)
+	}
+}
+
+// The fatal case must be decided before any copying, or a run that is going to
+// fail still writes a partial backupID/data/ tree that ListBackups can neither
+// show nor clean up, because it keys on the manifest that never gets written.
+func TestNoDataFailureLeavesNothingBehind(t *testing.T) {
+	dataDir := t.TempDir()
+	writeRaw(t, dataDir, "db/cpu/2026/09/12/13/a\\x.parquet", "PAR1-rows")
+	// Iceberg metadata IS addressable, so the old ordering would have copied it
+	// all and only then failed.
+	writeRaw(t, dataDir, "arc_db.db/cpu/metadata/00001-x.metadata.json", "{}")
+
+	backupDir := t.TempDir()
+	data, err := storage.NewLocalBackend(dataDir, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := NewManager(&ManagerConfig{DataStorage: data, BackupPath: backupDir, Logger: zerolog.Nop()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := m.CreateBackup(context.Background(), BackupOptions{}); err == nil {
+		t.Fatal("a backup with no addressable data file must fail")
+	}
+
+	// Nothing copied means nothing to orphan.
+	dest, err := storage.NewLocalBackend(backupDir, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := dest.List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("List backup dir: %v", err)
+	}
+	if len(left) != 0 {
+		t.Errorf("the failed run left %v in backup storage, with no manifest to find it by", left)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -156,6 +156,16 @@ type Metrics struct {
 	// this counter is the only place the condition is aggregated.
 	storageInvalidPathQuarantinedTotal atomic.Int64
 
+	// storageUnaddressableFiles is how many data files the MOST RECENT backup
+	// found in source storage that no listing returns, so nothing could copy
+	// them (#756).
+	//
+	// A gauge, not a counter, and the distinction is what makes it alertable:
+	// the condition is a property of the store right now, and renaming the
+	// files has to clear it. A counter would keep the alert firing forever
+	// after the first bad file, including after the operator fixed it.
+	storageUnaddressableFiles atomic.Int64
+
 	// Cluster auth metrics (Enterprise only — mutated on every FSM apply
 	// of a token command). clusterAuthApplyTotal increments per applied
 	// command type so operators can see "create vs update vs revoke"
@@ -416,6 +426,13 @@ func (m *Metrics) IncClusterManifestRejectedPaths() { m.clusterManifestRejectedP
 // to counting it here is a loop that retries the same key forever.
 func (m *Metrics) IncStorageInvalidPathQuarantined() { m.storageInvalidPathQuarantinedTotal.Add(1) }
 
+// SetStorageUnaddressableFiles records how many data files the backup that just
+// ran could not copy because no listing returns them (#756). Called on every
+// backup including with 0, so fixing the files clears the gauge.
+func (m *Metrics) SetStorageUnaddressableFiles(n int64) {
+	m.storageUnaddressableFiles.Store(n)
+}
+
 // Cluster Auth metrics — incremented from the FSM apply path on every
 // Token command. apply_* counts successful applies per type;
 // IncClusterAuthRejected counts applier-side validation refusals.
@@ -603,6 +620,7 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 		// Cluster FSM security (Enterprise)
 		"cluster_manifest_rejected_paths_total":  m.clusterManifestRejectedPathsTotal.Load(),
 		"storage_invalid_path_quarantined_total": m.storageInvalidPathQuarantinedTotal.Load(),
+		"storage_unaddressable_files":            m.storageUnaddressableFiles.Load(),
 
 		// Cluster Auth (Enterprise, Phase A)
 		"cluster_auth_apply_create_total": m.clusterAuthApplyCreateTotal.Load(),
@@ -962,6 +980,10 @@ func (m *Metrics) PrometheusFormat() string {
 	b = append(b, "# HELP arc_storage_invalid_path_quarantined_total Total entries dropped from a cleanup, reconciliation or replication work set because a storage key was permanently unusable. Non-zero growth means a stored key (compaction manifest, cluster manifest entry, edge-sync ledger row) names something no storage backend can address; the entry is no longer retried and needs operator action.\n"...)
 	b = append(b, "# TYPE arc_storage_invalid_path_quarantined_total counter\n"...)
 	b = appendMetric(b, "arc_storage_invalid_path_quarantined_total", float64(m.storageInvalidPathQuarantinedTotal.Load()))
+
+	b = append(b, "# HELP arc_storage_unaddressable_files Data files the most recent backup found in source storage that no listing returns, so they could not be copied. Non-zero means that backup is incomplete: the files exist and the query path still serves them, but their key does not conform to the storage key rules and no backend method can address one. Rename them and the next backup clears this.\n"...)
+	b = append(b, "# TYPE arc_storage_unaddressable_files gauge\n"...)
+	b = appendMetric(b, "arc_storage_unaddressable_files", float64(m.storageUnaddressableFiles.Load()))
 
 	// Cluster Auth metrics (Enterprise, Phase A — Cluster Auth Convergence).
 	// apply_* counters increment per applied token command, per node — so

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -656,6 +656,62 @@ func (b *AzureBlobBackend) ListObjects(ctx context.Context, prefix string) ([]Ob
 	return objects, nil
 }
 
+// ListUnusable implements UnusableLister.
+//
+// Returns exactly what ListObjects drops, so the two partition the container.
+// Like S3 and unlike local, ".part" blobs are reported: Azure does not stage
+// writes and does not implement StagingInspector, so such a blob is an ordinary
+// committed object that #744's reserved suffix made unaddressable.
+func (b *AzureBlobBackend) ListUnusable(ctx context.Context, prefix string) ([]UnusableObject, error) {
+	var objects []UnusableObject
+
+	containerClient := b.client.ServiceClient().NewContainerClient(b.containerName)
+	pager := containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
+		Prefix: &prefix,
+	})
+
+	for pager.More() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list Azure blobs: %w", err)
+		}
+
+		for _, blobItem := range page.Segment.BlobItems {
+			if blobItem.Name == nil {
+				continue
+			}
+			reason := ValidateKey(*blobItem.Name)
+			if reason == nil {
+				continue // ListObjects returns it
+			}
+			info := UnusableObject{Path: *blobItem.Name, Err: reason}
+			if blobItem.Properties != nil {
+				if blobItem.Properties.ContentLength != nil {
+					info.Size = *blobItem.Properties.ContentLength
+				}
+				if blobItem.Properties.LastModified != nil {
+					info.LastModified = *blobItem.Properties.LastModified
+				}
+			}
+			// Zero-length directory-marker blob. Heuristic, same as S3: the
+			// suffix alone is not proof, so the size is part of the test.
+			// Note ADLS Gen2 hierarchical-namespace directories do NOT carry a
+			// trailing separator, but they also pass ValidateKey, so they never
+			// reach here.
+			if info.Size == 0 && strings.HasSuffix(info.Path, "/") {
+				continue
+			}
+			objects = append(objects, info)
+		}
+	}
+
+	return objects, nil
+}
+
 // isAzureNotFoundError checks if an error indicates the blob doesn't exist
 func isAzureNotFoundError(err error) bool {
 	if err == nil {

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -137,6 +137,54 @@ type ObjectLister interface {
 	ListObjects(ctx context.Context, prefix string) ([]ObjectInfo, error)
 }
 
+// UnusableObject is an object that exists in the store but that no listing
+// returns, so nothing driven by a listing can see it.
+type UnusableObject struct {
+	Path         string
+	Size         int64
+	LastModified time.Time
+	// Err is why the object is unlistable. It wraps ErrInvalidPath when the
+	// key contract is the reason, so callers can classify with errors.Is the
+	// way the reconciliation sweeps do.
+	Err error
+}
+
+// UnusableLister enumerates objects that ListObjects deliberately hides.
+//
+// Listings drop keys the backend would then refuse, because handing one back
+// turns every List-then-Read caller into a failure (#743, #744). That is the
+// right trade for the caller and the wrong one for the operator: on local
+// storage the dropped entries are real Parquet files holding real rows, the
+// query path still serves them because read_parquet globs the filesystem, and
+// nothing anywhere could name them. A backup would then omit them and report
+// success, which is the failure #743's own commit message called worse than the
+// bug it was fixing.
+//
+// This is the counterpart #744 already established for the case it created:
+// when it hid write-staging partials it added ListStaged to reclaim them. The
+// contract drop had no equivalent (#756).
+//
+// The set is defined by OBSERVATION, not by predicate: it is what a full
+// listing sees and ListObjects does not return. Re-deriving it from ValidateKey
+// would miss the entries a listing skips for other reasons, and would drift
+// again the next time a listing grows a filter.
+//
+// Excluded, because they are provably not data an operator can lose:
+//   - Arc's own in-flight ".arc-*.tmp" writes, which is why listings skip
+//     dot-prefixed names at all.
+//   - On backends that stage, a ".part" staging path for an addressable key.
+//     That covers an in-flight WriteReader and an abandoned partial alike, and
+//     reporting either would be a permanent false alarm carrying advice that
+//     would publish a truncated file. Object stores do not stage, so a ".part"
+//     key there is an ordinary committed object and IS reported.
+type UnusableLister interface {
+	Backend
+
+	// ListUnusable returns objects under prefix that ListObjects omits.
+	// An empty result is the healthy case.
+	ListUnusable(ctx context.Context, prefix string) ([]UnusableObject, error)
+}
+
 // DirectoryRemover removes an empty directory.
 // This is used to clean up database directories after all files are deleted.
 // For object storage (S3, Azure), this is typically a no-op since directories don't exist as objects.

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -457,11 +457,6 @@ func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error
 			return nil
 		}
 
-		// Skip hidden files (e.g., .DS_Store on macOS)
-		if strings.HasPrefix(d.Name(), ".") {
-			return nil
-		}
-
 		// Get relative path from base
 		relPath, err := filepath.Rel(b.basePath, path)
 		if err != nil {
@@ -473,8 +468,9 @@ func (b *LocalBackend) List(ctx context.Context, prefix string) ([]string, error
 		// since #744 that includes write-staging partials: they are not
 		// objects, and returning one gave every List-then-Read caller a key
 		// that fails. StagingInspector.ListStaged is how an abandoned partial
-		// is found.
-		if ValidateKey(relPath) != nil {
+		// is found, and ListUnusable is how everything else dropped here is
+		// found (#756).
+		if omittedFromListing(d.Name(), relPath) != nil {
 			return nil
 		}
 
@@ -582,13 +578,12 @@ func (b *LocalBackend) ListDirectories(ctx context.Context, prefix string) ([]st
 	var dirs []string
 	for _, entry := range entries {
 		if entry.IsDir() {
-			// Skip hidden directories
-			if strings.HasPrefix(entry.Name(), ".") {
-				continue
-			}
 			// Callers join this name into a key, so a name the contract would
-			// refuse produces an unusable key. Same rule as List (#743).
-			if ValidateKey(entry.Name()) != nil {
+			// refuse produces an unusable key. Same rule as List (#743), and
+			// the same function, so the four listings cannot drift apart about
+			// what they drop (#756). A directory name is one segment, so it is
+			// both the base name and the relative path here.
+			if omittedFromListing(entry.Name(), entry.Name()) != nil {
 				continue
 			}
 			dirs = append(dirs, entry.Name())
@@ -673,11 +668,6 @@ func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]Object
 			return nil
 		}
 
-		// Skip hidden files
-		if strings.HasPrefix(d.Name(), ".") {
-			return nil
-		}
-
 		// Get relative path from base
 		relPath, err := filepath.Rel(b.basePath, path)
 		if err != nil {
@@ -686,7 +676,7 @@ func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]Object
 		relPath = filepath.ToSlash(relPath)
 		// See List: a listing never returns a key this backend would refuse,
 		// which since #744 includes write-staging partials.
-		if ValidateKey(relPath) != nil {
+		if omittedFromListing(d.Name(), relPath) != nil {
 			return nil
 		}
 
@@ -717,6 +707,39 @@ func (b *LocalBackend) ListObjects(ctx context.Context, prefix string) ([]Object
 	}
 
 	return results, nil
+}
+
+// errHiddenName marks an entry a listing skips because its name is
+// dot-prefixed. Not an ErrInvalidPath: the key contract accepts leading dots
+// (ValidateKeySegment does so deliberately), so this is a listing convention
+// rather than a property of the key.
+var errHiddenName = errors.New("storage: name is dot-prefixed")
+
+// omittedFromListing reports why a walked file is NOT returned by List and
+// ListObjects, or nil when it is returned.
+//
+// List, ListObjects, ListDirectories and ListUnusable all consult this one
+// function, so a listing and the enumeration of what that listing hid cannot
+// disagree about which entries were dropped. Deriving the hidden set from ValidateKey instead
+// would miss everything skipped for another reason, and would drift again the
+// next time a listing grows a filter (#756).
+func omittedFromListing(base, relPath string) error {
+	// Dot-prefixed names cover Arc's own in-flight ".arc-*.tmp" writes and OS
+	// debris such as .DS_Store. Note it also covers dot-prefixed DATA files,
+	// which the key contract accepts, which is why this is part of the
+	// definition rather than a special case of it.
+	if strings.HasPrefix(base, ".") {
+		return errHiddenName
+	}
+	return ValidateKey(relPath)
+}
+
+// isInFlightWrite reports whether base is a temp file an in-progress Write owns.
+// Write creates these with os.CreateTemp(dir, ".arc-*.tmp"), so that is the
+// pattern, not the ".tmp.*" spelling some older comments in the tree use. They
+// are not objects and must never be reported as data an operator lost.
+func isInFlightWrite(base string) bool {
+	return strings.HasPrefix(base, ".arc-") && strings.HasSuffix(base, ".tmp")
 }
 
 // PartSuffix is appended to build the staging file a local write lands in
@@ -1028,6 +1051,108 @@ func (b *LocalBackend) DeleteStaged(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to delete staged file: %w", err)
 	}
 	return nil
+}
+
+// ListUnusable implements UnusableLister.
+//
+// It walks the same tree ListObjects walks and returns exactly what ListObjects
+// drops, so the two partition the store between them. On local these entries
+// are real files holding real rows: the query path still serves them because
+// read_parquet globs the filesystem, but no Backend method can address one and
+// no listing names one, so a backup omits them and reports success (#756).
+func (b *LocalBackend) ListUnusable(ctx context.Context, prefix string) ([]UnusableObject, error) {
+	searchPath, err := b.validateListPath(prefix)
+	if err != nil {
+		return nil, fmt.Errorf("invalid prefix: %w", err)
+	}
+
+	var results []UnusableObject
+
+	err = filepath.WalkDir(searchPath, func(path string, d os.DirEntry, err error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		// Directories are not objects. Skipping them also keeps Path from ever
+		// being "" or ".", which for the root would name the data directory.
+		if d.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(b.basePath, path)
+		if err != nil {
+			return err
+		}
+		relPath = filepath.ToSlash(relPath)
+
+		reason := omittedFromListing(d.Name(), relPath)
+		if reason == nil {
+			return nil // ListObjects returns it; not our business
+		}
+		// A write in progress owns this file and will rename it away.
+		if isInFlightWrite(d.Name()) {
+			return nil
+		}
+		// A staging path for an addressable key, which is where WriteReader
+		// parks bytes until the final rename. Excluded, and the test is the
+		// base KEY rather than whether a file currently sits at it: an
+		// in-flight compaction output and an abandoned partial both have no
+		// committed base yet, and reporting either as data an operator lost
+		// would be a permanent false alarm attached to advice ("rename it")
+		// that would publish a truncated Parquet as a committed object.
+		//
+		// The directory case is the exception. If the base name is occupied by
+		// a directory then no write to that key can ever stage here, so this is
+		// not a partial at all: it is a committed object that merely looks like
+		// one, and it is reported.
+		//
+		// Everything else with the suffix IS reported, because the base is not
+		// a key any write could use: "x.part.part" (base still ends in the
+		// reserved suffix) and ".part" alone (base is a directory prefix).
+		//
+		// The trade-off, stated plainly: a committed object written before #744
+		// reserved the suffix, whose real name is "X.part" for some valid key
+		// X, is indistinguishable from a partial for X and is excluded here.
+		// That is deliberate. The alternative reports every in-progress
+		// compaction output as data an operator lost, on every backup, forever,
+		// which is both a constant false alarm and dangerous advice. Such an
+		// object is the staging namespace collision #744 exists to prevent, and
+		// it is reachable through StagingInspector rather than through nothing
+		// (though see #762: no caller enumerates staged partials under the data
+		// root yet, and ListStaged reports them under the base key).
+		if committed, ok := strings.CutSuffix(relPath, PartSuffix); ok && ValidateKey(committed) == nil {
+			if fi, statErr := os.Stat(b.pathPrefix + committed); statErr != nil || !fi.IsDir() {
+				return nil
+			}
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		results = append(results, UnusableObject{
+			Path:         relPath,
+			Size:         info.Size(),
+			LastModified: info.ModTime(),
+			Err:          reason,
+		})
+		return nil
+	})
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []UnusableObject{}, nil
+		}
+		return nil, fmt.Errorf("failed to list unusable objects: %w", err)
+	}
+	return results, nil
 }
 
 // ListStaged implements StagingInspector.

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -875,3 +875,71 @@ func (b *S3Backend) ListObjects(ctx context.Context, prefix string) ([]ObjectInf
 
 	return objects, nil
 }
+
+// ListUnusable implements UnusableLister.
+//
+// Returns exactly what ListObjects drops, so the two partition the bucket.
+//
+// Unlike the local backend this does NOT exclude ".part" keys. S3 does not
+// stage writes and does not implement StagingInspector, so a ".part" object
+// here is an ordinary committed object that #744's reserved suffix made
+// unaddressable, and this is its only escape hatch.
+func (b *S3Backend) ListUnusable(ctx context.Context, prefix string) ([]UnusableObject, error) {
+	var objects []UnusableObject
+	var continuationToken *string
+
+	fullPrefix, err := b.prefixedListPrefix(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		result, err := b.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(b.bucket),
+			Prefix:            aws.String(fullPrefix),
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list S3 objects: %w", err)
+		}
+
+		for _, obj := range result.Contents {
+			if obj.Key == nil {
+				continue
+			}
+			key := strings.TrimPrefix(*obj.Key, b.prefix)
+			reason := ValidateKey(key)
+			if reason == nil {
+				continue // ListObjects returns it
+			}
+			var size int64
+			if obj.Size != nil {
+				size = *obj.Size
+			}
+			// A zero-length key ending in a separator is a directory marker,
+			// written by consoles and sync tools rather than by Arc, and holds
+			// no data. This is a heuristic, not a guarantee: a trailing-slash
+			// key CAN hold bytes on S3, which is why the size is part of the
+			// test rather than the suffix alone.
+			if size == 0 && strings.HasSuffix(key, "/") {
+				continue
+			}
+			info := UnusableObject{Path: key, Size: size, Err: reason}
+			if obj.LastModified != nil {
+				info.LastModified = *obj.LastModified
+			}
+			objects = append(objects, info)
+		}
+
+		if result.IsTruncated == nil || !*result.IsTruncated {
+			break
+		}
+		continuationToken = result.NextContinuationToken
+	}
+
+	return objects, nil
+}

--- a/internal/storage/unusable_objectstore_test.go
+++ b/internal/storage/unusable_objectstore_test.go
@@ -1,0 +1,163 @@
+//go:build objectstore
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// On an object store the same partition property must hold, and the two
+// exclusions have to behave the opposite way round from local:
+//
+//   - a ".part" key IS reported, because S3 does not stage writes and does not
+//     implement StagingInspector, so nothing else could ever name it;
+//   - a zero-length directory marker is NOT reported, because consoles and sync
+//     tools write those and they hold no data.
+func TestS3ListUnusablePartitionsTheBucket(t *testing.T) {
+	b := minioBackend(t)
+	ctx := context.Background()
+	const base = "unusable756"
+
+	// Written through the backend: ordinary, addressable.
+	good := base + "/cpu/2026/09/12/13/good.parquet"
+	if err := b.Write(ctx, good, []byte("PAR1")); err != nil {
+		t.Fatalf("write good: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Delete(ctx, good) })
+
+	// Written past the backend, because the contract is what refuses them.
+	unusable := []string{
+		base + "/cpu/2026/09/12/13/ba\\d.parquet", // backslash
+		base + "/cpu/2026/09/12/13/legacy.part",   // reserved suffix, committed object here
+	}
+	for _, k := range unusable {
+		if err := rawPut(t, b, k, []byte("PAR1-rows")); err != nil {
+			t.Fatalf("raw put %q: %v", k, err)
+		}
+		t.Cleanup(func() { _ = rawDelete(t, b, k) })
+	}
+	// A zero-length directory marker.
+	marker := base + "/cpu/"
+	if err := rawPut(t, b, marker, nil); err != nil {
+		t.Fatalf("raw put marker: %v", err)
+	}
+	t.Cleanup(func() { _ = rawDelete(t, b, marker) })
+
+	objs, err := b.ListObjects(ctx, base+"/")
+	if err != nil {
+		t.Fatalf("ListObjects: %v", err)
+	}
+	hidden, err := b.ListUnusable(ctx, base+"/")
+	if err != nil {
+		t.Fatalf("ListUnusable: %v", err)
+	}
+
+	listed := map[string]bool{}
+	for _, o := range objs {
+		listed[o.Path] = true
+	}
+	reported := map[string]bool{}
+	for _, o := range hidden {
+		if listed[o.Path] {
+			t.Errorf("%q is both listed and reported unusable", o.Path)
+		}
+		reported[o.Path] = true
+	}
+
+	if !listed[good] {
+		t.Errorf("the ordinary object must be listed, got %v", objs)
+	}
+	for _, k := range unusable {
+		if !reported[k] {
+			t.Errorf("%q must be reported as unusable; on S3 nothing else can name it. got %v", k, hidden)
+		}
+	}
+	if reported[marker] {
+		t.Errorf("a zero-length directory marker must not be reported as lost data")
+	}
+}
+
+// rawPut writes a key past the backend's validation, with a SigV4-signed PUT,
+// so the test can create the shapes the contract exists to refuse.
+func rawPut(t *testing.T, b *S3Backend, key string, body []byte) error {
+	t.Helper()
+	return rawS3(t, b, http.MethodPut, key, body)
+}
+
+func rawDelete(t *testing.T, b *S3Backend, key string) error {
+	t.Helper()
+	return rawS3(t, b, http.MethodDelete, key, nil)
+}
+
+func rawS3(t *testing.T, b *S3Backend, method, key string, body []byte) error {
+	t.Helper()
+	endpoint := b.endpoint
+	if endpoint == "" {
+		endpoint = "http://localhost:9000"
+	}
+	full := b.prefix + key
+	u := strings.TrimSuffix(endpoint, "/") + "/" + b.bucket + "/" + urlEscapeKey(full)
+
+	req, err := http.NewRequest(method, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	payload := sha256.Sum256(body)
+	payloadHex := hex.EncodeToString(payload[:])
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	req.Header.Set("x-amz-date", amzDate)
+	req.Header.Set("x-amz-content-sha256", payloadHex)
+	req.Header.Set("host", req.URL.Host)
+
+	canonicalURI := "/" + b.bucket + "/" + urlEscapeKey(full)
+	canonicalHeaders := fmt.Sprintf("host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n", req.URL.Host, payloadHex, amzDate)
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+	canonicalRequest := strings.Join([]string{method, canonicalURI, "", canonicalHeaders, signedHeaders, payloadHex}, "\n")
+	crHash := sha256.Sum256([]byte(canonicalRequest))
+
+	scope := dateStamp + "/us-east-1/s3/aws4_request"
+	stringToSign := strings.Join([]string{"AWS4-HMAC-SHA256", amzDate, scope, hex.EncodeToString(crHash[:])}, "\n")
+
+	mac := func(k, d []byte) []byte { h := hmac.New(sha256.New, k); h.Write(d); return h.Sum(nil) }
+	kDate := mac([]byte("AWS4"+"minioadmin"), []byte(dateStamp))
+	kRegion := mac(kDate, []byte("us-east-1"))
+	kService := mac(kRegion, []byte("s3"))
+	kSigning := mac(kService, []byte("aws4_request"))
+	sig := hex.EncodeToString(mac(kSigning, []byte(stringToSign)))
+
+	req.Header.Set("Authorization", fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=minioadmin/%s, SignedHeaders=%s, Signature=%s", scope, signedHeaders, sig))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("%s %s: HTTP %d", method, key, resp.StatusCode)
+	}
+	return nil
+}
+
+// urlEscapeKey path-escapes each segment, keeping separators, which is what S3
+// expects and what url.PathEscape alone does not do.
+func urlEscapeKey(key string) string {
+	parts := strings.Split(key, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}

--- a/internal/storage/unusable_test.go
+++ b/internal/storage/unusable_test.go
@@ -1,0 +1,326 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// The property: ListObjects and ListUnusable partition the store between them.
+//
+// This is the shape that matters, rather than a list of known-bad spellings.
+// #756 exists because the hidden set was derived from ValidateKey while the
+// listings dropped entries for another reason too, so the two definitions
+// disagreed and a contract-VALID data file went missing from every backup with
+// nothing reporting it. Asserting the partition directly is what stops that
+// from happening again the next time a listing grows a filter.
+func TestListingsPartitionTheStore(t *testing.T) {
+	root := t.TempDir()
+	b, err := NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	ctx := context.Background()
+
+	// Every file below is a real file on disk holding bytes.
+	onDisk := []string{
+		"db/cpu/2026/09/12/13/good.parquet",        // ordinary
+		"db/cpu/2026/09/12/13/ba\\d.parquet",       // backslash: refused by the contract
+		"db/cpu/2026/09/12/13/.hidden.parquet",     // dot-prefixed: ACCEPTED by the contract
+		"db/cpu/2026/09/12/13/legacy.part",         // reserved suffix, no committed base
+		"db/cpu/2026/09/12/13/.arc-123456.tmp",     // a write in progress
+		"db/cpu/2026/09/12/13/staged.parquet",      // committed…
+		"db/cpu/2026/09/12/13/staged.parquet.part", // …with its ordinary staging partial
+	}
+	for _, rel := range onDisk {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte("ROWS:"+rel), 0o600); err != nil {
+			t.Skipf("filesystem will not hold %q: %v", rel, err)
+		}
+	}
+
+	objs, err := b.ListObjects(ctx, "")
+	if err != nil {
+		t.Fatalf("ListObjects: %v", err)
+	}
+	hidden, err := b.ListUnusable(ctx, "")
+	if err != nil {
+		t.Fatalf("ListUnusable: %v", err)
+	}
+
+	seen := map[string]string{}
+	for _, o := range objs {
+		seen[o.Path] = "listed"
+	}
+	for _, o := range hidden {
+		if prev, dup := seen[o.Path]; dup {
+			t.Errorf("%q is both %s and reported unusable; the two must partition", o.Path, prev)
+		}
+		seen[o.Path] = "unusable"
+	}
+
+	want := map[string]string{
+		"db/cpu/2026/09/12/13/good.parquet":        "listed",
+		"db/cpu/2026/09/12/13/staged.parquet":      "listed",
+		"db/cpu/2026/09/12/13/ba\\d.parquet":       "unusable",
+		"db/cpu/2026/09/12/13/.hidden.parquet":     "unusable",
+		"db/cpu/2026/09/12/13/legacy.part":         "", // base key "legacy" is valid: staging, not loss
+		"db/cpu/2026/09/12/13/.arc-123456.tmp":     "", // in-flight: neither
+		"db/cpu/2026/09/12/13/staged.parquet.part": "", // ordinary staging: neither
+	}
+	for path, expect := range want {
+		got := seen[path]
+		if got != expect {
+			t.Errorf("%q: got %q, want %q", path, orNone(got), orNone(expect))
+		}
+	}
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(neither)"
+	}
+	return s
+}
+
+// A dot-prefixed data file passes the key contract, is writable and readable
+// through Backend, and is still absent from every listing. Deriving the hidden
+// set from ValidateKey would therefore never report it, which is the specific
+// hole this test pins.
+func TestContractValidFileHiddenByListingIsReported(t *testing.T) {
+	b, err := NewLocalBackend(t.TempDir(), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	ctx := context.Background()
+	const key = "db/cpu/2026/09/12/13/.hidden.parquet"
+
+	if err := ValidateKey(key); err != nil {
+		t.Fatalf("premise: the key must PASS the contract, got %v", err)
+	}
+	if err := b.Write(ctx, key, []byte("HIDDEN-ROWS")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := b.Read(ctx, key); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	objs, _ := b.ListObjects(ctx, "")
+	if len(objs) != 0 {
+		t.Fatalf("premise: the listing must hide it, got %v", objs)
+	}
+
+	hidden, err := b.ListUnusable(ctx, "")
+	if err != nil {
+		t.Fatalf("ListUnusable: %v", err)
+	}
+	if len(hidden) != 1 || hidden[0].Path != key {
+		t.Fatalf("ListUnusable = %v, want exactly %q", hidden, key)
+	}
+	if hidden[0].Size != int64(len("HIDDEN-ROWS")) {
+		t.Errorf("Size = %d, want %d", hidden[0].Size, len("HIDDEN-ROWS"))
+	}
+}
+
+// Keys the contract refuses are reported with an error callers can classify,
+// matching how the reconciliation sweeps branch on ErrInvalidPath.
+func TestUnusableReportsClassifiableError(t *testing.T) {
+	root := t.TempDir()
+	b, err := NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+
+	dir := filepath.Join(root, "db", "cpu")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ba\\d.parquet"), []byte("x"), 0o600); err != nil {
+		t.Skipf("no backslash filenames here: %v", err)
+	}
+
+	hidden, err := b.ListUnusable(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListUnusable: %v", err)
+	}
+	if len(hidden) != 1 {
+		t.Fatalf("want 1 entry, got %v", hidden)
+	}
+	if !errors.Is(hidden[0].Err, ErrInvalidPath) {
+		t.Errorf("Err = %v, want it to wrap ErrInvalidPath", hidden[0].Err)
+	}
+}
+
+// An over-long key is producible by nesting (a >255-byte SEGMENT is not
+// creatable on ext4 at all), and it must be reported rather than vanish.
+func TestOverLongKeyIsReported(t *testing.T) {
+	root := t.TempDir()
+	b, err := NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	seg := strings.Repeat("d", 200)
+	rel := filepath.Join("db", seg, seg, seg, seg, seg, seg, "f.parquet")
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+		t.Skipf("cannot nest that deep: %v", err)
+	}
+	if err := os.WriteFile(full, []byte("LONG"), 0o600); err != nil {
+		t.Skipf("cannot create: %v", err)
+	}
+
+	ctx := context.Background()
+	objs, _ := b.ListObjects(ctx, "")
+	if len(objs) != 0 {
+		t.Fatalf("premise: the listing must hide it, got %v", objs)
+	}
+	hidden, err := b.ListUnusable(ctx, "")
+	if err != nil {
+		t.Fatalf("ListUnusable: %v", err)
+	}
+	if len(hidden) != 1 {
+		t.Fatalf("want the over-long key reported, got %v", hidden)
+	}
+	if !errors.Is(hidden[0].Err, ErrInvalidPath) {
+		t.Errorf("Err = %v, want ErrInvalidPath", hidden[0].Err)
+	}
+}
+
+// Directories are never reported. Reporting the walk root would give Path ""
+// or ".", which names the data directory itself.
+func TestUnusableNeverReportsADirectory(t *testing.T) {
+	root := t.TempDir()
+	b, err := NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	// A directory whose own name the contract refuses.
+	if err := os.MkdirAll(filepath.Join(root, "db", "me\\as"), 0o700); err != nil {
+		t.Skipf("no backslash names here: %v", err)
+	}
+	hidden, err := b.ListUnusable(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListUnusable: %v", err)
+	}
+	for _, o := range hidden {
+		if o.Path == "" || o.Path == "." {
+			t.Fatalf("reported a directory as an object: %+v", o)
+		}
+	}
+	if len(hidden) != 0 {
+		t.Errorf("an empty bad directory holds no objects, got %v", hidden)
+	}
+}
+
+// A file UNDER a directory whose name the contract refuses is still real data
+// and must be reported: the directory is not enumerable, so this is the only
+// way it can ever be found.
+func TestUnusableSeesFilesUnderABadDirectory(t *testing.T) {
+	root := t.TempDir()
+	b, err := NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	dir := filepath.Join(root, "db", "me\\as", "2026")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Skipf("no backslash names here: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "f.parquet"), []byte("ROWS"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	ctx := context.Background()
+	if objs, _ := b.ListObjects(ctx, ""); len(objs) != 0 {
+		t.Fatalf("premise: the listing must hide it, got %v", objs)
+	}
+	hidden, err := b.ListUnusable(ctx, "")
+	if err != nil {
+		t.Fatalf("ListUnusable: %v", err)
+	}
+	if len(hidden) != 1 || !strings.HasSuffix(hidden[0].Path, "f.parquet") {
+		t.Fatalf("want the file under the bad directory reported, got %v", hidden)
+	}
+}
+
+// The .part exclusion must key off the base KEY, not off whether something
+// exists at that name. Testing existence with os.Stat let three real files fall
+// into neither listing, which breaks the partition this design rests on.
+func TestPartExclusionDoesNotSwallowRealObjects(t *testing.T) {
+	root := t.TempDir()
+	b, err := NewLocalBackend(root, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("backend: %v", err)
+	}
+	ctx := context.Background()
+
+	mk := func(rel, body string) {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatalf("mkdir %q: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %q: %v", rel, err)
+		}
+	}
+
+	// 1. Base name is occupied by a DIRECTORY, so no write to key "db/cpu"
+	//    could ever stage here. An existence test would see the directory and
+	//    call this an ordinary partial.
+	mk("db/cpu/data.parquet", "PAR1")
+	mk("db/cpu.part", "PAR1-real-rows")
+
+	// 2. Base still carries the reserved suffix, so it is not a key either.
+	mk("db/mem/legacy.part", "PAR1-legacy")
+	mk("db/mem/legacy.part.part", "PAR1-legacy-partial")
+
+	// 3. Base is a directory prefix, not a key at all.
+	mk("db/disk/.part", "PAR1-dotpart")
+
+	// And the shapes that MUST stay excluded.
+	mk("db/net/good.parquet", "PAR1-good")
+	mk("db/net/good.parquet.part", "ordinary staging partial")
+	mk("db/net/inflight.parquet.part", "a WriteReader or compaction output in progress")
+
+	objs, err := b.ListObjects(ctx, "")
+	if err != nil {
+		t.Fatalf("ListObjects: %v", err)
+	}
+	hidden, err := b.ListUnusable(ctx, "")
+	if err != nil {
+		t.Fatalf("ListUnusable: %v", err)
+	}
+
+	where := map[string]string{}
+	for _, o := range objs {
+		where[o.Path] = "listed"
+	}
+	for _, o := range hidden {
+		if prev, dup := where[o.Path]; dup {
+			t.Errorf("%q is both %s and unusable", o.Path, prev)
+		}
+		where[o.Path] = "unusable"
+	}
+
+	for path, want := range map[string]string{
+		"db/cpu/data.parquet":          "listed",
+		"db/net/good.parquet":          "listed",
+		"db/cpu.part":                  "unusable",
+		"db/mem/legacy.part":           "", // base key "legacy" is valid: indistinguishable from a partial
+		"db/mem/legacy.part.part":      "unusable",
+		"db/disk/.part":                "unusable",
+		"db/net/good.parquet.part":     "", // ordinary staging
+		"db/net/inflight.parquet.part": "", // in flight, no committed base yet
+	} {
+		if got := where[path]; got != want {
+			t.Errorf("%q: got %q, want %q", path, orNone(got), orNone(want))
+		}
+	}
+}


### PR DESCRIPTION
Closes #756.

## The premise, corrected and measured

The issue says local listings do **not** filter unusable keys. They have since #744 (`dca623f`), merged about six hours before the issue was filed: `local.go` `List`, `ListDirectories` and `ListObjects` each carry a silent `ValidateKey` drop. So option 1 shipped, which is the option the issue argued against, and the consequence it predicted is live.

Probed against a real local backend and real DuckDB:

```
ValidateKey("db/cpu/.../ba\d.parquet") = invalid path: contains a backslash
List(db/)        -> [db/cpu/2026/09/12/13/good.parquet]     the backslash file is gone
ListObjects(db/) -> [db/cpu/2026/09/12/13/good.parquet]     gone here too
Read(backslash key) = invalid path                          unreachable via Backend
on disk: "BACKSLASH-ROWS" (14 bytes)                        the rows are there
ListStaged(db/) -> 0 entries                                nothing enumerates it

read_parquet('<root>/db/cpu/**/*.parquet') -> 2 rows        the query path serves BOTH
```

Backup inventories what a listing returns. Every mechanism that makes an incomplete backup visible reads that inventory: the skipped-file counter, the "backup will be incomplete" warning, and `checkSkipRatio`. A file the listing never returned reaches none of them. Before the filter existed, the same file failed loudly at read and was counted.

One correction to the issue's second shape: an over-long **segment** is not creatable on ext4 (`ENAMETOOLONG`). The producible form is a whole key over the 1019-byte bound built from many legal segments, confirmed at 1218 bytes.

## What this does

Backends can enumerate what a listing hid (`storage.UnusableLister`). That is the counterpart #744 already established for the case it created: when it hid staged partials it added `ListStaged`. The contract drop had no equivalent, and that asymmetry is the defect.

Not un-filtering: #743's reasoning stands, and handing back a key the backend then refuses is worse.

**The hidden set is defined by observation, not by re-deriving `ValidateKey`** — it is what a full walk sees and `ListObjects` does not return, through one `omittedFromListing` that all four local listings consult. That distinction is load-bearing, and it found a second case a predicate could never have reported:

```
ValidateKey("db/cpu/.../.hidden.parquet") = <nil>     PASSES the contract
Write -> ok;  Read -> "HIDDEN-ROWS", err=<nil>        writable and readable
List('') -> [];  ListObjects('') -> 0 entries         hidden anyway
```

Backup now records a count and a bounded sample in the manifest, warns naming the files, and exports a gauge. **A backup whose data files are all unaddressable now fails**, where it previously reported success over a backup containing nothing, because `checkSkipRatio` divides by the inventory size and returns early when that is zero.

## What the review changed

The adversarial pass on the plan defeated four pieces of it with probes, and the implementation review found three more. Worth listing because several were my design, not incidental bugs:

- **A delete method was cut.** Its containment was `filepath.Rel`, which is lexical. A symlinked measurement directory plus a backslash key deleted a file **outside** the storage root. Enumeration is what the issue asked for; the remedy for such a file is `mv`; a delete API mostly offers the option of destroying the data instead. If it ever ships it needs `os.OpenRoot`.
- **The predicate was wrong** (the dot-prefixed case above).
- **The guard was wrong twice.** I had planned to add these to `checkSkipRatio`'s numerator. It short-circuits on `skipped == 0 || totalFiles == 0`, so that was a no-op in exactly the targeted case, and blind to total loss. Its ratio would also hard-fail a nine-file deployment with one legacy file forever, and its message ("source storage may be degraded") sends an operator to check disks rather than rename a file.
- **Staging exclusion tested existence, not the base key.** That let three real files fall into neither set, breaking the partition the design rests on: a `.part` whose base name is a **directory**, `x.part.part`, and `.part` alone. Now pinned by `TestPartExclusionDoesNotSwallowRealObjects`.
- **The `.parquet` filter discarded two classes** the storage layer exists to surface: unaddressable Iceberg metadata (which loses a whole table, worse than a data file) and `.part` keys on object stores.
- **The metric was a counter with gauge semantics**, so the alert it invites could never clear. It is a gauge, set on every backup including zero.
- **The fatal case ran after all the copying**, leaving a partial tree in backup storage with no manifest for `ListBackups` to find it by. It is decided before any work now.
- **The two passes are ordered deliberately**: hidden set first, inventory second. A file renamed between them is then reported *and* copied, a spurious warning. The reverse order loses it from both, silently reproducing the bug.

## Deliberate trade-off

A committed object written before #744 whose real name is `X.part` for a valid key `X` is indistinguishable from an in-flight partial for `X`, and is excluded. The alternative reports every in-progress compaction output as data an operator lost, on every backup, forever, carrying advice that would publish a truncated Parquet. Stated in the code and in the release notes.

## Tests

Verified to fail when the mechanism is disabled, rather than asserted to pass:

```
--- FAIL: TestBackupReportsFilesItCouldNotAddress   UnaddressableFiles = 0, want 1
--- FAIL: TestBackupFailsWhenNoDataFileIsAddressable  a backup containing no data must fail
--- FAIL: TestUnaddressableSampleIsBounded          premise: need more than the cap, got 0
```

Plus the partition property across all shapes, the three staging holes, Iceberg metadata, the early-fail leaving nothing behind, and an `objectstore` test against MinIO that uses a raw SigV4 PUT to create a backslash key, a committed `.part` and a zero-length directory marker, asserting the first two are reported and the marker is not.

## Filed while auditing

- **#760** the same silence in the Iceberg exporter. Worse in kind: the exported table answers queries **wrong** to Spark/Trino/DuckDB, rather than merely losing bytes discovered at restore. The guard I added in #746 for exactly this is now unreachable.
- **#761** a long but legal source key makes **every** backup fail permanently, because `destPath` adds 37 bytes and overruns the limit.
- **#762** restore has no skip accounting at all and reports `completed` while dropping files; retention's skip counter has been unreachable since #744; `ListStaged` reports partials under a key that is not theirs.

## Verification

`go build`, `go vet`, `go test -race`, all with `-tags=duckdb_arrow`, plus the `objectstore` suite against MinIO. All green.
