### PR TITLE
security(query): add PREPARE and EXECUTE to dangerousSQLPattern (#739)

### DIFF
--- a/RELEASE_NOTES_2026.09.2.md
+++ b/RELEASE_NOTES_2026.09.2.md
@@ -1391,3 +1391,8 @@ warehouse metadata directory, after the files are removed, so a racing
 reconcile pass can only empty tables rather than recreate them. Cleanup
 failures are logged and re-running the DELETE retries them, including when the
 files are already gone.
+
+### PREPARE and EXECUTE statements blocked in query validator ([#739](https://github.com/Basekick-Labs/arc/issues/739))
+
+`ValidateSQLRequest` now rejects `PREPARE` and `EXECUTE` commands up front in `dangerousSQLPattern`, hardening against dynamic SQL execution attempts across all user query endpoints.
+

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -764,6 +764,10 @@ var dangerousSQLPattern = regexp.MustCompile(`(?i)(?:` +
 	// bypassable via `CALL(proc)` (no whitespace before paren) — gemini
 	// round 1.
 	`|\bCALL\b` +
+	// PREPARE / EXECUTE match bare keywords as defense-in-depth against
+	// dynamic SQL evaluation (#739).
+	`|\bPREPARE\b` +
+	`|\bEXECUTE\b` +
 	// Secrets manager: CREATE/DROP SECRET lets any authenticated user replace
 	// or delete Arc's S3 credentials (redirecting reads to attacker-controlled
 	// creds, or knocking out S3 access entirely) and probe the secret manager.

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -1006,18 +1006,27 @@ func TestValidateSQLRequest_BypassesAndFalsePositives(t *testing.T) {
 		{name: "DROP dash-comment then newline", sql: "DROP --evil\nTABLE users", shouldFail: true},
 		{name: "ATTACH block-comment", sql: "ATTACH /* sneaky */ 'evil' AS x", shouldFail: true},
 		{name: "LOAD block-comment", sql: "LOAD /**/'http://x'", shouldFail: true},
+		{name: "PREPARE statement blocked", sql: "PREPARE p AS SELECT * FROM cpu", shouldFail: true},
+		{name: "EXECUTE statement blocked", sql: "EXECUTE p", shouldFail: true},
+		{name: "EXECUTE with arguments blocked", sql: "EXECUTE p(1, 2)", shouldFail: true},
+		{name: "PREPARE block-comment evasion", sql: "PREPARE/**/p AS SELECT 1", shouldFail: true},
+		{name: "EXECUTE block-comment evasion", sql: "EXECUTE/**/p", shouldFail: true},
 
 		// String-literal false-positives — must NOT be blocked.
 		{name: "literal contains DROP TABLE", sql: "SELECT * FROM logs WHERE msg = 'DROP TABLE users'", shouldFail: false},
 		{name: "literal contains LOAD", sql: "SELECT * FROM logs WHERE event = 'LOAD failed'", shouldFail: false},
 		{name: "literal contains ATTACH", sql: "SELECT 'attach this' AS note FROM t", shouldFail: false},
 		{name: "literal contains SET GLOBAL", sql: "SELECT * FROM t WHERE msg LIKE '%SET GLOBAL foo=%'", shouldFail: false},
+		{name: "literal contains PREPARE", sql: "SELECT * FROM logs WHERE msg = 'PREPARE failed'", shouldFail: false},
+		{name: "literal contains EXECUTE", sql: "SELECT * FROM logs WHERE msg = 'EXECUTE query'", shouldFail: false},
 
 		// Quoted-identifier false-positives — must NOT be blocked
 		// (column literally named COPY/LOAD etc.). MaskStringLiterals
 		// masks both single and double quotes.
 		{name: "double-quoted COPY identifier", sql: `SELECT "COPY" FROM t`, shouldFail: false},
 		{name: "double-quoted LOAD identifier", sql: `SELECT "LOAD", x FROM t`, shouldFail: false},
+		{name: "double-quoted PREPARE identifier", sql: `SELECT "PREPARE" FROM t`, shouldFail: false},
+		{name: "double-quoted EXECUTE identifier", sql: `SELECT "EXECUTE" FROM t`, shouldFail: false},
 
 		// Comment + literal interaction — comment inside literal must NOT be stripped first.
 		{name: "literal containing /* */ keeps inner DROP TABLE blocked? NO -- inside literal", sql: "SELECT 'a /* */ DROP TABLE x' FROM t", shouldFail: false},
@@ -2277,3 +2286,38 @@ func TestValidateSQLRequest_BlocksSecretStatements(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateSQLRequest_BlocksPrepareAndExecute: PREPARE and EXECUTE in user SQL
+// are rejected up front as defense-in-depth against dynamic SQL execution (#739).
+func TestValidateSQLRequest_BlocksPrepareAndExecute(t *testing.T) {
+	blocked := []string{
+		"PREPARE stmt AS SELECT * FROM cpu",
+		"prepare p AS SELECT 1",
+		"PREPARE /* sneaky */ p AS SELECT 1",
+		"EXECUTE stmt",
+		"execute p",
+		"EXECUTE p(1, 2)",
+		"EXECUTE(p)",
+		"EXECUTE/**/p",
+	}
+	for _, q := range blocked {
+		if err := ValidateSQLRequest(q); err == nil {
+			t.Errorf("ValidateSQLRequest(%q): expected rejection for PREPARE/EXECUTE, got nil", q)
+		}
+	}
+
+	// Quoted identifiers and string literals containing the keywords must pass.
+	allowed := []string{
+		`SELECT "PREPARE" FROM cpu`,
+		`SELECT "EXECUTE" FROM cpu`,
+		"SELECT * FROM cpu WHERE msg = 'PREPARE failed'",
+		"SELECT * FROM cpu WHERE msg = 'EXECUTE statement'",
+		"SELECT * FROM cpu WHERE msg = 'EXECUTE(x)'",
+	}
+	for _, q := range allowed {
+		if err := ValidateSQLRequest(q); err != nil {
+			t.Errorf("ValidateSQLRequest(%q): expected allowed, got %v", q, err)
+		}
+	}
+}
+


### PR DESCRIPTION
## Summary

* Blocked `PREPARE` and `EXECUTE` in `dangerousSQLPattern` to prevent dynamic SQL execution through all user-SQL endpoints:

  * `/api/v1/query`
  * `/api/v1/query/arrow`
  * `/api/v1/query/msgpack`
* Added defense-in-depth protection against dynamic SQL execution attempts, following up on #738 / GHSA-w6w2-x8xv-q8x2.

Fixes #739

## Motivation & Background

DuckDB supports indirect SQL execution through `PREPARE` and `EXECUTE`. While Arc's current single-statement restriction prevents the known attack path, these keywords were not previously blocked by `dangerousSQLPattern`.

Blocking both keywords ensures dynamic SQL execution is rejected at the read-API boundary, even if SQL parsing or statement restrictions change in the future.

## Changes

### `internal/api/query.go`

* Added `\bPREPARE\b` and `\bEXECUTE\b` to `dangerousSQLPattern`.

### `internal/api/query_test.go`

* Added tests for:

  * Direct `PREPARE`/`EXECUTE` statements.
  * Arguments and comment-based bypass attempts.
  * Double-quoted identifiers such as `"PREPARE"`.
  * String literals containing `PREPARE`/`EXECUTE`.
* Added `TestValidateSQLRequest_BlocksPrepareAndExecute`.

### `RELEASE_NOTES_2026.09.2.md`

* Added a release note entry referencing #739.

## Test Plan

* [x] `go test -tags=duckdb_arrow ./internal/api/ -run "TestValidateSQLRequest" -v`
* [x] `go test ./internal/api/ -run "TestValidateSQLRequest"`
